### PR TITLE
feat: expand champion projectile and displacement showcase

### DIFF
--- a/mods/CoreInputMod/Systems/LocalOrderSourceHelper.cs
+++ b/mods/CoreInputMod/Systems/LocalOrderSourceHelper.cs
@@ -277,6 +277,11 @@ namespace CoreInputMod.Systems
                     overrideMapping.HeldPolicy = inputOverride.HeldPolicy;
                 }
 
+                if (inputOverride.HasSelectionType)
+                {
+                    overrideMapping.SelectionType = inputOverride.SelectionType;
+                }
+
                 if (inputOverride.HasCastModeOverride)
                 {
                     overrideMapping.CastModeOverride = inputOverride.CastModeOverride;

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxVisualFeedback.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxVisualFeedback.cs
@@ -72,6 +72,16 @@ namespace ChampionSkillSandboxMod.Runtime
         private static readonly Vector4 EzrealETailColor = new(0.3f, 0.76f, 1.0f, 0.42f);
         private static readonly Vector4 EzrealRColor = new(0.76f, 0.95f, 1.0f, 0.98f);
         private static readonly Vector4 EzrealRTailColor = new(0.3f, 0.78f, 1.0f, 0.38f);
+        private static readonly Vector4 CatapultColor = new(0.98f, 0.67f, 0.34f, 0.96f);
+        private static readonly Vector4 CatapultTailColor = new(0.74f, 0.42f, 0.18f, 0.42f);
+        private static readonly Vector4 VolleyColor = new(0.82f, 0.95f, 0.5f, 0.94f);
+        private static readonly Vector4 VolleyTailColor = new(0.52f, 0.74f, 0.28f, 0.38f);
+        private static readonly Vector4 PiercerColor = new(0.66f, 0.9f, 1.0f, 0.96f);
+        private static readonly Vector4 PiercerTailColor = new(0.38f, 0.68f, 0.92f, 0.36f);
+        private static readonly Vector4 MissileColor = new(1.0f, 0.54f, 0.42f, 0.96f);
+        private static readonly Vector4 MissileTailColor = new(0.92f, 0.32f, 0.18f, 0.34f);
+        private static readonly Vector4 BoomerangColor = new(1.0f, 0.74f, 0.44f, 0.96f);
+        private static readonly Vector4 BoomerangTailColor = new(0.84f, 0.44f, 0.2f, 0.34f);
 
         private readonly CombatTextEntry[] _combatTextEntries = new CombatTextEntry[32];
         private readonly TransientPrimitiveEntry[] _transientPrimitiveEntries = new TransientPrimitiveEntry[64];
@@ -97,6 +107,16 @@ namespace ChampionSkillSandboxMod.Runtime
         private int _ezrealEssenceFluxPopEffectId;
         private int _ezrealArcaneShiftHitEffectId;
         private int _ezrealTrueshotHitEffectId;
+        private int _artilleristCatapultProjectileEffectId;
+        private int _artilleristVolleyProjectileEffectId;
+        private int _artilleristSkyPiercerProjectileEffectId;
+        private int _artilleristCruiseMissileProjectileEffectId;
+        private int _trickbladeBoomerangProjectileEffectId;
+        private int _artilleristCatapultHitEffectId;
+        private int _artilleristVolleyHitEffectId;
+        private int _artilleristSkyPiercerHitEffectId;
+        private int _artilleristCruiseMissileHitEffectId;
+        private int _trickbladeBoomerangHitEffectId;
         private int _ezrealWMarkTagId;
         private bool _cueIdsInitialized;
         private bool _directIdsInitialized;
@@ -366,7 +386,8 @@ namespace ChampionSkillSandboxMod.Runtime
                     forward = Vector3.Normalize(forward);
                 }
 
-                Vector3 head = visual.Position + new Vector3(0f, spec.HeightOffset, 0f);
+                float arcOffset = ResolveArcHeightOffset(world, in projectile, in positionCm);
+                Vector3 head = visual.Position + new Vector3(0f, spec.HeightOffset + arcOffset, 0f);
                 for (int segmentIndex = 0; segmentIndex < spec.SegmentCount; segmentIndex++)
                 {
                     float t = spec.SegmentCount <= 1
@@ -440,6 +461,16 @@ namespace ChampionSkillSandboxMod.Runtime
                 _ezrealEssenceFluxPopEffectId = EffectTemplateIdRegistry.GetId("Effect.Champion.Ezreal.EssenceFluxPop");
                 _ezrealArcaneShiftHitEffectId = EffectTemplateIdRegistry.GetId("Effect.Champion.Ezreal.ArcaneShiftBoltHit");
                 _ezrealTrueshotHitEffectId = EffectTemplateIdRegistry.GetId("Effect.Champion.Ezreal.TrueshotBarrageHit");
+                _artilleristCatapultProjectileEffectId = EffectTemplateIdRegistry.GetId("Effect.Champion.Artillerist.CatapultShot");
+                _artilleristVolleyProjectileEffectId = EffectTemplateIdRegistry.GetId("Effect.Champion.Artillerist.ArrowVolley");
+                _artilleristSkyPiercerProjectileEffectId = EffectTemplateIdRegistry.GetId("Effect.Champion.Artillerist.SkyPiercer");
+                _artilleristCruiseMissileProjectileEffectId = EffectTemplateIdRegistry.GetId("Effect.Champion.Artillerist.CruiseMissile");
+                _trickbladeBoomerangProjectileEffectId = EffectTemplateIdRegistry.GetId("Effect.Champion.Trickblade.BoomerangBlade");
+                _artilleristCatapultHitEffectId = EffectTemplateIdRegistry.GetId("Effect.Champion.Artillerist.CatapultHit");
+                _artilleristVolleyHitEffectId = EffectTemplateIdRegistry.GetId("Effect.Champion.Artillerist.ArrowVolleyHit");
+                _artilleristSkyPiercerHitEffectId = EffectTemplateIdRegistry.GetId("Effect.Champion.Artillerist.SkyPiercerHit");
+                _artilleristCruiseMissileHitEffectId = EffectTemplateIdRegistry.GetId("Effect.Champion.Artillerist.CruiseMissileHit");
+                _trickbladeBoomerangHitEffectId = EffectTemplateIdRegistry.GetId("Effect.Champion.Trickblade.BoomerangBladeHit");
                 _ezrealWMarkTagId = TagRegistry.GetId("State.Champion.Ezreal.WMark");
 
                 _projectilePrimitiveSpecs.Clear();
@@ -482,6 +513,56 @@ namespace ChampionSkillSandboxMod.Runtime
                     SegmentSpacing = 0.18f,
                     RadiusFalloff = 0.006f,
                     HeightOffset = 0.94f,
+                });
+                RegisterProjectilePrimitiveSpec(_artilleristCatapultProjectileEffectId, new ProjectilePrimitiveSpec
+                {
+                    HeadColor = CatapultColor,
+                    TailColor = CatapultTailColor,
+                    HeadRadius = 0.18f,
+                    SegmentCount = 6,
+                    SegmentSpacing = 0.16f,
+                    RadiusFalloff = 0.012f,
+                    HeightOffset = 0.58f,
+                });
+                RegisterProjectilePrimitiveSpec(_artilleristVolleyProjectileEffectId, new ProjectilePrimitiveSpec
+                {
+                    HeadColor = VolleyColor,
+                    TailColor = VolleyTailColor,
+                    HeadRadius = 0.1f,
+                    SegmentCount = 5,
+                    SegmentSpacing = 0.12f,
+                    RadiusFalloff = 0.01f,
+                    HeightOffset = 0.78f,
+                });
+                RegisterProjectilePrimitiveSpec(_artilleristSkyPiercerProjectileEffectId, new ProjectilePrimitiveSpec
+                {
+                    HeadColor = PiercerColor,
+                    TailColor = PiercerTailColor,
+                    HeadRadius = 0.12f,
+                    SegmentCount = 7,
+                    SegmentSpacing = 0.16f,
+                    RadiusFalloff = 0.008f,
+                    HeightOffset = 0.8f,
+                });
+                RegisterProjectilePrimitiveSpec(_artilleristCruiseMissileProjectileEffectId, new ProjectilePrimitiveSpec
+                {
+                    HeadColor = MissileColor,
+                    TailColor = MissileTailColor,
+                    HeadRadius = 0.16f,
+                    SegmentCount = 8,
+                    SegmentSpacing = 0.15f,
+                    RadiusFalloff = 0.01f,
+                    HeightOffset = 0.82f,
+                });
+                RegisterProjectilePrimitiveSpec(_trickbladeBoomerangProjectileEffectId, new ProjectilePrimitiveSpec
+                {
+                    HeadColor = BoomerangColor,
+                    TailColor = BoomerangTailColor,
+                    HeadRadius = 0.14f,
+                    SegmentCount = 6,
+                    SegmentSpacing = 0.14f,
+                    RadiusFalloff = 0.01f,
+                    HeightOffset = 0.78f,
                 });
 
                 _directIdsInitialized = true;
@@ -662,6 +743,36 @@ namespace ChampionSkillSandboxMod.Runtime
                 return true;
             }
 
+            if (effectTemplateId == _artilleristCatapultHitEffectId)
+            {
+                QueueAnchoredPulse(anchor, CatapultColor, lifetime: 0.26f, startRadius: 0.2f, endRadius: 0.52f, new Vector3(0f, 0.88f, 0f));
+                return true;
+            }
+
+            if (effectTemplateId == _artilleristVolleyHitEffectId)
+            {
+                QueueAnchoredPulse(anchor, VolleyColor, lifetime: 0.18f, startRadius: 0.14f, endRadius: 0.32f, new Vector3(0f, 0.84f, 0f));
+                return true;
+            }
+
+            if (effectTemplateId == _artilleristSkyPiercerHitEffectId)
+            {
+                QueueAnchoredPulse(anchor, PiercerColor, lifetime: 0.2f, startRadius: 0.16f, endRadius: 0.36f, new Vector3(0f, 0.84f, 0f));
+                return true;
+            }
+
+            if (effectTemplateId == _artilleristCruiseMissileHitEffectId)
+            {
+                QueueAnchoredPulse(anchor, MissileColor, lifetime: 0.28f, startRadius: 0.22f, endRadius: 0.56f, new Vector3(0f, 0.92f, 0f));
+                return true;
+            }
+
+            if (effectTemplateId == _trickbladeBoomerangHitEffectId)
+            {
+                QueueAnchoredPulse(anchor, BoomerangColor, lifetime: 0.18f, startRadius: 0.14f, endRadius: 0.34f, new Vector3(0f, 0.84f, 0f));
+                return true;
+            }
+
             return false;
         }
 
@@ -727,6 +838,29 @@ namespace ChampionSkillSandboxMod.Runtime
             }
 
             return Vector2.UnitX;
+        }
+
+        private static float ResolveArcHeightOffset(World world, in ProjectileState projectile, in WorldPositionCm positionCm)
+        {
+            if (projectile.ArcHeight <= 0 ||
+                projectile.HasLaunchOrigin == 0 ||
+                projectile.HasTargetPoint == 0)
+            {
+                return 0f;
+            }
+
+            Vector2 launch = projectile.LaunchOriginCm.ToVector2();
+            Vector2 target = projectile.TargetPointCm.ToVector2();
+            float totalDistance = Vector2.Distance(launch, target);
+            if (totalDistance <= 0.001f)
+            {
+                return 0f;
+            }
+
+            float traveled = Vector2.Distance(launch, positionCm.Value.ToVector2());
+            float progress = Math.Clamp(traveled / totalDistance, 0f, 1f);
+            float normalizedArc = 4f * progress * (1f - progress);
+            return (projectile.ArcHeight / 100f) * normalizedArc;
         }
 
         private static Vector2 NormalizeOrFallback(Vector2 value)

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Entities/templates.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Entities/templates.json
@@ -186,6 +186,92 @@
     }
   },
   {
+    "id": "champion_skill_sandbox_artillerist",
+    "components": {
+      "Name": { "Value": "Artillerist" },
+      "Team": { "Id": 1 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } },
+      "FacingDirection": { "AngleRad": 0.0 },
+      "Presentation": { "visualTemplateId": "core.character.hero_skinned" },
+      "AttributeBuffer": { "base": { "Health": 175, "Shield": 0, "MoveSpeed": 320, "Armor": 5 } },
+      "Collider2D": {
+        "shape": {
+          "type": "circle",
+          "radiusCm": 38
+        }
+      },
+      "PhysicsMaterial2D": {
+        "friction": 0.92,
+        "restitution": 0.0,
+        "baseDamping": 0.94
+      },
+      "NavKinematics2D": {
+        "maxAccelCmPerSec2": 1680,
+        "radiusCm": 38,
+        "neighborDistCm": 288,
+        "timeHorizonSec": 2.4,
+        "maxNeighbors": 20
+      },
+      "AbilityStateBuffer": {
+        "abilityIds": [
+          "Ability.Champion.Artillerist.CatapultShot",
+          "Ability.Champion.Artillerist.ArrowVolley",
+          "Ability.Champion.Artillerist.SkyPiercer",
+          "Ability.Champion.Artillerist.CruiseMissile"
+        ]
+      },
+      "GameplayTagContainer": {},
+      "OrderBuffer": {},
+      "BlackboardSpatialBuffer": {},
+      "BlackboardEntityBuffer": {},
+      "BlackboardIntBuffer": {}
+    }
+  },
+  {
+    "id": "champion_skill_sandbox_trickblade",
+    "components": {
+      "Name": { "Value": "Trickblade" },
+      "Team": { "Id": 1 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } },
+      "FacingDirection": { "AngleRad": 0.0 },
+      "Presentation": { "visualTemplateId": "core.character.hero_skinned" },
+      "AttributeBuffer": { "base": { "Health": 168, "Shield": 0, "MoveSpeed": 360, "Armor": 4 } },
+      "Collider2D": {
+        "shape": {
+          "type": "circle",
+          "radiusCm": 36
+        }
+      },
+      "PhysicsMaterial2D": {
+        "friction": 0.92,
+        "restitution": 0.0,
+        "baseDamping": 0.94
+      },
+      "NavKinematics2D": {
+        "maxAccelCmPerSec2": 1820,
+        "radiusCm": 36,
+        "neighborDistCm": 272,
+        "timeHorizonSec": 2.4,
+        "maxNeighbors": 20
+      },
+      "AbilityStateBuffer": {
+        "abilityIds": [
+          "Ability.Champion.Trickblade.BoomerangBlade",
+          "Ability.Champion.Trickblade.BlinkStep",
+          "Ability.Champion.Trickblade.RammingDash",
+          "Ability.Champion.Trickblade.GravityHook"
+        ]
+      },
+      "GameplayTagContainer": {},
+      "OrderBuffer": {},
+      "BlackboardSpatialBuffer": {},
+      "BlackboardEntityBuffer": {},
+      "BlackboardIntBuffer": {}
+    }
+  },
+  {
     "id": "champion_skill_sandbox_runic_beacon",
     "components": {
       "Name": { "Value": "Runic Beacon" },

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/abilities.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/abilities.json
@@ -490,6 +490,216 @@
     }
   },
   {
+    "id": "Ability.Champion.Artillerist.CatapultShot",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 54, "tag": "Cooldown.Champion.Artillerist.Q" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.Artillerist.CatapultShot" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "input": {
+      "selectionType": "Position"
+    },
+    "indicator": { "shape": "Circle", "range": 860, "radius": 180, "showRangeCircle": true, "validColor": "#F29D5C88", "invalidColor": "#E2575788" },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.Artillerist.Q"] },
+    "presentation": {
+      "displayName": "Catapult Shot",
+      "iconGlyph": "Q",
+      "accentColor": "#F29D5C",
+      "hintText": "Lob an arcing payload that bursts on impact",
+      "modeHints": {
+        "SmartCastWithIndicator": "Hold to preview the impact zone",
+        "PressReleaseAimCast": "Release key, then confirm the landing zone"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.Artillerist.ArrowVolley",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 42, "tag": "Cooldown.Champion.Artillerist.W" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.Artillerist.ArrowVolley" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "input": {
+      "selectionType": "Direction"
+    },
+    "indicator": { "shape": "Line", "range": 920, "radius": 180, "showRangeCircle": true, "validColor": "#BEE07A77", "invalidColor": "#E2575788" },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.Artillerist.W"] },
+    "presentation": {
+      "displayName": "Arrow Volley",
+      "iconGlyph": "W",
+      "accentColor": "#BEE07A",
+      "hintText": "Fire a five-arrow spread down the lane",
+      "modeHints": {
+        "SmartCastWithIndicator": "Hold to preview the volley fan",
+        "PressReleaseAimCast": "Release key, then confirm the volley"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.Artillerist.SkyPiercer",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 36, "tag": "Cooldown.Champion.Artillerist.E" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.Artillerist.SkyPiercer" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "input": {
+      "selectionType": "Direction"
+    },
+    "indicator": { "shape": "Line", "range": 1100, "radius": 60, "showRangeCircle": true, "validColor": "#8FDBFF77", "invalidColor": "#E2575788" },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.Artillerist.E"] },
+    "presentation": {
+      "displayName": "Skypiercer",
+      "iconGlyph": "E",
+      "accentColor": "#8FDBFF",
+      "hintText": "Piercing arrow that drills through a full line",
+      "modeHints": {
+        "SmartCastWithIndicator": "Hold to preview the piercing lane",
+        "PressReleaseAimCast": "Release key, then confirm the line shot"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.Artillerist.CruiseMissile",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 120, "tag": "Cooldown.Champion.Artillerist.R" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.Artillerist.CruiseMissile" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "indicator": { "shape": "Circle", "range": 1180, "radius": 160, "showRangeCircle": true, "validColor": "#FF8B76AA", "invalidColor": "#E2575788" },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.Artillerist.R"] },
+    "input": {
+      "autoTargetPolicy": "NearestEnemyInRange",
+      "autoTargetRangeCm": 1180
+    },
+    "presentation": {
+      "displayName": "Cruise Missile",
+      "iconGlyph": "R",
+      "accentColor": "#FF8B76",
+      "hintText": "Lock on and steer a blast missile into clustered targets",
+      "modeHints": {
+        "SmartCastWithIndicator": "Hold to preview the lock range",
+        "PressReleaseAimCast": "Release key, then confirm the missile lock"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.Trickblade.BoomerangBlade",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 30, "tag": "Cooldown.Champion.Trickblade.Q" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.Trickblade.BoomerangBlade" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "input": {
+      "selectionType": "Direction"
+    },
+    "indicator": { "shape": "Line", "range": 720, "radius": 70, "showRangeCircle": true, "validColor": "#FFB57077", "invalidColor": "#E2575788" },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.Trickblade.Q"] },
+    "presentation": {
+      "displayName": "Boomerang Blade",
+      "iconGlyph": "Q",
+      "accentColor": "#FFB570",
+      "hintText": "Throw a blade that cuts on the way out and back",
+      "modeHints": {
+        "SmartCastWithIndicator": "Hold to preview the outbound lane",
+        "PressReleaseAimCast": "Release key, then confirm the throw"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.Trickblade.BlinkStep",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 54, "tag": "Cooldown.Champion.Trickblade.W" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.Trickblade.BlinkStep", "dispatchTarget": "Source" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "input": {
+      "selectionType": "Position"
+    },
+    "indicator": { "shape": "Circle", "range": 520, "radius": 110, "showRangeCircle": true, "validColor": "#7EE9FF77", "invalidColor": "#E2575788" },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.Trickblade.W"] },
+    "presentation": {
+      "displayName": "Blink Step",
+      "iconGlyph": "W",
+      "accentColor": "#7EE9FF",
+      "hintText": "Instantly reposition through danger",
+      "modeHints": {
+        "SmartCastWithIndicator": "Hold to preview the blink endpoint",
+        "PressReleaseAimCast": "Release key, then confirm the blink"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.Trickblade.RammingDash",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 66, "tag": "Cooldown.Champion.Trickblade.E" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.Trickblade.RammingDashMove", "dispatchTarget": "Source" },
+        { "kind": "EffectSignal", "tick": 6, "template": "Effect.Champion.Trickblade.RammingDashShockwave" },
+        { "kind": "End", "tick": 6 }
+      ]
+    },
+    "input": {
+      "selectionType": "Position"
+    },
+    "indicator": { "shape": "Circle", "range": 480, "radius": 160, "showRangeCircle": true, "validColor": "#FFC86A77", "invalidColor": "#E2575788" },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.Trickblade.E"] },
+    "presentation": {
+      "displayName": "Ramming Dash",
+      "iconGlyph": "E",
+      "accentColor": "#FFC86A",
+      "hintText": "Dash in, then knock nearby enemies away",
+      "modeHints": {
+        "SmartCastWithIndicator": "Hold to preview the dash endpoint",
+        "PressReleaseAimCast": "Release key, then confirm the dash"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.Trickblade.GravityHook",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 84, "tag": "Cooldown.Champion.Trickblade.R" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.Trickblade.GravityHook" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "input": {
+      "selectionType": "Position"
+    },
+    "indicator": { "shape": "Circle", "range": 760, "radius": 160, "showRangeCircle": true, "validColor": "#DDA8FF77", "invalidColor": "#E2575788" },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.Trickblade.R"] },
+    "presentation": {
+      "displayName": "Gravity Hook",
+      "iconGlyph": "R",
+      "accentColor": "#DDA8FF",
+      "hintText": "Latch onto a cluster and drag it back to you",
+      "modeHints": {
+        "SmartCastWithIndicator": "Hold to preview the pull zone",
+        "PressReleaseAimCast": "Release key, then confirm the hook"
+      }
+    }
+  },
+  {
     "id": "Ability.ChampionStress.Warrior.Cleave",
     "exec": {
       "clockId": "FixedFrame",

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/effects.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/effects.json
@@ -643,5 +643,247 @@
     "modifiers": [
       { "attribute": "Health", "op": "Add", "value": -5.0 }
     ]
+  },
+  {
+    "id": "Effect.Champion.Artillerist.CatapultShot",
+    "tags": ["Effect.Champion.Projectile", "Effect.Champion.Artillery"],
+    "presetType": "LaunchProjectile",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "projectile": {
+      "speed": 900,
+      "range": 860,
+      "arcHeight": 420,
+      "impactEffect": "Effect.Champion.Artillerist.CatapultImpact",
+      "presentationEffect": "Effect.Champion.Artillerist.CatapultShot"
+    }
+  },
+  {
+    "id": "Effect.Champion.Artillerist.CatapultImpact",
+    "tags": ["Effect.Champion.Damage", "Effect.Champion.Area"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Circle", "radius": 180 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 16 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.Artillerist.CatapultHit" }
+  },
+  {
+    "id": "Effect.Champion.Artillerist.CatapultHit",
+    "tags": ["Effect.Champion.Damage"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -18.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.Artillerist.ArrowVolley",
+    "tags": ["Effect.Champion.Projectile", "Effect.Champion.Volley"],
+    "presetType": "LaunchProjectile",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "projectile": {
+      "speed": 1900,
+      "range": 920,
+      "arcHeight": 0,
+      "hitEffect": "Effect.Champion.Artillerist.ArrowVolleyHit",
+      "presentationEffect": "Effect.Champion.Artillerist.ArrowVolley",
+      "travelMode": "Direction",
+      "impactPolicy": "DestroyOnFirstHit",
+      "collisionHalfWidth": 48,
+      "collisionRelationFilter": "Hostile",
+      "collisionExcludeSource": true,
+      "maxHitCount": 1,
+      "spawnCount": 5,
+      "spreadAngleDeg": 32
+    }
+  },
+  {
+    "id": "Effect.Champion.Artillerist.ArrowVolleyHit",
+    "tags": ["Effect.Champion.Damage"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -10.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.Artillerist.SkyPiercer",
+    "tags": ["Effect.Champion.Projectile", "Effect.Champion.Pierce"],
+    "presetType": "LaunchProjectile",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "projectile": {
+      "speed": 2200,
+      "range": 1100,
+      "arcHeight": 0,
+      "hitEffect": "Effect.Champion.Artillerist.SkyPiercerHit",
+      "presentationEffect": "Effect.Champion.Artillerist.SkyPiercer",
+      "travelMode": "Direction",
+      "impactPolicy": "ContinueOnHit",
+      "collisionHalfWidth": 52,
+      "collisionRelationFilter": "Hostile",
+      "collisionExcludeSource": true,
+      "maxHitCount": 8
+    }
+  },
+  {
+    "id": "Effect.Champion.Artillerist.SkyPiercerHit",
+    "tags": ["Effect.Champion.Damage"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -14.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.Artillerist.CruiseMissile",
+    "tags": ["Effect.Champion.Projectile", "Effect.Champion.Guided"],
+    "presetType": "LaunchProjectile",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "projectile": {
+      "speed": 1200,
+      "range": 1400,
+      "arcHeight": 0,
+      "impactEffect": "Effect.Champion.Artillerist.CruiseMissileImpact",
+      "hitEffect": "Effect.Champion.Artillerist.CruiseMissileImpact",
+      "presentationEffect": "Effect.Champion.Artillerist.CruiseMissile",
+      "travelMode": "TrackTarget",
+      "impactPolicy": "DestroyOnFirstHit",
+      "collisionHalfWidth": 90,
+      "collisionRelationFilter": "Hostile",
+      "collisionExcludeSource": true,
+      "maxHitCount": 1,
+      "turnRateDegPerSecond": 240
+    }
+  },
+  {
+    "id": "Effect.Champion.Artillerist.CruiseMissileImpact",
+    "tags": ["Effect.Champion.Damage", "Effect.Champion.Area"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Circle", "radius": 170 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 12 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.Artillerist.CruiseMissileHit" }
+  },
+  {
+    "id": "Effect.Champion.Artillerist.CruiseMissileHit",
+    "tags": ["Effect.Champion.Damage"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -19.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.Trickblade.BoomerangBlade",
+    "tags": ["Effect.Champion.Projectile", "Effect.Champion.Return"],
+    "presetType": "LaunchProjectile",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "projectile": {
+      "speed": 1700,
+      "range": 720,
+      "arcHeight": 0,
+      "hitEffect": "Effect.Champion.Trickblade.BoomerangBladeHit",
+      "presentationEffect": "Effect.Champion.Trickblade.BoomerangBlade",
+      "travelMode": "Direction",
+      "impactPolicy": "ContinueOnHit",
+      "collisionHalfWidth": 60,
+      "collisionRelationFilter": "Hostile",
+      "collisionExcludeSource": true,
+      "maxHitCount": 12,
+      "returnMode": "ReturnToSource",
+      "resetHitHistoryOnReturn": true
+    }
+  },
+  {
+    "id": "Effect.Champion.Trickblade.BoomerangBladeHit",
+    "tags": ["Effect.Champion.Damage"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -9.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.Trickblade.BlinkStep",
+    "tags": ["Effect.Champion.Movement"],
+    "presetType": "Displacement",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "displacement": {
+      "directionMode": "ToTarget",
+      "totalDistanceCm": 520,
+      "totalDurationTicks": 1,
+      "overrideNavigation": true
+    }
+  },
+  {
+    "id": "Effect.Champion.Trickblade.RammingDashMove",
+    "tags": ["Effect.Champion.Movement"],
+    "presetType": "Displacement",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "displacement": {
+      "directionMode": "ToTarget",
+      "totalDistanceCm": 480,
+      "totalDurationTicks": 6,
+      "overrideNavigation": true
+    }
+  },
+  {
+    "id": "Effect.Champion.Trickblade.RammingDashShockwave",
+    "tags": ["Effect.Champion.Control"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Circle", "radius": 160 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 8 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.Trickblade.RammingDashKnockback" }
+  },
+  {
+    "id": "Effect.Champion.Trickblade.RammingDashKnockback",
+    "tags": ["Effect.Champion.Control"],
+    "presetType": "Displacement",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "displacement": {
+      "directionMode": "AwayFromSource",
+      "totalDistanceCm": 260,
+      "totalDurationTicks": 4,
+      "overrideNavigation": true
+    }
+  },
+  {
+    "id": "Effect.Champion.Trickblade.GravityHook",
+    "tags": ["Effect.Champion.Control"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Circle", "radius": 160 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 4 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.Trickblade.GravityHookPull" }
+  },
+  {
+    "id": "Effect.Champion.Trickblade.GravityHookPull",
+    "tags": ["Effect.Champion.Control"],
+    "presetType": "Displacement",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "displacement": {
+      "directionMode": "TowardSource",
+      "totalDistanceCm": 360,
+      "totalDurationTicks": 6,
+      "overrideNavigation": true
+    }
   }
 ]

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Maps/champion_skill_sandbox.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Maps/champion_skill_sandbox.json
@@ -3,11 +3,11 @@
   "Tags": ["champion.skill.sandbox", "showcase.3c"],
   "DefaultCamera": {
     "VirtualCameraId": "ChampionSkillSandbox.Camera.Tactical",
-    "TargetXCm": 1850,
-    "TargetYCm": 980,
-    "DistanceCm": 3900,
-    "Pitch": 54,
-    "FovYDeg": 42
+    "TargetXCm": 1910,
+    "TargetYCm": 1450,
+    "DistanceCm": 6500,
+    "Pitch": 58,
+    "FovYDeg": 50
   },
   "Entities": [
     {
@@ -128,6 +128,78 @@
       "Overrides": {
         "Name": { "Value": "Target Dummy F" },
         "WorldPositionCm": { "Value": { "X": 2460, "Y": 1420 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_artillerist",
+      "Overrides": {
+        "Name": { "Value": "Artillerist Alpha" },
+        "PlayerOwner": { "PlayerId": 1 },
+        "WorldPositionCm": { "Value": { "X": 1400, "Y": 2060 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_trickblade",
+      "Overrides": {
+        "Name": { "Value": "Trickblade Alpha" },
+        "PlayerOwner": { "PlayerId": 1 },
+        "WorldPositionCm": { "Value": { "X": 1820, "Y": 2060 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_enemy_dummy",
+      "Overrides": {
+        "Name": { "Value": "Projectile Dummy A" },
+        "WorldPositionCm": { "Value": { "X": 1820, "Y": 1940 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_enemy_dummy",
+      "Overrides": {
+        "Name": { "Value": "Projectile Dummy B" },
+        "WorldPositionCm": { "Value": { "X": 2000, "Y": 2060 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_enemy_dummy",
+      "Overrides": {
+        "Name": { "Value": "Projectile Dummy C" },
+        "WorldPositionCm": { "Value": { "X": 2200, "Y": 2060 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_enemy_brute",
+      "Overrides": {
+        "Name": { "Value": "Projectile Brute A" },
+        "WorldPositionCm": { "Value": { "X": 2120, "Y": 2200 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_enemy_dummy",
+      "Overrides": {
+        "Name": { "Value": "Mobility Dummy A" },
+        "WorldPositionCm": { "Value": { "X": 2300, "Y": 1940 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_enemy_dummy",
+      "Overrides": {
+        "Name": { "Value": "Mobility Dummy B" },
+        "WorldPositionCm": { "Value": { "X": 2460, "Y": 2060 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_enemy_dummy",
+      "Overrides": {
+        "Name": { "Value": "Mobility Dummy C" },
+        "WorldPositionCm": { "Value": { "X": 2460, "Y": 2220 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_enemy_brute",
+      "Overrides": {
+        "Name": { "Value": "Mobility Brute A" },
+        "WorldPositionCm": { "Value": { "X": 2640, "Y": 2060 } }
       }
     }
   ]

--- a/src/Core/Gameplay/GAS/AbilityDefinitionRegistry.cs
+++ b/src/Core/Gameplay/GAS/AbilityDefinitionRegistry.cs
@@ -13,6 +13,8 @@ namespace Ludots.Core.Gameplay.GAS
         public InputTriggerType Trigger;
         public bool HasHeldPolicy;
         public HeldPolicy HeldPolicy;
+        public bool HasSelectionType;
+        public OrderSelectionType SelectionType;
         public bool HasCastModeOverride;
         public InteractionModeType CastModeOverride;
         public bool HasAutoTargetPolicy;

--- a/src/Core/Gameplay/GAS/BuiltinHandlers.cs
+++ b/src/Core/Gameplay/GAS/BuiltinHandlers.cs
@@ -199,47 +199,66 @@ namespace Ludots.Core.Gameplay.GAS
                 hasTargetPoint,
                 targetPointCm,
                 out var direction);
+            int spawnCount = proj.SpawnCount <= 0 ? 1 : proj.SpawnCount;
+            Fix64 totalSpreadDeg = Fix64.FromInt(proj.SpreadAngleDeg);
+            Fix64 startSpreadDeg = spawnCount <= 1 ? Fix64.Zero : -totalSpreadDeg / Fix64.FromInt(2);
+            Fix64 spreadStepDeg = spawnCount <= 1 ? Fix64.Zero : totalSpreadDeg / Fix64.FromInt(spawnCount - 1);
 
-            var request = new RuntimeEntitySpawnRequest
+            for (int spawnIndex = 0; spawnIndex < spawnCount; spawnIndex++)
             {
-                Kind = RuntimeEntitySpawnKind.Assembly,
-                Source = context.Source,
-                TargetContext = context.TargetContext,
-                Projectile = new ProjectileState
+                var spawnedDirection = direction;
+                bool spawnedHasDirection = hasDirection;
+                if (spawnedHasDirection && proj.SpreadAngleDeg != 0)
                 {
-                    Speed = Fix64.FromInt(proj.Speed),
-                    Range = proj.Range,
-                    ArcHeight = proj.ArcHeight,
-                    ImpactEffectTemplateId = proj.ImpactEffectTemplateId,
-                    HitEffectTemplateId = proj.HitEffectTemplateId,
-                    PresentationEffectTemplateId = proj.PresentationEffectTemplateId,
-                    TravelMode = proj.TravelMode,
-                    ImpactPolicy = proj.ImpactPolicy,
-                    CollisionHalfWidthCm = proj.CollisionHalfWidthCm,
-                    CollisionRelationFilter = proj.CollisionRelationFilter,
-                    CollisionExcludeSource = (byte)(proj.CollisionExcludeSource ? 1 : 0),
-                    MaxHitCount = proj.MaxHitCount,
+                    Fix64 spreadDeg = startSpreadDeg + (spreadStepDeg * Fix64.FromInt(spawnIndex));
+                    spawnedDirection = RotateDirection(spawnedDirection, spreadDeg * Fix64.Deg2Rad);
+                }
+
+                var request = new RuntimeEntitySpawnRequest
+                {
+                    Kind = RuntimeEntitySpawnKind.Assembly,
                     Source = context.Source,
-                    Target = context.Target,
-                    LaunchOriginCm = launchOrigin,
-                    HasLaunchOrigin = (byte)(hasLaunchOrigin ? 1 : 0),
-                    TargetPointCm = targetPointCm,
-                    HasTargetPoint = (byte)(hasTargetPoint ? 1 : 0),
-                    Direction = direction,
-                    HasDirection = (byte)(hasDirection ? 1 : 0),
-                },
-                HasProjectileState = 1,
-            };
+                    TargetContext = context.TargetContext,
+                    Projectile = new ProjectileState
+                    {
+                        Speed = Fix64.FromInt(proj.Speed),
+                        Range = proj.Range,
+                        ArcHeight = proj.ArcHeight,
+                        ImpactEffectTemplateId = proj.ImpactEffectTemplateId,
+                        HitEffectTemplateId = proj.HitEffectTemplateId,
+                        PresentationEffectTemplateId = proj.PresentationEffectTemplateId,
+                        TravelMode = proj.TravelMode,
+                        ImpactPolicy = proj.ImpactPolicy,
+                        CollisionHalfWidthCm = proj.CollisionHalfWidthCm,
+                        CollisionRelationFilter = proj.CollisionRelationFilter,
+                        CollisionExcludeSource = (byte)(proj.CollisionExcludeSource ? 1 : 0),
+                        MaxHitCount = proj.MaxHitCount,
+                        TurnRateDegPerSecond = proj.TurnRateDegPerSecond,
+                        ReturnMode = proj.ReturnMode,
+                        ResetHitHistoryOnReturn = (byte)(proj.ResetHitHistoryOnReturn ? 1 : 0),
+                        FlightPhase = ProjectileFlightPhase.Outbound,
+                        Source = context.Source,
+                        Target = context.Target,
+                        LaunchOriginCm = launchOrigin,
+                        HasLaunchOrigin = (byte)(hasLaunchOrigin ? 1 : 0),
+                        TargetPointCm = targetPointCm,
+                        HasTargetPoint = (byte)(hasTargetPoint ? 1 : 0),
+                        Direction = spawnedDirection,
+                        HasDirection = (byte)(spawnedHasDirection ? 1 : 0),
+                    },
+                    HasProjectileState = 1,
+                };
 
-            if (hasLaunchOrigin)
-            {
-                request.WorldPositionCm = launchOrigin;
-                request.HasWorldPosition = 1;
-            }
+                if (hasLaunchOrigin)
+                {
+                    request.WorldPositionCm = launchOrigin;
+                    request.HasWorldPosition = 1;
+                }
 
-            if (!runtime.SpawnRequests.TryEnqueue(request))
-            {
-                throw new InvalidOperationException("RuntimeEntitySpawnQueue capacity exceeded while handling CreateProjectile.");
+                if (!runtime.SpawnRequests.TryEnqueue(request))
+                {
+                    throw new InvalidOperationException("RuntimeEntitySpawnQueue capacity exceeded while handling CreateProjectile.");
+                }
             }
         }
 
@@ -456,6 +475,15 @@ namespace Ludots.Core.Gameplay.GAS
 
             direction = Fix64Vec2.UnitX;
             return false;
+        }
+
+        private static Fix64Vec2 RotateDirection(in Fix64Vec2 direction, Fix64 radians)
+        {
+            Fix64 cos = Fix64Math.Cos(radians);
+            Fix64 sin = Fix64Math.Sin(radians);
+            return new Fix64Vec2(
+                direction.X * cos - direction.Y * sin,
+                direction.X * sin + direction.Y * cos).Normalized();
         }
 
         private static Fix64Vec2 ComputeScatterOffsetCm(Entity source, int unitTypeId, int index, int radiusCm)

--- a/src/Core/Gameplay/GAS/Config/AbilityExecLoader.cs
+++ b/src/Core/Gameplay/GAS/Config/AbilityExecLoader.cs
@@ -516,6 +516,20 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 hasAny = true;
             }
 
+            if (inputObj["selectionType"] is JsonValue selectionTypeNode)
+            {
+                string rawSelectionType = selectionTypeNode.GetValue<string>();
+                if (!Enum.TryParse(rawSelectionType, ignoreCase: true, out OrderSelectionType selectionType))
+                {
+                    throw new InvalidOperationException(
+                        $"Ability '{id}' in '{path}' input.selectionType uses unsupported value '{rawSelectionType}'.");
+                }
+
+                result.SelectionType = selectionType;
+                result.HasSelectionType = true;
+                hasAny = true;
+            }
+
             if (inputObj["castModeOverride"] is JsonValue castModeNode)
             {
                 string rawCastMode = castModeNode.GetValue<string>();

--- a/src/Core/Gameplay/GAS/Config/EffectTemplateConfig.cs
+++ b/src/Core/Gameplay/GAS/Config/EffectTemplateConfig.cs
@@ -180,6 +180,11 @@ namespace Ludots.Core.Gameplay.GAS.Config
         public string CollisionRelationFilter { get; set; }
         public bool CollisionExcludeSource { get; set; } = true;
         public int MaxHitCount { get; set; }
+        public int SpawnCount { get; set; } = 1;
+        public int SpreadAngleDeg { get; set; }
+        public int TurnRateDegPerSecond { get; set; }
+        public string ReturnMode { get; set; }
+        public bool ResetHitHistoryOnReturn { get; set; }
     }
 
     /// <summary>Unit creation component configuration.</summary>

--- a/src/Core/Gameplay/GAS/Config/EffectTemplateLoader.cs
+++ b/src/Core/Gameplay/GAS/Config/EffectTemplateLoader.cs
@@ -355,6 +355,7 @@ namespace Ludots.Core.Gameplay.GAS.Config
 
             ProjectileTravelMode travelMode = ParseProjectileTravelMode(cfg.TravelMode);
             ProjectileImpactPolicy impactPolicy = ParseProjectileImpactPolicy(cfg.ImpactPolicy);
+            ProjectileReturnMode returnMode = ParseProjectileReturnMode(cfg.ReturnMode);
             if (impactPolicy != ProjectileImpactPolicy.Legacy)
             {
                 if (hitId <= 0)
@@ -366,6 +367,16 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 {
                     throw new InvalidOperationException($"Effect template '{ownerId}' in {relativePath}: projectile.impactPolicy '{impactPolicy}' requires projectile.collisionHalfWidth > 0.");
                 }
+            }
+
+            if (cfg.SpawnCount < 0)
+            {
+                throw new InvalidOperationException($"Effect template '{ownerId}' in {relativePath}: projectile.spawnCount must be >= 0.");
+            }
+
+            if (cfg.TurnRateDegPerSecond < 0)
+            {
+                throw new InvalidOperationException($"Effect template '{ownerId}' in {relativePath}: projectile.turnRateDegPerSecond must be >= 0.");
             }
 
             return new ProjectileDescriptor
@@ -381,7 +392,12 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 CollisionHalfWidthCm = cfg.CollisionHalfWidth,
                 CollisionRelationFilter = RelationshipFilterUtil.Parse(cfg.CollisionRelationFilter),
                 CollisionExcludeSource = cfg.CollisionExcludeSource,
-                MaxHitCount = cfg.MaxHitCount
+                MaxHitCount = cfg.MaxHitCount,
+                SpawnCount = cfg.SpawnCount <= 0 ? 1 : cfg.SpawnCount,
+                SpreadAngleDeg = cfg.SpreadAngleDeg,
+                TurnRateDegPerSecond = cfg.TurnRateDegPerSecond,
+                ReturnMode = returnMode,
+                ResetHitHistoryOnReturn = cfg.ResetHitHistoryOnReturn,
             };
         }
 
@@ -414,6 +430,21 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 "destroyonfirsthit" => ProjectileImpactPolicy.DestroyOnFirstHit,
                 "continueonhit" => ProjectileImpactPolicy.ContinueOnHit,
                 _ => throw new InvalidOperationException($"Unsupported projectile.impactPolicy '{raw}'.")
+            };
+        }
+
+        private static ProjectileReturnMode ParseProjectileReturnMode(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return ProjectileReturnMode.None;
+            }
+
+            return raw.Trim().ToLowerInvariant() switch
+            {
+                "none" => ProjectileReturnMode.None,
+                "returntosource" => ProjectileReturnMode.ReturnToSource,
+                _ => throw new InvalidOperationException($"Unsupported projectile.returnMode '{raw}'.")
             };
         }
 

--- a/src/Core/Gameplay/GAS/EffectTemplateRegistry.cs
+++ b/src/Core/Gameplay/GAS/EffectTemplateRegistry.cs
@@ -148,7 +148,7 @@ namespace Ludots.Core.Gameplay.GAS
     /// </summary>
     public struct ProjectileDescriptor
     {
-        /// <summary>Projectile speed in cm/tick.</summary>
+        /// <summary>Projectile speed in cm/sec.</summary>
         public int Speed;
         /// <summary>Maximum range in cm.</summary>
         public int Range;
@@ -172,6 +172,16 @@ namespace Ludots.Core.Gameplay.GAS
         public bool CollisionExcludeSource;
         /// <summary>Maximum number of distinct collision hits before despawn. 0 = unlimited.</summary>
         public int MaxHitCount;
+        /// <summary>How many projectiles are emitted by this effect.</summary>
+        public int SpawnCount;
+        /// <summary>Total spread angle across the emitted projectile fan. 0 = no spread.</summary>
+        public int SpreadAngleDeg;
+        /// <summary>Maximum turn rate while tracking a target, expressed in degrees per second. 0 = instant steering.</summary>
+        public int TurnRateDegPerSecond;
+        /// <summary>How the projectile behaves after its outbound leg completes.</summary>
+        public ProjectileReturnMode ReturnMode;
+        /// <summary>Whether the projectile can hit the same targets again after switching to its return leg.</summary>
+        public bool ResetHitHistoryOnReturn;
     }
 
     public enum ProjectileTravelMode : byte
@@ -186,6 +196,12 @@ namespace Ludots.Core.Gameplay.GAS
         Legacy = 0,
         DestroyOnFirstHit = 1,
         ContinueOnHit = 2,
+    }
+
+    public enum ProjectileReturnMode : byte
+    {
+        None = 0,
+        ReturnToSource = 1,
     }
 
     /// <summary>

--- a/src/Core/Gameplay/GAS/ProjectileState.cs
+++ b/src/Core/Gameplay/GAS/ProjectileState.cs
@@ -4,6 +4,12 @@ using Ludots.Core.Gameplay.Teams;
 
 namespace Ludots.Core.Gameplay.GAS
 {
+    public enum ProjectileFlightPhase : byte
+    {
+        Outbound = 0,
+        Returning = 1,
+    }
+
     public unsafe struct ProjectileState
     {
         public const int HitHistoryCapacity = 32;
@@ -20,6 +26,10 @@ namespace Ludots.Core.Gameplay.GAS
         public RelationshipFilter CollisionRelationFilter;
         public byte CollisionExcludeSource;
         public int MaxHitCount;
+        public int TurnRateDegPerSecond;
+        public ProjectileReturnMode ReturnMode;
+        public byte ResetHitHistoryOnReturn;
+        public ProjectileFlightPhase FlightPhase;
         public Entity Source;
         public Entity Target;
         public Fix64Vec2 LaunchOriginCm;
@@ -66,6 +76,11 @@ namespace Ludots.Core.Gameplay.GAS
             HitVersions[DistinctHitCount] = entity.Version;
             DistinctHitCount++;
             return true;
+        }
+
+        public void ClearHitHistory()
+        {
+            DistinctHitCount = 0;
         }
     }
 }

--- a/src/Core/Gameplay/GAS/Systems/ProjectileRuntimeSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/ProjectileRuntimeSystem.cs
@@ -71,39 +71,46 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             }
 
             Fix64Vec2 current = position.Value;
-            bool completed = false;
+            bool legCompleted = false;
 
-            Fix64 remainingRangeCm = Fix64.FromInt(projectile.Range) - projectile.TraveledCm;
-            if (remainingRangeCm <= Fix64.Zero)
+            if (projectile.FlightPhase == ProjectileFlightPhase.Outbound)
             {
-                completed = true;
-            }
-            else if (remainingRangeCm < stepBudgetCm)
-            {
-                stepBudgetCm = remainingRangeCm;
+                Fix64 remainingRangeCm = Fix64.FromInt(projectile.Range) - projectile.TraveledCm;
+                if (remainingRangeCm <= Fix64.Zero)
+                {
+                    legCompleted = true;
+                }
+                else if (remainingRangeCm < stepBudgetCm)
+                {
+                    stepBudgetCm = remainingRangeCm;
+                }
             }
 
             Fix64Vec2 next = current;
             Fix64 actualStepCm = stepBudgetCm;
 
-            if (!completed)
+            if (!legCompleted)
             {
-                switch (projectile.TravelMode)
+                if (projectile.FlightPhase == ProjectileFlightPhase.Returning)
                 {
-                    case ProjectileTravelMode.Direction:
-                        if (!TryMoveDirection(in projectile, current, stepBudgetCm, out next))
-                        {
-                            next = current + new Fix64Vec2(stepBudgetCm, Fix64.Zero);
-                        }
-                        break;
+                    legCompleted = TryMoveReturnToSource(ref projectile, current, stepBudgetCm, deltaTime, out next, out actualStepCm);
+                }
+                else
+                {
+                    switch (projectile.TravelMode)
+                    {
+                        case ProjectileTravelMode.Direction:
+                            TryMoveDirection(ref projectile, current, stepBudgetCm, out next);
+                            break;
 
-                    case ProjectileTravelMode.TrackTarget:
-                        completed = !TryMoveTrackTarget(in projectile, current, stepBudgetCm, out next, out actualStepCm);
-                        break;
+                        case ProjectileTravelMode.TrackTarget:
+                            legCompleted = TryMoveTrackTarget(ref projectile, current, stepBudgetCm, deltaTime, out next, out actualStepCm);
+                            break;
 
-                    default:
-                        completed = TryMoveLegacy(in projectile, current, stepBudgetCm, out next, out actualStepCm);
-                        break;
+                        default:
+                            legCompleted = TryMoveLegacy(ref projectile, current, stepBudgetCm, out next, out actualStepCm);
+                            break;
+                    }
                 }
             }
 
@@ -123,19 +130,60 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                     }
                 }
 
-                projectile.TraveledCm += actualStepCm;
+                if (projectile.FlightPhase == ProjectileFlightPhase.Outbound)
+                {
+                    projectile.TraveledCm += actualStepCm;
+                }
+
+                var delta = next - current;
+                if (delta.LengthSquared() > Fix64.OneValue)
+                {
+                    projectile.Direction = delta.Normalized();
+                    projectile.HasDirection = 1;
+                }
+
                 position.Value = next;
             }
 
-            if (projectile.TraveledCm >= Fix64.FromInt(projectile.Range))
+            if (projectile.FlightPhase == ProjectileFlightPhase.Outbound &&
+                projectile.TraveledCm >= Fix64.FromInt(projectile.Range))
             {
-                completed = true;
+                legCompleted = true;
             }
 
-            if (completed)
+            if (!legCompleted)
             {
-                PublishEffect(projectile.ImpactEffectTemplateId, in projectile, World.IsAlive(projectile.Target) ? projectile.Target : Entity.Null, position.Value);
-                _toDestroy.Add(entity);
+                return;
+            }
+
+            if (projectile.FlightPhase == ProjectileFlightPhase.Outbound &&
+                projectile.ReturnMode == ProjectileReturnMode.ReturnToSource)
+            {
+                BeginReturn(ref projectile, position.Value);
+                return;
+            }
+
+            PublishEffect(projectile.ImpactEffectTemplateId, in projectile, World.IsAlive(projectile.Target) ? projectile.Target : Entity.Null, position.Value);
+            _toDestroy.Add(entity);
+        }
+
+        private void BeginReturn(ref ProjectileState projectile, in Fix64Vec2 currentPosition)
+        {
+            projectile.FlightPhase = ProjectileFlightPhase.Returning;
+            if (projectile.ResetHitHistoryOnReturn != 0)
+            {
+                projectile.ClearHitHistory();
+            }
+
+            if (World.IsAlive(projectile.Source) && World.Has<WorldPositionCm>(projectile.Source))
+            {
+                var sourcePosition = World.Get<WorldPositionCm>(projectile.Source).Value;
+                var delta = sourcePosition - currentPosition;
+                if (delta.LengthSquared() > Fix64.OneValue)
+                {
+                    projectile.Direction = delta.Normalized();
+                    projectile.HasDirection = 1;
+                }
             }
         }
 
@@ -328,7 +376,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             _effectRequests.Publish(request);
         }
 
-        private static bool TryMoveDirection(in ProjectileState projectile, in Fix64Vec2 current, Fix64 stepBudgetCm, out Fix64Vec2 next)
+        private static bool TryMoveDirection(ref ProjectileState projectile, in Fix64Vec2 current, Fix64 stepBudgetCm, out Fix64Vec2 next)
         {
             if (projectile.HasDirection == 0)
             {
@@ -340,24 +388,13 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             return true;
         }
 
-        private bool TryMoveTrackTarget(in ProjectileState projectile, in Fix64Vec2 current, Fix64 stepBudgetCm, out Fix64Vec2 next, out Fix64 actualStepCm)
+        private bool TryMoveTrackTarget(ref ProjectileState projectile, in Fix64Vec2 current, Fix64 stepBudgetCm, Fix64 deltaTime, out Fix64Vec2 next, out Fix64 actualStepCm)
         {
             actualStepCm = stepBudgetCm;
             if (World.IsAlive(projectile.Target) && World.Has<WorldPositionCm>(projectile.Target))
             {
                 var targetPosition = World.Get<WorldPositionCm>(projectile.Target).Value;
-                var delta = targetPosition - current;
-                Fix64 distance = delta.Length();
-
-                if (distance <= stepBudgetCm || distance <= Fix64.OneValue)
-                {
-                    next = targetPosition;
-                    actualStepCm = distance;
-                    return true;
-                }
-
-                next = current + delta.Normalized() * stepBudgetCm;
-                return true;
+                return TryMoveTowardPoint(ref projectile, current, targetPosition, stepBudgetCm, deltaTime, out next, out actualStepCm);
             }
 
             next = current;
@@ -365,39 +402,33 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             return false;
         }
 
-        private bool TryMoveLegacy(in ProjectileState projectile, in Fix64Vec2 current, Fix64 stepBudgetCm, out Fix64Vec2 next, out Fix64 actualStepCm)
+        private bool TryMoveReturnToSource(ref ProjectileState projectile, in Fix64Vec2 current, Fix64 stepBudgetCm, Fix64 deltaTime, out Fix64Vec2 next, out Fix64 actualStepCm)
+        {
+            actualStepCm = stepBudgetCm;
+            if (World.IsAlive(projectile.Source) && World.Has<WorldPositionCm>(projectile.Source))
+            {
+                var sourcePosition = World.Get<WorldPositionCm>(projectile.Source).Value;
+                return TryMoveTowardPoint(ref projectile, current, sourcePosition, stepBudgetCm, deltaTime, out next, out actualStepCm);
+            }
+
+            next = current;
+            actualStepCm = Fix64.Zero;
+            return false;
+        }
+
+        private bool TryMoveLegacy(ref ProjectileState projectile, in Fix64Vec2 current, Fix64 stepBudgetCm, out Fix64Vec2 next, out Fix64 actualStepCm)
         {
             actualStepCm = stepBudgetCm;
 
             if (World.IsAlive(projectile.Target) && World.Has<WorldPositionCm>(projectile.Target))
             {
                 var targetPosition = World.Get<WorldPositionCm>(projectile.Target).Value;
-                var delta = targetPosition - current;
-                Fix64 distance = delta.Length();
-                if (distance <= stepBudgetCm || distance <= Fix64.OneValue)
-                {
-                    next = targetPosition;
-                    actualStepCm = distance;
-                    return true;
-                }
-
-                next = current + delta.Normalized() * stepBudgetCm;
-                return false;
+                return TryMoveTowardPoint(ref projectile, current, targetPosition, stepBudgetCm, Fix64.Zero, out next, out actualStepCm);
             }
 
             if (projectile.HasTargetPoint != 0)
             {
-                var delta = projectile.TargetPointCm - current;
-                Fix64 distance = delta.Length();
-                if (distance <= stepBudgetCm || distance <= Fix64.OneValue)
-                {
-                    next = projectile.TargetPointCm;
-                    actualStepCm = distance;
-                    return true;
-                }
-
-                next = current + delta.Normalized() * stepBudgetCm;
-                return false;
+                return TryMoveTowardPoint(ref projectile, current, projectile.TargetPointCm, stepBudgetCm, Fix64.Zero, out next, out actualStepCm);
             }
 
             if (projectile.HasDirection != 0)
@@ -408,6 +439,75 @@ namespace Ludots.Core.Gameplay.GAS.Systems
 
             next = current + new Fix64Vec2(stepBudgetCm, Fix64.Zero);
             return false;
+        }
+
+        private bool TryMoveTowardPoint(
+            ref ProjectileState projectile,
+            in Fix64Vec2 current,
+            in Fix64Vec2 destination,
+            Fix64 stepBudgetCm,
+            Fix64 deltaTime,
+            out Fix64Vec2 next,
+            out Fix64 actualStepCm)
+        {
+            var delta = destination - current;
+            Fix64 distance = delta.Length();
+            if (distance <= stepBudgetCm || distance <= Fix64.OneValue)
+            {
+                next = destination;
+                actualStepCm = distance;
+                if (distance > Fix64.OneValue)
+                {
+                    projectile.Direction = delta.Normalized();
+                    projectile.HasDirection = 1;
+                }
+
+                return true;
+            }
+
+            var desiredDirection = delta.Normalized();
+            var travelDirection = ResolveTravelDirection(ref projectile, desiredDirection, deltaTime);
+            next = current + travelDirection * stepBudgetCm;
+            actualStepCm = stepBudgetCm;
+            return false;
+        }
+
+        private static Fix64Vec2 ResolveTravelDirection(ref ProjectileState projectile, in Fix64Vec2 desiredDirection, Fix64 deltaTime)
+        {
+            Fix64Vec2 direction = desiredDirection;
+            if (projectile.TurnRateDegPerSecond > 0 &&
+                projectile.HasDirection != 0 &&
+                deltaTime > Fix64.Zero)
+            {
+                Fix64 maxTurnRad = Fix64.FromInt(projectile.TurnRateDegPerSecond) * deltaTime * Fix64.Deg2Rad;
+                Fix64 currentRad = Fix64Math.Atan2Fast(projectile.Direction.Y, projectile.Direction.X);
+                Fix64 desiredRad = Fix64Math.Atan2Fast(desiredDirection.Y, desiredDirection.X);
+                Fix64 deltaRad = NormalizeRadians(desiredRad - currentRad);
+                if (Fix64.Abs(deltaRad) > maxTurnRad)
+                {
+                    desiredRad = currentRad + (deltaRad > Fix64.Zero ? maxTurnRad : -maxTurnRad);
+                    direction = new Fix64Vec2(Fix64Math.Cos(desiredRad), Fix64Math.Sin(desiredRad));
+                }
+            }
+
+            projectile.Direction = direction;
+            projectile.HasDirection = 1;
+            return direction;
+        }
+
+        private static Fix64 NormalizeRadians(Fix64 radians)
+        {
+            while (radians > Fix64.Pi)
+            {
+                radians -= Fix64.TwoPi;
+            }
+
+            while (radians < -Fix64.Pi)
+            {
+                radians += Fix64.TwoPi;
+            }
+
+            return radians;
         }
 
         private static int ComputeDirectionDeg(in Fix64Vec2 delta)

--- a/src/Tests/GasTests/Production/ChampionSkillSandboxConfigTests.cs
+++ b/src/Tests/GasTests/Production/ChampionSkillSandboxConfigTests.cs
@@ -226,6 +226,8 @@ namespace Ludots.Tests.GAS.Production
             AssertNamedEntityOwner(engine.World, "Jayce Cannon", expectedPlayerId: 1);
             AssertNamedEntityOwner(engine.World, "Jayce Hammer", expectedPlayerId: 1);
             AssertNamedEntityOwner(engine.World, "Geomancer Alpha", expectedPlayerId: 1);
+            AssertNamedEntityOwner(engine.World, "Artillerist Alpha", expectedPlayerId: 1);
+            AssertNamedEntityOwner(engine.World, "Trickblade Alpha", expectedPlayerId: 1);
 
             AssertEntityHasTag(engine.World, "Ezreal Cooldown", "Cooldown.Champion.Ezreal.R");
             AssertEntityHasTag(engine.World, "Garen Courage", "State.Champion.Garen.Courage");
@@ -302,6 +304,22 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(geomancerSlots[1].DisplayLabel, Is.EqualTo("Rune Field"));
             Assert.That(geomancerSlots[2].DisplayLabel, Is.EqualTo("Stone Pillar"));
             Assert.That(geomancerSlots[3].DisplayLabel, Is.EqualTo("Prismatic Beam"));
+
+            var artilleristSlots = new EntityCommandPanelSlotView[8];
+            int artilleristCount = source.CopySlots(FindEntityByName(engine.World, "Artillerist Alpha"), 0, artilleristSlots);
+            Assert.That(artilleristCount, Is.EqualTo(4));
+            Assert.That(artilleristSlots[0].DisplayLabel, Is.EqualTo("Catapult Shot"));
+            Assert.That(artilleristSlots[1].DisplayLabel, Is.EqualTo("Arrow Volley"));
+            Assert.That(artilleristSlots[2].DisplayLabel, Is.EqualTo("Skypiercer"));
+            Assert.That(artilleristSlots[3].DisplayLabel, Is.EqualTo("Cruise Missile"));
+
+            var trickbladeSlots = new EntityCommandPanelSlotView[8];
+            int trickbladeCount = source.CopySlots(FindEntityByName(engine.World, "Trickblade Alpha"), 0, trickbladeSlots);
+            Assert.That(trickbladeCount, Is.EqualTo(4));
+            Assert.That(trickbladeSlots[0].DisplayLabel, Is.EqualTo("Boomerang Blade"));
+            Assert.That(trickbladeSlots[1].DisplayLabel, Is.EqualTo("Blink Step"));
+            Assert.That(trickbladeSlots[2].DisplayLabel, Is.EqualTo("Ramming Dash"));
+            Assert.That(trickbladeSlots[3].DisplayLabel, Is.EqualTo("Gravity Hook"));
         }
 
         [Test]
@@ -422,11 +440,11 @@ namespace Ludots.Tests.GAS.Production
             Tick(engine, 4);
 
             Assert.That(engine.GameSession.Camera.VirtualCameraBrain?.ActiveCameraId, Is.EqualTo(SandboxTacticalCameraId));
-            Assert.That(engine.GameSession.Camera.State.TargetCm.X, Is.EqualTo(1850f).Within(0.01f));
-            Assert.That(engine.GameSession.Camera.State.TargetCm.Y, Is.EqualTo(980f).Within(0.01f));
-            Assert.That(engine.GameSession.Camera.State.DistanceCm, Is.EqualTo(3900f).Within(0.01f));
-            Assert.That(engine.GameSession.Camera.State.Pitch, Is.EqualTo(54f).Within(0.01f));
-            Assert.That(engine.GameSession.Camera.State.FovYDeg, Is.EqualTo(42f).Within(0.01f));
+            Assert.That(engine.GameSession.Camera.State.TargetCm.X, Is.EqualTo(1910f).Within(0.01f));
+            Assert.That(engine.GameSession.Camera.State.TargetCm.Y, Is.EqualTo(1450f).Within(0.01f));
+            Assert.That(engine.GameSession.Camera.State.DistanceCm, Is.EqualTo(6500f).Within(0.01f));
+            Assert.That(engine.GameSession.Camera.State.Pitch, Is.EqualTo(58f).Within(0.01f));
+            Assert.That(engine.GameSession.Camera.State.FovYDeg, Is.EqualTo(50f).Within(0.01f));
         }
 
         [Test]
@@ -558,6 +576,82 @@ namespace Ludots.Tests.GAS.Production
                 expectedImpactPolicy: ProjectileImpactPolicy.ContinueOnHit,
                 expectedRelationFilter: RelationshipFilter.Hostile,
                 expectedMaxHitCount: 32);
+        }
+
+        [Test]
+        public void ChampionSkillSandbox_ProjectileShowcaseSemantics_AreRegistered()
+        {
+            using var engine = CreateEngine();
+
+            var effects = engine.GetService(CoreServiceKeys.EffectTemplateRegistry)
+                ?? throw new InvalidOperationException("EffectTemplateRegistry missing.");
+
+            int catapultId = EffectTemplateIdRegistry.GetId("Effect.Champion.Artillerist.CatapultShot");
+            int volleyId = EffectTemplateIdRegistry.GetId("Effect.Champion.Artillerist.ArrowVolley");
+            int piercerId = EffectTemplateIdRegistry.GetId("Effect.Champion.Artillerist.SkyPiercer");
+            int missileId = EffectTemplateIdRegistry.GetId("Effect.Champion.Artillerist.CruiseMissile");
+            int boomerangId = EffectTemplateIdRegistry.GetId("Effect.Champion.Trickblade.BoomerangBlade");
+
+            Assert.That(effects.TryGet(catapultId, out var catapult), Is.True);
+            Assert.That(catapult.Projectile.ArcHeight, Is.EqualTo(420));
+            Assert.That(catapult.Projectile.ImpactEffectTemplateId, Is.EqualTo(EffectTemplateIdRegistry.GetId("Effect.Champion.Artillerist.CatapultImpact")));
+            Assert.That(catapult.Projectile.SpawnCount, Is.EqualTo(1));
+
+            Assert.That(effects.TryGet(volleyId, out var volley), Is.True);
+            Assert.That(volley.Projectile.TravelMode, Is.EqualTo(ProjectileTravelMode.Direction));
+            Assert.That(volley.Projectile.ImpactPolicy, Is.EqualTo(ProjectileImpactPolicy.DestroyOnFirstHit));
+            Assert.That(volley.Projectile.SpawnCount, Is.EqualTo(5));
+            Assert.That(volley.Projectile.SpreadAngleDeg, Is.EqualTo(32));
+
+            Assert.That(effects.TryGet(piercerId, out var piercer), Is.True);
+            Assert.That(piercer.Projectile.TravelMode, Is.EqualTo(ProjectileTravelMode.Direction));
+            Assert.That(piercer.Projectile.ImpactPolicy, Is.EqualTo(ProjectileImpactPolicy.ContinueOnHit));
+            Assert.That(piercer.Projectile.MaxHitCount, Is.EqualTo(8));
+
+            Assert.That(effects.TryGet(missileId, out var missile), Is.True);
+            Assert.That(missile.Projectile.TravelMode, Is.EqualTo(ProjectileTravelMode.TrackTarget));
+            Assert.That(missile.Projectile.ImpactPolicy, Is.EqualTo(ProjectileImpactPolicy.DestroyOnFirstHit));
+            Assert.That(missile.Projectile.TurnRateDegPerSecond, Is.EqualTo(240));
+
+            Assert.That(effects.TryGet(boomerangId, out var boomerang), Is.True);
+            Assert.That(boomerang.Projectile.TravelMode, Is.EqualTo(ProjectileTravelMode.Direction));
+            Assert.That(boomerang.Projectile.ImpactPolicy, Is.EqualTo(ProjectileImpactPolicy.ContinueOnHit));
+            Assert.That(boomerang.Projectile.ReturnMode, Is.EqualTo(ProjectileReturnMode.ReturnToSource));
+            Assert.That(boomerang.Projectile.ResetHitHistoryOnReturn, Is.True);
+        }
+
+        [Test]
+        public void ChampionSkillSandbox_DisplacementShowcaseSemantics_AreRegistered()
+        {
+            using var engine = CreateEngine();
+
+            var effects = engine.GetService(CoreServiceKeys.EffectTemplateRegistry)
+                ?? throw new InvalidOperationException("EffectTemplateRegistry missing.");
+
+            AssertThatDisplacement(
+                effects,
+                "Effect.Champion.Trickblade.BlinkStep",
+                DisplacementDirectionMode.ToTarget,
+                totalDistanceCm: 520,
+                totalDurationTicks: 1);
+            AssertThatDisplacement(
+                effects,
+                "Effect.Champion.Trickblade.RammingDashMove",
+                DisplacementDirectionMode.ToTarget,
+                totalDistanceCm: 480,
+                totalDurationTicks: 6);
+            AssertThatDisplacement(
+                effects,
+                "Effect.Champion.Trickblade.RammingDashKnockback",
+                DisplacementDirectionMode.AwayFromSource,
+                totalDistanceCm: 260,
+                totalDurationTicks: 4);
+            AssertThatDisplacement(
+                effects,
+                "Effect.Champion.Trickblade.GravityHookPull",
+                DisplacementDirectionMode.TowardSource,
+                totalDistanceCm: 360,
+                totalDurationTicks: 6);
         }
 
         [Test]
@@ -710,6 +804,26 @@ namespace Ludots.Tests.GAS.Production
                 projectileBindings,
                 projectileEffectKey: "Effect.Champion.Ezreal.TrueshotBarrage",
                 hitEffectKey: "Effect.Champion.Ezreal.TrueshotBarrageHit");
+            AssertProjectileUsesDirectPrimitiveFeedback(
+                effects,
+                projectileBindings,
+                projectileEffectKey: "Effect.Champion.Artillerist.ArrowVolley",
+                hitEffectKey: "Effect.Champion.Artillerist.ArrowVolleyHit");
+            AssertProjectileUsesDirectPrimitiveFeedback(
+                effects,
+                projectileBindings,
+                projectileEffectKey: "Effect.Champion.Artillerist.SkyPiercer",
+                hitEffectKey: "Effect.Champion.Artillerist.SkyPiercerHit");
+            AssertProjectileUsesDirectPrimitiveFeedback(
+                effects,
+                projectileBindings,
+                projectileEffectKey: "Effect.Champion.Artillerist.CruiseMissile",
+                hitEffectKey: "Effect.Champion.Artillerist.CruiseMissileImpact");
+            AssertProjectileUsesDirectPrimitiveFeedback(
+                effects,
+                projectileBindings,
+                projectileEffectKey: "Effect.Champion.Trickblade.BoomerangBlade",
+                hitEffectKey: "Effect.Champion.Trickblade.BoomerangBladeHit");
             AssertProjectileEffect(
                 effects,
                 projectileBindings,
@@ -734,6 +848,9 @@ namespace Ludots.Tests.GAS.Production
                 bindingEffectKey: "Effect.ChampionStress.LaserMage.LaserResolve",
                 hitEffectKey: null,
                 projectilePerformerKey: "champion_skill_sandbox.projectile.stress_laser");
+            Assert.That(effects.TryGet(EffectTemplateIdRegistry.GetId("Effect.Champion.Artillerist.CatapultShot"), out var catapultShot), Is.True);
+            Assert.That(catapultShot.Projectile.PresentationEffectTemplateId, Is.EqualTo(EffectTemplateIdRegistry.GetId("Effect.Champion.Artillerist.CatapultShot")));
+            Assert.That(catapultShot.Projectile.ImpactEffectTemplateId, Is.EqualTo(EffectTemplateIdRegistry.GetId("Effect.Champion.Artillerist.CatapultImpact")));
 
             Assert.That(performers.GetId("champion_skill_sandbox.cue.ezreal_arcane_shift"), Is.GreaterThan(0));
             Assert.That(performers.GetId("champion_skill_sandbox.cue.ezreal_essence_flux_cast"), Is.GreaterThan(0));
@@ -1247,6 +1364,23 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(
                 effect.UnitCreation.OnSpawnEffectTemplateId,
                 Is.EqualTo(EffectTemplateIdRegistry.GetId(onSpawnEffectKey)));
+        }
+
+        private static void AssertThatDisplacement(
+            EffectTemplateRegistry effects,
+            string effectKey,
+            DisplacementDirectionMode directionMode,
+            int totalDistanceCm,
+            int totalDurationTicks)
+        {
+            int effectId = EffectTemplateIdRegistry.GetId(effectKey);
+            Assert.That(effectId, Is.GreaterThan(0), $"{effectKey} should be registered.");
+            Assert.That(effects.TryGet(effectId, out var effect), Is.True);
+            Assert.That(effect.PresetType, Is.EqualTo(EffectPresetType.Displacement));
+            Assert.That(effect.Displacement.DirectionMode, Is.EqualTo(directionMode));
+            Assert.That(effect.Displacement.TotalDistanceCm, Is.EqualTo(totalDistanceCm));
+            Assert.That(effect.Displacement.TotalDurationTicks, Is.EqualTo(totalDurationTicks));
+            Assert.That(effect.Displacement.OverrideNavigation, Is.True);
         }
 
         private static IEntityCommandPanelSource ResolveGasPanelSource(GameEngine engine)

--- a/src/Tests/GasTests/Production/ChampionSkillSandboxPlayableAcceptanceTests.cs
+++ b/src/Tests/GasTests/Production/ChampionSkillSandboxPlayableAcceptanceTests.cs
@@ -205,7 +205,7 @@ namespace Ludots.Tests.GAS.Production
             TickUntil(
                 engine,
                 frameTimesMs,
-                () => IsCameraNear(engine.GameSession.Camera.State, new Vector2(1850f, 980f), 3900f, 54f, 42f),
+                () => IsCameraNear(engine.GameSession.Camera.State, new Vector2(1910f, 1450f), 6500f, 58f, 50f),
                 maxFrames: 6);
             Tick(engine, 2, frameTimesMs);
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "camera_reset");
@@ -237,8 +237,11 @@ namespace Ludots.Tests.GAS.Production
                 GetSelectedEntityName(engine),
                 frameTimesMs);
             backend.SetMousePosition(indicatorHoverPoint);
-            Tick(engine, 1, frameTimesMs);
-            Assert.That(ReadHoveredEntityName(engine), Is.EqualTo(indicatorHoverEntityName));
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => string.Equals(ReadHoveredEntityName(engine), indicatorHoverEntityName, StringComparison.Ordinal),
+                maxFrames: 3);
             SetMouseWorld(engine, backend, GetEntityScreen(engine, "Target Dummy A"), frameTimesMs);
             int baselineIndicatorLines = CountOverlays(overlays, GroundOverlayShape.Line);
             int baselineIndicatorRings = CountOverlays(overlays, GroundOverlayShape.Ring);
@@ -571,6 +574,258 @@ namespace Ludots.Tests.GAS.Production
             File.WriteAllText(Path.Combine(artifactDir, "trace.jsonl"), BuildTraceJsonl(snapshots));
             File.WriteAllText(Path.Combine(artifactDir, "battle-report.md"), BuildBattleReport(timeline, snapshots, frameTimesMs));
             File.WriteAllText(Path.Combine(artifactDir, "path.mmd"), BuildPathMermaid());
+        }
+
+        [Test]
+        public void ChampionSkillProjectiles_PlayableFlow_WritesAcceptanceArtifacts()
+        {
+            string repoRoot = FindRepoRoot();
+            string artifactDir = Path.Combine(repoRoot, "artifacts", "acceptance", "champion-skill-projectiles");
+            string screensDir = Path.Combine(artifactDir, "screens");
+            Directory.CreateDirectory(artifactDir);
+            Directory.CreateDirectory(screensDir);
+
+            var timeline = new List<string>();
+            var snapshots = new List<ProjectileShowcaseSnapshot>();
+            var frameTimesMs = new List<double>();
+
+            using var engine = CreateEngine();
+            var primitives = engine.GetService(CoreServiceKeys.PresentationPrimitiveDrawBuffer)
+                ?? throw new InvalidOperationException("PrimitiveDrawBuffer missing.");
+            var worldHud = engine.GetService(CoreServiceKeys.PresentationWorldHudBuffer)
+                ?? throw new InvalidOperationException("WorldHudBatchBuffer missing.");
+            var toolbar = engine.GetService(CoreServiceKeys.EntityCommandPanelToolbarProvider)
+                ?? throw new InvalidOperationException("Toolbar provider missing.");
+            var backend = GetInputBackend(engine);
+
+            LoadMap(engine, MapId, frameTimesMs);
+            toolbar.Activate(SmartCastModeId);
+            Tick(engine, 1, frameTimesMs);
+            Assert.That(GetActiveModeId(engine), Is.EqualTo(SmartCastModeId));
+            CaptureProjectileShowcaseSnapshot(engine, primitives, worldHud, snapshots, "map_loaded");
+            timeline.Add("[T+001] champion_skill_sandbox loaded -> projectile/displacement extension lane is ready.");
+
+            SelectNamedEntity(engine, backend, "Artillerist Alpha", frameTimesMs);
+            var artilleristSlots = CopySelectedSlots(engine);
+            Assert.That(artilleristSlots[0].Label, Is.EqualTo("Catapult Shot"));
+            Assert.That(artilleristSlots[1].Label, Is.EqualTo("Arrow Volley"));
+            Assert.That(artilleristSlots[2].Label, Is.EqualTo("Skypiercer"));
+            Assert.That(artilleristSlots[3].Label, Is.EqualTo("Cruise Missile"));
+            Entity artillerist = FindEntityByName(engine.World, "Artillerist Alpha");
+            Entity projectileBrute = FindEntityByName(engine.World, "Projectile Brute A");
+            Entity projectileDummyC = FindEntityByName(engine.World, "Projectile Dummy C");
+            Entity mobilityDummyA = FindEntityByName(engine.World, "Mobility Dummy A");
+            Entity mobilityDummyB = FindEntityByName(engine.World, "Mobility Dummy B");
+            Entity mobilityDummyC = FindEntityByName(engine.World, "Mobility Dummy C");
+            Entity mobilityBrute = FindEntityByName(engine.World, "Mobility Brute A");
+            CaptureProjectileShowcaseSnapshot(engine, primitives, worldHud, snapshots, "select_artillerist");
+            timeline.Add("[T+002] Select(Artillerist Alpha) -> panel exposes catapult / volley / pierce / cruise missile.");
+
+            float artilleristDistanceToCatapultCluster = ReadDistance(engine.World, "Artillerist Alpha", "Projectile Brute A");
+            Assert.That(
+                artilleristDistanceToCatapultCluster,
+                Is.LessThanOrEqualTo(860f),
+                "Projectile showcase layout should keep the artillery splash cluster inside Catapult Shot range.");
+            Vector2 projectileBruteWorld = ReadPosition(engine.World, "Projectile Brute A");
+            Vector2 projectileDummyCWorld = ReadPosition(engine.World, "Projectile Dummy C");
+            float bruteBeforeCatapult = ReadHealth(engine.World, "Projectile Brute A");
+            float dummyBeforeCatapult = ReadHealth(engine.World, "Projectile Dummy C");
+            CastAbilityAtEntity(engine, artillerist, projectileBrute, slot: 0);
+            bool catapultSpawned = false;
+            for (int frame = 0; frame < 8; frame++)
+            {
+                Tick(engine, 1, frameTimesMs);
+                if (CountProjectiles(engine.World) > 0)
+                {
+                    catapultSpawned = true;
+                    break;
+                }
+            }
+
+            Assert.That(
+                catapultSpawned,
+                Is.True,
+                $"{BuildInputActionDiagnostics(engine, "SkillQ")} || {BuildAbilityDiagnostics(engine, "Artillerist Alpha")} || {BuildSelectionStateDiagnostics(engine)} || {BuildLocalOrderDiagnostics(engine)} || {BuildGasPresentationDiagnostics(engine)} || projectileCount={CountProjectiles(engine.World)}");
+            CaptureProjectileShowcaseSnapshot(engine, primitives, worldHud, snapshots, "catapult_arc");
+            bool bruteDamagedByCatapult = WaitUntil(
+                engine,
+                frameTimesMs,
+                () => ReadHealth(engine.World, "Projectile Brute A") < bruteBeforeCatapult,
+                maxFrames: 96);
+            Assert.That(
+                bruteDamagedByCatapult,
+                Is.True,
+                $"{BuildInputActionDiagnostics(engine, "SkillQ")} || {BuildAbilityDiagnostics(engine, "Artillerist Alpha")} || {BuildSelectionStateDiagnostics(engine)} || {BuildLocalOrderDiagnostics(engine)} || {BuildGasPresentationDiagnostics(engine)} || projectileCount={CountProjectiles(engine.World)} || bruteHp={ReadHealth(engine.World, "Projectile Brute A"):0.##} || dummyHp={ReadHealth(engine.World, "Projectile Dummy C"):0.##}");
+            bool dummyDamagedByCatapult = WaitUntil(
+                engine,
+                frameTimesMs,
+                () => ReadHealth(engine.World, "Projectile Dummy C") < dummyBeforeCatapult,
+                maxFrames: 48);
+            Assert.That(
+                dummyDamagedByCatapult,
+                Is.True,
+                $"{BuildInputActionDiagnostics(engine, "SkillQ")} || {BuildAbilityDiagnostics(engine, "Artillerist Alpha")} || {BuildSelectionStateDiagnostics(engine)} || {BuildLocalOrderDiagnostics(engine)} || {BuildGasPresentationDiagnostics(engine)} || projectileCount={CountProjectiles(engine.World)} || bruteHp={ReadHealth(engine.World, "Projectile Brute A"):0.##} || dummyHp={ReadHealth(engine.World, "Projectile Dummy C"):0.##}");
+            float bruteAfterCatapult = ReadHealth(engine.World, "Projectile Brute A");
+            float dummyAfterCatapult = ReadHealth(engine.World, "Projectile Dummy C");
+            Assert.That(bruteAfterCatapult, Is.LessThan(bruteBeforeCatapult));
+            Assert.That(dummyAfterCatapult, Is.LessThan(dummyBeforeCatapult));
+            CaptureProjectileShowcaseSnapshot(engine, primitives, worldHud, snapshots, "catapult_impact");
+            timeline.Add($"[T+003] Catapult Shot -> arcing payload lands on Projectile Brute A and splashes Dummy C | brute {bruteBeforeCatapult:0}->{bruteAfterCatapult:0} | dummy {dummyBeforeCatapult:0}->{dummyAfterCatapult:0}.");
+
+            float dummyBeforeVolleyB = ReadHealth(engine.World, "Projectile Dummy B");
+            float dummyBeforeVolleyC = ReadHealth(engine.World, "Projectile Dummy C");
+            CastAbilityAtEntity(engine, artillerist, projectileDummyC, slot: 1);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => CountProjectiles(engine.World) >= 5,
+                maxFrames: 8);
+            int volleyProjectiles = CountProjectiles(engine.World);
+            Assert.That(volleyProjectiles, Is.GreaterThanOrEqualTo(5), "Arrow Volley should fan out into multiple live projectile entities.");
+            CaptureProjectileShowcaseSnapshot(engine, primitives, worldHud, snapshots, "volley_fan");
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => ReadHealth(engine.World, "Projectile Dummy B") < dummyBeforeVolleyB ||
+                      ReadHealth(engine.World, "Projectile Dummy C") < dummyBeforeVolleyC,
+                maxFrames: 24);
+            timeline.Add($"[T+004] Arrow Volley -> spawned fan count {volleyProjectiles} with visible multi-projectile spread.");
+
+            float dummyBeforePiercerB = ReadHealth(engine.World, "Projectile Dummy B");
+            float dummyBeforePiercerC = ReadHealth(engine.World, "Projectile Dummy C");
+            CastAbilityAtEntity(engine, artillerist, projectileDummyC, slot: 2);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => ReadHealth(engine.World, "Projectile Dummy B") < dummyBeforePiercerB &&
+                      ReadHealth(engine.World, "Projectile Dummy C") < dummyBeforePiercerC,
+                maxFrames: 40);
+            float dummyAfterPiercerB = ReadHealth(engine.World, "Projectile Dummy B");
+            float dummyAfterPiercerC = ReadHealth(engine.World, "Projectile Dummy C");
+            Assert.That(dummyAfterPiercerB, Is.LessThan(dummyBeforePiercerB));
+            Assert.That(dummyAfterPiercerC, Is.LessThan(dummyBeforePiercerC));
+            CaptureProjectileShowcaseSnapshot(engine, primitives, worldHud, snapshots, "sky_piercer_line");
+            timeline.Add($"[T+005] Skypiercer -> one line shot pierced Dummy B and Dummy C | B {dummyBeforePiercerB:0}->{dummyAfterPiercerB:0} | C {dummyBeforePiercerC:0}->{dummyAfterPiercerC:0}.");
+
+            float bruteBeforeMissile = ReadHealth(engine.World, "Projectile Brute A");
+            float dummyBeforeMissile = ReadHealth(engine.World, "Projectile Dummy C");
+            int projectileCountBeforeMissile = CountProjectiles(engine.World);
+            CastAbilityAtEntity(engine, artillerist, projectileBrute, slot: 3);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => CountProjectiles(engine.World) > projectileCountBeforeMissile,
+                maxFrames: 8);
+            CaptureProjectileShowcaseSnapshot(engine, primitives, worldHud, snapshots, "cruise_missile_track");
+            var cruiseMissileFrames = new List<string>(72);
+            bool bruteDamagedByMissile = WaitUntil(
+                engine,
+                frameTimesMs,
+                () =>
+                {
+                    cruiseMissileFrames.Add(
+                        $"frame={cruiseMissileFrames.Count + 1} count={CountProjectiles(engine.World)} brute={ReadHealth(engine.World, "Projectile Brute A"):0.##} dummy={ReadHealth(engine.World, "Projectile Dummy C"):0.##} projectiles={DescribeProjectiles(engine.World)}");
+                    return ReadHealth(engine.World, "Projectile Brute A") < bruteBeforeMissile;
+                },
+                maxFrames: 72);
+            Assert.That(
+                bruteDamagedByMissile,
+                Is.True,
+                $"Cruise Missile never damaged Projectile Brute A. {BuildAbilityDiagnostics(engine, "Artillerist Alpha")} || projectileCount={CountProjectiles(engine.World)} || bruteHp={ReadHealth(engine.World, "Projectile Brute A"):0.##} || dummyHp={ReadHealth(engine.World, "Projectile Dummy C"):0.##} || trace={string.Join(" || ", cruiseMissileFrames)}");
+            bool dummyDamagedByMissile = WaitUntil(
+                engine,
+                frameTimesMs,
+                () => ReadHealth(engine.World, "Projectile Dummy C") < dummyBeforeMissile,
+                maxFrames: 24);
+            Assert.That(
+                dummyDamagedByMissile,
+                Is.True,
+                $"Cruise Missile impact damaged Projectile Brute A but did not splash Projectile Dummy C. projectileCount={CountProjectiles(engine.World)} || bruteHp={ReadHealth(engine.World, "Projectile Brute A"):0.##} || dummyHp={ReadHealth(engine.World, "Projectile Dummy C"):0.##} || projectiles={DescribeProjectiles(engine.World)}");
+            float bruteAfterMissile = ReadHealth(engine.World, "Projectile Brute A");
+            float dummyAfterMissile = ReadHealth(engine.World, "Projectile Dummy C");
+            Assert.That(bruteAfterMissile, Is.LessThan(bruteBeforeMissile));
+            Assert.That(dummyAfterMissile, Is.LessThan(dummyBeforeMissile));
+            timeline.Add($"[T+006] Cruise Missile -> tracked Projectile Brute A, then splashed Dummy C from the clustered blast | brute {bruteBeforeMissile:0}->{bruteAfterMissile:0} | dummy {dummyBeforeMissile:0}->{dummyAfterMissile:0}.");
+
+            SelectNamedEntity(engine, backend, "Trickblade Alpha", frameTimesMs);
+            var trickbladeSlots = CopySelectedSlots(engine);
+            Assert.That(trickbladeSlots[0].Label, Is.EqualTo("Boomerang Blade"));
+            Assert.That(trickbladeSlots[1].Label, Is.EqualTo("Blink Step"));
+            Assert.That(trickbladeSlots[2].Label, Is.EqualTo("Ramming Dash"));
+            Assert.That(trickbladeSlots[3].Label, Is.EqualTo("Gravity Hook"));
+            Entity trickblade = FindEntityByName(engine.World, "Trickblade Alpha");
+            CaptureProjectileShowcaseSnapshot(engine, primitives, worldHud, snapshots, "select_trickblade");
+            timeline.Add("[T+007] Select(Trickblade Alpha) -> panel exposes boomerang plus blink / dash / pull mobility kit.");
+
+            float mobilityDummyBeforeBoomerang = ReadHealth(engine.World, "Mobility Dummy B");
+            CastAbilityAtEntity(engine, trickblade, mobilityDummyB, slot: 0);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => CountProjectiles(engine.World) > 0,
+                maxFrames: 8);
+            CaptureProjectileShowcaseSnapshot(engine, primitives, worldHud, snapshots, "boomerang_outbound");
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => CountProjectiles(engine.World) == 0,
+                maxFrames: 72);
+            float mobilityDummyAfterBoomerang = ReadHealth(engine.World, "Mobility Dummy B");
+            Assert.That(
+                mobilityDummyAfterBoomerang,
+                Is.LessThanOrEqualTo(mobilityDummyBeforeBoomerang - 18f),
+                "Boomerang should be able to hit the same stationary dummy on both outbound and return legs.");
+            CaptureProjectileShowcaseSnapshot(engine, primitives, worldHud, snapshots, "boomerang_return");
+            timeline.Add($"[T+008] Boomerang Blade -> outbound plus return both connected on Mobility Dummy B | HP {mobilityDummyBeforeBoomerang:0}->{mobilityDummyAfterBoomerang:0}.");
+
+            Vector2 trickbladeBeforeDash = ReadPosition(engine.World, "Trickblade Alpha");
+            Vector2 dummyBeforeDash = ReadPosition(engine.World, "Mobility Dummy A");
+            CastAbilityAtEntity(engine, trickblade, mobilityDummyA, slot: 2);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => ReadPosition(engine.World, "Trickblade Alpha").X > trickbladeBeforeDash.X + 300f,
+                maxFrames: 12);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => ReadPosition(engine.World, "Mobility Dummy A").Y < dummyBeforeDash.Y - 60f,
+                maxFrames: 18);
+            Vector2 trickbladeAfterDash = ReadPosition(engine.World, "Trickblade Alpha");
+            Vector2 dummyAfterDash = ReadPosition(engine.World, "Mobility Dummy A");
+            Assert.That(trickbladeAfterDash.X, Is.GreaterThan(trickbladeBeforeDash.X + 300f));
+            Assert.That(dummyAfterDash.Y, Is.LessThan(dummyBeforeDash.Y - 60f));
+            CaptureProjectileShowcaseSnapshot(engine, primitives, worldHud, snapshots, "ramming_dash");
+            timeline.Add($"[T+009] Ramming Dash -> Trickblade advanced from ({trickbladeBeforeDash.X:0},{trickbladeBeforeDash.Y:0}) to ({trickbladeAfterDash.X:0},{trickbladeAfterDash.Y:0}) and knocked Mobility Dummy A away.");
+
+            float bruteBeforeHookX = ReadPosition(engine.World, "Mobility Brute A").X;
+            CastAbilityAtEntity(engine, trickblade, mobilityBrute, slot: 3);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => ReadPosition(engine.World, "Mobility Brute A").X < bruteBeforeHookX - 100f,
+                maxFrames: 24);
+            float bruteAfterHookX = ReadPosition(engine.World, "Mobility Brute A").X;
+            Assert.That(bruteAfterHookX, Is.LessThan(bruteBeforeHookX - 100f));
+            CaptureProjectileShowcaseSnapshot(engine, primitives, worldHud, snapshots, "gravity_hook");
+            timeline.Add($"[T+010] Gravity Hook -> Mobility Brute A was pulled back toward Trickblade | X {bruteBeforeHookX:0}->{bruteAfterHookX:0}.");
+
+            Vector2 trickbladeBeforeBlink = ReadPosition(engine.World, "Trickblade Alpha");
+            CastAbilityAtEntity(engine, trickblade, mobilityDummyC, slot: 1);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => Vector2.Distance(ReadPosition(engine.World, "Trickblade Alpha"), trickbladeBeforeBlink) > 240f,
+                maxFrames: 4);
+            Vector2 trickbladeAfterBlink = ReadPosition(engine.World, "Trickblade Alpha");
+            Assert.That(Vector2.Distance(trickbladeAfterBlink, trickbladeBeforeBlink), Is.GreaterThan(240f));
+            CaptureProjectileShowcaseSnapshot(engine, primitives, worldHud, snapshots, "blink_step");
+            timeline.Add($"[T+011] Blink Step -> Trickblade snapped from ({trickbladeBeforeBlink.X:0},{trickbladeBeforeBlink.Y:0}) to ({trickbladeAfterBlink.X:0},{trickbladeAfterBlink.Y:0}).");
+
+            File.WriteAllText(Path.Combine(artifactDir, "trace.jsonl"), BuildProjectileShowcaseTraceJsonl(snapshots));
+            File.WriteAllText(Path.Combine(artifactDir, "battle-report.md"), BuildProjectileShowcaseBattleReport(timeline, snapshots, frameTimesMs));
+            File.WriteAllText(Path.Combine(artifactDir, "path.mmd"), BuildProjectileShowcasePathMermaid());
+            WriteProjectileShowcaseScreenshots(snapshots, screensDir);
         }
 
         [Test]
@@ -1016,6 +1271,52 @@ namespace Ludots.Tests.GAS.Production
             Tick(engine, 1, frameTimesMs);
         }
 
+        private static void CastAbilityAtWorldPoint(GameEngine engine, Entity actor, int slot, Vector2 targetWorldCm)
+        {
+            var orders = engine.GetService(CoreServiceKeys.OrderQueue) as OrderQueue
+                ?? throw new InvalidOperationException("OrderQueue service is missing.");
+
+            var args = new OrderArgs
+            {
+                I0 = slot,
+                Spatial = new OrderSpatial
+                {
+                    Kind = OrderSpatialKind.WorldCm,
+                    Mode = OrderCollectionMode.Single,
+                    WorldCm = new Vector3(targetWorldCm.X, 0f, targetWorldCm.Y)
+                }
+            };
+
+            bool enqueued = orders.TryEnqueue(new Order
+            {
+                OrderTypeId = engine.MergedConfig.Constants.OrderTypeIds["castAbility"],
+                PlayerId = 1,
+                Actor = actor,
+                Args = args,
+                SubmitMode = OrderSubmitMode.Immediate
+            });
+
+            Assert.That(enqueued, Is.True, $"World-point cast order should enqueue for slot {slot}.");
+        }
+
+        private static void CastAbilityAtEntity(GameEngine engine, Entity actor, Entity target, int slot)
+        {
+            var orders = engine.GetService(CoreServiceKeys.OrderQueue) as OrderQueue
+                ?? throw new InvalidOperationException("OrderQueue service is missing.");
+
+            bool enqueued = orders.TryEnqueue(new Order
+            {
+                OrderTypeId = engine.MergedConfig.Constants.OrderTypeIds["castAbility"],
+                PlayerId = 1,
+                Actor = actor,
+                Target = target,
+                Args = new OrderArgs { I0 = slot },
+                SubmitMode = OrderSubmitMode.Immediate
+            });
+
+            Assert.That(enqueued, Is.True, $"Entity-target cast order should enqueue for slot {slot}.");
+        }
+
         private static void Tick(GameEngine engine, int frames, List<double> frameTimesMs)
         {
             for (int i = 0; i < frames; i++)
@@ -1282,6 +1583,255 @@ namespace Ludots.Tests.GAS.Production
                 "    T --> U[\"Arena: Cataclysm Ring spawns 10 box blocker segments\"]",
                 "    U --> V[\"Beam: Guided Laser hold-starts, hits Dummy D, retargets to Dummy E, release removes manifestation\"]"
             });
+        }
+
+        private static void CaptureProjectileShowcaseSnapshot(
+            GameEngine engine,
+            PrimitiveDrawBuffer primitives,
+            WorldHudBatchBuffer worldHud,
+            List<ProjectileShowcaseSnapshot> snapshots,
+            string step)
+        {
+            string[] trackedEntities =
+            {
+                "Artillerist Alpha",
+                "Trickblade Alpha",
+                "Projectile Dummy A",
+                "Projectile Dummy B",
+                "Projectile Dummy C",
+                "Projectile Brute A",
+                "Mobility Dummy A",
+                "Mobility Dummy B",
+                "Mobility Dummy C",
+                "Mobility Brute A"
+            };
+
+            var entities = new List<ProjectileShowcaseEntityState>(trackedEntities.Length);
+            for (int i = 0; i < trackedEntities.Length; i++)
+            {
+                if (!TryFindEntityByName(engine.World, trackedEntities[i], out Entity entity) ||
+                    !engine.World.Has<WorldPositionCm>(entity))
+                {
+                    continue;
+                }
+
+                Vector2 position = engine.World.Get<WorldPositionCm>(entity).Value.ToVector2();
+                entities.Add(new ProjectileShowcaseEntityState(
+                    trackedEntities[i],
+                    position.X,
+                    position.Y,
+                    ReadHealth(engine.World, trackedEntities[i])));
+            }
+
+            var projectilePositions = new List<Vector2>(16);
+            var projectileQuery = new QueryDescription().WithAll<ProjectileState, WorldPositionCm>();
+            engine.World.Query(in projectileQuery, (Entity _, ref ProjectileState __, ref WorldPositionCm position) =>
+            {
+                if (projectilePositions.Count < 16)
+                {
+                    projectilePositions.Add(position.Value.ToVector2());
+                }
+            });
+
+            snapshots.Add(new ProjectileShowcaseSnapshot(
+                Step: step,
+                SelectedEntity: GetSelectedEntityName(engine),
+                ProjectileCount: CountProjectiles(engine.World),
+                PrimitiveCount: CountPrimitiveMarkers(primitives),
+                WorldTextCount: CountWorldHudItems(worldHud, WorldHudItemKind.Text),
+                Entities: entities,
+                ProjectilePositions: projectilePositions));
+        }
+
+        private static string BuildProjectileShowcaseTraceJsonl(IReadOnlyList<ProjectileShowcaseSnapshot> snapshots)
+        {
+            var lines = new List<string>(snapshots.Count);
+            for (int i = 0; i < snapshots.Count; i++)
+            {
+                ProjectileShowcaseSnapshot snapshot = snapshots[i];
+                lines.Add(JsonSerializer.Serialize(new
+                {
+                    event_id = $"champion-projectiles-{i + 1:000}",
+                    step = snapshot.Step,
+                    selected_entity = snapshot.SelectedEntity,
+                    projectile_count = snapshot.ProjectileCount,
+                    primitive_count = snapshot.PrimitiveCount,
+                    world_text_count = snapshot.WorldTextCount,
+                    entities = snapshot.Entities.Select(entity => new
+                    {
+                        name = entity.Name,
+                        x_cm = entity.XCm,
+                        y_cm = entity.YCm,
+                        health = entity.Health
+                    }),
+                    projectiles = snapshot.ProjectilePositions.Select(position => new
+                    {
+                        x_cm = position.X,
+                        y_cm = position.Y
+                    })
+                }));
+            }
+
+            return string.Join(Environment.NewLine, lines);
+        }
+
+        private static string BuildProjectileShowcaseBattleReport(
+            IReadOnlyList<string> timeline,
+            IReadOnlyList<ProjectileShowcaseSnapshot> snapshots,
+            IReadOnlyList<double> frameTimesMs)
+        {
+            double medianTickMs = Median(frameTimesMs);
+            double maxTickMs = frameTimesMs.Count == 0 ? 0d : frameTimesMs.Max();
+            ProjectileShowcaseSnapshot finalSnapshot = snapshots[^1];
+            int peakProjectiles = snapshots.Max(snapshot => snapshot.ProjectileCount);
+            int peakPrimitives = snapshots.Max(snapshot => snapshot.PrimitiveCount);
+            int peakWorldText = snapshots.Max(snapshot => snapshot.WorldTextCount);
+
+            var sb = new StringBuilder();
+            sb.AppendLine("# Scenario: champion-skill-projectiles");
+            sb.AppendLine();
+            sb.AppendLine("## Header");
+            sb.AppendLine("- build: GasTests / ChampionSkillProjectiles_PlayableFlow_WritesAcceptanceArtifacts");
+            sb.AppendLine("- map: champion_skill_sandbox");
+            sb.AppendLine("- clock: FixedFrame @ 60 Hz");
+            sb.AppendLine($"- execution_timestamp_utc: {DateTime.UtcNow:O}");
+            sb.AppendLine("- screenshots: `screens/*.svg`, `screens/timeline.svg`");
+            sb.AppendLine();
+            sb.AppendLine("## Timeline");
+            foreach (string entry in timeline)
+            {
+                sb.AppendLine(entry);
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("## Outcome");
+            sb.AppendLine("- result: success");
+            sb.AppendLine("- design: projectile guidance stayed inside Projectile runtime; displacement stayed inside Displacement runtime.");
+            sb.AppendLine($"- final_selected: {finalSnapshot.SelectedEntity}");
+            sb.AppendLine($"- final_projectiles: {finalSnapshot.ProjectileCount}");
+            sb.AppendLine($"- final_feedback_primitives: {finalSnapshot.PrimitiveCount}");
+            sb.AppendLine($"- final_feedback_world_text: {finalSnapshot.WorldTextCount}");
+            sb.AppendLine();
+            sb.AppendLine("## Summary Stats");
+            sb.AppendLine($"- total_actions: {timeline.Count}");
+            sb.AppendLine("- projectile_showcases: 5");
+            sb.AppendLine("- displacement_showcases: 3");
+            sb.AppendLine($"- peak_projectiles: {peakProjectiles}");
+            sb.AppendLine($"- peak_primitives: {peakPrimitives}");
+            sb.AppendLine($"- peak_world_text: {peakWorldText}");
+            sb.AppendLine($"- median_tick_ms: {medianTickMs:0.###}");
+            sb.AppendLine($"- max_tick_ms: {maxTickMs:0.###}");
+            return sb.ToString();
+        }
+
+        private static string BuildProjectileShowcasePathMermaid()
+        {
+            return string.Join(Environment.NewLine, new[]
+            {
+                "flowchart TD",
+                "    A[\"MapLoaded: sandbox extension lane ready\"] --> B[\"Select Artillerist -> projectile loadout visible\"]",
+                "    B --> C[\"Catapult Shot: arc flight -> area impact\"]",
+                "    C --> D[\"Arrow Volley: fan-out creates 5 live projectiles\"]",
+                "    D --> E[\"Skypiercer: one shot damages a full line\"]",
+                "    E --> F[\"Cruise Missile: turn-limited homing -> explosion\"]",
+                "    F --> G[\"Select Trickblade -> boomerang and mobility loadout visible\"]",
+                "    G --> H[\"Boomerang Blade: outbound and return both connect\"]",
+                "    H --> I[\"Ramming Dash: source moves, nearby dummy knocked away\"]",
+                "    I --> J[\"Gravity Hook: target cluster pulled toward source\"]",
+                "    J --> K[\"Blink Step: instant reposition completes displacement showcase\"]"
+            });
+        }
+
+        private static void WriteProjectileShowcaseScreenshots(IReadOnlyList<ProjectileShowcaseSnapshot> snapshots, string screensDir)
+        {
+            for (int i = 0; i < snapshots.Count; i++)
+            {
+                ProjectileShowcaseSnapshot snapshot = snapshots[i];
+                WriteProjectileShowcaseSnapshotSvg(snapshot, Path.Combine(screensDir, $"{i + 1:000}_{snapshot.Step}.svg"));
+            }
+
+            WriteProjectileShowcaseTimelineSvg(snapshots, Path.Combine(screensDir, "timeline.svg"));
+        }
+
+        private static void WriteProjectileShowcaseSnapshotSvg(ProjectileShowcaseSnapshot snapshot, string path)
+        {
+            const float width = 1600f;
+            const float height = 900f;
+            const float mapLeft = 56f;
+            const float mapTop = 140f;
+            const float mapWidth = 1488f;
+            const float mapHeight = 700f;
+
+            float minX = snapshot.Entities.Count == 0 ? 0f : snapshot.Entities.Min(entity => entity.XCm) - 220f;
+            float maxX = snapshot.Entities.Count == 0 ? 1f : snapshot.Entities.Max(entity => entity.XCm) + 220f;
+            float minY = snapshot.Entities.Count == 0 ? 0f : snapshot.Entities.Min(entity => entity.YCm) - 220f;
+            float maxY = snapshot.Entities.Count == 0 ? 1f : snapshot.Entities.Max(entity => entity.YCm) + 220f;
+            float worldWidth = Math.Max(1f, maxX - minX);
+            float worldHeight = Math.Max(1f, maxY - minY);
+
+            float ProjectX(float xCm) => mapLeft + ((xCm - minX) / worldWidth) * mapWidth;
+            float ProjectY(float yCm) => mapTop + ((yCm - minY) / worldHeight) * mapHeight;
+
+            var body = new StringBuilder();
+            body.AppendLine($"""  <rect x="{mapLeft}" y="{mapTop}" width="{mapWidth}" height="{mapHeight}" rx="18" fill="#101a24" stroke="#35536b" stroke-width="1.5" />""");
+
+            for (int i = 0; i < snapshot.ProjectilePositions.Count; i++)
+            {
+                Vector2 projectile = snapshot.ProjectilePositions[i];
+                body.AppendLine($"""  <circle cx="{ProjectX(projectile.X):0.##}" cy="{ProjectY(projectile.Y):0.##}" r="8" fill="#ff9a57" opacity="0.88" />""");
+            }
+
+            for (int i = 0; i < snapshot.Entities.Count; i++)
+            {
+                ProjectileShowcaseEntityState entity = snapshot.Entities[i];
+                bool selected = string.Equals(entity.Name, snapshot.SelectedEntity, StringComparison.Ordinal);
+                bool hostile = entity.Name.Contains("Dummy", StringComparison.Ordinal) || entity.Name.Contains("Brute", StringComparison.Ordinal);
+                string fill = selected ? "#f7d36d" : hostile ? "#ff7d7d" : "#6ac5ff";
+                float cx = ProjectX(entity.XCm);
+                float cy = ProjectY(entity.YCm);
+                body.AppendLine($"""  <circle cx="{cx:0.##}" cy="{cy:0.##}" r="{(selected ? 18f : 14f):0.##}" fill="{fill}" opacity="0.9" />""");
+                body.AppendLine($"""  <text x="{cx + 20f:0.##}" y="{cy - 4f:0.##}" fill="#ffffff" font-size="18" font-family="Consolas, monospace">{EscapeSvg(entity.Name)}</text>""");
+                body.AppendLine($"""  <text x="{cx + 20f:0.##}" y="{cy + 18f:0.##}" fill="#bccdde" font-size="16" font-family="Consolas, monospace">HP {entity.Health:0.#} @ ({entity.XCm:0},{entity.YCm:0})</text>""");
+            }
+
+            string svg = $$"""
+<svg xmlns="http://www.w3.org/2000/svg" width="{{width:0}}" height="{{height:0}}" viewBox="0 0 {{width:0}} {{height:0}}">
+  <rect width="{{width:0}}" height="{{height:0}}" fill="#0b1016" />
+  <text x="56" y="68" fill="#f7d36d" font-size="34" font-family="Consolas, monospace">Champion Projectile Showcase | {{EscapeSvg(snapshot.Step)}}</text>
+  <text x="56" y="108" fill="#ffffff" font-size="22" font-family="Consolas, monospace">Selected: {{EscapeSvg(snapshot.SelectedEntity)}} | Projectiles={{snapshot.ProjectileCount}} | Feedback={{snapshot.PrimitiveCount}}/{{snapshot.WorldTextCount}}</text>
+{{body}}
+</svg>
+""";
+            File.WriteAllText(path, svg);
+        }
+
+        private static void WriteProjectileShowcaseTimelineSvg(IReadOnlyList<ProjectileShowcaseSnapshot> snapshots, string path)
+        {
+            if (snapshots.Count == 0)
+            {
+                return;
+            }
+
+            var lines = new List<string>(snapshots.Count * 4);
+            int y = 100;
+            for (int i = 0; i < snapshots.Count; i++)
+            {
+                ProjectileShowcaseSnapshot snapshot = snapshots[i];
+                lines.Add($"""  <rect x="40" y="{y - 36}" width="1520" height="72" rx="12" fill="#14212e" stroke="#35536b" stroke-width="1.5" />""");
+                lines.Add($"""  <text x="72" y="{y}" fill="#f7d36d" font-size="24" font-family="Consolas, monospace">{EscapeSvg($"{i + 1:000} {snapshot.Step}")}</text>""");
+                lines.Add($"""  <text x="420" y="{y}" fill="#ffffff" font-size="20" font-family="Consolas, monospace">{EscapeSvg(snapshot.SelectedEntity)}</text>""");
+                lines.Add($"""  <text x="72" y="{y + 28}" fill="#bccdde" font-size="18" font-family="Consolas, monospace">{EscapeSvg($"proj={snapshot.ProjectileCount} | feedback={snapshot.PrimitiveCount}/{snapshot.WorldTextCount} | entities={snapshot.Entities.Count}")}</text>""");
+                y += 96;
+            }
+
+            string svg = $$"""
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="{{Math.Max(240, y + 40)}}" viewBox="0 0 1600 {{Math.Max(240, y + 40)}}">
+  <rect width="1600" height="{{Math.Max(240, y + 40)}}" fill="#080a10" />
+  <text x="20" y="36" fill="#ffffff" font-size="28" font-family="Consolas, monospace">Champion projectile showcase timeline</text>
+{{string.Join(Environment.NewLine, lines)}}
+</svg>
+""";
+            File.WriteAllText(path, svg);
         }
 
         private static void CaptureStressSnapshot(
@@ -1584,6 +2134,45 @@ namespace Ludots.Tests.GAS.Production
             var query = new QueryDescription().WithAll<ProjectileState>();
             world.Query(in query, (Entity _, ref ProjectileState __) => count++);
             return count;
+        }
+
+        private static string DescribeProjectiles(World world)
+        {
+            var projectiles = new List<string>(8);
+            var query = new QueryDescription().WithAll<ProjectileState, WorldPositionCm>();
+            world.Query(in query, (Entity entity, ref ProjectileState projectile, ref WorldPositionCm position) =>
+            {
+                if (projectiles.Count >= 8)
+                {
+                    return;
+                }
+
+                Vector2 pos = position.Value.ToVector2();
+                string targetName = TryGetEntityDebugName(world, projectile.Target);
+                projectiles.Add(
+                    $"#{entity.Id}@({pos.X:0},{pos.Y:0}) target={projectile.Target.Id}:{targetName}:alive={world.IsAlive(projectile.Target)} range={projectile.Range} phase={projectile.FlightPhase} mode={projectile.TravelMode}");
+            });
+            return projectiles.Count == 0 ? "<none>" : string.Join(" | ", projectiles);
+        }
+
+        private static string TryGetEntityDebugName(World world, Entity entity)
+        {
+            if (!world.IsAlive(entity))
+            {
+                return "<dead>";
+            }
+
+            if (world.Has<Name>(entity))
+            {
+                return world.Get<Name>(entity).Value;
+            }
+
+            if (world.Has<MapEntity>(entity))
+            {
+                return world.Get<MapEntity>(entity).MapId.Value;
+            }
+
+            return "<unnamed>";
         }
 
         private static string GetActiveModeId(GameEngine engine)
@@ -2256,6 +2845,18 @@ namespace Ludots.Tests.GAS.Production
             return $"feedback=primitives:{CountPrimitiveMarkers(primitives)},worldText:{CountWorldHudItems(worldHud, WorldHudItemKind.Text)}";
         }
 
+        private static string BuildLocalOrderDiagnostics(GameEngine engine)
+        {
+            string lastGround = engine.GlobalContext.TryGetValue(LocalOrderSourceHelper.LastGroundWorldDebugKey, out var lastGroundObj)
+                ? lastGroundObj?.ToString() ?? "<null>"
+                : "<missing>";
+            string lastOrder = engine.GlobalContext.TryGetValue(LocalOrderSourceHelper.LastOrderDebugKey, out var lastOrderObj)
+                ? lastOrderObj?.ToString() ?? "<null>"
+                : "<missing>";
+            int orderQueueCount = engine.GetService(CoreServiceKeys.OrderQueue)?.Count ?? -1;
+            return $"localOrder=lastGround:{lastGround},lastOrder:{lastOrder},queue:{orderQueueCount}";
+        }
+
         private static unsafe string BuildEzrealMarkDiagnostics(World world, string entityName)
         {
             Entity entity = FindEntityByName(world, entityName);
@@ -2467,6 +3068,21 @@ namespace Ludots.Tests.GAS.Production
 
         private sealed record EntityState(
             string Name,
+            float Health);
+
+        private sealed record ProjectileShowcaseSnapshot(
+            string Step,
+            string SelectedEntity,
+            int ProjectileCount,
+            int PrimitiveCount,
+            int WorldTextCount,
+            IReadOnlyList<ProjectileShowcaseEntityState> Entities,
+            IReadOnlyList<Vector2> ProjectilePositions);
+
+        private sealed record ProjectileShowcaseEntityState(
+            string Name,
+            float XCm,
+            float YCm,
             float Health);
 
         private sealed record StressAcceptanceSnapshot(

--- a/src/Tests/GasTests/Production/ProductionAllModsValidationTests.cs
+++ b/src/Tests/GasTests/Production/ProductionAllModsValidationTests.cs
@@ -108,7 +108,7 @@ namespace Ludots.Tests.GAS.Production
 
             yield return new TestCaseData(new ModCase(
                     "ChampionSkillSandboxMod",
-                    new[] { "LudotsCoreMod", "CoreInputMod", "CameraProfilesMod", "EntityCommandPanelMod", "ChampionSkillSandboxMod" },
+                    new[] { "LudotsCoreMod", "DiagnosticsOverlayMod", "CoreInputMod", "CameraProfilesMod", "EntityCommandPanelMod", "ChampionSkillSandboxMod" },
                     true))
                 .SetName("ProdModSmoke_ChampionSkillSandboxMod");
 

--- a/src/Tests/GasTests/TagEffectArchitectureTests.cs
+++ b/src/Tests/GasTests/TagEffectArchitectureTests.cs
@@ -501,6 +501,92 @@ namespace Ludots.Tests.GAS
         }
 
         [Test]
+        public void ProjectileRuntimeSystem_TrackTarget_MovesBeforeImpacting()
+        {
+            using var world = World.Create();
+            var requests = new EffectRequestQueue();
+            var caster = world.Create(WorldPositionCm.FromCm(0, 0));
+            var target = world.Create(WorldPositionCm.FromCm(300, 0));
+            var projectile = world.Create(
+                new ProjectileState
+                {
+                    Speed = Fix64.FromInt(100),
+                    Range = 1000,
+                    ImpactEffectTemplateId = 77,
+                    TravelMode = ProjectileTravelMode.TrackTarget,
+                    Source = caster,
+                    Target = target,
+                    LaunchOriginCm = Fix64Vec2.Zero,
+                    HasLaunchOrigin = 1,
+                    Direction = Fix64Vec2.UnitX,
+                    HasDirection = 1,
+                },
+                WorldPositionCm.FromCm(0, 0),
+                new PreviousWorldPositionCm { Value = WorldPositionCm.FromCm(0, 0).Value });
+
+            using var system = new ProjectileRuntimeSystem(world, requests, spatialQueries: null);
+
+            system.Update(1.0f);
+
+            That(world.IsAlive(projectile), Is.True, "TrackTarget projectile should remain alive while still traveling.");
+            That(world.Get<WorldPositionCm>(projectile).Value.X.ToFloat(), Is.EqualTo(100f).Within(0.01f));
+            That(requests.Count, Is.EqualTo(0));
+
+            system.Update(1.0f);
+            system.Update(1.0f);
+
+            That(world.IsAlive(projectile), Is.False, "TrackTarget projectile should resolve only after reaching the target.");
+            That(requests.Count, Is.EqualTo(1));
+            That(requests[0].TemplateId, Is.EqualTo(77));
+            That(requests[0].HasCallerParams, Is.True);
+            That(requests[0].CallerParams.TryGetFloat(EffectParamKeys.TargetPosX, out float targetX), Is.True);
+            That(targetX, Is.EqualTo(300f).Within(0.01f));
+        }
+
+        [Test]
+        public void ProjectileRuntimeSystem_ReturnToSource_MovesBeforeReturnImpact()
+        {
+            using var world = World.Create();
+            var requests = new EffectRequestQueue();
+            var caster = world.Create(WorldPositionCm.FromCm(0, 0));
+            var projectile = world.Create(
+                new ProjectileState
+                {
+                    Speed = Fix64.FromInt(100),
+                    Range = 300,
+                    ImpactEffectTemplateId = 66,
+                    ReturnMode = ProjectileReturnMode.ReturnToSource,
+                    FlightPhase = ProjectileFlightPhase.Returning,
+                    Source = caster,
+                    Target = Entity.Null,
+                    LaunchOriginCm = Fix64Vec2.Zero,
+                    HasLaunchOrigin = 1,
+                    Direction = new Fix64Vec2(Fix64.FromInt(-1), Fix64.Zero),
+                    HasDirection = 1,
+                },
+                WorldPositionCm.FromCm(300, 0),
+                new PreviousWorldPositionCm { Value = WorldPositionCm.FromCm(300, 0).Value });
+
+            using var system = new ProjectileRuntimeSystem(world, requests, spatialQueries: null);
+
+            system.Update(1.0f);
+
+            That(world.IsAlive(projectile), Is.True, "Returning projectile should remain alive until it reaches the source.");
+            That(world.Get<WorldPositionCm>(projectile).Value.X.ToFloat(), Is.EqualTo(200f).Within(0.01f));
+            That(requests.Count, Is.EqualTo(0));
+
+            system.Update(1.0f);
+            system.Update(1.0f);
+
+            That(world.IsAlive(projectile), Is.False);
+            That(requests.Count, Is.EqualTo(1));
+            That(requests[0].TemplateId, Is.EqualTo(66));
+            That(requests[0].HasCallerParams, Is.True);
+            That(requests[0].CallerParams.TryGetFloat(EffectParamKeys.TargetPosX, out float impactX), Is.True);
+            That(impactX, Is.EqualTo(0f).Within(0.01f));
+        }
+
+        [Test]
         public void BuiltinHandlers_CreateUnit_EnqueuesRuntimeSpawnRequests()
         {
             using var world = World.Create();


### PR DESCRIPTION
## Summary
- extend champion sandbox with catapult, arrow volley, skypiercer, cruise missile, boomerang, blink, dash, and hook showcase content
- add projectile runtime support for spread, turn-limited tracking, and boomerang return without introducing a generic mover abstraction
- add playable acceptance coverage, runtime regression tests, and acceptance artifacts for the new projectile/displacement lane

## Player-facing audit
- no blocking issues found for this branch from a player-facing second-pass audit
- projectile and displacement flows are readable, distinct, and now deterministic in the sandbox showcase
- non-blocking follow-up: architecture docs for displacement are a bit behind the shipped runtime, and some sandbox projectile visuals are still hand-authored in mod runtime

## Validation
- dotnet test src/Tests/GasTests/GasTests.csproj --filter FullyQualifiedName~ChampionSkillSandbox --no-restore
- dotnet test src/Tests/GasTests/GasTests.csproj --filter FullyQualifiedName~ProjectileRuntimeSystem_TrackTarget_MovesBeforeImpacting|FullyQualifiedName~ProjectileRuntimeSystem_ReturnToSource_MovesBeforeReturnImpact|FullyQualifiedName~ChampionSkillProjectiles_PlayableFlow_WritesAcceptanceArtifacts --no-restore

## Acceptance artifacts
- artifacts/acceptance/champion-skill-projectiles/battle-report.md
- artifacts/acceptance/champion-skill-projectiles/trace.jsonl
- artifacts/acceptance/champion-skill-projectiles/path.mmd
- artifacts/acceptance/champion-skill-projectiles/screens/*.svg