### PR TITLE
Add response chain showcase mod and launcher evidence

### DIFF
--- a/launcher.config.json
+++ b/launcher.config.json
@@ -40,6 +40,14 @@
         "value": "mods/showcases/champion_skill_stress_entry/ChampionSkillStressEntryMod",
         "projectPath": "ChampionSkillStressEntryMod.csproj"
       }
+    },
+    {
+      "name": "response_chain_showcase",
+      "target": {
+        "type": "path",
+        "value": "mods/showcases/response_chain/ResponseChainShowcaseMod",
+        "projectPath": "ResponseChainShowcaseMod.csproj"
+      }
     }
   ],
   "adapters": {

--- a/launcher.presets.json
+++ b/launcher.presets.json
@@ -54,6 +54,24 @@
       ],
       "adapterId": "raylib",
       "buildMode": "auto"
+    },
+    {
+      "id": "response_chain_showcase_raylib",
+      "name": "Response Chain Showcase Raylib",
+      "selectors": [
+        "$response_chain_showcase"
+      ],
+      "adapterId": "raylib",
+      "buildMode": "auto"
+    },
+    {
+      "id": "response_chain_showcase_web",
+      "name": "Response Chain Showcase Web",
+      "selectors": [
+        "$response_chain_showcase"
+      ],
+      "adapterId": "web",
+      "buildMode": "auto"
     }
   ]
 }

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/ChampionSkillSandboxModEntry.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/ChampionSkillSandboxModEntry.cs
@@ -3,6 +3,7 @@ using ChampionSkillSandboxMod.Runtime;
 using ChampionSkillSandboxMod.Triggers;
 using CoreInputMod.ViewMode;
 using Ludots.Core.Modding;
+using Ludots.Core.Physics2D.Config;
 using Ludots.Core.Scripting;
 
 namespace ChampionSkillSandboxMod
@@ -12,7 +13,7 @@ namespace ChampionSkillSandboxMod
         public void OnLoad(IModContext context)
         {
             context.Log("[ChampionSkillSandboxMod] Loaded");
-            ChampionSkillSandboxComponentAuthoring.Register(context.ModId);
+            Physics2DComponentAuthoring.Register(context.ModId);
 
             var runtime = new ChampionSkillSandboxRuntime();
             var toolbarProvider = new ChampionSkillCastModeToolbarProvider();

--- a/mods/showcases/response_chain/ResponseChainShowcaseMod/ResponseChainShowcaseIds.cs
+++ b/mods/showcases/response_chain/ResponseChainShowcaseMod/ResponseChainShowcaseIds.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace ResponseChainShowcaseMod
+{
+    internal static class ResponseChainShowcaseIds
+    {
+        public const string MapId = "response_chain_showcase";
+        public const string InputContextId = "ResponseChainShowcase.Controls";
+        public const string ResetActionId = "ResetShowcase";
+        public const string ResetRequestKey = "ResponseChainShowcase.ResetRequested";
+        public const string RuntimeInstalledKey = "ResponseChainShowcase.Installed";
+
+        public const string ConductorName = "Conductor";
+        public const string ComboRaiderName = "Combo Raider";
+        public const string CounterRaiderName = "Counter Raider";
+        public const string ScholarName = "Scholar";
+        public const string ProtectorName = "Protector";
+
+        public const string ComboOpenerEffect = "Effect.Showcase.Combo.Opener";
+        public const string ComboFollowUpEffect = "Effect.Showcase.Combo.FollowUp";
+        public const string CounterSwingEffect = "Effect.Showcase.Counter.Swing";
+        public const string CounterTakeHitEffect = "Effect.Showcase.Counter.TakeHit";
+        public const string CounterRiposteEffect = "Effect.Showcase.Counter.Riposte";
+        public const string CounterFlourishEffect = "Effect.Showcase.Counter.Flourish";
+        public const string RedirectBoltEffect = "Effect.Showcase.Redirect.Bolt";
+        public const string RedirectHitScholarEffect = "Effect.Showcase.Redirect.HitScholar";
+        public const string RedirectToGuardEffect = "Effect.Showcase.Redirect.ToGuard";
+        public const string RedirectFlourishEffect = "Effect.Showcase.Redirect.Flourish";
+
+        public static bool IsShowcaseMap(string? mapId)
+        {
+            return string.Equals(mapId, MapId, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/mods/showcases/response_chain/ResponseChainShowcaseMod/ResponseChainShowcaseMod.csproj
+++ b/mods/showcases/response_chain/ResponseChainShowcaseMod/ResponseChainShowcaseMod.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Core.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Physics2D\Ludots.Physics2D.csproj" />
+    <ProjectReference Include="..\..\..\CoreInputMod\CoreInputMod.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/mods/showcases/response_chain/ResponseChainShowcaseMod/ResponseChainShowcaseModEntry.cs
+++ b/mods/showcases/response_chain/ResponseChainShowcaseMod/ResponseChainShowcaseModEntry.cs
@@ -1,0 +1,29 @@
+using ResponseChainShowcaseMod.Runtime;
+using ResponseChainShowcaseMod.Triggers;
+using Ludots.Core.Modding;
+using Ludots.Core.Physics2D.Config;
+using Ludots.Core.Scripting;
+
+namespace ResponseChainShowcaseMod
+{
+    public sealed class ResponseChainShowcaseModEntry : IMod
+    {
+        public void OnLoad(IModContext context)
+        {
+            context.Log("[ResponseChainShowcaseMod] Loaded");
+            Physics2DComponentAuthoring.Register(context.ModId);
+
+            var runtime = new ResponseChainShowcaseRuntime();
+            context.OnEvent(
+                GameEvents.GameStart,
+                new InstallResponseChainShowcaseOnGameStartTrigger(context, runtime).ExecuteAsync);
+            context.OnEvent(GameEvents.MapLoaded, runtime.HandleMapFocusedAsync);
+            context.OnEvent(GameEvents.MapResumed, runtime.HandleMapFocusedAsync);
+            context.OnEvent(GameEvents.MapUnloaded, runtime.HandleMapUnloadedAsync);
+        }
+
+        public void OnUnload()
+        {
+        }
+    }
+}

--- a/mods/showcases/response_chain/ResponseChainShowcaseMod/Runtime/ResponseChainShowcaseRuntime.cs
+++ b/mods/showcases/response_chain/ResponseChainShowcaseMod/Runtime/ResponseChainShowcaseRuntime.cs
@@ -1,0 +1,344 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Threading.Tasks;
+using Arch.Core;
+using Ludots.Core.Components;
+using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.Input.Selection;
+using Ludots.Core.Mathematics.FixedPoint;
+using Ludots.Core.Presentation.Hud;
+using Ludots.Core.Presentation.Systems;
+using Ludots.Core.Scripting;
+
+namespace ResponseChainShowcaseMod.Runtime
+{
+    internal sealed class ResponseChainShowcaseRuntime
+    {
+        private const int OverlayPanelWidth = 520;
+        private const int OverlayPanelHeight = 248;
+
+        private readonly Dictionary<string, ShowcaseSnapshot> _snapshots = new(StringComparer.Ordinal);
+        private string _lastMapId = string.Empty;
+        private bool _selectionSeeded;
+        private bool _listenersInstalled;
+
+        public Task HandleMapFocusedAsync(ScriptContext context)
+        {
+            if (context.GetEngine() is GameEngine engine)
+            {
+                EnsureScenarioState(engine);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task HandleMapUnloadedAsync(ScriptContext context)
+        {
+            if (ResponseChainShowcaseIds.IsShowcaseMap(context.Get(CoreServiceKeys.MapId).Value))
+            {
+                Disable();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public void Update(GameEngine engine)
+        {
+            if (!ResponseChainShowcaseIds.IsShowcaseMap(engine.CurrentMapSession?.MapId.Value))
+            {
+                Disable();
+                return;
+            }
+
+            EnsureScenarioState(engine);
+            if (ConsumeResetRequest(engine))
+            {
+                ResetScenario(engine);
+            }
+
+            DrawOverlay(engine);
+        }
+
+        private void EnsureScenarioState(GameEngine engine)
+        {
+            string mapId = engine.CurrentMapSession?.MapId.Value ?? string.Empty;
+            if (!string.Equals(_lastMapId, mapId, StringComparison.OrdinalIgnoreCase))
+            {
+                _lastMapId = mapId;
+                _selectionSeeded = false;
+                _listenersInstalled = false;
+                _snapshots.Clear();
+            }
+
+            CaptureSnapshots(engine);
+            EnsureInitialSelection(engine);
+            EnsureResponseListeners(engine);
+        }
+
+        private void CaptureSnapshots(GameEngine engine)
+        {
+            CaptureSnapshot(engine, ResponseChainShowcaseIds.ConductorName);
+            CaptureSnapshot(engine, ResponseChainShowcaseIds.ComboRaiderName);
+            CaptureSnapshot(engine, ResponseChainShowcaseIds.CounterRaiderName);
+            CaptureSnapshot(engine, ResponseChainShowcaseIds.ScholarName);
+            CaptureSnapshot(engine, ResponseChainShowcaseIds.ProtectorName);
+        }
+
+        private void CaptureSnapshot(GameEngine engine, string name)
+        {
+            if (_snapshots.ContainsKey(name))
+            {
+                return;
+            }
+
+            Entity entity = FindEntityByName(engine.World, name);
+            if (entity == Entity.Null)
+            {
+                return;
+            }
+
+            int healthId = AttributeRegistry.GetId("Health");
+            float health = 0f;
+            if (healthId >= 0 && engine.World.Has<AttributeBuffer>(entity))
+            {
+                health = engine.World.Get<AttributeBuffer>(entity).GetCurrent(healthId);
+            }
+
+            Fix64Vec2 position = engine.World.Has<WorldPositionCm>(entity)
+                ? engine.World.Get<WorldPositionCm>(entity).Value
+                : default;
+
+            _snapshots[name] = new ShowcaseSnapshot(position, health);
+        }
+
+        private void EnsureInitialSelection(GameEngine engine)
+        {
+            if (_selectionSeeded)
+            {
+                return;
+            }
+
+            Entity conductor = FindEntityByName(engine.World, ResponseChainShowcaseIds.ConductorName);
+            if (conductor == Entity.Null)
+            {
+                return;
+            }
+
+            engine.GlobalContext[CoreServiceKeys.LocalPlayerEntity.Name] = conductor;
+
+            SelectionRuntime? selection = engine.GetService(CoreServiceKeys.SelectionRuntime);
+            if (selection != null)
+            {
+                Span<Entity> one = stackalloc Entity[1];
+                one[0] = conductor;
+                selection.ReplaceSelection(conductor, SelectionSetKeys.Ambient, one);
+                selection.TryBindView(conductor, SelectionViewKeys.Primary, conductor, SelectionSetKeys.Ambient);
+                engine.GlobalContext[CoreServiceKeys.SelectionViewViewerEntity.Name] = conductor;
+                engine.GlobalContext[CoreServiceKeys.SelectionViewKey.Name] = SelectionViewKeys.Primary;
+            }
+
+            _selectionSeeded = true;
+        }
+
+        private void EnsureResponseListeners(GameEngine engine)
+        {
+            if (_listenersInstalled)
+            {
+                return;
+            }
+
+            Entity conductor = FindEntityByName(engine.World, ResponseChainShowcaseIds.ConductorName);
+            Entity scholar = FindEntityByName(engine.World, ResponseChainShowcaseIds.ScholarName);
+            if (conductor == Entity.Null || scholar == Entity.Null)
+            {
+                return;
+            }
+
+            int comboTagId = TagRegistry.GetId(ResponseChainShowcaseIds.ComboOpenerEffect);
+            int counterTagId = TagRegistry.GetId(ResponseChainShowcaseIds.CounterSwingEffect);
+            int redirectTagId = TagRegistry.GetId(ResponseChainShowcaseIds.RedirectBoltEffect);
+            int comboFollowUpEffectId = EffectTemplateIdRegistry.GetId(ResponseChainShowcaseIds.ComboFollowUpEffect);
+            int counterTakeHitEffectId = EffectTemplateIdRegistry.GetId(ResponseChainShowcaseIds.CounterTakeHitEffect);
+            int counterRiposteEffectId = EffectTemplateIdRegistry.GetId(ResponseChainShowcaseIds.CounterRiposteEffect);
+            int counterFlourishEffectId = EffectTemplateIdRegistry.GetId(ResponseChainShowcaseIds.CounterFlourishEffect);
+            int redirectHitScholarEffectId = EffectTemplateIdRegistry.GetId(ResponseChainShowcaseIds.RedirectHitScholarEffect);
+            int redirectEffectId = EffectTemplateIdRegistry.GetId(ResponseChainShowcaseIds.RedirectToGuardEffect);
+            int redirectFlourishEffectId = EffectTemplateIdRegistry.GetId(ResponseChainShowcaseIds.RedirectFlourishEffect);
+            if (comboTagId <= 0 || counterTagId <= 0 || redirectTagId <= 0 ||
+                comboFollowUpEffectId <= 0 || counterTakeHitEffectId <= 0 || counterRiposteEffectId <= 0 ||
+                counterFlourishEffectId <= 0 || redirectHitScholarEffectId <= 0 || redirectEffectId <= 0 ||
+                redirectFlourishEffectId <= 0)
+            {
+                return;
+            }
+
+            var conductorListener = new ResponseChainListener();
+            conductorListener.Add(comboTagId, ResponseType.PromptInput, priority: 100, effectTemplateId: comboFollowUpEffectId);
+            conductorListener.Add(counterTagId, ResponseType.Chain, priority: 30, effectTemplateId: counterRiposteEffectId);
+            conductorListener.Add(counterTagId, ResponseType.Chain, priority: 20, effectTemplateId: counterTakeHitEffectId);
+            conductorListener.Add(counterTagId, ResponseType.PromptInput, priority: 100, effectTemplateId: counterFlourishEffectId);
+            WriteListener(engine.World, conductor, conductorListener);
+
+            var scholarListener = new ResponseChainListener();
+            scholarListener.Add(redirectTagId, ResponseType.Chain, priority: 30, effectTemplateId: redirectEffectId);
+            scholarListener.Add(redirectTagId, ResponseType.Chain, priority: 20, effectTemplateId: redirectHitScholarEffectId);
+            scholarListener.Add(redirectTagId, ResponseType.PromptInput, priority: 100, effectTemplateId: redirectFlourishEffectId);
+            WriteListener(engine.World, scholar, scholarListener);
+
+            _listenersInstalled = true;
+        }
+
+        private void ResetScenario(GameEngine engine)
+        {
+            if (engine.GetService(CoreServiceKeys.ResponseChainUiState) is ResponseChainUiState uiState &&
+                uiState.Visible)
+            {
+                return;
+            }
+
+            int healthId = AttributeRegistry.GetId("Health");
+            foreach ((string name, ShowcaseSnapshot snapshot) in _snapshots)
+            {
+                Entity entity = FindEntityByName(engine.World, name);
+                if (entity == Entity.Null)
+                {
+                    continue;
+                }
+
+                if (engine.World.Has<WorldPositionCm>(entity))
+                {
+                    var position = engine.World.Get<WorldPositionCm>(entity);
+                    position.Value = snapshot.Position;
+                    engine.World.Set(entity, position);
+                }
+
+                if (healthId >= 0 && engine.World.Has<AttributeBuffer>(entity))
+                {
+                    var attributes = engine.World.Get<AttributeBuffer>(entity);
+                    attributes.SetBase(healthId, snapshot.Health);
+                    attributes.SetCurrent(healthId, snapshot.Health);
+                    engine.World.Set(entity, attributes);
+                }
+
+                if (engine.World.Has<OrderBuffer>(entity))
+                {
+                    engine.World.Set(entity, OrderBuffer.CreateEmpty());
+                }
+            }
+        }
+
+        private void DrawOverlay(GameEngine engine)
+        {
+            ScreenOverlayBuffer? overlay = engine.GetService(CoreServiceKeys.ScreenOverlayBuffer);
+            if (overlay == null)
+            {
+                return;
+            }
+
+            float comboCurrent = ReadHealth(engine, ResponseChainShowcaseIds.ComboRaiderName);
+            float comboBase = ReadBaseHealth(ResponseChainShowcaseIds.ComboRaiderName);
+            float counterCurrent = ReadHealth(engine, ResponseChainShowcaseIds.CounterRaiderName);
+            float counterBase = ReadBaseHealth(ResponseChainShowcaseIds.CounterRaiderName);
+            float conductorCurrent = ReadHealth(engine, ResponseChainShowcaseIds.ConductorName);
+            float conductorBase = ReadBaseHealth(ResponseChainShowcaseIds.ConductorName);
+            float scholarCurrent = ReadHealth(engine, ResponseChainShowcaseIds.ScholarName);
+            float scholarBase = ReadBaseHealth(ResponseChainShowcaseIds.ScholarName);
+            float protectorCurrent = ReadHealth(engine, ResponseChainShowcaseIds.ProtectorName);
+            float protectorBase = ReadBaseHealth(ResponseChainShowcaseIds.ProtectorName);
+
+            string comboStatus = comboCurrent < comboBase ? "Resolved" : "Ready";
+            string counterStatus = counterCurrent < counterBase && conductorCurrent >= conductorBase ? "Resolved" : "Ready";
+            string redirectStatus = protectorCurrent < protectorBase && scholarCurrent >= scholarBase ? "Resolved" : "Ready";
+            bool windowOpen = engine.GetService(CoreServiceKeys.ResponseChainUiState) is ResponseChainUiState uiState && uiState.Visible;
+
+            Vector4 panelFill = new(0.04f, 0.07f, 0.09f, 0.88f);
+            Vector4 panelBorder = new(0.34f, 0.58f, 0.79f, 0.95f);
+            Vector4 title = new(0.97f, 0.84f, 0.42f, 1f);
+            Vector4 text = new(0.91f, 0.95f, 0.99f, 1f);
+            Vector4 hint = new(0.73f, 0.83f, 0.92f, 1f);
+            Vector4 good = new(0.48f, 0.94f, 0.58f, 1f);
+
+            int x = 18;
+            int y = 96;
+            overlay.AddRect(x, y, OverlayPanelWidth, OverlayPanelHeight, panelFill, panelBorder, stableId: 48100, dirtySerial: 1);
+            overlay.AddText(x + 16, y + 18, "Response Chain Showcase", 22, title, stableId: 48101, dirtySerial: 1);
+            overlay.AddText(x + 16, y + 48, "Q -> 1 -> Space -> Space | W/E -> N -> Space -> Space | F4 reset", 15, text, stableId: 48102, dirtySerial: 1);
+            overlay.AddText(x + 16, y + 72, "Window: 1 adds the combo follow-up, N negates the latest branch, double-Space resolves the window", 14, hint, stableId: 48103, dirtySerial: 1);
+            overlay.AddText(x + 16, y + 102, $"Combo Drill [{comboStatus}]  target={ResponseChainShowcaseIds.ComboRaiderName}  hp {comboCurrent:0}/{comboBase:0}", 14, comboStatus == "Resolved" ? good : text, stableId: 48104, dirtySerial: 1);
+            overlay.AddText(x + 16, y + 126, $"Counter Drill [{counterStatus}]  raider {counterCurrent:0}/{counterBase:0}  conductor {conductorCurrent:0}/{conductorBase:0}", 14, counterStatus == "Resolved" ? good : text, stableId: 48105, dirtySerial: 1);
+            overlay.AddText(x + 16, y + 150, $"Redirect Drill [{redirectStatus}]  scholar {scholarCurrent:0}/{scholarBase:0}  protector {protectorCurrent:0}/{protectorBase:0}", 14, redirectStatus == "Resolved" ? good : text, stableId: 48106, dirtySerial: 1);
+            overlay.AddText(x + 16, y + 182, "Play loop: click Conductor, hover marked ally/enemy, press ability, then answer the window.", 14, hint, stableId: 48107, dirtySerial: 1);
+            overlay.AddText(x + 16, y + 206, windowOpen ? "Response window open." : "Response window idle.", 14, windowOpen ? title : hint, stableId: 48108, dirtySerial: 1);
+        }
+
+        private float ReadHealth(GameEngine engine, string name)
+        {
+            Entity entity = FindEntityByName(engine.World, name);
+            if (entity == Entity.Null || !engine.World.Has<AttributeBuffer>(entity))
+            {
+                return 0f;
+            }
+
+            int healthId = AttributeRegistry.GetId("Health");
+            return healthId >= 0 ? engine.World.Get<AttributeBuffer>(entity).GetCurrent(healthId) : 0f;
+        }
+
+        private float ReadBaseHealth(string name)
+        {
+            return _snapshots.TryGetValue(name, out ShowcaseSnapshot snapshot) ? snapshot.Health : 0f;
+        }
+
+        private static void WriteListener(World world, Entity entity, ResponseChainListener listener)
+        {
+            if (world.Has<ResponseChainListener>(entity))
+            {
+                world.Set(entity, listener);
+                return;
+            }
+
+            world.Add(entity, listener);
+        }
+
+        private static Entity FindEntityByName(World world, string name)
+        {
+            Entity found = Entity.Null;
+            var query = new QueryDescription().WithAll<Name>();
+            world.Query(in query, (Entity entity, ref Name entityName) =>
+            {
+                if (found != Entity.Null || !string.Equals(entityName.Value, name, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                found = entity;
+            });
+            return found;
+        }
+
+        private static bool ConsumeResetRequest(GameEngine engine)
+        {
+            if (!engine.GlobalContext.TryGetValue(ResponseChainShowcaseIds.ResetRequestKey, out object? requestedObj) ||
+                requestedObj is not bool requested ||
+                !requested)
+            {
+                return false;
+            }
+
+            engine.GlobalContext.Remove(ResponseChainShowcaseIds.ResetRequestKey);
+            return true;
+        }
+
+        private void Disable()
+        {
+            _lastMapId = string.Empty;
+            _selectionSeeded = false;
+            _listenersInstalled = false;
+            _snapshots.Clear();
+        }
+
+        private readonly record struct ShowcaseSnapshot(Fix64Vec2 Position, float Health);
+    }
+}

--- a/mods/showcases/response_chain/ResponseChainShowcaseMod/Systems/ResponseChainShowcaseLocalOrderSourceSystem.cs
+++ b/mods/showcases/response_chain/ResponseChainShowcaseMod/Systems/ResponseChainShowcaseLocalOrderSourceSystem.cs
@@ -1,0 +1,96 @@
+using Arch.Core;
+using Arch.System;
+using CoreInputMod.Systems;
+using Ludots.Core.Gameplay.GAS.Orders;
+using Ludots.Core.Input.Orders;
+using Ludots.Core.Input.Runtime;
+using Ludots.Core.Modding;
+using Ludots.Core.Scripting;
+
+namespace ResponseChainShowcaseMod.Systems
+{
+    internal sealed class ResponseChainShowcaseLocalOrderSourceSystem : ISystem<float>
+    {
+        private readonly World _world;
+        private readonly Dictionary<string, object> _globals;
+        private readonly LocalOrderSourceHelper _helper;
+        private readonly IModContext _context;
+        private InputOrderMappingSystem? _mapping;
+        private bool _initialized;
+
+        public ResponseChainShowcaseLocalOrderSourceSystem(
+            World world,
+            Dictionary<string, object> globals,
+            OrderQueue orders,
+            IModContext context)
+        {
+            _world = world;
+            _globals = globals;
+            _context = context;
+            _helper = new LocalOrderSourceHelper(world, globals, orders);
+        }
+
+        public void Initialize()
+        {
+        }
+
+        public void BeforeUpdate(in float dt)
+        {
+        }
+
+        public void Update(in float dt)
+        {
+            EnsureInitialized();
+            if (_mapping == null)
+            {
+                return;
+            }
+
+            Entity actor = _helper.GetControlledActor();
+            if (!_world.IsAlive(actor))
+            {
+                return;
+            }
+
+            _mapping.SetLocalPlayer(actor, 1);
+            _mapping.Update(dt);
+
+            if (_globals.TryGetValue(CoreServiceKeys.AuthoritativeInput.Name, out object? inputObj) &&
+                inputObj is IInputActionReader input &&
+                input.PressedThisFrame(ResponseChainShowcaseIds.ResetActionId))
+            {
+                _globals[ResponseChainShowcaseIds.ResetRequestKey] = true;
+            }
+        }
+
+        public void AfterUpdate(in float dt)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+
+        private void EnsureInitialized()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            _initialized = true;
+            _mapping = _helper.TryCreateMapping(_context);
+            if (_mapping == null)
+            {
+                return;
+            }
+
+            _mapping.SetQueueModifierProvider(() =>
+            {
+                return _globals.TryGetValue(CoreServiceKeys.AuthoritativeInput.Name, out object? inputObj) &&
+                       inputObj is IInputActionReader input &&
+                       input.IsDown("QueueModifier");
+            });
+        }
+    }
+}

--- a/mods/showcases/response_chain/ResponseChainShowcaseMod/Systems/ResponseChainShowcasePresentationSystem.cs
+++ b/mods/showcases/response_chain/ResponseChainShowcaseMod/Systems/ResponseChainShowcasePresentationSystem.cs
@@ -1,0 +1,39 @@
+using Arch.System;
+using Ludots.Core.Engine;
+using ResponseChainShowcaseMod.Runtime;
+
+namespace ResponseChainShowcaseMod.Systems
+{
+    internal sealed class ResponseChainShowcasePresentationSystem : ISystem<float>
+    {
+        private readonly GameEngine _engine;
+        private readonly ResponseChainShowcaseRuntime _runtime;
+
+        public ResponseChainShowcasePresentationSystem(GameEngine engine, ResponseChainShowcaseRuntime runtime)
+        {
+            _engine = engine;
+            _runtime = runtime;
+        }
+
+        public void Initialize()
+        {
+        }
+
+        public void BeforeUpdate(in float dt)
+        {
+        }
+
+        public void Update(in float dt)
+        {
+            _runtime.Update(_engine);
+        }
+
+        public void AfterUpdate(in float dt)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/mods/showcases/response_chain/ResponseChainShowcaseMod/Triggers/InstallResponseChainShowcaseOnGameStartTrigger.cs
+++ b/mods/showcases/response_chain/ResponseChainShowcaseMod/Triggers/InstallResponseChainShowcaseOnGameStartTrigger.cs
@@ -1,0 +1,55 @@
+using System.Threading.Tasks;
+using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.GAS.Orders;
+using Ludots.Core.Gameplay.Teams;
+using Ludots.Core.Modding;
+using Ludots.Core.Scripting;
+using ResponseChainShowcaseMod.Runtime;
+using ResponseChainShowcaseMod.Systems;
+
+namespace ResponseChainShowcaseMod.Triggers
+{
+    internal sealed class InstallResponseChainShowcaseOnGameStartTrigger : Trigger
+    {
+        private readonly IModContext _context;
+        private readonly ResponseChainShowcaseRuntime _runtime;
+
+        public InstallResponseChainShowcaseOnGameStartTrigger(IModContext context, ResponseChainShowcaseRuntime runtime)
+        {
+            _context = context;
+            _runtime = runtime;
+            EventKey = GameEvents.GameStart;
+        }
+
+        public override Task ExecuteAsync(ScriptContext context)
+        {
+            GameEngine? engine = context.GetEngine();
+            if (engine == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            if (engine.GlobalContext.TryGetValue(ResponseChainShowcaseIds.RuntimeInstalledKey, out object? installedObj) &&
+                installedObj is bool installed &&
+                installed)
+            {
+                return Task.CompletedTask;
+            }
+
+            engine.GlobalContext[ResponseChainShowcaseIds.RuntimeInstalledKey] = true;
+            TeamManager.SetRelationshipSymmetric(1, 2, TeamRelationship.Hostile);
+
+            if (engine.GlobalContext.TryGetValue(CoreServiceKeys.OrderQueue.Name, out object? ordersObj) &&
+                ordersObj is OrderQueue orders)
+            {
+                engine.RegisterSystem(
+                    new ResponseChainShowcaseLocalOrderSourceSystem(engine.World, engine.GlobalContext, orders, _context),
+                    SystemGroup.InputCollection);
+            }
+
+            engine.RegisterPresentationSystem(new ResponseChainShowcasePresentationSystem(engine, _runtime));
+            _context.Log("[ResponseChainShowcaseMod] Registered local order source and showcase HUD runtime.");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/mods/showcases/response_chain/ResponseChainShowcaseMod/assets/Entities/templates.json
+++ b/mods/showcases/response_chain/ResponseChainShowcaseMod/assets/Entities/templates.json
@@ -1,0 +1,135 @@
+[
+  {
+    "id": "response_chain_showcase_conductor",
+    "components": {
+      "Name": { "Value": "Conductor" },
+      "Team": { "Id": 1 },
+      "PlayerOwner": { "PlayerId": 1 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } },
+      "FacingDirection": { "AngleRad": 0.0 },
+      "Presentation": {
+        "visualTemplateId": "core.character.hero_skinned",
+        "startupPerformerIds": [
+          "response_chain_showcase.marker.conductor"
+        ]
+      },
+      "AttributeBuffer": { "base": { "Health": 120, "Shield": 0, "MoveSpeed": 330, "Armor": 6 } },
+      "Collider2D": {
+        "shape": {
+          "type": "circle",
+          "radiusCm": 38
+        }
+      },
+      "PhysicsMaterial2D": {
+        "friction": 0.92,
+        "restitution": 0.0,
+        "baseDamping": 0.94
+      },
+      "NavKinematics2D": {
+        "maxAccelCmPerSec2": 1700,
+        "radiusCm": 38,
+        "neighborDistCm": 260,
+        "timeHorizonSec": 2.4,
+        "maxNeighbors": 16
+      },
+      "AbilityStateBuffer": {
+        "abilityIds": [
+          "Ability.Showcase.Combo.Drill",
+          "Ability.Showcase.Counter.Drill",
+          "Ability.Showcase.Redirect.Drill"
+        ]
+      },
+      "GameplayTagContainer": {},
+      "OrderBuffer": {},
+      "BlackboardSpatialBuffer": {},
+      "BlackboardEntityBuffer": {},
+      "BlackboardIntBuffer": {}
+    }
+  },
+  {
+    "id": "response_chain_showcase_enemy_raider",
+    "components": {
+      "Name": { "Value": "Enemy Raider" },
+      "Team": { "Id": 2 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } },
+      "FacingDirection": { "AngleRad": 0.0 },
+      "Presentation": { "visualTemplateId": "core.character.hero_skinned" },
+      "AttributeBuffer": { "base": { "Health": 80, "Shield": 0, "MoveSpeed": 0, "Armor": 2 } },
+      "Collider2D": {
+        "shape": {
+          "type": "circle",
+          "radiusCm": 38
+        }
+      },
+      "PhysicsMaterial2D": {
+        "friction": 0.92,
+        "restitution": 0.0,
+        "baseDamping": 0.94
+      },
+      "GameplayTagContainer": {},
+      "OrderBuffer": {}
+    }
+  },
+  {
+    "id": "response_chain_showcase_scholar",
+    "components": {
+      "Name": { "Value": "Scholar" },
+      "Team": { "Id": 1 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } },
+      "FacingDirection": { "AngleRad": 0.0 },
+      "Presentation": {
+        "visualTemplateId": "core.character.hero_skinned",
+        "startupPerformerIds": [
+          "response_chain_showcase.marker.scholar"
+        ]
+      },
+      "AttributeBuffer": { "base": { "Health": 90, "Shield": 0, "MoveSpeed": 0, "Armor": 1 } },
+      "Collider2D": {
+        "shape": {
+          "type": "circle",
+          "radiusCm": 36
+        }
+      },
+      "PhysicsMaterial2D": {
+        "friction": 0.92,
+        "restitution": 0.0,
+        "baseDamping": 0.94
+      },
+      "GameplayTagContainer": {},
+      "OrderBuffer": {}
+    }
+  },
+  {
+    "id": "response_chain_showcase_protector",
+    "components": {
+      "Name": { "Value": "Protector" },
+      "Team": { "Id": 1 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } },
+      "FacingDirection": { "AngleRad": 0.0 },
+      "Presentation": {
+        "visualTemplateId": "core.character.hero_skinned",
+        "startupPerformerIds": [
+          "response_chain_showcase.marker.protector"
+        ]
+      },
+      "AttributeBuffer": { "base": { "Health": 120, "Shield": 0, "MoveSpeed": 0, "Armor": 10 } },
+      "Collider2D": {
+        "shape": {
+          "type": "circle",
+          "radiusCm": 40
+        }
+      },
+      "PhysicsMaterial2D": {
+        "friction": 0.92,
+        "restitution": 0.0,
+        "baseDamping": 0.94
+      },
+      "GameplayTagContainer": {},
+      "OrderBuffer": {}
+    }
+  }
+]

--- a/mods/showcases/response_chain/ResponseChainShowcaseMod/assets/GAS/abilities.json
+++ b/mods/showcases/response_chain/ResponseChainShowcaseMod/assets/GAS/abilities.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "Ability.Showcase.Combo.Drill",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Showcase.Combo.Opener" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "indicator": {
+      "shape": "Circle",
+      "range": 560,
+      "radius": 110,
+      "showRangeCircle": true,
+      "validColor": "#F4B04A88",
+      "invalidColor": "#D65B5B88"
+    },
+    "presentation": {
+      "displayName": "Combo Drill",
+      "iconGlyph": "Q",
+      "accentColor": "#F4B04A",
+      "hintText": "Hover Combo Raider, cast, press 1, then double-space to resolve the finisher"
+    }
+  },
+  {
+    "id": "Ability.Showcase.Counter.Drill",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Showcase.Counter.Swing", "dispatchTarget": "Source" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "indicator": {
+      "shape": "Circle",
+      "range": 0,
+      "radius": 140,
+      "showRangeCircle": false,
+      "validColor": "#FF7E6B77",
+      "invalidColor": "#D65B5B88"
+    },
+    "presentation": {
+      "displayName": "Counter Drill",
+      "iconGlyph": "W",
+      "accentColor": "#FF7E6B",
+      "hintText": "Press N to cancel the incoming hit and keep the riposte"
+    }
+  },
+  {
+    "id": "Ability.Showcase.Redirect.Drill",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Showcase.Redirect.Bolt" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "indicator": {
+      "shape": "Circle",
+      "range": 560,
+      "radius": 110,
+      "showRangeCircle": true,
+      "validColor": "#6EC7E688",
+      "invalidColor": "#D65B5B88"
+    },
+    "presentation": {
+      "displayName": "Redirect Drill",
+      "iconGlyph": "E",
+      "accentColor": "#6EC7E6",
+      "hintText": "Hover Scholar, then press N so the fixed guard line takes the hit"
+    }
+  }
+]

--- a/mods/showcases/response_chain/ResponseChainShowcaseMod/assets/GAS/effects.json
+++ b/mods/showcases/response_chain/ResponseChainShowcaseMod/assets/GAS/effects.json
@@ -1,0 +1,188 @@
+[
+  {
+    "id": "Effect.Showcase.Combo.Opener",
+    "tags": ["Effect.Showcase.Combo.Opener"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -12.0 }
+    ]
+  },
+  {
+    "id": "Effect.Showcase.Combo.FollowUp",
+    "tags": ["Effect.Showcase.Combo.FollowUp"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -18.0 }
+    ]
+  },
+  {
+    "id": "Effect.Showcase.Counter.Swing",
+    "tags": ["Effect.Showcase.Counter.Swing"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": 0.0 }
+    ]
+  },
+  {
+    "id": "Effect.Showcase.Counter.TakeHit",
+    "tags": ["Effect.Showcase.Counter.TakeHit"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -10.0 }
+    ]
+  },
+  {
+    "id": "Effect.Showcase.Counter.Riposte",
+    "tags": ["Effect.Showcase.Counter.Riposte"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "targetQuery": {
+      "kind": "BuiltinSpatial",
+      "shape": "Circle",
+      "radius": 520
+    },
+    "targetFilter": {
+      "relationFilter": "Hostile",
+      "excludeSource": true,
+      "maxTargets": 1
+    },
+    "targetDispatch": {
+      "payloadEffect": "Effect.Showcase.Counter.RiposteHit"
+    }
+  },
+  {
+    "id": "Effect.Showcase.Counter.RiposteHit",
+    "tags": ["Effect.Showcase.Counter.RiposteHit"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -16.0 }
+    ]
+  },
+  {
+    "id": "Effect.Showcase.Counter.Flourish",
+    "tags": ["Effect.Showcase.Counter.Flourish"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "targetQuery": {
+      "kind": "BuiltinSpatial",
+      "shape": "Circle",
+      "radius": 520
+    },
+    "targetFilter": {
+      "relationFilter": "Hostile",
+      "excludeSource": true,
+      "maxTargets": 1
+    },
+    "targetDispatch": {
+      "payloadEffect": "Effect.Showcase.Counter.FlourishHit"
+    }
+  },
+  {
+    "id": "Effect.Showcase.Counter.FlourishHit",
+    "tags": ["Effect.Showcase.Counter.FlourishHit"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -6.0 }
+    ]
+  },
+  {
+    "id": "Effect.Showcase.Redirect.Bolt",
+    "tags": ["Effect.Showcase.Redirect.Bolt"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": 0.0 }
+    ]
+  },
+  {
+    "id": "Effect.Showcase.Redirect.HitScholar",
+    "tags": ["Effect.Showcase.Redirect.HitScholar"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -14.0 }
+    ]
+  },
+  {
+    "id": "Effect.Showcase.Redirect.ToGuard",
+    "tags": ["Effect.Showcase.Redirect.ToGuard"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "targetQuery": {
+      "kind": "BuiltinSpatial",
+      "shape": "Ring",
+      "radius": 540,
+      "innerRadius": 360
+    },
+    "targetFilter": {
+      "relationFilter": "Friendly",
+      "excludeSource": false,
+      "maxTargets": 1
+    },
+    "targetDispatch": {
+      "payloadEffect": "Effect.Showcase.Redirect.GuardHit",
+      "contextMapping": {
+        "payloadSource": "OriginalSource",
+        "payloadTarget": "ResolvedEntity",
+        "payloadTargetContext": "OriginalTarget"
+      }
+    }
+  },
+  {
+    "id": "Effect.Showcase.Redirect.GuardHit",
+    "tags": ["Effect.Showcase.Redirect.GuardHit"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -14.0 }
+    ]
+  },
+  {
+    "id": "Effect.Showcase.Redirect.Flourish",
+    "tags": ["Effect.Showcase.Redirect.Flourish"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "targetQuery": {
+      "kind": "BuiltinSpatial",
+      "shape": "Circle",
+      "radius": 540
+    },
+    "targetFilter": {
+      "relationFilter": "Hostile",
+      "excludeSource": true,
+      "maxTargets": 1
+    },
+    "targetDispatch": {
+      "payloadEffect": "Effect.Showcase.Redirect.FlourishHit"
+    }
+  },
+  {
+    "id": "Effect.Showcase.Redirect.FlourishHit",
+    "tags": ["Effect.Showcase.Redirect.FlourishHit"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -6.0 }
+    ]
+  }
+]

--- a/mods/showcases/response_chain/ResponseChainShowcaseMod/assets/Input/default_input.json
+++ b/mods/showcases/response_chain/ResponseChainShowcaseMod/assets/Input/default_input.json
@@ -1,0 +1,23 @@
+{
+  "actions": [
+    { "id": "SkillQ", "name": "ResponseChainShowcase_SkillQ", "type": "Button" },
+    { "id": "SkillW", "name": "ResponseChainShowcase_SkillW", "type": "Button" },
+    { "id": "SkillE", "name": "ResponseChainShowcase_SkillE", "type": "Button" },
+    { "id": "QueueModifier", "name": "ResponseChainShowcase_QueueModifier", "type": "Button" },
+    { "id": "ResetShowcase", "name": "ResponseChainShowcase_Reset", "type": "Button" }
+  ],
+  "contexts": [
+    {
+      "id": "ResponseChainShowcase.Controls",
+      "name": "Response Chain Showcase Controls",
+      "priority": 90,
+      "bindings": [
+        { "actionId": "SkillQ", "path": "<Keyboard>/q" },
+        { "actionId": "SkillW", "path": "<Keyboard>/w" },
+        { "actionId": "SkillE", "path": "<Keyboard>/e" },
+        { "actionId": "QueueModifier", "path": "<Keyboard>/leftShift" },
+        { "actionId": "ResetShowcase", "path": "<Keyboard>/f4" }
+      ]
+    }
+  ]
+}

--- a/mods/showcases/response_chain/ResponseChainShowcaseMod/assets/Input/input_order_mappings.json
+++ b/mods/showcases/response_chain/ResponseChainShowcaseMod/assets/Input/input_order_mappings.json
@@ -1,0 +1,45 @@
+{
+  "interactionMode": "SmartCast",
+  "mappings": [
+    {
+      "actionId": "SkillQ",
+      "trigger": "PressedThisFrame",
+      "orderTypeKey": "castAbility",
+      "argsTemplate": { "i0": 0 },
+      "requireSelection": false,
+      "selectionType": "Position",
+      "autoTargetPolicy": "NearestEnemyInRange",
+      "autoTargetRangeCm": 600,
+      "cursorTargetPolicy": "NearestEnemyInRange",
+      "cursorTargetRangeCm": 220,
+      "isSkillMapping": true,
+      "modifierBehavior": "QueueOnModifier"
+    },
+    {
+      "actionId": "SkillW",
+      "trigger": "PressedThisFrame",
+      "orderTypeKey": "castAbility",
+      "argsTemplate": { "i0": 1 },
+      "requireSelection": false,
+      "selectionType": "None",
+      "isSkillMapping": true,
+      "modifierBehavior": "QueueOnModifier"
+    },
+    {
+      "actionId": "SkillE",
+      "trigger": "PressedThisFrame",
+      "orderTypeKey": "castAbility",
+      "argsTemplate": { "i0": 2 },
+      "requireSelection": false,
+      "selectionType": "Position",
+      "cursorTargetPolicy": "NearestEnemyInRange",
+      "cursorTargetRangeCm": 0,
+      "isSkillMapping": true,
+      "modifierBehavior": "QueueOnModifier"
+    }
+  ],
+  "userOverrides": {
+    "enabled": true,
+    "persistPath": "user://ResponseChainShowcaseMod/input_preferences.json"
+  }
+}

--- a/mods/showcases/response_chain/ResponseChainShowcaseMod/assets/Maps/response_chain_showcase.json
+++ b/mods/showcases/response_chain/ResponseChainShowcaseMod/assets/Maps/response_chain_showcase.json
@@ -1,0 +1,61 @@
+{
+  "Id": "response_chain_showcase",
+  "Tags": ["showcase.response-chain", "showcase.qte"],
+  "DefaultCamera": {
+    "VirtualCameraId": "Camera.Profile.Tactical",
+    "TargetXCm": 1400,
+    "TargetYCm": 1020,
+    "DistanceCm": 3600,
+    "Pitch": 54,
+    "FovYDeg": 42
+  },
+  "Entities": [
+    {
+      "Template": "response_chain_showcase_conductor",
+      "Overrides": {
+        "Name": { "Value": "Conductor" },
+        "WorldPositionCm": { "Value": { "X": 1180, "Y": 980 } }
+      }
+    },
+    {
+      "Template": "response_chain_showcase_enemy_raider",
+      "Overrides": {
+        "Name": { "Value": "Combo Raider" },
+        "Presentation": {
+          "visualTemplateId": "core.character.hero_skinned",
+          "startupPerformerIds": [
+            "response_chain_showcase.marker.combo"
+          ]
+        },
+        "WorldPositionCm": { "Value": { "X": 1680, "Y": 760 } }
+      }
+    },
+    {
+      "Template": "response_chain_showcase_enemy_raider",
+      "Overrides": {
+        "Name": { "Value": "Counter Raider" },
+        "Presentation": {
+          "visualTemplateId": "core.character.hero_skinned",
+          "startupPerformerIds": [
+            "response_chain_showcase.marker.counter"
+          ]
+        },
+        "WorldPositionCm": { "Value": { "X": 1460, "Y": 1120 } }
+      }
+    },
+    {
+      "Template": "response_chain_showcase_scholar",
+      "Overrides": {
+        "Name": { "Value": "Scholar" },
+        "WorldPositionCm": { "Value": { "X": 1240, "Y": 1320 } }
+      }
+    },
+    {
+      "Template": "response_chain_showcase_protector",
+      "Overrides": {
+        "Name": { "Value": "Protector" },
+        "WorldPositionCm": { "Value": { "X": 1490, "Y": 1320 } }
+      }
+    }
+  ]
+}

--- a/mods/showcases/response_chain/ResponseChainShowcaseMod/assets/Presentation/performers.json
+++ b/mods/showcases/response_chain/ResponseChainShowcaseMod/assets/Presentation/performers.json
@@ -1,0 +1,87 @@
+[
+  {
+    "id": "response_chain_showcase.marker.conductor",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Ring",
+    "defaultColor": [0.35, 0.83, 1.0, 0.18],
+    "defaultScale": 1.12,
+    "defaultLifetime": -1,
+    "positionOffset": [0, 0.04, 0],
+    "bindings": [
+      { "paramKey": 1, "source": "constant", "constantValue": 0.72 },
+      { "paramKey": 8, "source": "constant", "constantValue": 0.35 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.83 },
+      { "paramKey": 10, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.04 }
+    ]
+  },
+  {
+    "id": "response_chain_showcase.marker.combo",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Ring",
+    "defaultColor": [0.96, 0.68, 0.24, 0.18],
+    "defaultScale": 1.18,
+    "defaultLifetime": -1,
+    "positionOffset": [0, 0.04, 0],
+    "bindings": [
+      { "paramKey": 1, "source": "constant", "constantValue": 0.86 },
+      { "paramKey": 8, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.71 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.29 },
+      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.05 }
+    ]
+  },
+  {
+    "id": "response_chain_showcase.marker.counter",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Ring",
+    "defaultColor": [0.96, 0.44, 0.35, 0.18],
+    "defaultScale": 1.18,
+    "defaultLifetime": -1,
+    "positionOffset": [0, 0.04, 0],
+    "bindings": [
+      { "paramKey": 1, "source": "constant", "constantValue": 0.86 },
+      { "paramKey": 8, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.47 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.38 },
+      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.05 }
+    ]
+  },
+  {
+    "id": "response_chain_showcase.marker.scholar",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Ring",
+    "defaultColor": [0.41, 0.78, 0.9, 0.16],
+    "defaultScale": 1.12,
+    "defaultLifetime": -1,
+    "positionOffset": [0, 0.04, 0],
+    "bindings": [
+      { "paramKey": 1, "source": "constant", "constantValue": 0.74 },
+      { "paramKey": 8, "source": "constant", "constantValue": 0.43 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.83 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.93 },
+      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.04 }
+    ]
+  },
+  {
+    "id": "response_chain_showcase.marker.protector",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Ring",
+    "defaultColor": [0.44, 0.89, 0.58, 0.18],
+    "defaultScale": 1.16,
+    "defaultLifetime": -1,
+    "positionOffset": [0, 0.04, 0],
+    "bindings": [
+      { "paramKey": 1, "source": "constant", "constantValue": 0.8 },
+      { "paramKey": 8, "source": "constant", "constantValue": 0.47 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.95 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.61 },
+      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.045 }
+    ]
+  }
+]

--- a/mods/showcases/response_chain/ResponseChainShowcaseMod/assets/game.json
+++ b/mods/showcases/response_chain/ResponseChainShowcaseMod/assets/game.json
@@ -1,0 +1,7 @@
+{
+  "startupMapId": "response_chain_showcase",
+  "startupInputContexts": [
+    "Default_Gameplay",
+    "ResponseChainShowcase.Controls"
+  ]
+}

--- a/mods/showcases/response_chain/ResponseChainShowcaseMod/mod.json
+++ b/mods/showcases/response_chain/ResponseChainShowcaseMod/mod.json
@@ -1,0 +1,14 @@
+{
+  "name": "ResponseChainShowcaseMod",
+  "version": "1.0.0",
+  "description": "Playable response-chain showcase for combo, counter, and redirect drills built on the production GAS and response window stack.",
+  "main": "bin/net8.0/ResponseChainShowcaseMod.dll",
+  "priority": 200,
+  "dependencies": {
+    "LudotsCoreMod": "^1.0.0",
+    "CoreInputMod": "^1.0.0",
+    "CameraProfilesMod": "^1.0.0"
+  },
+  "author": "Ludots Team",
+  "tags": ["showcase", "response-chain", "gas", "qte", "effects"]
+}

--- a/src/Core/Ludots.Physics2D/Config/Physics2DComponentAuthoring.cs
+++ b/src/Core/Ludots.Physics2D/Config/Physics2DComponentAuthoring.cs
@@ -4,15 +4,13 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Arch.Core;
 using Arch.Core.Extensions;
-using Ludots.Core.Config;
 using Ludots.Core.Mathematics.FixedPoint;
 using Ludots.Core.Navigation2D.Components;
-using Ludots.Core.Physics2D;
 using Ludots.Core.Physics2D.Components;
 
-namespace ChampionSkillSandboxMod.Runtime
+namespace Ludots.Core.Physics2D.Config
 {
-    internal static class ChampionSkillSandboxComponentAuthoring
+    public static class Physics2DComponentAuthoring
     {
         public static void Register(string modId)
         {

--- a/src/Tests/GasTests/GasTests.csproj
+++ b/src/Tests/GasTests/GasTests.csproj
@@ -53,6 +53,7 @@
     <ProjectReference Include="..\..\..\mods\showcases\camera\CameraShowcaseMod\CameraShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\interaction\InteractionShowcaseMod\InteractionShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\champion_skill_sandbox\ChampionSkillSandboxMod\ChampionSkillSandboxMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\response_chain\ResponseChainShowcaseMod\ResponseChainShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\ux_prototype\UxPrototypeMod\UxPrototypeMod.csproj" />
     <ProjectReference Include="..\..\..\mods\Navigation2DPlaygroundMod\Navigation2DPlaygroundMod.csproj" />
     <ProjectReference Include="..\..\Libraries\Ludots.UI.Skia\Ludots.UI.Skia.csproj" />

--- a/src/Tests/GasTests/Production/ResponseChainShowcasePlayableAcceptanceTests.cs
+++ b/src/Tests/GasTests/Production/ResponseChainShowcasePlayableAcceptanceTests.cs
@@ -1,0 +1,598 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Text.Json;
+using Arch.Core;
+using Ludots.Core.Components;
+using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.Components;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS;
+using Ludots.Core.Gameplay.GAS.Presentation;
+using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.Input.Config;
+using Ludots.Core.Input.Runtime;
+using Ludots.Core.Input.Selection;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Presentation.Camera;
+using Ludots.Core.Presentation.Systems;
+using Ludots.Core.Scripting;
+using Ludots.Core.Systems;
+using Ludots.Platform.Abstractions;
+using NUnit.Framework;
+
+namespace Ludots.Tests.GAS.Production
+{
+    [NonParallelizable]
+    [TestFixture]
+    public sealed class ResponseChainShowcasePlayableAcceptanceTests
+    {
+        private const float DeltaTime = 1f / 60f;
+        private const string MapId = "response_chain_showcase";
+        private const string TestInputBackendKey = "Tests.ResponseChainShowcase.InputBackend";
+
+        private static readonly string[] AcceptanceMods =
+        {
+            "LudotsCoreMod",
+            "CoreInputMod",
+            "CameraProfilesMod",
+            "ResponseChainShowcaseMod"
+        };
+
+        [Test]
+        public void ResponseChainShowcase_PlayableFlow_WritesAcceptanceArtifacts()
+        {
+            string repoRoot = FindRepoRoot();
+            string artifactDir = Path.Combine(repoRoot, "artifacts", "acceptance", "response-chain-showcase");
+            Directory.CreateDirectory(artifactDir);
+
+            var frameTimesMs = new List<double>();
+            var timeline = new List<string>();
+            var snapshots = new List<AcceptanceSnapshot>();
+
+            using var engine = CreateEngine();
+            var backend = GetInputBackend(engine);
+
+            LoadMap(engine, MapId, frameTimesMs);
+            Assert.That(engine.TriggerManager.Errors.Count, Is.EqualTo(0));
+            Assert.That(GetSelectedEntityName(engine), Is.EqualTo("Conductor"));
+            CaptureSnapshot(engine, snapshots, "map_loaded");
+            timeline.Add("[T+001] response_chain_showcase loaded | Conductor auto-selected | HUD and response-window stack live");
+
+            float comboBefore = ReadHealth(engine.World, "Combo Raider");
+            SetMouseWorld(engine, backend, GetEntityScreen(engine, "Combo Raider"), frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/q", frameTimesMs);
+            TickUntil(engine, frameTimesMs, () => GetUiState(engine).Visible, maxFrames: 18);
+            PressButton(engine, backend, "<Keyboard>/1", frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/space", frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/space", frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => ReadHealth(engine.World, "Combo Raider") < comboBefore,
+                maxFrames: 24,
+                failureMessageFactory: () => BuildResponseDiagnostics(engine));
+            float comboAfter = ReadHealth(engine.World, "Combo Raider");
+            Assert.That(comboAfter, Is.LessThan(comboBefore));
+            CaptureSnapshot(engine, snapshots, "combo_finished");
+            timeline.Add($"[T+002] Q on Combo Raider -> 1 follow-up -> pass-pass resolve | HP {comboBefore:0} -> {comboAfter:0}");
+
+            PressButton(engine, backend, "<Keyboard>/f4", frameTimesMs);
+            TickUntil(engine, frameTimesMs, () => Math.Abs(ReadHealth(engine.World, "Combo Raider") - comboBefore) < 0.01f, maxFrames: 18);
+            CaptureSnapshot(engine, snapshots, "after_reset_one");
+            timeline.Add("[T+003] F4 reset restored the drill board to its baseline state");
+
+            float conductorBeforeCounter = ReadHealth(engine.World, "Conductor");
+            float counterBefore = ReadHealth(engine.World, "Counter Raider");
+            PressButton(engine, backend, "<Keyboard>/w", frameTimesMs);
+            TickUntil(engine, frameTimesMs, () => GetUiState(engine).Visible, maxFrames: 18);
+            PressButton(engine, backend, "<Keyboard>/n", frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/space", frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/space", frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => !GetUiState(engine).Visible &&
+                      ReadHealth(engine.World, "Counter Raider") < counterBefore,
+                maxFrames: 32,
+                failureMessageFactory: () => BuildResponseDiagnostics(engine));
+            float conductorAfterCounter = ReadHealth(engine.World, "Conductor");
+            float counterAfter = ReadHealth(engine.World, "Counter Raider");
+            Assert.That(counterAfter, Is.LessThan(counterBefore));
+            Assert.That(conductorAfterCounter, Is.EqualTo(conductorBeforeCounter).Within(0.01f));
+            CaptureSnapshot(engine, snapshots, "counter_parried");
+            timeline.Add($"[T+004] W self-window -> N parry -> pass-pass close | Conductor {conductorBeforeCounter:0} stays intact, Counter Raider {counterBefore:0} -> {counterAfter:0}");
+
+            PressButton(engine, backend, "<Keyboard>/f4", frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => Math.Abs(ReadHealth(engine.World, "Counter Raider") - counterBefore) < 0.01f &&
+                      Math.Abs(ReadHealth(engine.World, "Conductor") - conductorBeforeCounter) < 0.01f,
+                maxFrames: 18);
+            CaptureSnapshot(engine, snapshots, "after_reset_two");
+            timeline.Add("[T+005] F4 reset restored both the duelist and the counter lane");
+
+            float scholarBefore = ReadHealth(engine.World, "Scholar");
+            float protectorBefore = ReadHealth(engine.World, "Protector");
+            SetMouseWorld(engine, backend, GetEntityScreen(engine, "Scholar"), frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/e", frameTimesMs);
+            TickUntil(engine, frameTimesMs, () => GetUiState(engine).Visible, maxFrames: 18);
+            PressButton(engine, backend, "<Keyboard>/n", frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/space", frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/space", frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => !GetUiState(engine).Visible &&
+                      ReadHealth(engine.World, "Protector") < protectorBefore,
+                maxFrames: 32,
+                failureMessageFactory: () => BuildResponseDiagnostics(engine));
+            float scholarAfter = ReadHealth(engine.World, "Scholar");
+            float protectorAfter = ReadHealth(engine.World, "Protector");
+            Assert.That(scholarAfter, Is.EqualTo(scholarBefore).Within(0.01f));
+            Assert.That(protectorAfter, Is.LessThan(protectorBefore));
+            CaptureSnapshot(engine, snapshots, "redirect_intercepted");
+            timeline.Add($"[T+006] E on Scholar -> N fixed intercept -> pass-pass close | Scholar {scholarBefore:0} stays clean, Protector {protectorBefore:0} -> {protectorAfter:0}");
+
+            File.WriteAllText(Path.Combine(artifactDir, "trace.jsonl"), BuildTraceJsonl(snapshots));
+            File.WriteAllText(Path.Combine(artifactDir, "battle-report.md"), BuildBattleReport(timeline, snapshots, frameTimesMs));
+            File.WriteAllText(Path.Combine(artifactDir, "path.mmd"), BuildPathMermaid());
+        }
+
+        private static GameEngine CreateEngine()
+        {
+            string repoRoot = FindRepoRoot();
+            string assetsRoot = Path.Combine(repoRoot, "assets");
+            var modPaths = RepoModPaths.ResolveExplicit(repoRoot, AcceptanceMods);
+
+            var engine = new GameEngine();
+            engine.InitializeWithConfigPipeline(modPaths, assetsRoot);
+            InstallInput(engine);
+
+            var view = new StubViewController(1920f, 1080f);
+            engine.SetService(CoreServiceKeys.ViewController, view);
+            engine.SetService(CoreServiceKeys.ScreenRayProvider, new WorldMappedScreenRayProvider());
+            engine.SetService(CoreServiceKeys.ScreenProjector, new WorldMappedScreenProjector());
+
+            var culling = new CameraCullingSystem(engine.World, engine.GameSession.Camera, engine.SpatialQueries, view);
+            engine.RegisterPresentationSystem(culling);
+            engine.SetService(CoreServiceKeys.CameraCullingDebugState, culling.DebugState);
+
+            engine.Start();
+            return engine;
+        }
+
+        private static void InstallInput(GameEngine engine)
+        {
+            var inputConfig = new InputConfigPipelineLoader(engine.ConfigPipeline).Load();
+            var backend = new TestInputBackend();
+            var inputHandler = new PlayerInputHandler(backend, inputConfig);
+            for (int i = 0; i < engine.MergedConfig.StartupInputContexts.Count; i++)
+            {
+                inputHandler.PushContext(engine.MergedConfig.StartupInputContexts[i]);
+            }
+
+            engine.SetService(CoreServiceKeys.InputHandler, inputHandler);
+            engine.SetService(CoreServiceKeys.InputBackend, (IInputBackend)backend);
+            engine.SetService(CoreServiceKeys.UiCaptured, false);
+            engine.GlobalContext[TestInputBackendKey] = backend;
+        }
+
+        private static void LoadMap(GameEngine engine, string mapId, List<double> frameTimesMs, int frames = 6)
+        {
+            engine.LoadMap(mapId);
+            Assert.That(engine.CurrentMapSession, Is.Not.Null, $"{mapId} should create a live map session.");
+            Tick(engine, frames, frameTimesMs);
+        }
+
+        private static void Tick(GameEngine engine, int frames, List<double> frameTimesMs)
+        {
+            for (int i = 0; i < frames; i++)
+            {
+                long t0 = Stopwatch.GetTimestamp();
+                engine.Tick(DeltaTime);
+                frameTimesMs.Add((Stopwatch.GetTimestamp() - t0) * 1000d / Stopwatch.Frequency);
+            }
+        }
+
+        private static void TickUntil(
+            GameEngine engine,
+            List<double> frameTimesMs,
+            Func<bool> predicate,
+            int maxFrames,
+            Func<string>? failureMessageFactory = null)
+        {
+            for (int i = 0; i < maxFrames; i++)
+            {
+                if (predicate())
+                {
+                    return;
+                }
+
+                Tick(engine, 1, frameTimesMs);
+            }
+
+            string detail = failureMessageFactory?.Invoke() ?? string.Empty;
+            Assert.That(
+                predicate(),
+                Is.True,
+                $"Predicate was not satisfied within {maxFrames} frames.{(string.IsNullOrWhiteSpace(detail) ? string.Empty : $" {detail}")}");
+        }
+
+        private static TestInputBackend GetInputBackend(GameEngine engine)
+        {
+            return engine.GlobalContext[TestInputBackendKey] as TestInputBackend
+                ?? throw new InvalidOperationException("Response-chain showcase test input backend is missing.");
+        }
+
+        private static void PressButton(GameEngine engine, TestInputBackend backend, string path, List<double> frameTimesMs)
+        {
+            backend.SetButton(path, true);
+            Tick(engine, 2, frameTimesMs);
+            backend.SetButton(path, false);
+            Tick(engine, 2, frameTimesMs);
+        }
+
+        private static void SetMouseWorld(GameEngine engine, TestInputBackend backend, Vector2 screenPosition, List<double> frameTimesMs)
+        {
+            backend.SetMousePosition(screenPosition);
+            Tick(engine, 1, frameTimesMs);
+        }
+
+        private static Vector2 GetEntityScreen(GameEngine engine, string name)
+        {
+            Entity entity = FindEntityByName(engine.World, name);
+            Assert.That(entity, Is.Not.EqualTo(Entity.Null), $"Entity '{name}' was not found.");
+
+            var projector = engine.GetService(CoreServiceKeys.ScreenProjector)
+                ?? throw new InvalidOperationException("ScreenProjector was not installed.");
+            ref var position = ref engine.World.Get<WorldPositionCm>(entity);
+            return projector.WorldToScreen(WorldUnits.WorldCmToVisualMeters(position.Value, yMeters: 0f));
+        }
+
+        private static string GetSelectedEntityName(GameEngine engine)
+        {
+            if (SelectionContextRuntime.TryGetCurrentPrimary(engine.World, engine.GlobalContext, out Entity selected) &&
+                engine.World.TryGet(selected, out Name name))
+            {
+                return name.Value;
+            }
+
+            return string.Empty;
+        }
+
+        private static ResponseChainUiState GetUiState(GameEngine engine)
+        {
+            return engine.GetService(CoreServiceKeys.ResponseChainUiState)
+                ?? throw new InvalidOperationException("ResponseChainUiState service missing.");
+        }
+
+        private static Entity FindEntityByName(World world, string name)
+        {
+            Entity result = Entity.Null;
+            var query = new QueryDescription().WithAll<Name>();
+            world.Query(in query, (Entity entity, ref Name entityName) =>
+            {
+                if (result == Entity.Null &&
+                    string.Equals(entityName.Value, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    result = entity;
+                }
+            });
+            return result;
+        }
+
+        private static float ReadHealth(World world, string name)
+        {
+            Entity entity = FindEntityByName(world, name);
+            Assert.That(entity, Is.Not.EqualTo(Entity.Null), $"Entity '{name}' was not found.");
+
+            int healthId = AttributeRegistry.GetId("Health");
+            if (healthId < 0 || !world.TryGet(entity, out AttributeBuffer attributes))
+            {
+                return 0f;
+            }
+
+            return attributes.GetCurrent(healthId);
+        }
+
+        private static string BuildResponseDiagnostics(GameEngine engine)
+        {
+            string selected = GetSelectedEntityName(engine);
+            string hovered = GetHoveredEntityName(engine);
+            ResponseChainUiState ui = GetUiState(engine);
+            string telemetry = BuildResponseTelemetryDiagnostics(engine);
+            string gas = BuildGasEventDiagnostics(engine);
+
+            return string.Join(
+                " || ",
+                $"selected={selected}",
+                $"hovered={hovered}",
+                $"uiVisible={ui.Visible}",
+                $"promptTagId={ui.PromptTagId}",
+                $"combo={ReadHealth(engine.World, "Combo Raider"):0.##}",
+                $"counter={ReadHealth(engine.World, "Counter Raider"):0.##}",
+                $"scholar={ReadHealth(engine.World, "Scholar"):0.##}",
+                $"protector={ReadHealth(engine.World, "Protector"):0.##}",
+                telemetry,
+                gas);
+        }
+
+        private static string GetHoveredEntityName(GameEngine engine)
+        {
+            if (engine.GlobalContext.TryGetValue(CoreServiceKeys.HoveredEntity.Name, out object? hoveredObj) &&
+                hoveredObj is Entity hovered &&
+                engine.World.IsAlive(hovered) &&
+                engine.World.TryGet(hovered, out Name name))
+            {
+                return name.Value;
+            }
+
+            return string.Empty;
+        }
+
+        private static string BuildResponseTelemetryDiagnostics(GameEngine engine)
+        {
+            ResponseChainTelemetryBuffer? telemetry = engine.GetService(CoreServiceKeys.ResponseChainTelemetryBuffer);
+            if (telemetry == null || telemetry.Count == 0)
+            {
+                return "responseTelemetry=<none>";
+            }
+
+            var parts = new List<string>();
+            int start = Math.Max(0, telemetry.Count - 8);
+            for (int i = start; i < telemetry.Count; i++)
+            {
+                ResponseChainTelemetryEvent evt = telemetry[i];
+                parts.Add(
+                    $"{evt.Kind}/tpl:{evt.TemplateId}/tag:{evt.TagId}/proposal:{evt.ProposalIndex}/prompt:{evt.PromptTagId}/order:{evt.OrderTypeId}/outcome:{evt.Outcome}/target:{ReadEntityName(engine.World, evt.Target)}");
+            }
+
+            return $"responseTelemetry={string.Join(",", parts)}";
+        }
+
+        private static string BuildGasEventDiagnostics(GameEngine engine)
+        {
+            GasPresentationEventBuffer? buffer = engine.GetService(CoreServiceKeys.GasPresentationEventBuffer);
+            if (buffer == null || buffer.Count == 0)
+            {
+                return "gasEvents=<none>";
+            }
+
+            var parts = new List<string>();
+            ReadOnlySpan<GasPresentationEvent> events = buffer.Events;
+            int start = Math.Max(0, events.Length - 8);
+            for (int i = start; i < events.Length; i++)
+            {
+                ref readonly GasPresentationEvent evt = ref events[i];
+                parts.Add(
+                    $"{evt.Kind}/slot:{evt.AbilitySlot}/effect:{evt.EffectTemplateId}/delta:{evt.Delta:0.##}/actor:{ReadEntityName(engine.World, evt.Actor)}/target:{ReadEntityName(engine.World, evt.Target)}/fail:{evt.FailReason}");
+            }
+
+            return $"gasEvents={string.Join(",", parts)}";
+        }
+
+        private static string ReadEntityName(World world, Entity entity)
+        {
+            return world.IsAlive(entity) && world.TryGet(entity, out Name name) ? name.Value : $"#{entity.Id}";
+        }
+
+        private static void CaptureSnapshot(GameEngine engine, List<AcceptanceSnapshot> snapshots, string step)
+        {
+            var ui = GetUiState(engine);
+            snapshots.Add(new AcceptanceSnapshot(
+                Step: step,
+                Selected: GetSelectedEntityName(engine),
+                WindowVisible: ui.Visible,
+                PromptTagId: ui.PromptTagId,
+                ConductorHealth: ReadHealth(engine.World, "Conductor"),
+                ComboHealth: ReadHealth(engine.World, "Combo Raider"),
+                CounterHealth: ReadHealth(engine.World, "Counter Raider"),
+                ScholarHealth: ReadHealth(engine.World, "Scholar"),
+                ProtectorHealth: ReadHealth(engine.World, "Protector")));
+        }
+
+        private static string BuildTraceJsonl(IReadOnlyList<AcceptanceSnapshot> snapshots)
+        {
+            var lines = new List<string>(snapshots.Count);
+            for (int i = 0; i < snapshots.Count; i++)
+            {
+                AcceptanceSnapshot snapshot = snapshots[i];
+                lines.Add(JsonSerializer.Serialize(new
+                {
+                    event_id = $"response-chain-showcase-{i + 1:000}",
+                    step = snapshot.Step,
+                    selected = snapshot.Selected,
+                    window_visible = snapshot.WindowVisible,
+                    prompt_tag_id = snapshot.PromptTagId,
+                    conductor_hp = snapshot.ConductorHealth,
+                    combo_hp = snapshot.ComboHealth,
+                    counter_hp = snapshot.CounterHealth,
+                    scholar_hp = snapshot.ScholarHealth,
+                    protector_hp = snapshot.ProtectorHealth,
+                    status = "done"
+                }));
+            }
+
+            return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+        }
+
+        private static string BuildBattleReport(
+            IReadOnlyList<string> timeline,
+            IReadOnlyList<AcceptanceSnapshot> snapshots,
+            IReadOnlyList<double> frameTimesMs)
+        {
+            double medianTickMs = Median(frameTimesMs);
+            double maxTickMs = frameTimesMs.Count == 0 ? 0d : frameTimesMs.Max();
+            AcceptanceSnapshot final = snapshots[^1];
+
+            var sb = new StringBuilder();
+            sb.AppendLine("# Scenario Card: response-chain-showcase");
+            sb.AppendLine();
+            sb.AppendLine("## Intent");
+            sb.AppendLine("- Player goal: play one visible combo finish, one negate-driven counter, and one fixed-guard redirect using the production response-window stack.");
+            sb.AppendLine("- Gameplay domain: GAS effect requests, response chain collection, response window order input, fixed-target dispatch remapping, and showcase reset flow.");
+            sb.AppendLine();
+            sb.AppendLine("## Determinism Inputs");
+            sb.AppendLine("- Map: `response_chain_showcase`");
+            sb.AppendLine($"- Mods: `{string.Join("`, `", AcceptanceMods)}`");
+            sb.AppendLine("- Clock: fixed `1/60s` headless tick loop");
+            sb.AppendLine("- Input source: real input config + deterministic backend");
+            sb.AppendLine();
+            sb.AppendLine("## Action Script");
+            sb.AppendLine("1. Load the showcase map and confirm Conductor becomes the active player unit.");
+            sb.AppendLine("2. Hover Combo Raider, cast Q, press `1`, then `Space` twice so the combo follow-up resolves.");
+            sb.AppendLine("3. Press `F4` to restore the board.");
+            sb.AppendLine("4. Cast W, press `N`, then `Space` twice so the incoming hit is negated while the riposte remains.");
+            sb.AppendLine("5. Press `F4` again.");
+            sb.AppendLine("6. Hover Scholar, cast E, press `N`, then `Space` twice so Scholar's hit is negated while Protector intercepts.");
+            sb.AppendLine();
+            sb.AppendLine("## Evidence Artifacts");
+            sb.AppendLine("- `artifacts/acceptance/response-chain-showcase/trace.jsonl`");
+            sb.AppendLine("- `artifacts/acceptance/response-chain-showcase/battle-report.md`");
+            sb.AppendLine("- `artifacts/acceptance/response-chain-showcase/path.mmd`");
+            sb.AppendLine();
+            sb.AppendLine("## Timeline");
+            for (int i = 0; i < timeline.Count; i++)
+            {
+                sb.AppendLine($"- {timeline[i]}");
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("## Outcome");
+            sb.AppendLine("- success: yes");
+            sb.AppendLine("- verdict: combo, counter, redirect, and reset all stayed on the shared gameplay/input/response-window path.");
+            sb.AppendLine($"- final state: conductor={final.ConductorHealth:0}, combo={final.ComboHealth:0}, counter={final.CounterHealth:0}, scholar={final.ScholarHealth:0}, protector={final.ProtectorHealth:0}");
+            sb.AppendLine();
+            sb.AppendLine("## Summary Stats");
+            sb.AppendLine($"- snapshots captured: `{snapshots.Count}`");
+            sb.AppendLine($"- median headless tick: `{medianTickMs:F3}ms`");
+            sb.AppendLine($"- max headless tick: `{maxTickMs:F3}ms`");
+            return sb.ToString();
+        }
+
+        private static string BuildPathMermaid()
+        {
+            return string.Join(Environment.NewLine, new[]
+            {
+                "flowchart TD",
+                "    A[Load map -> Conductor selected] --> B[Q on Combo Raider]",
+                "    B --> C[Response window -> press 1 -> pass -> pass -> follow-up damage]",
+                "    C --> D[F4 reset restores board]",
+                "    D --> E[W self-window]",
+                "    E --> F[N negates take-hit chain]",
+                "    F --> G[Space then Space closes window -> riposte lands]",
+                "    G --> H[F4 reset restores board]",
+                "    H --> I[E on Scholar]",
+                "    I --> J[N negates scholar-hit chain]",
+                "    J --> K[Space then Space closes window -> Protector intercepts]"
+            }) + Environment.NewLine;
+        }
+
+        private static string FindRepoRoot()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            for (int i = 0; i < 10 && dir != null; i++)
+            {
+                string srcDir = Path.Combine(dir.FullName, "src");
+                string assetsDir = Path.Combine(dir.FullName, "assets");
+                if (Directory.Exists(srcDir) && Directory.Exists(assetsDir))
+                {
+                    return dir.FullName;
+                }
+
+                dir = dir.Parent;
+            }
+
+            throw new DirectoryNotFoundException("Failed to locate repository root from test output directory.");
+        }
+
+        private static double Median(IReadOnlyList<double> values)
+        {
+            if (values.Count == 0)
+            {
+                return 0d;
+            }
+
+            var ordered = values.OrderBy(v => v).ToArray();
+            int middle = ordered.Length / 2;
+            if ((ordered.Length & 1) == 0)
+            {
+                return (ordered[middle - 1] + ordered[middle]) * 0.5d;
+            }
+
+            return ordered[middle];
+        }
+
+        private sealed record AcceptanceSnapshot(
+            string Step,
+            string Selected,
+            bool WindowVisible,
+            int PromptTagId,
+            float ConductorHealth,
+            float ComboHealth,
+            float CounterHealth,
+            float ScholarHealth,
+            float ProtectorHealth);
+
+        private sealed class TestInputBackend : IInputBackend
+        {
+            private readonly Dictionary<string, bool> _buttons = new(StringComparer.Ordinal);
+            private Vector2 _mousePosition;
+            private float _mouseWheel;
+
+            public void SetButton(string path, bool isDown)
+            {
+                _buttons[path] = isDown;
+            }
+
+            public void SetMousePosition(Vector2 position)
+            {
+                _mousePosition = position;
+            }
+
+            public float GetAxis(string devicePath) => 0f;
+            public bool GetButton(string devicePath) => _buttons.TryGetValue(devicePath, out bool isDown) && isDown;
+            public Vector2 GetMousePosition() => _mousePosition;
+            public float GetMouseWheel() => _mouseWheel;
+            public void EnableIME(bool enable) { }
+            public void SetIMECandidatePosition(int x, int y) { }
+            public string GetCharBuffer() => string.Empty;
+        }
+
+        private sealed class StubViewController : IViewController
+        {
+            public StubViewController(float width, float height)
+            {
+                Resolution = new Vector2(width, height);
+            }
+
+            public Vector2 Resolution { get; }
+            public float Fov => 60f;
+            public float AspectRatio => Resolution.Y <= 0f ? 1f : Resolution.X / Resolution.Y;
+        }
+
+        private sealed class WorldMappedScreenRayProvider : IScreenRayProvider
+        {
+            public ScreenRay GetRay(Vector2 screenPosition)
+            {
+                return new ScreenRay(
+                    new Vector3(screenPosition.X / 100f, 10f, screenPosition.Y / 100f),
+                    -Vector3.UnitY);
+            }
+        }
+
+        private sealed class WorldMappedScreenProjector : IScreenProjector
+        {
+            public Vector2 WorldToScreen(Vector3 worldPosition)
+            {
+                return new Vector2(worldPosition.X * 100f, worldPosition.Z * 100f);
+            }
+        }
+    }
+}

--- a/src/Tools/Ludots.Launcher.Evidence/LauncherEvidenceRecorder.cs
+++ b/src/Tools/Ludots.Launcher.Evidence/LauncherEvidenceRecorder.cs
@@ -10,9 +10,14 @@ using Ludots.Adapter.Web.Services;
 using Ludots.Core.Components;
 using Ludots.Core.Config;
 using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.GAS;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Presentation;
+using Ludots.Core.Gameplay.GAS.Registry;
 using Ludots.Core.Hosting;
 using Ludots.Core.Input.Config;
 using Ludots.Core.Input.Runtime;
+using Ludots.Core.Input.Selection;
 using Ludots.Core.Mathematics;
 using Ludots.Core.Navigation2D.Components;
 using Ludots.Core.Navigation2D.Runtime;
@@ -76,6 +81,8 @@ public static class LauncherEvidenceRecorder
     private const int DefaultHeight = 1080;
     private const int CameraImageWidth = 1600;
     private const int CameraImageHeight = 900;
+    private const int ResponseImageWidth = 1600;
+    private const int ResponseImageHeight = 900;
     private const int NavImageWidth = 1600;
     private const int NavImageHeight = 900;
     private const int NavAcceptanceAgentsPerTeam = 64;
@@ -95,6 +102,20 @@ public static class LauncherEvidenceRecorder
     private const float NavWorldMinY = -9000f;
     private const float NavWorldMaxY = 9000f;
     private static readonly Vector2 CameraProjectionClickWorldCm = new(3200f, 2000f);
+    private const string ResponseChainShowcaseModId = "ResponseChainShowcaseMod";
+    private const string ResponseChainMapId = "response_chain_showcase";
+    private const string ResponseConductorName = "Conductor";
+    private const string ResponseComboRaiderName = "Combo Raider";
+    private const string ResponseCounterRaiderName = "Counter Raider";
+    private const string ResponseScholarName = "Scholar";
+    private const string ResponseProtectorName = "Protector";
+    private const string ActionSkillQ = "SkillQ";
+    private const string ActionSkillW = "SkillW";
+    private const string ActionSkillE = "SkillE";
+    private const string ActionResponseNegate = "ResponseChainNegate";
+    private const string ActionResponseActivate = "ResponseChainActivate";
+    private const string ActionResponsePass = "ResponseChainPass";
+    private const string ActionResetShowcase = "ResetShowcase";
 
     public static Task<LauncherRecordingResult> RecordAsync(LauncherRecordingRequest request, CancellationToken ct = default)
     {
@@ -105,6 +126,7 @@ public static class LauncherEvidenceRecorder
         return InferScenario(request.Plan) switch
         {
             EvidenceScenario.CameraAcceptanceProjectionClick => Task.FromResult(RecordCameraAcceptanceProjection(request)),
+            EvidenceScenario.ResponseChainShowcase => Task.FromResult(RecordResponseChainShowcase(request)),
             EvidenceScenario.Navigation2DPlaygroundTimedAvoidance => Task.FromResult(RecordNavigation2DTimedAvoidance(request)),
             _ => throw new InvalidOperationException($"No recording scenario is registered for root mods: {string.Join(", ", request.Plan.RootModIds)}")
         };
@@ -120,6 +142,11 @@ public static class LauncherEvidenceRecorder
         if (plan.RootModIds.Any(id => string.Equals(id, "Navigation2DPlaygroundMod", StringComparison.OrdinalIgnoreCase)))
         {
             return EvidenceScenario.Navigation2DPlaygroundTimedAvoidance;
+        }
+
+        if (plan.RootModIds.Any(id => string.Equals(id, ResponseChainShowcaseModId, StringComparison.OrdinalIgnoreCase)))
+        {
+            return EvidenceScenario.ResponseChainShowcase;
         }
 
         return EvidenceScenario.None;
@@ -773,6 +800,644 @@ public static class LauncherEvidenceRecorder
         using SKData data = image.Encode(SKEncodedImageFormat.Png, 100);
         using FileStream stream = File.Open(path, FileMode.Create, FileAccess.Write, FileShare.None);
         data.SaveTo(stream);
+    }
+
+    private static LauncherRecordingResult RecordResponseChainShowcase(LauncherRecordingRequest request)
+    {
+        string screensDir = Path.Combine(request.OutputDirectory, "screens");
+        Directory.CreateDirectory(screensDir);
+
+        var timeline = new List<ResponseChainSnapshot>();
+        var captureFrames = new List<CaptureFrame>();
+        var frameTimesMs = new List<double>();
+
+        using var runtime = CreateRuntime(request.Plan, request.BootstrapPath);
+        if (!string.Equals(runtime.Config.StartupMapId, ResponseChainMapId, StringComparison.OrdinalIgnoreCase))
+        {
+            runtime.Engine.LoadMap(ResponseChainMapId);
+        }
+
+        Tick(runtime, 6, frameTimesMs);
+        CaptureResponseChainSnapshot(runtime, screensDir, frameTimesMs, timeline, captureFrames, "000_map_loaded");
+
+        float comboBefore = ReadHealth(runtime.Engine.World, ResponseComboRaiderName);
+        SetMouseWorld(runtime, runtime.ProjectWorldCm(GetEntityWorld(runtime.Engine.World, ResponseComboRaiderName)), frameTimesMs);
+        PressAction(runtime, ActionSkillQ, frameTimesMs);
+        TickUntil(runtime, frameTimesMs, () => GetResponseUiState(runtime.Engine).Visible, 18, () => BuildResponseChainDiagnostics(runtime.Engine));
+        CaptureResponseChainSnapshot(runtime, screensDir, frameTimesMs, timeline, captureFrames, "001_combo_window");
+
+        PressAction(runtime, ActionResponseActivate, frameTimesMs);
+        PressAction(runtime, ActionResponsePass, frameTimesMs);
+        PressAction(runtime, ActionResponsePass, frameTimesMs);
+        TickUntil(runtime, frameTimesMs, () => ReadHealth(runtime.Engine.World, ResponseComboRaiderName) < comboBefore, 24, () => BuildResponseChainDiagnostics(runtime.Engine));
+        CaptureResponseChainSnapshot(runtime, screensDir, frameTimesMs, timeline, captureFrames, "002_combo_finish");
+
+        PressAction(runtime, ActionResetShowcase, frameTimesMs);
+        TickUntil(runtime, frameTimesMs, () => Math.Abs(ReadHealth(runtime.Engine.World, ResponseComboRaiderName) - comboBefore) < 0.01f, 18, () => BuildResponseChainDiagnostics(runtime.Engine));
+
+        float conductorBeforeCounter = ReadHealth(runtime.Engine.World, ResponseConductorName);
+        float counterBefore = ReadHealth(runtime.Engine.World, ResponseCounterRaiderName);
+        PressAction(runtime, ActionSkillW, frameTimesMs);
+        TickUntil(runtime, frameTimesMs, () => GetResponseUiState(runtime.Engine).Visible, 18, () => BuildResponseChainDiagnostics(runtime.Engine));
+        CaptureResponseChainSnapshot(runtime, screensDir, frameTimesMs, timeline, captureFrames, "003_counter_window");
+
+        PressAction(runtime, ActionResponseNegate, frameTimesMs);
+        PressAction(runtime, ActionResponsePass, frameTimesMs);
+        PressAction(runtime, ActionResponsePass, frameTimesMs);
+        TickUntil(
+            runtime,
+            frameTimesMs,
+            () => !GetResponseUiState(runtime.Engine).Visible && ReadHealth(runtime.Engine.World, ResponseCounterRaiderName) < counterBefore,
+            32,
+            () => BuildResponseChainDiagnostics(runtime.Engine));
+        CaptureResponseChainSnapshot(runtime, screensDir, frameTimesMs, timeline, captureFrames, "004_counter_finish");
+
+        PressAction(runtime, ActionResetShowcase, frameTimesMs);
+        TickUntil(
+            runtime,
+            frameTimesMs,
+            () => Math.Abs(ReadHealth(runtime.Engine.World, ResponseCounterRaiderName) - counterBefore) < 0.01f &&
+                  Math.Abs(ReadHealth(runtime.Engine.World, ResponseConductorName) - conductorBeforeCounter) < 0.01f,
+            18,
+            () => BuildResponseChainDiagnostics(runtime.Engine));
+
+        float scholarBefore = ReadHealth(runtime.Engine.World, ResponseScholarName);
+        float protectorBefore = ReadHealth(runtime.Engine.World, ResponseProtectorName);
+        SetMouseWorld(runtime, runtime.ProjectWorldCm(GetEntityWorld(runtime.Engine.World, ResponseScholarName)), frameTimesMs);
+        PressAction(runtime, ActionSkillE, frameTimesMs);
+        TickUntil(runtime, frameTimesMs, () => GetResponseUiState(runtime.Engine).Visible, 18, () => BuildResponseChainDiagnostics(runtime.Engine));
+        CaptureResponseChainSnapshot(runtime, screensDir, frameTimesMs, timeline, captureFrames, "005_redirect_window");
+
+        PressAction(runtime, ActionResponseNegate, frameTimesMs);
+        PressAction(runtime, ActionResponsePass, frameTimesMs);
+        PressAction(runtime, ActionResponsePass, frameTimesMs);
+        TickUntil(
+            runtime,
+            frameTimesMs,
+            () => !GetResponseUiState(runtime.Engine).Visible && ReadHealth(runtime.Engine.World, ResponseProtectorName) < protectorBefore,
+            32,
+            () => BuildResponseChainDiagnostics(runtime.Engine));
+        CaptureResponseChainSnapshot(runtime, screensDir, frameTimesMs, timeline, captureFrames, "006_redirect_finish");
+
+        WriteTimelineSheet("Response chain showcase timeline", captureFrames, screensDir, Path.Combine(screensDir, "timeline.png"));
+
+        ResponseChainAcceptanceResult acceptance = EvaluateResponseChainAcceptance(timeline);
+        string battleReportPath = Path.Combine(request.OutputDirectory, "battle-report.md");
+        string tracePath = Path.Combine(request.OutputDirectory, "trace.jsonl");
+        string pathPath = Path.Combine(request.OutputDirectory, "path.mmd");
+        string visibleChecklistPath = Path.Combine(request.OutputDirectory, "visible-checklist.md");
+        string summaryPath = Path.Combine(request.OutputDirectory, "summary.json");
+
+        File.WriteAllText(battleReportPath, BuildResponseChainBattleReport(request, timeline, frameTimesMs, acceptance));
+        File.WriteAllText(tracePath, BuildResponseChainTraceJsonl(request.Plan.AdapterId, timeline));
+        File.WriteAllText(pathPath, BuildResponseChainPathMermaid());
+        File.WriteAllText(visibleChecklistPath, BuildResponseChainVisibleChecklist(timeline));
+        File.WriteAllText(summaryPath, BuildResponseChainSummaryJson(request, acceptance));
+
+        if (!acceptance.Success)
+        {
+            throw new InvalidOperationException(acceptance.FailureSummary);
+        }
+
+        return new LauncherRecordingResult(
+            request.OutputDirectory,
+            battleReportPath,
+            tracePath,
+            pathPath,
+            summaryPath,
+            visibleChecklistPath,
+            captureFrames.Select(frame => Path.Combine(screensDir, frame.FileName)).Append(Path.Combine(screensDir, "timeline.png")).ToList(),
+            acceptance.NormalizedSignature);
+    }
+
+    private static void CaptureResponseChainSnapshot(
+        RecordingRuntime runtime,
+        string screensDir,
+        IReadOnlyList<double> frameTimesMs,
+        List<ResponseChainSnapshot> timeline,
+        List<CaptureFrame> captureFrames,
+        string step)
+    {
+        ResponseChainSnapshot snapshot = SampleResponseChainSnapshot(runtime, step, frameTimesMs.Count > 0 ? frameTimesMs[^1] : 0d);
+        timeline.Add(snapshot);
+        string fileName = $"{step}.png";
+        string outputPath = Path.Combine(screensDir, fileName);
+        WriteResponseChainSnapshotImage(snapshot, outputPath);
+        captureFrames.Add(new CaptureFrame(snapshot.Tick, step, fileName, 0, 0, 0f, 0f));
+    }
+
+    private static ResponseChainSnapshot SampleResponseChainSnapshot(RecordingRuntime runtime, string step, double tickMs)
+    {
+        var namedEntities = new Dictionary<string, Vector2>(StringComparer.OrdinalIgnoreCase);
+        runtime.Engine.World.Query(in CameraNamedEntityQuery, (ref Name name, ref WorldPositionCm position) =>
+        {
+            if (!namedEntities.ContainsKey(name.Value))
+            {
+                namedEntities[name.Value] = position.Value.ToVector2();
+            }
+        });
+
+        ResponseChainUiState ui = GetResponseUiState(runtime.Engine);
+        return new ResponseChainSnapshot(
+            runtime.Engine.GameSession.CurrentTick,
+            step,
+            tickMs,
+            GetSelectedEntityName(runtime.Engine),
+            GetHoveredEntityName(runtime.Engine),
+            ui.Visible,
+            ui.PromptTagId,
+            ReadEntityName(runtime.Engine.World, ui.Actor),
+            ReadEntityName(runtime.Engine.World, ui.Target),
+            ReadHealth(runtime.Engine.World, ResponseConductorName),
+            ReadHealth(runtime.Engine.World, ResponseComboRaiderName),
+            ReadHealth(runtime.Engine.World, ResponseCounterRaiderName),
+            ReadHealth(runtime.Engine.World, ResponseScholarName),
+            ReadHealth(runtime.Engine.World, ResponseProtectorName),
+            namedEntities,
+            ExtractOverlayText(runtime.Engine.GetService(CoreServiceKeys.ScreenOverlayBuffer)),
+            BuildResponseTelemetryLines(runtime.Engine),
+            BuildGasPresentationLines(runtime.Engine));
+    }
+
+    private static ResponseChainAcceptanceResult EvaluateResponseChainAcceptance(IReadOnlyList<ResponseChainSnapshot> timeline)
+    {
+        ResponseChainSnapshot start = timeline[0];
+        ResponseChainSnapshot comboWindow = timeline[1];
+        ResponseChainSnapshot comboFinish = timeline[2];
+        ResponseChainSnapshot counterWindow = timeline[3];
+        ResponseChainSnapshot counterFinish = timeline[4];
+        ResponseChainSnapshot redirectWindow = timeline[5];
+        ResponseChainSnapshot redirectFinish = timeline[6];
+
+        var failures = new List<string>();
+        AddAcceptanceCheck(string.Equals(start.SelectedEntity, ResponseConductorName, StringComparison.Ordinal), "Conductor should be auto-selected when the showcase loads.", failures);
+        AddAcceptanceCheck(comboWindow.WindowVisible, "Combo drill should open the response window before follow-up input.", failures);
+        AddAcceptanceCheck(comboFinish.ComboHealth < start.ComboHealth, $"Combo drill should damage {ResponseComboRaiderName}, but HP stayed {start.ComboHealth:0}->{comboFinish.ComboHealth:0}.", failures);
+        AddAcceptanceCheck(counterWindow.WindowVisible, "Counter drill should open a response window on the self-hit branch.", failures);
+        AddAcceptanceCheck(counterFinish.CounterHealth < counterWindow.CounterHealth, $"Counter drill should damage {ResponseCounterRaiderName}, but HP stayed {counterWindow.CounterHealth:0}->{counterFinish.CounterHealth:0}.", failures);
+        AddAcceptanceCheck(Math.Abs(counterFinish.ConductorHealth - counterWindow.ConductorHealth) < 0.01f, $"Counter drill should preserve {ResponseConductorName} HP, but it moved {counterWindow.ConductorHealth:0}->{counterFinish.ConductorHealth:0}.", failures);
+        AddAcceptanceCheck(redirectWindow.WindowVisible, "Redirect drill should open a response window on the Scholar line.", failures);
+        AddAcceptanceCheck(Math.Abs(redirectFinish.ScholarHealth - redirectWindow.ScholarHealth) < 0.01f, $"Redirect drill should keep {ResponseScholarName} unharmed, but HP moved {redirectWindow.ScholarHealth:0}->{redirectFinish.ScholarHealth:0}.", failures);
+        AddAcceptanceCheck(redirectFinish.ProtectorHealth < redirectWindow.ProtectorHealth, $"Redirect drill should damage {ResponseProtectorName}, but HP stayed {redirectWindow.ProtectorHealth:0}->{redirectFinish.ProtectorHealth:0}.", failures);
+
+        string verdict = failures.Count == 0
+            ? "combo, counter, and redirect drills all resolved on the shared response-window stack."
+            : "one or more response-chain drills diverged from the expected shared-stack behavior.";
+        string signature =
+            $"response_chain_showcase|combo:{start.ComboHealth:0}->{comboFinish.ComboHealth:0}|counter:{counterWindow.CounterHealth:0}->{counterFinish.CounterHealth:0}|redirect:{redirectWindow.ProtectorHealth:0}->{redirectFinish.ProtectorHealth:0}|prompt:{comboWindow.PromptTagId}-{counterWindow.PromptTagId}-{redirectWindow.PromptTagId}";
+
+        return new ResponseChainAcceptanceResult(
+            failures.Count == 0,
+            verdict,
+            failures.Count == 0 ? "Response chain showcase acceptance passed." : string.Join(" ", failures),
+            failures,
+            comboWindow.ComboHealth,
+            comboFinish.ComboHealth,
+            counterWindow.CounterHealth,
+            counterFinish.CounterHealth,
+            counterWindow.ConductorHealth,
+            counterFinish.ConductorHealth,
+            redirectWindow.ScholarHealth,
+            redirectFinish.ScholarHealth,
+            redirectWindow.ProtectorHealth,
+            redirectFinish.ProtectorHealth,
+            redirectFinish.Tick,
+            signature);
+    }
+
+    private static string BuildResponseChainBattleReport(
+        LauncherRecordingRequest request,
+        IReadOnlyList<ResponseChainSnapshot> timeline,
+        IReadOnlyList<double> frameTimesMs,
+        ResponseChainAcceptanceResult acceptance)
+    {
+        double medianTickMs = Median(frameTimesMs.ToArray());
+        double maxTickMs = frameTimesMs.Count == 0 ? 0d : frameTimesMs.Max();
+        ResponseChainSnapshot final = timeline[^1];
+
+        var sb = new StringBuilder();
+        sb.AppendLine("# Scenario Card: response-chain-showcase");
+        sb.AppendLine();
+        sb.AppendLine("## Intent");
+        sb.AppendLine("- Player goal: play one combo insert, one negate-driven counter, and one fixed-guard redirect on the production response-window stack.");
+        sb.AppendLine("- Delivery surface: launcher-native evidence recording with scripted inputs, screenshots, trace, and readable acceptance narrative.");
+        sb.AppendLine();
+        sb.AppendLine("## Determinism Inputs");
+        sb.AppendLine($"- Adapter: `{request.Plan.AdapterId}`");
+        sb.AppendLine($"- Map: `{ResponseChainMapId}`");
+        sb.AppendLine($"- Root mods: `{string.Join("`, `", request.Plan.RootModIds)}`");
+        sb.AppendLine("- Clock: fixed `1/60s` tick loop");
+        sb.AppendLine("- Input source: launcher scripted backend reusing production input contexts");
+        sb.AppendLine();
+        sb.AppendLine("## Action Script");
+        sb.AppendLine("1. Load the showcase map and verify Conductor is selected.");
+        sb.AppendLine("2. Hover Combo Raider, press `Q`, then `1`, `Space`, `Space` to finish the combo branch.");
+        sb.AppendLine("3. Press `F4` to reset.");
+        sb.AppendLine("4. Press `W`, then `N`, `Space`, `Space` to negate the hit and keep the riposte.");
+        sb.AppendLine("5. Press `F4` to reset.");
+        sb.AppendLine("6. Hover Scholar, press `E`, then `N`, `Space`, `Space` so Protector intercepts.");
+        sb.AppendLine();
+        sb.AppendLine("## Timeline");
+        foreach (ResponseChainSnapshot snapshot in timeline)
+        {
+            sb.AppendLine($"- [T+{snapshot.Tick:000}] {snapshot.Step} | selected={snapshot.SelectedEntity} hovered={snapshot.HoveredEntity} window={(snapshot.WindowVisible ? "open" : "idle")} prompt={snapshot.PromptTagId} | combo={snapshot.ComboHealth:0} counter={snapshot.CounterHealth:0} scholar={snapshot.ScholarHealth:0} protector={snapshot.ProtectorHealth:0}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("## Outcome");
+        sb.AppendLine($"- success: {(acceptance.Success ? "yes" : "no")}");
+        sb.AppendLine($"- verdict: {acceptance.Verdict}");
+        foreach (string failedCheck in acceptance.FailedChecks)
+        {
+            sb.AppendLine($"- failed-check: {failedCheck}");
+        }
+
+        sb.AppendLine($"- final state: conductor={final.ConductorHealth:0}, combo={final.ComboHealth:0}, counter={final.CounterHealth:0}, scholar={final.ScholarHealth:0}, protector={final.ProtectorHealth:0}");
+        sb.AppendLine();
+        sb.AppendLine("## Summary Stats");
+        sb.AppendLine($"- trace samples: `{timeline.Count}`");
+        sb.AppendLine($"- screenshot captures: `{timeline.Count}`");
+        sb.AppendLine($"- median headless tick: `{medianTickMs:F3}ms`");
+        sb.AppendLine($"- max headless tick: `{maxTickMs:F3}ms`");
+        sb.AppendLine($"- normalized signature: `{acceptance.NormalizedSignature}`");
+        sb.AppendLine("- reusable wiring: `launcher.runtime.json`, `PlayerInputHandler`, `ResponseChainUiState`, `ResponseChainTelemetryBuffer`, `ScreenOverlayBuffer`");
+        return sb.ToString();
+    }
+
+    private static string BuildResponseChainTraceJsonl(string adapterId, IReadOnlyList<ResponseChainSnapshot> timeline)
+    {
+        var lines = new List<string>(timeline.Count);
+        for (int index = 0; index < timeline.Count; index++)
+        {
+            ResponseChainSnapshot snapshot = timeline[index];
+            lines.Add(JsonSerializer.Serialize(new
+            {
+                event_id = $"response-chain-{adapterId}-{index + 1:000}",
+                tick = snapshot.Tick,
+                step = snapshot.Step,
+                selected = snapshot.SelectedEntity,
+                hovered = snapshot.HoveredEntity,
+                window_visible = snapshot.WindowVisible,
+                prompt_tag_id = snapshot.PromptTagId,
+                actor = snapshot.ActorEntity,
+                target = snapshot.TargetEntity,
+                conductor_hp = Math.Round(snapshot.ConductorHealth, 2),
+                combo_hp = Math.Round(snapshot.ComboHealth, 2),
+                counter_hp = Math.Round(snapshot.CounterHealth, 2),
+                scholar_hp = Math.Round(snapshot.ScholarHealth, 2),
+                protector_hp = Math.Round(snapshot.ProtectorHealth, 2),
+                telemetry = snapshot.TelemetryLines,
+                gas = snapshot.GasLines,
+                status = "done"
+            }));
+        }
+
+        return string.Join(Environment.NewLine, lines) + Environment.NewLine;
+    }
+
+    private static string BuildResponseChainPathMermaid()
+    {
+        return string.Join(Environment.NewLine, new[]
+        {
+            "flowchart TD",
+            "    A[Load response_chain_showcase] --> B[Hover Combo Raider and cast Q]",
+            "    B --> C[Response window opens and player inserts 1]",
+            "    C --> D[Space then Space resolves follow-up damage]",
+            "    D --> E[F4 reset restores baseline]",
+            "    E --> F[Cast W self-window]",
+            "    F --> G[N negates the incoming hit branch]",
+            "    G --> H[Space then Space closes window and riposte lands]",
+            "    H --> I[F4 reset restores baseline]",
+            "    I --> J[Hover Scholar and cast E]",
+            "    J --> K[N negates scholar-hit branch]",
+            "    K --> L[Space then Space resolves fixed Protector intercept]"
+        }) + Environment.NewLine;
+    }
+
+    private static string BuildResponseChainVisibleChecklist(IReadOnlyList<ResponseChainSnapshot> timeline)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("# Visible Checklist: response-chain-showcase");
+        sb.AppendLine();
+        sb.AppendLine("- `000_map_loaded` should show Conductor selected with all three drills still marked Ready.");
+        sb.AppendLine("- `001_combo_window`, `003_counter_window`, and `005_redirect_window` should show the response window as open.");
+        sb.AppendLine("- `002_combo_finish` should show Combo Raider losing HP.");
+        sb.AppendLine("- `004_counter_finish` should show Counter Raider losing HP while Conductor stays intact.");
+        sb.AppendLine("- `006_redirect_finish` should show Protector losing HP while Scholar stays intact.");
+        sb.AppendLine("- `screens/timeline.png` is the compact frame-strip recording for quick review.");
+        sb.AppendLine();
+        foreach (ResponseChainSnapshot snapshot in timeline)
+        {
+            sb.AppendLine($"- `{snapshot.Step}.png`: window={(snapshot.WindowVisible ? "open" : "idle")}, selected={snapshot.SelectedEntity}, combo={snapshot.ComboHealth:0}, counter={snapshot.CounterHealth:0}, scholar={snapshot.ScholarHealth:0}, protector={snapshot.ProtectorHealth:0}");
+        }
+
+        return sb.ToString();
+    }
+
+    private static string BuildResponseChainSummaryJson(LauncherRecordingRequest request, ResponseChainAcceptanceResult acceptance)
+    {
+        return JsonSerializer.Serialize(new
+        {
+            scenario = "response_chain_showcase",
+            adapter = request.Plan.AdapterId,
+            selectors = request.Plan.Selectors,
+            root_mods = request.Plan.RootModIds,
+            combo = new
+            {
+                before = Math.Round(acceptance.ComboBefore, 2),
+                after = Math.Round(acceptance.ComboAfter, 2)
+            },
+            counter = new
+            {
+                raider_before = Math.Round(acceptance.CounterBefore, 2),
+                raider_after = Math.Round(acceptance.CounterAfter, 2),
+                conductor_before = Math.Round(acceptance.ConductorBefore, 2),
+                conductor_after = Math.Round(acceptance.ConductorAfter, 2)
+            },
+            redirect = new
+            {
+                scholar_before = Math.Round(acceptance.ScholarBefore, 2),
+                scholar_after = Math.Round(acceptance.ScholarAfter, 2),
+                protector_before = Math.Round(acceptance.ProtectorBefore, 2),
+                protector_after = Math.Round(acceptance.ProtectorAfter, 2)
+            },
+            final_tick = acceptance.FinalTick,
+            normalized_signature = acceptance.NormalizedSignature
+        }, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    private static void WriteResponseChainSnapshotImage(ResponseChainSnapshot snapshot, string path)
+    {
+        using var surface = SKSurface.Create(new SKImageInfo(ResponseImageWidth, ResponseImageHeight));
+        SKCanvas canvas = surface.Canvas;
+        canvas.Clear(new SKColor(10, 14, 22));
+
+        var worldPoints = snapshot.NamedEntities.Values.ToList();
+        if (worldPoints.Count == 0)
+        {
+            worldPoints.Add(Vector2.Zero);
+        }
+
+        float minX = worldPoints.Min(point => point.X) - 360f;
+        float maxX = worldPoints.Max(point => point.X) + 360f;
+        float minY = worldPoints.Min(point => point.Y) - 360f;
+        float maxY = worldPoints.Max(point => point.Y) + 360f;
+
+        using var gridPaint = new SKPaint { Color = new SKColor(38, 48, 66), IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = 1f };
+        using var titlePaint = new SKPaint { Color = SKColors.White, IsAntialias = true, TextSize = 26f };
+        using var bodyPaint = new SKPaint { Color = new SKColor(212, 220, 236), IsAntialias = true, TextSize = 18f };
+        using var notePaint = new SKPaint { Color = new SKColor(164, 178, 198), IsAntialias = true, TextSize = 16f };
+        using var selectedPaint = new SKPaint { Color = new SKColor(255, 210, 96), IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = 4f };
+        using var hoveredPaint = new SKPaint { Color = new SKColor(250, 250, 250), IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = 2f };
+        using var conductorPaint = new SKPaint { Color = new SKColor(92, 190, 255), IsAntialias = true, Style = SKPaintStyle.Fill };
+        using var comboPaint = new SKPaint { Color = new SKColor(244, 176, 74), IsAntialias = true, Style = SKPaintStyle.Fill };
+        using var counterPaint = new SKPaint { Color = new SKColor(255, 126, 107), IsAntialias = true, Style = SKPaintStyle.Fill };
+        using var scholarPaint = new SKPaint { Color = new SKColor(110, 199, 230), IsAntialias = true, Style = SKPaintStyle.Fill };
+        using var protectorPaint = new SKPaint { Color = new SKColor(113, 224, 138), IsAntialias = true, Style = SKPaintStyle.Fill };
+        using var fallbackPaint = new SKPaint { Color = new SKColor(196, 204, 224), IsAntialias = true, Style = SKPaintStyle.Fill };
+        using var panelFill = new SKPaint { Color = new SKColor(14, 18, 28, 220), IsAntialias = true, Style = SKPaintStyle.Fill };
+        using var panelBorder = new SKPaint { Color = new SKColor(88, 118, 156), IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = 2f };
+
+        DrawWorldGrid(canvas, minX, maxX, minY, maxY, gridPaint, ResponseImageWidth, ResponseImageHeight);
+
+        foreach ((string name, Vector2 position) in snapshot.NamedEntities.OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            SKPoint point = ToScreen(position, minX, maxX, minY, maxY, ResponseImageWidth, ResponseImageHeight);
+            SKPaint fill = ResolveResponseChainPaint(name, conductorPaint, comboPaint, counterPaint, scholarPaint, protectorPaint, fallbackPaint);
+            canvas.DrawCircle(point.X, point.Y, 18f, fill);
+            if (string.Equals(snapshot.SelectedEntity, name, StringComparison.Ordinal))
+            {
+                canvas.DrawCircle(point.X, point.Y, 26f, selectedPaint);
+            }
+
+            if (string.Equals(snapshot.HoveredEntity, name, StringComparison.Ordinal))
+            {
+                canvas.DrawCircle(point.X, point.Y, 32f, hoveredPaint);
+            }
+
+            canvas.DrawText(name, point.X + 24f, point.Y - 10f, bodyPaint);
+        }
+
+        var panel = SKRect.Create(24f, 24f, 600f, 210f);
+        canvas.DrawRect(panel, panelFill);
+        canvas.DrawRect(panel, panelBorder);
+        canvas.DrawText($"Response Chain Showcase | {snapshot.Step} | tick={snapshot.Tick}", 42f, 58f, titlePaint);
+        canvas.DrawText($"Selected={snapshot.SelectedEntity}  Hovered={snapshot.HoveredEntity}", 42f, 90f, bodyPaint);
+        canvas.DrawText($"Window={(snapshot.WindowVisible ? "open" : "idle")}  PromptTag={snapshot.PromptTagId}  Actor={snapshot.ActorEntity}  Target={snapshot.TargetEntity}", 42f, 118f, bodyPaint);
+        canvas.DrawText($"Combo={snapshot.ComboHealth:0}  Counter={snapshot.CounterHealth:0}  Scholar={snapshot.ScholarHealth:0}  Protector={snapshot.ProtectorHealth:0}", 42f, 146f, bodyPaint);
+        canvas.DrawText($"Conductor={snapshot.ConductorHealth:0}  Tick={snapshot.TickMs:F3}ms", 42f, 174f, bodyPaint);
+        if (snapshot.OverlayLines.Count > 0)
+        {
+            canvas.DrawText(snapshot.OverlayLines[0], 42f, 202f, notePaint);
+        }
+
+        if (snapshot.TelemetryLines.Count > 0)
+        {
+            canvas.DrawText(snapshot.TelemetryLines[0], 42f, ResponseImageHeight - 52f, notePaint);
+        }
+
+        if (snapshot.GasLines.Count > 0)
+        {
+            canvas.DrawText(snapshot.GasLines[0], 42f, ResponseImageHeight - 24f, notePaint);
+        }
+
+        using SKImage image = surface.Snapshot();
+        using SKData data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using FileStream stream = File.Open(path, FileMode.Create, FileAccess.Write, FileShare.None);
+        data.SaveTo(stream);
+    }
+
+    private static SKPaint ResolveResponseChainPaint(
+        string name,
+        SKPaint conductorPaint,
+        SKPaint comboPaint,
+        SKPaint counterPaint,
+        SKPaint scholarPaint,
+        SKPaint protectorPaint,
+        SKPaint fallbackPaint)
+    {
+        return name switch
+        {
+            ResponseConductorName => conductorPaint,
+            ResponseComboRaiderName => comboPaint,
+            ResponseCounterRaiderName => counterPaint,
+            ResponseScholarName => scholarPaint,
+            ResponseProtectorName => protectorPaint,
+            _ => fallbackPaint
+        };
+    }
+
+    private static void PressButton(RecordingRuntime runtime, string path, List<double> frameTimesMs)
+    {
+        runtime.InputBackend.SetButton(path, true);
+        Tick(runtime, 2, frameTimesMs);
+        runtime.InputBackend.SetButton(path, false);
+        Tick(runtime, 2, frameTimesMs);
+    }
+
+    private static void PressAction(RecordingRuntime runtime, string actionId, List<double> frameTimesMs)
+    {
+        PlayerInputHandler input = runtime.Engine.GetService(CoreServiceKeys.InputHandler)
+            ?? throw new InvalidOperationException("InputHandler service missing.");
+
+        input.InjectButtonPress(actionId);
+        Tick(runtime, 2, frameTimesMs);
+        input.InjectButtonRelease(actionId);
+        Tick(runtime, 2, frameTimesMs);
+    }
+
+    private static void SetMouseWorld(RecordingRuntime runtime, Vector2 screenPosition, List<double> frameTimesMs)
+    {
+        runtime.InputBackend.SetMousePosition(screenPosition);
+        Tick(runtime, 1, frameTimesMs);
+    }
+
+    private static void TickUntil(
+        RecordingRuntime runtime,
+        List<double> frameTimesMs,
+        Func<bool> predicate,
+        int maxFrames,
+        Func<string>? failureMessageFactory = null)
+    {
+        for (int frame = 0; frame < maxFrames; frame++)
+        {
+            if (predicate())
+            {
+                return;
+            }
+
+            Tick(runtime, 1, frameTimesMs);
+        }
+
+        string detail = failureMessageFactory?.Invoke() ?? string.Empty;
+        throw new InvalidOperationException(
+            $"Predicate was not satisfied within {maxFrames} frames.{(string.IsNullOrWhiteSpace(detail) ? string.Empty : $" {detail}")}");
+    }
+
+    private static ResponseChainUiState GetResponseUiState(GameEngine engine)
+    {
+        return engine.GetService(CoreServiceKeys.ResponseChainUiState)
+            ?? throw new InvalidOperationException("ResponseChainUiState service missing.");
+    }
+
+    private static string GetSelectedEntityName(GameEngine engine)
+    {
+        if (SelectionContextRuntime.TryGetCurrentPrimary(engine.World, engine.GlobalContext, out Entity selected) &&
+            engine.World.TryGet(selected, out Name name))
+        {
+            return name.Value;
+        }
+
+        return string.Empty;
+    }
+
+    private static string GetHoveredEntityName(GameEngine engine)
+    {
+        if (engine.GlobalContext.TryGetValue(CoreServiceKeys.HoveredEntity.Name, out object? hoveredObj) &&
+            hoveredObj is Entity hovered &&
+            engine.World.IsAlive(hovered) &&
+            engine.World.TryGet(hovered, out Name name))
+        {
+            return name.Value;
+        }
+
+        return string.Empty;
+    }
+
+    private static string BuildResponseChainDiagnostics(GameEngine engine)
+    {
+        return string.Join(
+            " || ",
+            $"selected={GetSelectedEntityName(engine)}",
+            $"hovered={GetHoveredEntityName(engine)}",
+            $"uiVisible={GetResponseUiState(engine).Visible}",
+            $"promptTagId={GetResponseUiState(engine).PromptTagId}",
+            $"combo={ReadHealth(engine.World, ResponseComboRaiderName):0.##}",
+            $"counter={ReadHealth(engine.World, ResponseCounterRaiderName):0.##}",
+            $"scholar={ReadHealth(engine.World, ResponseScholarName):0.##}",
+            $"protector={ReadHealth(engine.World, ResponseProtectorName):0.##}",
+            string.Join(" | ", BuildResponseTelemetryLines(engine)),
+            string.Join(" | ", BuildGasPresentationLines(engine)));
+    }
+
+    private static List<string> BuildResponseTelemetryLines(GameEngine engine)
+    {
+        ResponseChainTelemetryBuffer? telemetry = engine.GetService(CoreServiceKeys.ResponseChainTelemetryBuffer);
+        var lines = new List<string>();
+        if (telemetry == null || telemetry.Count == 0)
+        {
+            return lines;
+        }
+
+        int start = Math.Max(0, telemetry.Count - 3);
+        for (int index = start; index < telemetry.Count; index++)
+        {
+            ResponseChainTelemetryEvent evt = telemetry[index];
+            lines.Add($"rc:{evt.Kind}/tag:{evt.TagId}/proposal:{evt.ProposalIndex}/prompt:{evt.PromptTagId}/order:{evt.OrderTypeId}/outcome:{evt.Outcome}/target:{ReadEntityName(engine.World, evt.Target)}");
+        }
+
+        return lines;
+    }
+
+    private static List<string> BuildGasPresentationLines(GameEngine engine)
+    {
+        GasPresentationEventBuffer? buffer = engine.GetService(CoreServiceKeys.GasPresentationEventBuffer);
+        var lines = new List<string>();
+        if (buffer == null || buffer.Count == 0)
+        {
+            return lines;
+        }
+
+        ReadOnlySpan<GasPresentationEvent> events = buffer.Events;
+        int start = Math.Max(0, events.Length - 3);
+        for (int index = start; index < events.Length; index++)
+        {
+            ref readonly GasPresentationEvent evt = ref events[index];
+            lines.Add($"gas:{evt.Kind}/effect:{evt.EffectTemplateId}/delta:{evt.Delta:0.##}/actor:{ReadEntityName(engine.World, evt.Actor)}/target:{ReadEntityName(engine.World, evt.Target)}");
+        }
+
+        return lines;
+    }
+
+    private static Entity FindEntityByName(World world, string name)
+    {
+        Entity found = Entity.Null;
+        world.Query(in CameraNamedEntityQuery, (Entity entity, ref Name entityName, ref WorldPositionCm _) =>
+        {
+            if (found == Entity.Null && string.Equals(entityName.Value, name, StringComparison.OrdinalIgnoreCase))
+            {
+                found = entity;
+            }
+        });
+        return found;
+    }
+
+    private static Vector2 GetEntityWorld(World world, string name)
+    {
+        Entity entity = FindEntityByName(world, name);
+        if (entity == Entity.Null || !world.TryGet(entity, out WorldPositionCm position))
+        {
+            throw new InvalidOperationException($"Entity '{name}' was not found.");
+        }
+
+        return position.Value.ToVector2();
+    }
+
+    private static float ReadHealth(World world, string name)
+    {
+        Entity entity = FindEntityByName(world, name);
+        if (entity == Entity.Null || !world.TryGet(entity, out AttributeBuffer attributes))
+        {
+            return 0f;
+        }
+
+        int healthId = AttributeRegistry.GetId("Health");
+        return healthId >= 0 ? attributes.GetCurrent(healthId) : 0f;
+    }
+
+    private static string ReadEntityName(World world, Entity entity)
+    {
+        return world.IsAlive(entity) && world.TryGet(entity, out Name name) ? name.Value : string.Empty;
     }
 
     private static LauncherRecordingResult RecordNavigation2DTimedAvoidance(LauncherRecordingRequest request)
@@ -1441,6 +2106,7 @@ public static class LauncherEvidenceRecorder
     {
         None,
         CameraAcceptanceProjectionClick,
+        ResponseChainShowcase,
         Navigation2DPlaygroundTimedAvoidance
     }
 
@@ -1537,6 +2203,44 @@ public static class LauncherEvidenceRecorder
         bool CueMarkerVisibleAfterClick,
         bool CueMarkerVisibleMidCapture,
         bool CueMarkerVisibleFinalCapture,
+        int FinalTick,
+        string NormalizedSignature);
+
+    private readonly record struct ResponseChainSnapshot(
+        int Tick,
+        string Step,
+        double TickMs,
+        string SelectedEntity,
+        string HoveredEntity,
+        bool WindowVisible,
+        int PromptTagId,
+        string ActorEntity,
+        string TargetEntity,
+        float ConductorHealth,
+        float ComboHealth,
+        float CounterHealth,
+        float ScholarHealth,
+        float ProtectorHealth,
+        IReadOnlyDictionary<string, Vector2> NamedEntities,
+        IReadOnlyList<string> OverlayLines,
+        IReadOnlyList<string> TelemetryLines,
+        IReadOnlyList<string> GasLines);
+
+    private sealed record ResponseChainAcceptanceResult(
+        bool Success,
+        string Verdict,
+        string FailureSummary,
+        IReadOnlyList<string> FailedChecks,
+        float ComboBefore,
+        float ComboAfter,
+        float CounterBefore,
+        float CounterAfter,
+        float ConductorBefore,
+        float ConductorAfter,
+        float ScholarBefore,
+        float ScholarAfter,
+        float ProtectorBefore,
+        float ProtectorAfter,
         int FinalTick,
         string NormalizedSignature);
 


### PR DESCRIPTION
## Summary
- add a playable response-chain showcase mod for combo, counter, and redirect drills on the production GAS/response-window stack
- extract shared Physics2D component authoring into `src/Core/Ludots.Physics2D/Config/Physics2DComponentAuthoring.cs` and reuse it from showcase mods
- add launcher binding/presets plus native launcher evidence recording for the response-chain showcase, including screenshots and acceptance artifacts

## Player Audit
- no blocking player-facing issues found in a second-pass audit
- non-blocking UX note: the `W` counter drill is self-triggered, so if the cursor is still resting on the previous enemy the hover ring can look like an enemy-targeted cast for a moment

## Verification
- `dotnet test src\\Tests\\GasTests\\GasTests.csproj --filter ResponseChainShowcase -v minimal`
- `./scripts/run-mod-launcher.cmd cli launch response_chain_showcase --adapter raylib --record artifacts/acceptance/launcher-response-chain-showcase-raylib`

## Evidence
- `artifacts/acceptance/response-chain-showcase/battle-report.md`
- `artifacts/acceptance/launcher-response-chain-showcase-raylib/battle-report.md`
- `artifacts/acceptance/launcher-response-chain-showcase-raylib/response-chain-showcase-raylib.gif`
- `artifacts/acceptance/launcher-response-chain-showcase-raylib/response-chain-showcase-raylib.mp4`
