### PR TITLE
fix(gas): close selection protocol gap

### DIFF
--- a/docs/audits/convergence_disposition_matrix.md
+++ b/docs/audits/convergence_disposition_matrix.md
@@ -112,3 +112,10 @@
 - Mod 运行时唯一真相与收束准则：见 [Mod 运行时唯一真相与收束准则](../architecture/mod_runtime_single_source_of_truth.md)
 - ConfigPipeline 合并管线：见 [ConfigPipeline 合并管线](../architecture/config_pipeline.md)
 
+
+## 3.2 Selection Protocol Closure (2026-03-08)
+
+- `SelectionResponse` now carries confirmed world point and preserved target context instead of only entity ids.
+- `GasSelectionResponseSystem` consumes requests in FIFO order and fails fast when the response buffer is full.
+- `AbilityExecSystem` now restores `TargetContext` and `TargetPosCm` when a `SelectionGate` response is consumed.
+- Regression coverage lives in `src/Tests/GasTests/InteractionSelectionConvergenceTests.cs`.

--- a/src/Core/Gameplay/GAS/Input/InputProtocol.cs
+++ b/src/Core/Gameplay/GAS/Input/InputProtocol.cs
@@ -1,4 +1,5 @@
-using Arch.Core;
+﻿using Arch.Core;
+using Ludots.Core.Mathematics;
 
 namespace Ludots.Core.Gameplay.GAS.Input
 {
@@ -46,10 +47,50 @@ namespace Ludots.Core.Gameplay.GAS.Input
     {
         public int RequestId { get; set; }
         public int ResponseTagId;
+        public Entity TargetContext;
+        public int WorldCmX;
+        public int WorldCmY;
+        public byte HasWorldPoint;
         public int Count;
         public fixed int EntityIds[64];
         public fixed int WorldIds[64];
         public fixed int Versions[64];
+
+        public void SetEntity(int index, Entity entity)
+        {
+            if ((uint)index >= 64u)
+            {
+                throw new System.ArgumentOutOfRangeException(nameof(index), index, "Selection response entity index must be within [0, 63].");
+            }
+
+            fixed (int* ids = EntityIds)
+            fixed (int* worldIds = WorldIds)
+            fixed (int* versions = Versions)
+            {
+                ids[index] = entity.Id;
+                worldIds[index] = entity.WorldId;
+                versions[index] = entity.Version;
+            }
+        }
+
+        public void SetWorldPoint(in WorldCmInt2 worldCm)
+        {
+            WorldCmX = worldCm.X;
+            WorldCmY = worldCm.Y;
+            HasWorldPoint = 1;
+        }
+
+        public bool TryGetWorldPoint(out WorldCmInt2 worldCm)
+        {
+            if (HasWorldPoint == 0)
+            {
+                worldCm = default;
+                return false;
+            }
+
+            worldCm = new WorldCmInt2(WorldCmX, WorldCmY);
+            return true;
+        }
 
         public Entity GetEntity(int index)
         {
@@ -63,4 +104,3 @@ namespace Ludots.Core.Gameplay.GAS.Input
         }
     }
 }
-

--- a/src/Core/Gameplay/GAS/Input/InputQueues.cs
+++ b/src/Core/Gameplay/GAS/Input/InputQueues.cs
@@ -1,4 +1,4 @@
-namespace Ludots.Core.Gameplay.GAS.Input
+﻿namespace Ludots.Core.Gameplay.GAS.Input
 {
     /// <summary>
     /// Generic ring buffer for request types with auto-incrementing RequestId.
@@ -28,6 +28,18 @@ namespace Ludots.Core.Gameplay.GAS.Input
             _items[_tail] = r;
             _tail = (_tail + 1) % _items.Length;
             _count++;
+            return true;
+        }
+
+        public bool TryPeek(out T request)
+        {
+            if (_count == 0)
+            {
+                request = default;
+                return false;
+            }
+
+            request = _items[_head];
             return true;
         }
 
@@ -97,8 +109,6 @@ namespace Ludots.Core.Gameplay.GAS.Input
             _count = 0;
         }
     }
-
-    // ── Concrete types ──
 
     public sealed class InputRequestQueue : RingBuffer<InputRequest>
     {

--- a/src/Core/Gameplay/GAS/Input/SelectionRequestTags.cs
+++ b/src/Core/Gameplay/GAS/Input/SelectionRequestTags.cs
@@ -1,7 +1,8 @@
-namespace Ludots.Core.Gameplay.GAS.Input
+﻿namespace Ludots.Core.Gameplay.GAS.Input
 {
     public static class SelectionRequestTags
     {
+        public const int DefaultAreaAll = 0;
         public const int Single = 1;
         public const int CircleEnemy = 2;
         public const int CircleAll = 3;

--- a/src/Core/Gameplay/GAS/Input/SelectionRuleRegistry.cs
+++ b/src/Core/Gameplay/GAS/Input/SelectionRuleRegistry.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using Ludots.Core.Gameplay.Teams;
+
+namespace Ludots.Core.Gameplay.GAS.Input
+{
+    public enum SelectionRuleMode : byte
+    {
+        None = 0,
+        SingleNearest = 1,
+        Radius = 2,
+    }
+
+    public struct SelectionRule
+    {
+        public SelectionRuleMode Mode;
+        public RelationshipFilter RelationshipFilter;
+        public int RadiusCm;
+        public int MaxCount;
+
+        public readonly bool IsValid => Mode != SelectionRuleMode.None;
+    }
+
+    public sealed class SelectionRuleRegistry
+    {
+        private readonly Dictionary<int, SelectionRule> _rules = new();
+
+        public void Register(int requestTypeId, in SelectionRule rule)
+        {
+            if (requestTypeId < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(requestTypeId), "Selection request type id must be non-negative.");
+            }
+
+            if (!rule.IsValid)
+            {
+                throw new ArgumentException("Selection rule must define a valid mode.", nameof(rule));
+            }
+
+            _rules[requestTypeId] = rule;
+        }
+
+        public bool TryGet(int requestTypeId, out SelectionRule rule)
+        {
+            return _rules.TryGetValue(requestTypeId, out rule);
+        }
+
+        public static SelectionRuleRegistry CreateWithDefaults(
+            int singlePickRadiusCm = 120,
+            int areaRadiusCm = 250,
+            int areaMaxCount = 64)
+        {
+            var registry = new SelectionRuleRegistry();
+            RegisterDefaults(registry, singlePickRadiusCm, areaRadiusCm, areaMaxCount);
+            return registry;
+        }
+
+        public static void RegisterDefaults(
+            SelectionRuleRegistry registry,
+            int singlePickRadiusCm = 120,
+            int areaRadiusCm = 250,
+            int areaMaxCount = 64)
+        {
+            if (registry == null)
+            {
+                throw new ArgumentNullException(nameof(registry));
+            }
+
+            registry.Register(SelectionRequestTags.DefaultAreaAll, new SelectionRule
+            {
+                Mode = SelectionRuleMode.Radius,
+                RelationshipFilter = RelationshipFilter.All,
+                RadiusCm = areaRadiusCm,
+                MaxCount = areaMaxCount,
+            });
+            registry.Register(SelectionRequestTags.Single, new SelectionRule
+            {
+                Mode = SelectionRuleMode.SingleNearest,
+                RelationshipFilter = RelationshipFilter.All,
+                RadiusCm = singlePickRadiusCm,
+                MaxCount = 1,
+            });
+            registry.Register(SelectionRequestTags.CircleEnemy, new SelectionRule
+            {
+                Mode = SelectionRuleMode.Radius,
+                RelationshipFilter = RelationshipFilter.Hostile,
+                RadiusCm = areaRadiusCm,
+                MaxCount = areaMaxCount,
+            });
+            registry.Register(SelectionRequestTags.CircleAll, new SelectionRule
+            {
+                Mode = SelectionRuleMode.Radius,
+                RelationshipFilter = RelationshipFilter.All,
+                RadiusCm = areaRadiusCm,
+                MaxCount = areaMaxCount,
+            });
+        }
+    }
+}

--- a/src/Core/Gameplay/GAS/Systems/AbilityExecSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/AbilityExecSystem.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Arch.Core;
 using Arch.Core.Extensions;
 using Arch.System;
@@ -94,8 +94,8 @@ namespace Ludots.Core.Gameplay.GAS.Systems
         {
             while (!UpdateSlice(dt, int.MaxValue)) { }
             
-            // After Phase 2 finishes abilities (which calls NotifyOrderComplete → 
-            // promotes next queued order → activates tags), re-run Phase 1 to pick up
+            // After Phase 2 finishes abilities (which calls NotifyOrderComplete 鈫?
+            // promotes next queued order 鈫?activates tags), re-run Phase 1 to pick up
             // newly promoted orders in the same frame. Without this, there would be 
             // a one-frame delay between ability completion and the next queued ability starting.
             for (int rescan = 0; rescan < MaxRescanIterations; rescan++)
@@ -111,7 +111,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
         {
             int workUnits = 0;
 
-            // ── Phase 1: Query entities with Active_CastAbility tag + Blackboard (no AbilityExecInstance yet) ──
+            // 鈹€鈹€ Phase 1: Query entities with Active_CastAbility tag + Blackboard (no AbilityExecInstance yet) 鈹€鈹€
             if (_castAbilityOrderTagId > 0)
             {
                 int newCount = World.CountEntities(in _newOrderQuery);
@@ -205,7 +205,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                         }
                     }
 
-                    // ── Toggle check: if ability has toggle spec and toggle tag is ON, deactivate instead ──
+                    // 鈹€鈹€ Toggle check: if ability has toggle spec and toggle tag is ON, deactivate instead 鈹€鈹€
                     if (slot.AbilityId > 0 && _abilityDefinitions != null &&
                         _abilityDefinitions.TryGet(slot.AbilityId, out var toggleDef) &&
                         toggleDef.HasToggleSpec && toggleDef.ToggleSpec.ToggleTagId > 0 &&
@@ -278,7 +278,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                 }
             }
 
-            // ── Phase 2: Advance all active exec instances ──
+            // 鈹€鈹€ Phase 2: Advance all active exec instances 鈹€鈹€
             if (!_sliceActive)
             {
                 _sliceActive = true;
@@ -323,7 +323,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
 
                 if (slot.AbilityId <= 0 || _abilityDefinitions == null || !_abilityDefinitions.TryGet(slot.AbilityId, out var def))
                 {
-                    // No valid ability definition found — fail-fast, remove exec instance
+                    // No valid ability definition found 鈥?fail-fast, remove exec instance
                     World.Remove<AbilityExecInstance>(actor);
                     workUnits++;
                     continue;
@@ -416,7 +416,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             _execEntityCount = 0;
         }
 
-        // ──────────────────── Item processing ────────────────────
+        // 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€ Item processing 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 
         private void AdvanceItems(Entity actor, ref AbilityExecSpec spec,
             ref AbilityExecCallerParamsPool callerPool, bool hasCallerPool,
@@ -444,7 +444,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                         inst.State = AbilityExecRunState.Finished;
                         return;
 
-                    // ── Clips ──
+                    // 鈹€鈹€ Clips 鈹€鈹€
                     case ExecItemKind.EffectClip:
                         FireEffectItem(actor, ref spec, idx, ref callerPool, hasCallerPool, ref inst);
                         inst.NextItemIndex++;
@@ -461,7 +461,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                         inst.NextItemIndex++;
                         continue;
 
-                    // ── Signals ──
+                    // 鈹€鈹€ Signals 鈹€鈹€
                     case ExecItemKind.EffectSignal:
                         FireEffectItem(actor, ref spec, idx, ref callerPool, hasCallerPool, ref inst);
                         inst.NextItemIndex++;
@@ -488,7 +488,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                         inst.NextItemIndex++;
                         continue;
 
-                    // ── Gates ──
+                    // 鈹€鈹€ Gates 鈹€鈹€
                     case ExecItemKind.InputGate:
                     case ExecItemKind.EventGate:
                     case ExecItemKind.SelectionGate:
@@ -510,7 +510,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             inst.State = AbilityExecRunState.Finished;
         }
 
-        // ── Effect dispatch (shared for EffectClip & EffectSignal) ──
+        // 鈹€鈹€ Effect dispatch (shared for EffectClip & EffectSignal) 鈹€鈹€
 
         private void FireEffectItem(Entity actor, ref AbilityExecSpec spec, int idx,
             ref AbilityExecCallerParamsPool callerPool, bool hasCallerPool,
@@ -567,7 +567,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             _effectRequests.Publish(req);
         }
 
-        // ── Tag Clip (add at start, auto-remove via TimedTag) ──
+        // 鈹€鈹€ Tag Clip (add at start, auto-remove via TimedTag) 鈹€鈹€
 
         private void FireTagClip(Entity actor, ref AbilityExecSpec spec, int idx,
             ref AbilityExecInstance inst)
@@ -593,7 +593,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             }
         }
 
-        // ── Tag Signal (instant add/remove) ──
+        // 鈹€鈹€ Tag Signal (instant add/remove) 鈹€鈹€
 
         private void FireTagSignal(Entity actor, ref AbilityExecSpec spec, int idx)
         {
@@ -624,7 +624,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             }
         }
 
-        // ── Event Signal ──
+        // 鈹€鈹€ Event Signal 鈹€鈹€
 
         private void FireEventSignal(Entity actor, ref AbilityExecSpec spec, int idx,
             ref AbilityExecInstance inst)
@@ -653,7 +653,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             _phaseExecutor.ExecuteGraph(World, _graphApi, actor, target, default, default, graphProgramId);
         }
 
-        // ── Gate enter / process ──
+        // 鈹€鈹€ Gate enter / process 鈹€鈹€
 
         private void EnterGate(Entity actor, ref AbilityExecSpec spec, int idx,
             ref AbilityExecInstance inst)
@@ -758,6 +758,15 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                             var chosen = resp.GetEntity(0);
                             if (World.IsAlive(chosen)) inst.Target = chosen;
                         }
+                        if (World.IsAlive(resp.TargetContext))
+                        {
+                            inst.TargetContext = resp.TargetContext;
+                        }
+                        if (resp.TryGetWorldPoint(out var worldPoint))
+                        {
+                            inst.TargetPosCm = Fix64Vec2.FromInt(worldPoint.X, worldPoint.Y);
+                            inst.HasTargetPos = 1;
+                        }
                         inst.WaitRequestId = 0;
                         inst.NextItemIndex++;
                         inst.State = AbilityExecRunState.Running;
@@ -797,7 +806,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             }
         }
 
-        // ──────────────────── Toggle Helpers ────────────────────
+        // 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€ Toggle Helpers 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 
         /// <summary>
         /// Activate toggle: add toggle tag and apply infinite active effects.
@@ -880,7 +889,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             }
             else
             {
-                // No deactivate timeline — instant deactivation, just complete the order
+                // No deactivate timeline 鈥?instant deactivation, just complete the order
                 _presentationEvents?.Publish(new GasPresentationEvent
                 {
                     Kind = GasPresentationEventKind.CastFinished,
@@ -897,7 +906,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             }
         }
 
-        // ──────────────────── Helpers ────────────────────
+        // 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€ Helpers 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 
         private void EnsureTagComponents(Entity actor)
         {
@@ -921,3 +930,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
         }
     }
 }
+
+
+

--- a/src/Core/Input/Interaction/InteractionActionBindings.cs
+++ b/src/Core/Input/Interaction/InteractionActionBindings.cs
@@ -1,0 +1,15 @@
+﻿namespace Ludots.Core.Input.Interaction
+{
+    public sealed class InteractionActionBindings
+    {
+        public const string DefaultConfirmActionId = "Select";
+        public const string DefaultCancelActionId = "Cancel";
+        public const string DefaultCommandActionId = "Command";
+        public const string DefaultPointerPositionActionId = "PointerPos";
+
+        public string ConfirmActionId { get; set; } = DefaultConfirmActionId;
+        public string CancelActionId { get; set; } = DefaultCancelActionId;
+        public string CommandActionId { get; set; } = DefaultCommandActionId;
+        public string PointerPositionActionId { get; set; } = DefaultPointerPositionActionId;
+    }
+}

--- a/src/Core/Presentation/Systems/GasSelectionResponseSystem.cs
+++ b/src/Core/Presentation/Systems/GasSelectionResponseSystem.cs
@@ -1,11 +1,12 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Arch.Core;
 using Arch.System;
 using Ludots.Core.Components;
 using Ludots.Core.Gameplay.Components;
-using Ludots.Core.Gameplay.Teams;
 using Ludots.Core.Gameplay.GAS.Input;
+using Ludots.Core.Gameplay.Teams;
+using Ludots.Core.Input.Interaction;
 using Ludots.Core.Input.Runtime;
 using Ludots.Core.Mathematics;
 using Ludots.Core.Presentation.Utils;
@@ -16,40 +17,32 @@ using Ludots.Platform.Abstractions;
 namespace Ludots.Core.Presentation.Systems
 {
     /// <summary>
-    /// 通用的 GAS SelectionRequest 响应系统。
-    /// 
-    /// 当 GAS 技能系统发出 SelectionRequest（例如"选择范围内的敌方目标"）时，
-    /// 此系统在下次用户点击时执行空间查询并返回 SelectionResponse。
-    /// 
-    /// 支持的 SelectionRequestTags：
-    /// - Single: 选择最近的单个实体
-    /// - CircleEnemy: 选择范围内的敌方实体（通过 Team 组件过滤）
-    /// - CircleAll: 选择范围内的所有实体
-    /// 
-    /// Mod 可通过 OnSelectionTriggered 回调添加视觉反馈（如范围指示器）。
+    /// Generic GAS selection-response system.
+    /// Abilities submit SelectionRequest and wait for the next confirm click.
+    /// This system resolves the request through a SelectionRuleRegistry and returns
+    /// the matching entities plus the confirmed world point via SelectionResponse.
     /// </summary>
     public sealed class GasSelectionResponseSystem : ISystem<float>
     {
+        private static readonly InteractionActionBindings DefaultBindings = new InteractionActionBindings();
+
         private readonly World _world;
         private readonly Dictionary<string, object> _globals;
         private readonly ISpatialQueryService _spatial;
-        private SelectionRequest _activeRequest;
-        private bool _hasActiveRequest;
+        private readonly SelectionRuleRegistry _rules;
 
-        /// <summary>默认拾取半径（厘米），用于 Single 模式。</summary>
-        public int PickRadiusCm { get; set; } = 120;
-
-        /// <summary>
-        /// 当 Selection 被触发时的回调。Mod 可注册此回调来添加视觉反馈（如范围圆圈）。
-        /// 参数：(SelectionRequest request, WorldCmInt2 clickPoint)
-        /// </summary>
         public Action<SelectionRequest, WorldCmInt2>? OnSelectionTriggered { get; set; }
 
-        public GasSelectionResponseSystem(World world, Dictionary<string, object> globals, ISpatialQueryService spatial)
+        public GasSelectionResponseSystem(
+            World world,
+            Dictionary<string, object> globals,
+            ISpatialQueryService spatial,
+            SelectionRuleRegistry? rules = null)
         {
             _world = world;
             _globals = globals;
             _spatial = spatial;
+            _rules = rules ?? ResolveRules(globals) ?? SelectionRuleRegistry.CreateWithDefaults();
         }
 
         public void Initialize() { }
@@ -60,33 +53,112 @@ namespace Ludots.Core.Presentation.Systems
             if (!_globals.TryGetValue(CoreServiceKeys.ScreenRayProvider.Name, out var rayObj) || rayObj is not IScreenRayProvider rayProvider) return;
             if (!_globals.TryGetValue(CoreServiceKeys.SelectionRequestQueue.Name, out var reqObj) || reqObj is not SelectionRequestQueue requests) return;
             if (!_globals.TryGetValue(CoreServiceKeys.SelectionResponseBuffer.Name, out var respObj) || respObj is not SelectionResponseBuffer responses) return;
+            if (!requests.TryPeek(out var request)) return;
 
-            if (!_hasActiveRequest && requests.TryDequeue(out var req))
-            {
-                _activeRequest = req;
-                _hasActiveRequest = true;
-            }
+            var bindings = ResolveBindings();
+            if (!input.PressedThisFrame(bindings.ConfirmActionId)) return;
 
-            if (!_hasActiveRequest) return;
-            if (!input.PressedThisFrame("Select")) return;
-
-            var mouse = input.ReadAction<System.Numerics.Vector2>("PointerPos");
+            var mouse = input.ReadAction<System.Numerics.Vector2>(bindings.PointerPositionActionId);
             var ray = rayProvider.GetRay(mouse);
             if (!GroundRaycastUtil.TryGetGroundWorldCm(in ray, out var worldCm)) return;
 
-            OnSelectionTriggered?.Invoke(_activeRequest, worldCm);
+            OnSelectionTriggered?.Invoke(request, worldCm);
 
             unsafe
             {
-                var response = BuildResponse(_activeRequest, worldCm);
-                responses.TryAdd(response);
-                _hasActiveRequest = false;
-                _activeRequest = default;
+                var response = BuildResponse(request, worldCm);
+                if (!responses.TryAdd(response))
+                {
+                    throw new InvalidOperationException($"GasSelectionResponseSystem: selection response buffer overflow while recording request {request.RequestId}.");
+                }
+            }
+
+            if (!requests.TryDequeue(out var dequeued) || dequeued.RequestId != request.RequestId)
+            {
+                throw new InvalidOperationException($"GasSelectionResponseSystem: selection request queue lost FIFO order for request {request.RequestId}.");
             }
         }
 
-        private Entity FindNearestEntity(in WorldCmInt2 worldCm, int radiusCm)
+        private unsafe SelectionResponse BuildResponse(in SelectionRequest request, in WorldCmInt2 worldCm)
         {
+            if (!_rules.TryGet(request.RequestTagId, out var rule))
+            {
+                throw new InvalidOperationException($"GasSelectionResponseSystem: no selection rule registered for request type id {request.RequestTagId}.");
+            }
+
+            var response = default(SelectionResponse);
+            response.RequestId = request.RequestId;
+            response.ResponseTagId = request.RequestTagId;
+            response.SetWorldPoint(worldCm);
+            if (_world.IsAlive(request.TargetContext))
+            {
+                response.TargetContext = request.TargetContext;
+            }
+
+            int originTeamId = 0;
+            if (_world.IsAlive(request.Origin))
+            {
+                ref var team = ref _world.TryGetRef<Team>(request.Origin, out bool hasTeam);
+                if (hasTeam)
+                {
+                    originTeamId = team.Id;
+                }
+            }
+
+            int radiusCm = request.PayloadA > 0 ? request.PayloadA : rule.RadiusCm;
+            int maxCount = request.PayloadB > 0 ? request.PayloadB : rule.MaxCount;
+            if (maxCount <= 0) maxCount = 64;
+            if (maxCount > 64) maxCount = 64;
+
+            switch (rule.Mode)
+            {
+                case SelectionRuleMode.SingleNearest:
+                {
+                    var entity = FindNearestEntity(worldCm, radiusCm, rule.RelationshipFilter, originTeamId);
+                    if (_world.IsAlive(entity))
+                    {
+                        response.Count = 1;
+                        response.SetEntity(0, entity);
+                    }
+                    return response;
+                }
+
+                case SelectionRuleMode.Radius:
+                {
+                    if (radiusCm <= 0)
+                    {
+                        return response;
+                    }
+
+                    Span<Entity> buffer = stackalloc Entity[Math.Min(Math.Max(maxCount * 4, maxCount), 512)];
+                    var result = _spatial.QueryRadius(worldCm, radiusCm, buffer);
+                    int written = 0;
+                    for (int i = 0; i < result.Count && written < maxCount; i++)
+                    {
+                        var entity = buffer[i];
+                        if (!_world.IsAlive(entity)) continue;
+                        if (!PassesRelationship(entity, rule.RelationshipFilter, originTeamId)) continue;
+
+                        response.SetEntity(written, entity);
+                        written++;
+                    }
+
+                    response.Count = written;
+                    return response;
+                }
+
+                default:
+                    return response;
+            }
+        }
+
+        private Entity FindNearestEntity(in WorldCmInt2 worldCm, int radiusCm, RelationshipFilter filter, int originTeamId)
+        {
+            if (radiusCm <= 0)
+            {
+                return default;
+            }
+
             Span<Entity> buffer = stackalloc Entity[256];
             var result = _spatial.QueryRadius(worldCm, radiusCm, buffer);
             int count = result.Count;
@@ -97,9 +169,11 @@ namespace Ludots.Core.Presentation.Systems
 
             for (int i = 0; i < count; i++)
             {
-                var e = buffer[i];
-                if (!_world.IsAlive(e)) continue;
-                ref var pos = ref _world.TryGetRef<WorldPositionCm>(e, out bool hasPos);
+                var entity = buffer[i];
+                if (!_world.IsAlive(entity)) continue;
+                if (!PassesRelationship(entity, filter, originTeamId)) continue;
+
+                ref var pos = ref _world.TryGetRef<WorldPositionCm>(entity, out bool hasPos);
                 if (!hasPos) continue;
 
                 var cmPos = pos.Value.ToWorldCmInt2();
@@ -109,66 +183,47 @@ namespace Ludots.Core.Presentation.Systems
                 if (d2 < bestD2)
                 {
                     bestD2 = d2;
-                    best = e;
+                    best = entity;
                 }
             }
 
             return best;
         }
 
-        private unsafe SelectionResponse BuildResponse(in SelectionRequest request, in WorldCmInt2 worldCm)
+        private bool PassesRelationship(Entity entity, RelationshipFilter filter, int originTeamId)
         {
-            var resp = default(SelectionResponse);
-            resp.RequestId = request.RequestId;
-            resp.ResponseTagId = request.RequestTagId;
-
-            int maxCount = request.PayloadB > 0 ? request.PayloadB : 64;
-            if (maxCount > 64) maxCount = 64;
-
-            if (request.RequestTagId == SelectionRequestTags.Single)
+            if (filter == RelationshipFilter.All)
             {
-                var e = FindNearestEntity(worldCm, PickRadiusCm);
-                if (_world.IsAlive(e))
-                {
-                    resp.Count = 1;
-                    resp.EntityIds[0] = e.Id;
-                    resp.WorldIds[0] = e.WorldId;
-                    resp.Versions[0] = e.Version;
-                }
-                return resp;
+                return true;
             }
 
-            int radiusCm = request.PayloadA > 0 ? request.PayloadA : 250;
-            Span<Entity> buffer = stackalloc Entity[Math.Min(maxCount * 4, 512)];
-            var result = _spatial.QueryRadius(worldCm, radiusCm, buffer);
-
-            int originTeam = 0;
-            if (_world.IsAlive(request.Origin))
+            ref var team = ref _world.TryGetRef<Team>(entity, out bool hasTeam);
+            if (!hasTeam)
             {
-                ref var t = ref _world.TryGetRef<Team>(request.Origin, out bool hasTeam);
-                if (hasTeam) originTeam = t.Id;
+                return false;
             }
 
-            int written = 0;
-            for (int i = 0; i < result.Count && written < maxCount; i++)
-            {
-                var e = buffer[i];
-                if (!_world.IsAlive(e)) continue;
-                if (request.RequestTagId == SelectionRequestTags.CircleEnemy)
-                {
-                    ref var team = ref _world.TryGetRef<Team>(e, out bool hasTeam);
-                    if (!hasTeam) continue;
-                    if (!RelationshipFilterUtil.Passes(RelationshipFilter.Hostile, originTeam, team.Id)) continue;
-                }
+            return RelationshipFilterUtil.Passes(filter, originTeamId, team.Id);
+        }
 
-                resp.EntityIds[written] = e.Id;
-                resp.WorldIds[written] = e.WorldId;
-                resp.Versions[written] = e.Version;
-                written++;
+        private InteractionActionBindings ResolveBindings()
+        {
+            if (_globals.TryGetValue(CoreServiceKeys.InteractionActionBindings.Name, out var obj) && obj is InteractionActionBindings bindings)
+            {
+                return bindings;
             }
 
-            resp.Count = written;
-            return resp;
+            return DefaultBindings;
+        }
+
+        private static SelectionRuleRegistry? ResolveRules(Dictionary<string, object> globals)
+        {
+            if (globals.TryGetValue(CoreServiceKeys.SelectionRuleRegistry.Name, out var obj) && obj is SelectionRuleRegistry rules)
+            {
+                return rules;
+            }
+
+            return null;
         }
 
         public void BeforeUpdate(in float dt) { }

--- a/src/Core/Scripting/ContextKeys.cs
+++ b/src/Core/Scripting/ContextKeys.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace Ludots.Core.Scripting
 {
@@ -45,6 +45,8 @@ namespace Ludots.Core.Scripting
         public const string InputResponseBuffer = "InputResponseBuffer";
         public const string SelectionRequestQueue = "SelectionRequestQueue";
         public const string SelectionResponseBuffer = "SelectionResponseBuffer";
+        public const string SelectionRuleRegistry = "SelectionRuleRegistry";
+        public const string InteractionActionBindings = "InteractionActionBindings";
         public const string OrderQueue = "OrderQueue";
         public const string OrderTypeRegistry = "OrderTypeRegistry";
         public const string OrderBufferSystem = "OrderBufferSystem";
@@ -88,10 +90,10 @@ namespace Ludots.Core.Scripting
         public const string GameConfig = "GameConfig";
         public const string PresentationFrameSetup = "PresentationFrameSetup";
         public const string TransientMarkerBuffer = "TransientMarkerBuffer";
-        // WorldHudConfig removed — unified into Performer entity-scoped definitions
+        // WorldHudConfig removed 鈥?unified into Performer entity-scoped definitions
         public const string GasPresentationEventBuffer = "GasPresentationEventBuffer";
         public const string GroundOverlayBuffer = "GroundOverlayBuffer";
-        // IndicatorRequestBuffer removed — unified into Performer direct API
+        // IndicatorRequestBuffer removed 鈥?unified into Performer direct API
         public const string PerformerDefinitionRegistry = "PerformerDefinitionRegistry";
         public const string PerformerInstanceBuffer = "PerformerInstanceBuffer";
         public const string Navigation2DRuntime = "Navigation2DRuntime";
@@ -110,3 +112,5 @@ namespace Ludots.Core.Scripting
         public const string TriggerDecoratorRegistry = "TriggerDecoratorRegistry";
     }
 }
+
+

--- a/src/Core/Scripting/CoreServiceKeys.cs
+++ b/src/Core/Scripting/CoreServiceKeys.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Arch.Core;
 using Ludots.Core.Config;
 using Ludots.Core.Diagnostics;
@@ -16,6 +16,7 @@ using Ludots.Core.Gameplay.GAS.Orders;
 using Ludots.Core.Gameplay.GAS.Presentation;
 using Ludots.Core.Gameplay.GAS.Systems;
 using Ludots.Core.GraphRuntime;
+using Ludots.Core.Input.Interaction;
 using Ludots.Core.Input.Runtime;
 using Ludots.Core.Map;
 using Ludots.Core.Map.Board;
@@ -107,6 +108,8 @@ namespace Ludots.Core.Scripting
         public static readonly ServiceKey<InputResponseBuffer> InputResponseBuffer = new("InputResponseBuffer");
         public static readonly ServiceKey<SelectionRequestQueue> SelectionRequestQueue = new("SelectionRequestQueue");
         public static readonly ServiceKey<SelectionResponseBuffer> SelectionResponseBuffer = new("SelectionResponseBuffer");
+        public static readonly ServiceKey<SelectionRuleRegistry> SelectionRuleRegistry = new("SelectionRuleRegistry");
+        public static readonly ServiceKey<InteractionActionBindings> InteractionActionBindings = new("InteractionActionBindings");
         public static readonly ServiceKey<OrderQueue> OrderQueue = new("OrderQueue");
         public static readonly ServiceKey<OrderTypeRegistry> OrderTypeRegistry = new("OrderTypeRegistry");
         public static readonly ServiceKey<OrderBufferSystem> OrderBufferSystem = new("OrderBufferSystem");
@@ -172,3 +175,5 @@ namespace Ludots.Core.Scripting
         public static readonly ServiceKey<ILogBackend> LogBackend = new("LogBackend");
     }
 }
+
+

--- a/src/Tests/GasTests/InteractionSelectionConvergenceTests.cs
+++ b/src/Tests/GasTests/InteractionSelectionConvergenceTests.cs
@@ -1,0 +1,281 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Arch.Core;
+using Ludots.Core.Components;
+using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.Components;
+using Ludots.Core.Gameplay.GAS;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Input;
+using Ludots.Core.Gameplay.GAS.Orders;
+using Ludots.Core.Gameplay.GAS.Systems;
+using Ludots.Core.Gameplay.Teams;
+using Ludots.Core.Input.Config;
+using Ludots.Core.Input.Interaction;
+using Ludots.Core.Input.Orders;
+using Ludots.Core.Input.Runtime;
+using Ludots.Core.Map.Hex;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Presentation.Systems;
+using Ludots.Core.Scripting;
+using Ludots.Core.Spatial;
+using Ludots.Platform.Abstractions;
+using NUnit.Framework;
+using static NUnit.Framework.Assert;
+
+namespace Ludots.Tests.GAS
+{
+    [TestFixture]
+    public sealed class InteractionSelectionConvergenceTests
+    {
+        [Test]
+        public void GasSelectionResponseSystem_UsesRegisteredRule_AndSharedInteractionBindings()
+        {
+            using var world = World.Create();
+
+            var input = new PlayerInputHandler(new NullInputBackend(), CreateInputConfig());
+            var globals = new Dictionary<string, object>
+            {
+                [CoreServiceKeys.InputHandler.Name] = input,
+                [CoreServiceKeys.ScreenRayProvider.Name] = new AnchoredScreenRayProvider(new Vector3(1.5f, 10f, 2.5f)),
+                [CoreServiceKeys.SelectionRequestQueue.Name] = new SelectionRequestQueue(),
+                [CoreServiceKeys.SelectionResponseBuffer.Name] = new SelectionResponseBuffer(),
+                [CoreServiceKeys.InteractionActionBindings.Name] = new InteractionActionBindings { ConfirmActionId = "Confirm" },
+            };
+
+            var origin = world.Create(new Team { Id = 1 });
+            var targetContext = world.Create();
+            var enemy = world.Create(WorldPositionCm.FromCm(50, 0), new Team { Id = 2 });
+            _ = world.Create(WorldPositionCm.FromCm(40, 0), new Team { Id = 1 });
+
+            var rules = new SelectionRuleRegistry();
+            rules.Register(77, new SelectionRule
+            {
+                Mode = SelectionRuleMode.Radius,
+                RelationshipFilter = RelationshipFilter.All,
+                RadiusCm = 200,
+                MaxCount = 8,
+            });
+
+            var system = new GasSelectionResponseSystem(world, globals, new StubSpatialQueryService(enemy), rules);
+            var requests = (SelectionRequestQueue)globals[CoreServiceKeys.SelectionRequestQueue.Name];
+            var responses = (SelectionResponseBuffer)globals[CoreServiceKeys.SelectionResponseBuffer.Name];
+            requests.TryEnqueue(new SelectionRequest
+            {
+                RequestId = 42,
+                RequestTagId = 77,
+                Origin = origin,
+                TargetContext = targetContext,
+            });
+
+            input.InjectButtonPress("Confirm");
+            input.Update();
+            system.Update(0f);
+
+            That(responses.TryConsume(42, out var response), Is.True);
+            That(response.Count, Is.EqualTo(1));
+            That(response.GetEntity(0), Is.EqualTo(enemy));
+            That(response.TargetContext, Is.EqualTo(targetContext));
+            That(response.TryGetWorldPoint(out var worldPoint), Is.True);
+            That(worldPoint, Is.EqualTo(new WorldCmInt2(150, 250)));
+        }
+
+
+
+        [Test]
+        public void GasSelectionResponseSystem_FailsFast_WhenSelectionResponseBufferIsFull()
+        {
+            using var world = World.Create();
+
+            var input = new PlayerInputHandler(new NullInputBackend(), CreateInputConfig());
+            var globals = new Dictionary<string, object>
+            {
+                [CoreServiceKeys.InputHandler.Name] = input,
+                [CoreServiceKeys.ScreenRayProvider.Name] = new ConstantScreenRayProvider(),
+                [CoreServiceKeys.SelectionRequestQueue.Name] = new SelectionRequestQueue(),
+                [CoreServiceKeys.SelectionResponseBuffer.Name] = new SelectionResponseBuffer(16),
+                [CoreServiceKeys.InteractionActionBindings.Name] = new InteractionActionBindings { ConfirmActionId = "Confirm" },
+            };
+
+            var origin = world.Create(new Team { Id = 1 });
+            var enemy = world.Create(WorldPositionCm.FromCm(50, 0), new Team { Id = 2 });
+            var rules = new SelectionRuleRegistry();
+            rules.Register(77, new SelectionRule
+            {
+                Mode = SelectionRuleMode.SingleNearest,
+                RelationshipFilter = RelationshipFilter.All,
+                RadiusCm = 200,
+                MaxCount = 1,
+            });
+
+            var system = new GasSelectionResponseSystem(world, globals, new StubSpatialQueryService(enemy), rules);
+            var requests = (SelectionRequestQueue)globals[CoreServiceKeys.SelectionRequestQueue.Name];
+            var responses = (SelectionResponseBuffer)globals[CoreServiceKeys.SelectionResponseBuffer.Name];
+            for (int i = 0; i < responses.Capacity; i++)
+            {
+                That(responses.TryAdd(new SelectionResponse { RequestId = 1000 + i }), Is.True);
+            }
+
+            requests.TryEnqueue(new SelectionRequest
+            {
+                RequestId = 42,
+                RequestTagId = 77,
+                Origin = origin,
+            });
+
+            input.InjectButtonPress("Confirm");
+            input.Update();
+
+            var ex = NUnit.Framework.Assert.Throws<InvalidOperationException>(() => system.Update(0f));
+            That(ex?.Message, Does.Contain("buffer overflow"));
+            That(requests.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void AbilityExecSystem_SelectionGate_PopulatesTargetContext_AndWorldPoint()
+        {
+            using var world = World.Create();
+            var actor = world.Create(new AbilityStateBuffer());
+            var enemy = world.Create();
+            var targetContext = world.Create();
+
+            ref var abilities = ref world.Get<AbilityStateBuffer>(actor);
+            abilities.AddAbility(9001);
+
+            var defs = new AbilityDefinitionRegistry();
+            var spec = default(AbilityExecSpec);
+            spec.ClockId = GasClockId.Step;
+            spec.SetItem(0, ExecItemKind.SelectionGate, tick: 0, tagId: 77);
+            spec.SetItem(1, ExecItemKind.EventGate, tick: 1, tagId: 999);
+            var def = new AbilityDefinition { ExecSpec = spec };
+            defs.Register(9001, in def);
+
+            world.Add(actor, new AbilityExecInstance
+            {
+                AbilityId = 9001,
+                AbilitySlot = 0,
+                State = AbilityExecRunState.GateWaiting,
+                WaitRequestId = 7,
+                NextItemIndex = 0,
+                ActiveClockId = GasClockId.Step,
+            });
+
+            var selectionResponses = new SelectionResponseBuffer();
+            var system = new AbilityExecSystem(
+                world,
+                new DiscreteClock(),
+                new InputRequestQueue(),
+                new InputResponseBuffer(),
+                new SelectionRequestQueue(),
+                selectionResponses,
+                new EffectRequestQueue(),
+                defs);
+
+            var response = default(SelectionResponse);
+            response.RequestId = 7;
+            response.ResponseTagId = 77;
+            response.TargetContext = targetContext;
+            response.SetWorldPoint(new WorldCmInt2(300, 400));
+            response.Count = 1;
+            response.SetEntity(0, enemy);
+            That(selectionResponses.TryAdd(response), Is.True);
+
+            system.Update(0f);
+
+            That(world.Has<AbilityExecInstance>(actor), Is.True);
+            ref var exec = ref world.Get<AbilityExecInstance>(actor);
+            That(exec.State, Is.EqualTo(AbilityExecRunState.Running));
+            That(exec.Target, Is.EqualTo(enemy));
+            That(exec.TargetContext, Is.EqualTo(targetContext));
+            That(exec.MultiTargetCount, Is.EqualTo(1));
+            That(exec.HasTargetPos, Is.EqualTo(1));
+            That(exec.TargetPosCm.ToWorldCmInt2(), Is.EqualTo(new WorldCmInt2(300, 400)));
+        }
+
+        private static InputConfigRoot CreateInputConfig()
+        {
+            return new InputConfigRoot
+            {
+                Actions = new List<InputActionDef>
+                {
+                    new() { Id = "SkillQ", Name = "SkillQ", Type = InputActionType.Button },
+                    new() { Id = "Confirm", Name = "Confirm", Type = InputActionType.Button },
+                    new() { Id = "Select", Name = "Select", Type = InputActionType.Button },
+                    new() { Id = "PointerPos", Name = "PointerPos", Type = InputActionType.Axis2D },
+                },
+                Contexts = new List<InputContextDef>
+                {
+                    new() { Id = "Test", Name = "Test", Priority = 1 },
+                },
+            };
+        }
+
+        private sealed class NullInputBackend : IInputBackend
+        {
+            public float GetAxis(string devicePath) => 0f;
+            public bool GetButton(string devicePath) => false;
+            public Vector2 GetMousePosition() => Vector2.Zero;
+            public float GetMouseWheel() => 0f;
+            public void EnableIME(bool enable) { }
+            public void SetIMECandidatePosition(int x, int y) { }
+            public string GetCharBuffer() => string.Empty;
+        }
+
+        private sealed class ConstantScreenRayProvider : IScreenRayProvider
+        {
+            public ScreenRay GetRay(Vector2 screenPosition)
+            {
+                return new ScreenRay(new Vector3(0f, 10f, 0f), new Vector3(0f, -1f, 0f));
+            }
+        }
+
+        private sealed class AnchoredScreenRayProvider : IScreenRayProvider
+        {
+            private readonly Vector3 _origin;
+
+            public AnchoredScreenRayProvider(Vector3 origin)
+            {
+                _origin = origin;
+            }
+
+            public ScreenRay GetRay(Vector2 screenPosition)
+            {
+                return new ScreenRay(_origin, new Vector3(0f, -1f, 0f));
+            }
+        }
+
+        private sealed class StubSpatialQueryService : ISpatialQueryService
+        {
+            private readonly Entity _priority;
+
+            public StubSpatialQueryService(Entity priority)
+            {
+                _priority = priority;
+            }
+
+            public SpatialQueryResult QueryAabb(in WorldAabbCm bounds, Span<Entity> buffer) => Write(buffer);
+            public SpatialQueryResult QueryRadius(WorldCmInt2 center, int radiusCm, Span<Entity> buffer) => Write(buffer);
+            public SpatialQueryResult QueryCone(WorldCmInt2 origin, int directionDeg, int halfAngleDeg, int rangeCm, Span<Entity> buffer) => Write(buffer);
+            public SpatialQueryResult QueryRectangle(WorldCmInt2 center, int halfWidthCm, int halfHeightCm, int rotationDeg, Span<Entity> buffer) => Write(buffer);
+            public SpatialQueryResult QueryLine(WorldCmInt2 origin, int directionDeg, int lengthCm, int halfWidthCm, Span<Entity> buffer) => Write(buffer);
+            public SpatialQueryResult QueryHexRange(HexCoordinates center, int hexRadius, Span<Entity> buffer) => Write(buffer);
+            public SpatialQueryResult QueryHexRing(HexCoordinates center, int hexRadius, Span<Entity> buffer) => Write(buffer);
+
+            private SpatialQueryResult Write(Span<Entity> buffer)
+            {
+                if (buffer.Length == 0)
+                {
+                    return new SpatialQueryResult(0, 1);
+                }
+
+                buffer[0] = _priority;
+                return new SpatialQueryResult(1, 0);
+            }
+        }
+    }
+}
+
+
+
+


### PR DESCRIPTION
## Summary
- close the selection protocol gap by carrying `TargetContext` and world-point data on `SelectionResponse`
- make `GasSelectionResponseSystem` consume the request queue in FIFO order and fail fast on response overflow
- hydrate `AbilityExecSystem` selection-gated instances with target context and target position
- add shared selection rule / interaction binding infrastructure and archive the convergence note in docs

## Tests
- `dotnet test src/Tests/GasTests/GasTests.csproj --no-build --filter "FullyQualifiedName~InteractionSelectionConvergenceTests|FullyQualifiedName~MudSc2AndYgoDemoTests|FullyQualifiedName~InputOrderAbilityAuditTests"` (`29/29`)
- `dotnet test src/Tests/GasTests/GasTests.csproj --no-build --collect "XPlat Code Coverage" --results-directory artifacts/TestResultsCoverage --filter "FullyQualifiedName~InteractionSelectionConvergenceTests|FullyQualifiedName~MudSc2AndYgoDemoTests|FullyQualifiedName~InputOrderAbilityAuditTests"` (`29/29`)

## Coverage
- `src/Core/Gameplay/GAS/Input/InputProtocol.cs`: `91.67%`
- `src/Core/Gameplay/GAS/Input/InputQueues.cs`: `74.29%`
- `src/Core/Presentation/Systems/GasSelectionResponseSystem.cs`: `81.82%`
- `src/Core/Gameplay/GAS/Systems/AbilityExecSystem.cs`: `57.23%`
