### PR TITLE
feat: add beam AOE manifestation showcase

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,4 +1,4 @@
-# 架构文档
+# 架构文档。
 
 本目录记录 Ludots 当前实现的核心架构、模块边界和数据流，聚焦“系统现在如何工作”。
 
@@ -9,7 +9,7 @@
 *   [适配器模式与平台抽象](adapter_pattern.md)
 *   [Pacemaker 时间与步进](pacemaker.md)
 *   [ConfigPipeline 合并管线](config_pipeline.md)
-*   [Trigger 开发指南](trigger_guide.md)
+*   [Trigger 开发指北](trigger_guide.md)
 *   [启动顺序与入口点](startup_entrypoints.md)
 *   [Map、Mod 与空间服务可插拔](map_mod_spatial.md)
 *   [Mod 运行时单一真相与收敛准则](mod_runtime_single_source_of_truth.md)
@@ -21,6 +21,7 @@
 
 *   [GAS 分层架构与 Sink 最佳实践](gas_layered_architecture.md)
 *   [GAS 战斗体系基建与 MOBA 实践指南](gas_combat_infrastructure.md)
+*   [GAS Beam / AOE Manifestation](gas_beam_aoe_manifestation.md)
 *   [交互模型与技能系统](interaction/README.md)
 *   [表现管线与 Performer 体系](presentation_performer.md)
 *   [表现层 visual snapshot contract](presentation_snapshot_contract.md)

--- a/docs/architecture/gas_beam_aoe_manifestation.md
+++ b/docs/architecture/gas_beam_aoe_manifestation.md
@@ -1,0 +1,261 @@
+# GAS Beam / AOE Manifestation
+
+## 1. Scope
+
+This document defines how Ludots extends the existing GAS, manifestation spawn, performer, and Raylib primitive pipelines to support visible, playable beam-like and wave-like showcase skills.
+
+Target showcase families:
+
+- penetrating beam
+- sweeping beam
+- sustained beam / channel beam
+- spline beam
+- diffusion wave
+- ring pulse
+
+The goal is not to introduce a separate beam runtime. The goal is to reuse the existing effect pipeline and give manifestations a reusable geometry payload that presentation adapters can render directly.
+
+## 2. Task Decision Record
+
+### 2.1 Judgment One
+
+This is still a feature task on top of existing pipelines, not a brand-new runtime stack.
+
+Existing infrastructure is sufficient for the authoritative side:
+
+- `src/Core/Gameplay/GAS/EffectTemplateRegistry.cs`
+- `src/Core/Gameplay/GAS/BuiltinHandlers.cs`
+- `src/Core/Gameplay/GAS/TargetResolverFanOutHelper.cs`
+- `src/Core/Gameplay/Spawning/Systems/ManifestationMotion2DSystem.cs`
+- `src/Core/Presentation/Systems/PerformerEmitSystem.cs`
+- `src/Core/Presentation/Rendering/PrimitiveDrawBuffer.cs`
+- `src/Client/Ludots.Client.Raylib/Rendering/RaylibPrimitiveRenderer.cs`
+
+Required work is an infrastructure-first extension inside those pipelines.
+
+### 2.2 Reuse List
+
+Reuse infrastructure:
+
+- Registry: `AbilityDefinitionRegistry` for showcase ability registration
+- Registry: `EffectTemplateRegistry` for authoritative beam / AOE effect definitions
+- Registry: `PerformerDefinitionRegistry` for manifestation performer authoring
+- Registry: `ComponentRegistry` for manifestation geometry JSON loading
+- Pipeline: `EffectRequestQueue -> EffectProcessingLoopSystem -> GasPresentationEventBuffer`
+- Pipeline: `PresentationCommandBuffer -> PerformerRuntimeSystem -> PerformerEmitSystem -> PrimitiveDrawBuffer`
+- System: `ManifestationMotion2DSystem` for follow-parent, target-facing, and sweep rotation
+- Mod: `ChampionSkillSandboxMod` as the playable showcase host
+
+### 2.3 Gap Analysis
+
+Existing GAS already supports the authoritative query shapes we need for most showcases:
+
+- `Circle`
+- `Cone`
+- `Rectangle`
+- `Line`
+- `Ring`
+
+Existing manifestation support already covers:
+
+- template-backed spawned units
+- parent linkage
+- persistent on-spawn effects
+- runtime follow / sweep motion
+
+The real gap is presentation:
+
+- manifestations do not carry structured beam / wave geometry
+- performer output can only emit `GroundOverlay`, `Marker3D`, `WorldText`, or `WorldBar`
+- Raylib primitive rendering does not know how to draw beam, spline, pulse, or disk-wave primitives
+
+## 3. Core Design
+
+### 3.1 Manifestation Geometry Is a Component
+
+Add `ManifestationGeometry2D` as a gameplay-side component on spawned manifestations.
+
+Responsibilities:
+
+- declare the presentation geometry family for a manifestation
+- carry reusable beam / wave parameters
+- stay authorable from template JSON
+- remain independent from adapter-specific rendering code
+
+This component is presentation-facing data owned by gameplay manifestations. It is not a duplicate effect runtime.
+
+### 3.2 Performer Emits a Manifestation Primitive Visual Kind
+
+Add a new performer visual kind:
+
+- `ManifestationPrimitive`
+
+This kind reuses the existing performer evaluation and binding rules, but emits a richer primitive payload into `PrimitiveDrawBuffer`.
+
+Resolution order stays the same:
+
+- imperative override
+- performer binding
+- performer default
+- manifestation geometry component values when the performer is attached to a manifestation entity
+
+### 3.3 Primitive Payload Becomes Shape-Aware
+
+`PrimitiveDrawItem` is extended so adapters can distinguish:
+
+- regular mesh marker draw
+- manifestation primitive draw
+
+The same shared draw buffer remains the adapter contract. Existing static mesh and skinned lanes keep working.
+
+### 3.4 Raylib Draws Beam / Wave Primitives Directly
+
+Raylib adds dedicated rendering for manifestation primitives:
+
+- beam segment strips
+- spline beam polyline strips
+- pulse ring loops
+- disk-wave loops
+
+Initial implementation favors deterministic line-strip rendering with width approximated by parallel offset strokes. This keeps the implementation debuggable and cross-platform while still making the showcases clearly visible.
+
+## 4. Geometry Contract
+
+### 4.1 Primitive Families
+
+`ManifestationPrimitiveKind`:
+
+- `Beam`
+- `SplineBeam`
+- `RingPulse`
+- `DiskWave`
+
+### 4.2 Shared Parameters
+
+`ManifestationGeometry2D` carries reusable AOE-facing parameters:
+
+- `LengthCm`
+- `WidthCm`
+- `EndWidthCm`
+- `InnerRadiusCm`
+- `OuterRadiusCm`
+- `SweepAngleDeg`
+- `SegmentCount`
+- `ArcHeightCm`
+- `ControlPoint0XCm`
+- `ControlPoint0YCm`
+- `ControlPoint1XCm`
+- `ControlPoint1YCm`
+- `PulseSpeed`
+- `PulseAmplitudeCm`
+
+These are intentionally generic enough to cover:
+
+- straight line AOE beams
+- widening beams
+- expanding circles
+- ring pulses
+- curved spline beams
+
+## 5. Showcase Mapping
+
+### 5.1 Existing Showcase Upgrades
+
+Upgrade current sandbox skills so they use visible manifestation primitives instead of only ground overlays:
+
+- `Prismatic Beam`: instant penetrating beam visual
+- `Guided Laser`: sustained target-facing beam manifestation
+- `Gravity Well`: disk-wave / diffusion-wave manifestation
+- `Cataclysm Ring`: ring pulse manifestation
+
+### 5.2 New Showcase Coverage
+
+Add one dedicated beam showcase champion so other developers can copy complete patterns:
+
+- line pierce
+- sweep beam
+- spline lash
+- pulse bloom
+
+The authoritative side should stay composed from existing `Search`, `PeriodicSearch`, and `CreateUnit` presets. When a visual family is richer than the authoritative query shape, the manifestation visuals remain richer while damage stays driven by supported GAS search patterns.
+
+## 6. Effect Authoring Guidance
+
+Recommended effect patterns:
+
+- one-shot penetrating beam:
+  - `Search` with `shape = Line`
+  - cue performer uses `ManifestationPrimitive`
+
+- sustained beam:
+  - `CreateUnit`
+  - spawned template carries `ManifestationMotion2D` and `ManifestationGeometry2D`
+  - spawned unit receives `PeriodicSearch` line effect
+
+- sweep beam:
+  - sustained beam pattern
+  - `ManifestationMotion2D.SweepDegreesPerSecond` rotates facing over time
+
+- ring pulse:
+  - `CreateUnit`
+  - `PeriodicSearch` with `shape = Ring` or `Circle`
+  - manifestation performer renders pulse ring
+
+- diffusion wave:
+  - `CreateUnit`
+  - `PeriodicSearch` with `shape = Circle`
+  - manifestation performer renders expanding disk wave
+
+- spline beam:
+  - `CreateUnit`
+  - authoritative damage composed from supported periodic searches
+  - visual side uses `SplineBeam`
+
+## 7. File Landing Plan
+
+Core runtime:
+
+- `src/Core/Gameplay/Spawning/ManifestationGeometry2D.cs`
+- `src/Core/Config/ComponentRegistry.cs`
+- `src/Core/Presentation/Performers/PerformerVisualKind.cs`
+- `src/Core/Presentation/Performers/WellKnownPerformerParamKeys.cs`
+- `src/Core/Presentation/Config/PerformerDefinitionConfigLoader.cs`
+- `src/Core/Presentation/Rendering/PrimitiveDrawKind.cs`
+- `src/Core/Presentation/Rendering/PrimitiveDrawItem.cs`
+- `src/Core/Presentation/Rendering/PresentationVisualProxy.cs`
+- `src/Core/Presentation/Rendering/PresentationVisualProxyEmitter.cs`
+- `src/Core/Presentation/Systems/PerformerEmitSystem.cs`
+- `src/Client/Ludots.Client.Raylib/Rendering/RaylibPrimitiveRenderer.cs`
+
+Sandbox:
+
+- `mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Entities/templates.json`
+- `mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/abilities.json`
+- `mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/effects.json`
+- `mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Maps/champion_skill_sandbox.json`
+- `mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Presentation/performers.json`
+- `mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxVisualFeedback.cs`
+
+Verification:
+
+- `src/Tests/PresentationTests/PresentationFoundationTests.cs`
+- `src/Tests/GasTests/Production/ChampionSkillSandboxConfigTests.cs`
+- `src/Tests/GasTests/Production/ChampionSkillSandboxPlayableAcceptanceTests.cs`
+
+## 8. Acceptance Expectations
+
+The finished delivery must provide:
+
+- headless acceptance coverage for the new showcase skills
+- artifact output under `artifacts/acceptance/champion-skill-sandbox/`
+- runtime screenshots captured from Raylib
+- a playable sandbox map where the new manifestation abilities can be selected and cast directly
+
+## 9. Non-Goals
+
+This work does not introduce:
+
+- a separate beam simulation subsystem
+- adapter-owned gameplay logic
+- a duplicate AOE authoring pipeline outside GAS
+- fallback compatibility shims for old beam-specific hacks

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxVisualFeedback.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxVisualFeedback.cs
@@ -526,6 +526,10 @@ namespace ChampionSkillSandboxMod.Runtime
             RegisterAbilityCue(performers, "Ability.Champion.SpellEngineer.GravityWell", "champion_skill_sandbox.cue.spell_engineer_gravity_well_cast");
             RegisterAbilityCue(performers, "Ability.Champion.SpellEngineer.CataclysmRing", "champion_skill_sandbox.cue.spell_engineer_cataclysm_ring_cast");
             RegisterAbilityCue(performers, "Ability.Champion.SpellEngineer.GuidedLaser", "champion_skill_sandbox.cue.spell_engineer_guided_laser_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.BeamArtisan.SweepArray", "champion_skill_sandbox.cue.beam_artisan_sweep_array_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.BeamArtisan.RibbonLash", "champion_skill_sandbox.cue.beam_artisan_ribbon_lash_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.BeamArtisan.DiffusionBloom", "champion_skill_sandbox.cue.beam_artisan_diffusion_bloom_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.BeamArtisan.HaloCircuit", "champion_skill_sandbox.cue.beam_artisan_halo_circuit_cast");
 
             RegisterEffectCue(performers, "Effect.Champion.Garen.JudgmentHit", "champion_skill_sandbox.cue.garen_judgment_hit");
             RegisterEffectCue(performers, "Effect.Champion.Garen.DemacianJusticeHit", "champion_skill_sandbox.cue.garen_demacian_justice_hit");

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Entities/templates.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Entities/templates.json
@@ -282,7 +282,15 @@
         ]
       },
       "AttributeBuffer": { "base": { "Health": 1, "Shield": 0, "MoveSpeed": 0, "Armor": 0 } },
-      "GameplayTagContainer": {}
+      "GameplayTagContainer": {},
+      "ManifestationGeometry2D": {
+        "primitiveKind": "DiskWave",
+        "innerRadiusCm": 30,
+        "outerRadiusCm": 240,
+        "sweepAngleDeg": 360,
+        "segmentCount": 40,
+        "pulseAmplitudeCm": 55
+      }
     }
   },
   {
@@ -326,6 +334,174 @@
         "followParentPosition": true,
         "facingSource": "ParentExecutionTarget",
         "forwardOffsetCm": 450
+      },
+      "ManifestationGeometry2D": {
+        "primitiveKind": "Beam",
+        "lengthCm": 900,
+        "widthCm": 90,
+        "endWidthCm": 132,
+        "segmentCount": 20,
+        "arcHeightCm": 24
+      },
+      "DestroyWhenParentExecutionEnds": {}
+    }
+  },
+  {
+    "id": "champion_skill_sandbox_cataclysm_ring_core",
+    "components": {
+      "Name": { "Value": "Cataclysm Ring Core" },
+      "SelectionSelectableTag": {},
+      "FacingDirection": { "AngleRad": 0.0 },
+      "Presentation": {
+        "startupPerformerIds": [
+          "champion_skill_sandbox.manifestation.cataclysm_ring_core"
+        ]
+      },
+      "AttributeBuffer": { "base": { "Health": 1, "Shield": 0, "MoveSpeed": 0, "Armor": 0 } },
+      "GameplayTagContainer": {},
+      "ManifestationGeometry2D": {
+        "primitiveKind": "RingPulse",
+        "innerRadiusCm": 220,
+        "outerRadiusCm": 300,
+        "sweepAngleDeg": 360,
+        "segmentCount": 52,
+        "pulseAmplitudeCm": 36
+      },
+      "DestroyWhenParentExecutionEnds": {}
+    }
+  },
+  {
+    "id": "champion_skill_sandbox_beam_artisan",
+    "components": {
+      "Name": { "Value": "Beam Artisan" },
+      "Team": { "Id": 1 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } },
+      "FacingDirection": { "AngleRad": 0.0 },
+      "Presentation": { "visualTemplateId": "core.character.hero_skinned" },
+      "AttributeBuffer": { "base": { "Health": 176, "Shield": 0, "MoveSpeed": 332, "Armor": 5 } },
+      "AbilityStateBuffer": {
+        "abilityIds": [
+          "Ability.Champion.BeamArtisan.SweepArray",
+          "Ability.Champion.BeamArtisan.RibbonLash",
+          "Ability.Champion.BeamArtisan.DiffusionBloom",
+          "Ability.Champion.BeamArtisan.HaloCircuit"
+        ]
+      },
+      "GameplayTagContainer": {},
+      "OrderBuffer": {},
+      "BlackboardSpatialBuffer": {},
+      "BlackboardEntityBuffer": {},
+      "BlackboardIntBuffer": {}
+    }
+  },
+  {
+    "id": "champion_skill_sandbox_beam_artisan_sweep_array",
+    "components": {
+      "Name": { "Value": "Sweep Array" },
+      "SelectionSelectableTag": {},
+      "FacingDirection": { "AngleRad": 0.0 },
+      "Presentation": {
+        "startupPerformerIds": [
+          "champion_skill_sandbox.manifestation.beam_artisan_sweep_array"
+        ]
+      },
+      "AttributeBuffer": { "base": { "Health": 1, "Shield": 0, "MoveSpeed": 0, "Armor": 0 } },
+      "GameplayTagContainer": {},
+      "ManifestationMotion2D": {
+        "followParentPosition": true,
+        "facingSource": "SweepVelocity",
+        "sweepDegreesPerSecond": 126,
+        "forwardOffsetCm": 380
+      },
+      "ManifestationGeometry2D": {
+        "primitiveKind": "Beam",
+        "lengthCm": 840,
+        "widthCm": 130,
+        "endWidthCm": 78,
+        "segmentCount": 22,
+        "arcHeightCm": 42
+      },
+      "DestroyWhenParentExecutionEnds": {}
+    }
+  },
+  {
+    "id": "champion_skill_sandbox_beam_artisan_ribbon_lash",
+    "components": {
+      "Name": { "Value": "Ribbon Lash" },
+      "SelectionSelectableTag": {},
+      "FacingDirection": { "AngleRad": 0.0 },
+      "Presentation": {
+        "startupPerformerIds": [
+          "champion_skill_sandbox.manifestation.beam_artisan_ribbon_lash"
+        ]
+      },
+      "AttributeBuffer": { "base": { "Health": 1, "Shield": 0, "MoveSpeed": 0, "Armor": 0 } },
+      "GameplayTagContainer": {},
+      "ManifestationMotion2D": {
+        "followParentPosition": true,
+        "facingSource": "ParentExecutionTarget",
+        "forwardOffsetCm": 360
+      },
+      "ManifestationGeometry2D": {
+        "primitiveKind": "SplineBeam",
+        "lengthCm": 880,
+        "widthCm": 74,
+        "endWidthCm": 138,
+        "segmentCount": 24,
+        "arcHeightCm": 86,
+        "controlPoint0XCm": -170,
+        "controlPoint0YCm": 250,
+        "controlPoint1XCm": 160,
+        "controlPoint1YCm": 620
+      },
+      "DestroyWhenParentExecutionEnds": {}
+    }
+  },
+  {
+    "id": "champion_skill_sandbox_beam_artisan_diffusion_bloom",
+    "components": {
+      "Name": { "Value": "Diffusion Bloom" },
+      "SelectionSelectableTag": {},
+      "FacingDirection": { "AngleRad": 0.0 },
+      "Presentation": {
+        "startupPerformerIds": [
+          "champion_skill_sandbox.manifestation.beam_artisan_diffusion_bloom"
+        ]
+      },
+      "AttributeBuffer": { "base": { "Health": 1, "Shield": 0, "MoveSpeed": 0, "Armor": 0 } },
+      "GameplayTagContainer": {},
+      "ManifestationGeometry2D": {
+        "primitiveKind": "DiskWave",
+        "innerRadiusCm": 20,
+        "outerRadiusCm": 260,
+        "sweepAngleDeg": 360,
+        "segmentCount": 44,
+        "pulseAmplitudeCm": 80
+      },
+      "DestroyWhenParentExecutionEnds": {}
+    }
+  },
+  {
+    "id": "champion_skill_sandbox_beam_artisan_halo_circuit",
+    "components": {
+      "Name": { "Value": "Halo Circuit" },
+      "SelectionSelectableTag": {},
+      "FacingDirection": { "AngleRad": 0.0 },
+      "Presentation": {
+        "startupPerformerIds": [
+          "champion_skill_sandbox.manifestation.beam_artisan_halo_circuit"
+        ]
+      },
+      "AttributeBuffer": { "base": { "Health": 1, "Shield": 0, "MoveSpeed": 0, "Armor": 0 } },
+      "GameplayTagContainer": {},
+      "ManifestationGeometry2D": {
+        "primitiveKind": "RingPulse",
+        "innerRadiusCm": 170,
+        "outerRadiusCm": 310,
+        "sweepAngleDeg": 360,
+        "segmentCount": 54,
+        "pulseAmplitudeCm": 44
       },
       "DestroyWhenParentExecutionEnds": {}
     }

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/abilities.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/abilities.json
@@ -634,6 +634,7 @@
       "items": [
         { "kind": "TagClip", "tick": 0, "duration": 90, "tag": "Cooldown.Champion.SpellEngineer.E" },
         { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.SpellEngineer.CataclysmRing" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.SpellEngineer.CataclysmRingVisual" },
         { "kind": "EventGate", "tick": 0, "payloadA": 180 },
         { "kind": "End", "tick": 0 }
       ]
@@ -676,6 +677,118 @@
       "hintText": "Hold to channel steerable beam, release to stop",
       "modeHints": {
         "SmartCast": "Hold to channel steerable beam, release to stop"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.BeamArtisan.SweepArray",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 72, "tag": "Cooldown.Champion.BeamArtisan.Q" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.BeamArtisan.SweepArray" },
+        { "kind": "EventGate", "tick": 0, "payloadA": 180 },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "indicator": { "shape": "Line", "range": 900, "radius": 80, "showRangeCircle": true, "validColor": "#F8C26E77", "invalidColor": "#E2575788" },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.BeamArtisan.Q"] },
+    "input": {
+      "trigger": "Held",
+      "heldPolicy": "StartEnd",
+      "castModeOverride": "SmartCast"
+    },
+    "presentation": {
+      "displayName": "Sweep Array",
+      "iconGlyph": "Q",
+      "accentColor": "#F8C26E",
+      "hintText": "Hold to spin a tethered beam fan",
+      "modeHints": {
+        "SmartCast": "Hold to spin the beam, release to stop"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.BeamArtisan.RibbonLash",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 78, "tag": "Cooldown.Champion.BeamArtisan.W" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.BeamArtisan.RibbonLash" },
+        { "kind": "EventGate", "tick": 0, "payloadA": 180 },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "indicator": { "shape": "Line", "range": 940, "radius": 88, "showRangeCircle": true, "validColor": "#8DE9FF77", "invalidColor": "#E2575788" },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.BeamArtisan.W"] },
+    "input": {
+      "trigger": "Held",
+      "heldPolicy": "StartEnd",
+      "castModeOverride": "SmartCast"
+    },
+    "presentation": {
+      "displayName": "Ribbon Lash",
+      "iconGlyph": "W",
+      "accentColor": "#8DE9FF",
+      "hintText": "Hold to project a curved spline lash",
+      "modeHints": {
+        "SmartCast": "Hold to sustain the curved lash, release to stop"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.BeamArtisan.DiffusionBloom",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 84, "tag": "Cooldown.Champion.BeamArtisan.E" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.BeamArtisan.DiffusionBloom" },
+        { "kind": "EventGate", "tick": 0, "payloadA": 180 },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "indicator": { "shape": "Circle", "range": 860, "radius": 260, "showRangeCircle": true, "validColor": "#8FF3B777", "invalidColor": "#E2575788" },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.BeamArtisan.E"] },
+    "input": {
+      "trigger": "Held",
+      "heldPolicy": "StartEnd",
+      "castModeOverride": "SmartCast"
+    },
+    "presentation": {
+      "displayName": "Diffusion Bloom",
+      "iconGlyph": "E",
+      "accentColor": "#8FF3B7",
+      "hintText": "Hold an expanding wave field at the target point",
+      "modeHints": {
+        "SmartCast": "Hold to sustain the bloom, release to stop"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.BeamArtisan.HaloCircuit",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 96, "tag": "Cooldown.Champion.BeamArtisan.R" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.BeamArtisan.HaloCircuit" },
+        { "kind": "EventGate", "tick": 0, "payloadA": 180 },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "indicator": { "shape": "Ring", "range": 860, "radius": 310, "innerRadius": 170, "showRangeCircle": true, "validColor": "#FFD96F77", "invalidColor": "#E2575788" },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.BeamArtisan.R"] },
+    "input": {
+      "trigger": "Held",
+      "heldPolicy": "StartEnd",
+      "castModeOverride": "SmartCast"
+    },
+    "presentation": {
+      "displayName": "Halo Circuit",
+      "iconGlyph": "R",
+      "accentColor": "#FFD96F",
+      "hintText": "Hold a ring-band lattice that punishes the perimeter",
+      "modeHints": {
+        "SmartCast": "Hold to sustain the halo, release to stop"
       }
     }
   }

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/effects.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/effects.json
@@ -596,6 +596,19 @@
     }
   },
   {
+    "id": "Effect.Champion.SpellEngineer.CataclysmRingVisual",
+    "tags": ["Effect.Champion.Manifestation", "Effect.Champion.Ring"],
+    "presetType": "CreateUnit",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "unitCreation": {
+      "templateId": "champion_skill_sandbox_cataclysm_ring_core",
+      "count": 1,
+      "copySourcePlayerOwner": true,
+      "linkSourceAsParent": true
+    }
+  },
+  {
     "id": "Effect.Champion.SpellEngineer.GuidedLaser",
     "tags": ["Effect.Champion.Manifestation", "Effect.Champion.Beam"],
     "presetType": "CreateUnit",
@@ -642,6 +655,201 @@
     "participatesInResponse": true,
     "modifiers": [
       { "attribute": "Health", "op": "Add", "value": -5.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.BeamArtisan.SweepArray",
+    "tags": ["Effect.Champion.Manifestation", "Effect.Champion.Beam"],
+    "presetType": "CreateUnit",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "unitCreation": {
+      "templateId": "champion_skill_sandbox_beam_artisan_sweep_array",
+      "count": 1,
+      "onSpawnEffect": "Effect.Champion.BeamArtisan.SweepArrayPersistent",
+      "copySourcePlayerOwner": true,
+      "linkSourceAsParent": true
+    }
+  },
+  {
+    "id": "Effect.Champion.BeamArtisan.SweepArrayPersistent",
+    "tags": ["Effect.Champion.Beam"],
+    "presetType": "PeriodicSearch",
+    "lifetime": "After",
+    "participatesInResponse": false,
+    "duration": {
+      "durationTicks": 1800,
+      "periodTicks": 5
+    },
+    "targetQuery": {
+      "kind": "BuiltinSpatial",
+      "shape": "Line",
+      "length": 840,
+      "halfWidth": 80
+    },
+    "targetFilter": {
+      "relationFilter": "Hostile",
+      "excludeSource": true,
+      "maxTargets": 16
+    },
+    "targetDispatch": {
+      "payloadEffect": "Effect.Champion.BeamArtisan.SweepArrayHit"
+    }
+  },
+  {
+    "id": "Effect.Champion.BeamArtisan.SweepArrayHit",
+    "tags": ["Effect.Champion.Damage"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -4.5 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.BeamArtisan.RibbonLash",
+    "tags": ["Effect.Champion.Manifestation", "Effect.Champion.Beam"],
+    "presetType": "CreateUnit",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "unitCreation": {
+      "templateId": "champion_skill_sandbox_beam_artisan_ribbon_lash",
+      "count": 1,
+      "onSpawnEffect": "Effect.Champion.BeamArtisan.RibbonLashPersistent",
+      "copySourcePlayerOwner": true,
+      "linkSourceAsParent": true
+    }
+  },
+  {
+    "id": "Effect.Champion.BeamArtisan.RibbonLashPersistent",
+    "tags": ["Effect.Champion.Beam"],
+    "presetType": "PeriodicSearch",
+    "lifetime": "After",
+    "participatesInResponse": false,
+    "duration": {
+      "durationTicks": 1800,
+      "periodTicks": 6
+    },
+    "targetQuery": {
+      "kind": "BuiltinSpatial",
+      "shape": "Line",
+      "length": 880,
+      "halfWidth": 88
+    },
+    "targetFilter": {
+      "relationFilter": "Hostile",
+      "excludeSource": true,
+      "maxTargets": 16
+    },
+    "targetDispatch": {
+      "payloadEffect": "Effect.Champion.BeamArtisan.RibbonLashHit"
+    }
+  },
+  {
+    "id": "Effect.Champion.BeamArtisan.RibbonLashHit",
+    "tags": ["Effect.Champion.Damage"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -6.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.BeamArtisan.DiffusionBloom",
+    "tags": ["Effect.Champion.Manifestation", "Effect.Champion.Zone"],
+    "presetType": "CreateUnit",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "unitCreation": {
+      "templateId": "champion_skill_sandbox_beam_artisan_diffusion_bloom",
+      "count": 1,
+      "onSpawnEffect": "Effect.Champion.BeamArtisan.DiffusionBloomPersistent",
+      "copySourcePlayerOwner": true,
+      "linkSourceAsParent": true
+    }
+  },
+  {
+    "id": "Effect.Champion.BeamArtisan.DiffusionBloomPersistent",
+    "tags": ["Effect.Champion.Zone"],
+    "presetType": "PeriodicSearch",
+    "lifetime": "After",
+    "participatesInResponse": false,
+    "duration": {
+      "durationTicks": 1800,
+      "periodTicks": 12
+    },
+    "targetQuery": {
+      "kind": "BuiltinSpatial",
+      "shape": "Circle",
+      "radius": 260
+    },
+    "targetFilter": {
+      "relationFilter": "Hostile",
+      "excludeSource": true,
+      "maxTargets": 16
+    },
+    "targetDispatch": {
+      "payloadEffect": "Effect.Champion.BeamArtisan.DiffusionBloomHit"
+    }
+  },
+  {
+    "id": "Effect.Champion.BeamArtisan.DiffusionBloomHit",
+    "tags": ["Effect.Champion.Damage"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -7.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.BeamArtisan.HaloCircuit",
+    "tags": ["Effect.Champion.Manifestation", "Effect.Champion.Ring"],
+    "presetType": "CreateUnit",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "unitCreation": {
+      "templateId": "champion_skill_sandbox_beam_artisan_halo_circuit",
+      "count": 1,
+      "onSpawnEffect": "Effect.Champion.BeamArtisan.HaloCircuitPersistent",
+      "copySourcePlayerOwner": true,
+      "linkSourceAsParent": true
+    }
+  },
+  {
+    "id": "Effect.Champion.BeamArtisan.HaloCircuitPersistent",
+    "tags": ["Effect.Champion.Ring"],
+    "presetType": "PeriodicSearch",
+    "lifetime": "After",
+    "participatesInResponse": false,
+    "duration": {
+      "durationTicks": 1800,
+      "periodTicks": 10
+    },
+    "targetQuery": {
+      "kind": "BuiltinSpatial",
+      "shape": "Ring",
+      "radius": 310,
+      "innerRadius": 170
+    },
+    "targetFilter": {
+      "relationFilter": "Hostile",
+      "excludeSource": true,
+      "maxTargets": 16
+    },
+    "targetDispatch": {
+      "payloadEffect": "Effect.Champion.BeamArtisan.HaloCircuitHit"
+    }
+  },
+  {
+    "id": "Effect.Champion.BeamArtisan.HaloCircuitHit",
+    "tags": ["Effect.Champion.Damage"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -8.0 }
     ]
   }
 ]

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Maps/champion_skill_sandbox.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Maps/champion_skill_sandbox.json
@@ -75,6 +75,14 @@
       }
     },
     {
+      "Template": "champion_skill_sandbox_beam_artisan",
+      "Overrides": {
+        "Name": { "Value": "Beam Artisan Alpha" },
+        "PlayerOwner": { "PlayerId": 1 },
+        "WorldPositionCm": { "Value": { "X": 3140, "Y": 1600 } }
+      }
+    },
+    {
       "Template": "champion_skill_sandbox_enemy_dummy",
       "Overrides": {
         "Name": { "Value": "Target Dummy A" },
@@ -128,6 +136,27 @@
       "Overrides": {
         "Name": { "Value": "Target Dummy F" },
         "WorldPositionCm": { "Value": { "X": 2460, "Y": 1420 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_enemy_dummy",
+      "Overrides": {
+        "Name": { "Value": "Target Dummy G" },
+        "WorldPositionCm": { "Value": { "X": 3620, "Y": 1600 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_enemy_dummy",
+      "Overrides": {
+        "Name": { "Value": "Target Dummy H" },
+        "WorldPositionCm": { "Value": { "X": 3540, "Y": 1760 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_enemy_dummy",
+      "Overrides": {
+        "Name": { "Value": "Target Dummy I" },
+        "WorldPositionCm": { "Value": { "X": 3540, "Y": 1440 } }
       }
     }
   ]

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Presentation/performers.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Presentation/performers.json
@@ -310,13 +310,20 @@
   },
   {
     "id": "champion_skill_sandbox.cue.geomancer_prismatic_beam_cast",
-    "visualKind": "Marker3D",
-    "meshOrShapeId": "Sphere",
-    "defaultColor": [0.5, 0.9, 1.0, 0.88],
-    "defaultScale": 0.38,
-    "defaultLifetime": 0.2,
+    "visualKind": "ManifestationPrimitive",
+    "meshOrShapeId": "Beam",
+    "defaultColor": [0.5, 0.9, 1.0, 0.78],
+    "defaultScale": 1.0,
+    "defaultLifetime": 0.22,
     "alphaFadeOverLifetime": true,
-    "positionOffset": [0, 0.76, 0]
+    "positionOffset": [0, 0.76, 0],
+    "bindings": [
+      { "paramKey": 0, "source": "constant", "constantValue": 9.2 },
+      { "paramKey": 1, "source": "constant", "constantValue": 1.4 },
+      { "paramKey": 2, "source": "constant", "constantValue": 0.95 },
+      { "paramKey": 3, "source": "constant", "constantValue": 0.28 },
+      { "paramKey": 11, "source": "constant", "constantValue": 18.0 }
+    ]
   },
   {
     "id": "champion_skill_sandbox.cue.geomancer_prismatic_beam_hit",
@@ -538,20 +545,12 @@
   },
   {
     "id": "champion_skill_sandbox.manifestation.gravity_well",
-    "visualKind": "GroundOverlay",
-    "meshOrShapeId": "Ring",
-    "defaultColor": [0.48, 0.62, 1.0, 0.12],
-    "defaultScale": 2.4,
+    "visualKind": "ManifestationPrimitive",
+    "meshOrShapeId": "DiskWave",
+    "defaultColor": [0.48, 0.62, 1.0, 0.2],
+    "defaultScale": 1.0,
     "defaultLifetime": -1,
-    "positionOffset": [0, 0.05, 0],
-    "bindings": [
-      { "paramKey": 1, "source": "constant", "constantValue": 1.68 },
-      { "paramKey": 8, "source": "constant", "constantValue": 0.55 },
-      { "paramKey": 9, "source": "constant", "constantValue": 0.69 },
-      { "paramKey": 10, "source": "constant", "constantValue": 1.0 },
-      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
-      { "paramKey": 12, "source": "constant", "constantValue": 0.045 }
-    ]
+    "positionOffset": [0, 0.06, 0]
   },
   {
     "id": "champion_skill_sandbox.manifestation.barrier_segment",
@@ -574,21 +573,128 @@
   },
   {
     "id": "champion_skill_sandbox.manifestation.guided_laser",
-    "visualKind": "GroundOverlay",
-    "meshOrShapeId": "Line",
-    "defaultColor": [0.72, 0.5, 1.0, 0.12],
+    "visualKind": "ManifestationPrimitive",
+    "meshOrShapeId": "Beam",
+    "defaultColor": [0.72, 0.5, 1.0, 0.22],
     "defaultScale": 1.0,
     "defaultLifetime": -1,
+    "positionOffset": [0, 0.08, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.manifestation.cataclysm_ring_core",
+    "visualKind": "ManifestationPrimitive",
+    "meshOrShapeId": "RingPulse",
+    "defaultColor": [1.0, 0.58, 0.42, 0.22],
+    "defaultScale": 1.0,
+    "defaultLifetime": -1,
+    "positionOffset": [0, 0.06, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.manifestation.beam_artisan_sweep_array",
+    "visualKind": "ManifestationPrimitive",
+    "meshOrShapeId": "Beam",
+    "defaultColor": [0.98, 0.78, 0.46, 0.22],
+    "defaultScale": 1.0,
+    "defaultLifetime": -1,
+    "positionOffset": [0, 0.08, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.manifestation.beam_artisan_ribbon_lash",
+    "visualKind": "ManifestationPrimitive",
+    "meshOrShapeId": "SplineBeam",
+    "defaultColor": [0.58, 0.94, 1.0, 0.22],
+    "defaultScale": 1.0,
+    "defaultLifetime": -1,
+    "positionOffset": [0, 0.08, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.manifestation.beam_artisan_diffusion_bloom",
+    "visualKind": "ManifestationPrimitive",
+    "meshOrShapeId": "DiskWave",
+    "defaultColor": [0.58, 1.0, 0.86, 0.18],
+    "defaultScale": 1.0,
+    "defaultLifetime": -1,
+    "positionOffset": [0, 0.06, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.manifestation.beam_artisan_halo_circuit",
+    "visualKind": "ManifestationPrimitive",
+    "meshOrShapeId": "RingPulse",
+    "defaultColor": [1.0, 0.86, 0.52, 0.2],
+    "defaultScale": 1.0,
+    "defaultLifetime": -1,
+    "positionOffset": [0, 0.06, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.beam_artisan_sweep_array_cast",
+    "visualKind": "ManifestationPrimitive",
+    "meshOrShapeId": "Beam",
+    "defaultColor": [0.98, 0.78, 0.46, 0.74],
+    "defaultScale": 1.0,
+    "defaultLifetime": 0.22,
+    "alphaFadeOverLifetime": true,
+    "positionOffset": [0, 0.76, 0],
+    "bindings": [
+      { "paramKey": 0, "source": "constant", "constantValue": 8.6 },
+      { "paramKey": 1, "source": "constant", "constantValue": 1.2 },
+      { "paramKey": 2, "source": "constant", "constantValue": 0.9 },
+      { "paramKey": 3, "source": "constant", "constantValue": 0.18 },
+      { "paramKey": 11, "source": "constant", "constantValue": 16.0 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.beam_artisan_ribbon_lash_cast",
+    "visualKind": "ManifestationPrimitive",
+    "meshOrShapeId": "SplineBeam",
+    "defaultColor": [0.58, 0.94, 1.0, 0.76],
+    "defaultScale": 1.0,
+    "defaultLifetime": 0.24,
+    "alphaFadeOverLifetime": true,
+    "positionOffset": [0, 0.76, 0],
+    "bindings": [
+      { "paramKey": 0, "source": "constant", "constantValue": 8.2 },
+      { "paramKey": 1, "source": "constant", "constantValue": 0.72 },
+      { "paramKey": 2, "source": "constant", "constantValue": 1.18 },
+      { "paramKey": 3, "source": "constant", "constantValue": 0.55 },
+      { "paramKey": 11, "source": "constant", "constantValue": 22.0 },
+      { "paramKey": 14, "source": "constant", "constantValue": -1.2 },
+      { "paramKey": 15, "source": "constant", "constantValue": 2.4 },
+      { "paramKey": 16, "source": "constant", "constantValue": 1.3 },
+      { "paramKey": 17, "source": "constant", "constantValue": 5.8 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.beam_artisan_diffusion_bloom_cast",
+    "visualKind": "ManifestationPrimitive",
+    "meshOrShapeId": "DiskWave",
+    "defaultColor": [0.58, 1.0, 0.86, 0.2],
+    "defaultScale": 1.0,
+    "defaultLifetime": 0.28,
+    "alphaFadeOverLifetime": true,
     "positionOffset": [0, 0.06, 0],
     "bindings": [
-      { "paramKey": 3, "source": "facingradians" },
-      { "paramKey": 8, "source": "constant", "constantValue": 0.82 },
-      { "paramKey": 9, "source": "constant", "constantValue": 0.66 },
-      { "paramKey": 10, "source": "constant", "constantValue": 1.0 },
-      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
-      { "paramKey": 12, "source": "constant", "constantValue": 0.08 },
-      { "paramKey": 13, "source": "constant", "constantValue": 9.0 },
-      { "paramKey": 14, "source": "constant", "constantValue": 1.4 }
+      { "paramKey": 8, "source": "constant", "constantValue": 0.2 },
+      { "paramKey": 9, "source": "constant", "constantValue": 2.2 },
+      { "paramKey": 10, "source": "constant", "constantValue": 360.0 },
+      { "paramKey": 11, "source": "constant", "constantValue": 42.0 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.5 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.beam_artisan_halo_circuit_cast",
+    "visualKind": "ManifestationPrimitive",
+    "meshOrShapeId": "RingPulse",
+    "defaultColor": [1.0, 0.86, 0.52, 0.22],
+    "defaultScale": 1.0,
+    "defaultLifetime": 0.26,
+    "alphaFadeOverLifetime": true,
+    "positionOffset": [0, 0.06, 0],
+    "bindings": [
+      { "paramKey": 8, "source": "constant", "constantValue": 1.6 },
+      { "paramKey": 9, "source": "constant", "constantValue": 3.0 },
+      { "paramKey": 10, "source": "constant", "constantValue": 360.0 },
+      { "paramKey": 11, "source": "constant", "constantValue": 48.0 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.35 }
     ]
   },
   {

--- a/src/Client/Ludots.Client.Raylib/Rendering/RaylibPrimitiveRenderer.cs
+++ b/src/Client/Ludots.Client.Raylib/Rendering/RaylibPrimitiveRenderer.cs
@@ -154,6 +154,11 @@ namespace Ludots.Client.Raylib.Rendering
                     continue;
                 }
 
+                if (TryDrawManifestationPrimitive(item))
+                {
+                    continue;
+                }
+
                 if (TryDrawPrototypeSkinned(item, meshes, scaleMul))
                 {
                     continue;
@@ -186,6 +191,11 @@ namespace Ludots.Client.Raylib.Rendering
             for (int i = 0; i < span.Length; i++)
             {
                 ref readonly var item = ref span[i];
+                if (TryDrawManifestationPrimitive(item))
+                {
+                    continue;
+                }
+
                 if (TryDrawPrototypeSkinned(item, meshes, scaleMul))
                 {
                     continue;
@@ -261,6 +271,27 @@ namespace Ludots.Client.Raylib.Rendering
             }
 
             DrawPrimitive(kind, position, scale, color);
+        }
+
+        private bool TryDrawManifestationPrimitive(in PrimitiveDrawItem item)
+        {
+            switch (item.PrimitiveKind)
+            {
+                case PrimitiveDrawKind.Beam:
+                    DrawBeamPrimitive(item.Position, item.Rotation, item.Color, item.PrimitiveLength, item.PrimitiveWidth, item.PrimitiveEndWidth, item.PrimitiveArcHeight, item.PrimitiveSegmentCount);
+                    return true;
+                case PrimitiveDrawKind.SplineBeam:
+                    DrawSplineBeamPrimitive(item.Position, item.Rotation, item.Color, item.PrimitiveLength, item.PrimitiveWidth, item.PrimitiveEndWidth, item.PrimitiveArcHeight, item.PrimitiveSegmentCount, item.PrimitiveControlPoint0, item.PrimitiveControlPoint1);
+                    return true;
+                case PrimitiveDrawKind.RingPulse:
+                    DrawRingPulsePrimitive(item.Position, item.Rotation, item.Color, item.PrimitiveInnerRadius, item.PrimitiveOuterRadius, item.PrimitiveSweepAngleDeg, item.PrimitiveSegmentCount, item.PrimitivePulseAmplitude);
+                    return true;
+                case PrimitiveDrawKind.DiskWave:
+                    DrawDiskWavePrimitive(item.Position, item.Rotation, item.Color, item.PrimitiveInnerRadius, item.PrimitiveOuterRadius, item.PrimitiveSweepAngleDeg, item.PrimitiveSegmentCount, item.PrimitivePulseAmplitude);
+                    return true;
+                default:
+                    return false;
+            }
         }
 
         private bool TryDrawPrototypeSkinned(in PrimitiveDrawItem item, MeshAssetRegistry meshes, float scaleMul)
@@ -396,6 +427,139 @@ namespace Ludots.Client.Raylib.Rendering
             {
                 float r = MathF.Max(scale.X, MathF.Max(scale.Y, scale.Z)) * 0.5f;
                 Rl.DrawSphere(position, r, c);
+            }
+        }
+
+        private void DrawBeamPrimitive(
+            Vector3 origin,
+            Quaternion rotation,
+            Vector4 color,
+            float length,
+            float width,
+            float endWidth,
+            float arcHeight,
+            int segmentCount)
+        {
+            if (length <= 0.01f)
+            {
+                return;
+            }
+
+            float yaw = ExtractYawRad(rotation);
+            int segments = Math.Max(4, segmentCount > 0 ? segmentCount : 14);
+            int stripes = ComputeStripeCount(MathF.Max(width, endWidth));
+            for (int stripe = -stripes; stripe <= stripes; stripe++)
+            {
+                float normalizedStripe = stripes == 0 ? 0f : stripe / (float)stripes;
+                Color stripeColor = ToRaylibColor(ScaleAlpha(color, StripeAlpha(normalizedStripe)));
+                Vector3 previous = EvaluateBeamPoint(origin, yaw, 0f, normalizedStripe, length, width, endWidth, arcHeight);
+                for (int segment = 1; segment <= segments; segment++)
+                {
+                    float t = segment / (float)segments;
+                    Vector3 current = EvaluateBeamPoint(origin, yaw, t, normalizedStripe, length, width, endWidth, arcHeight);
+                    Rl.DrawLine3D(previous, current, stripeColor);
+                    previous = current;
+                }
+            }
+        }
+
+        private void DrawSplineBeamPrimitive(
+            Vector3 origin,
+            Quaternion rotation,
+            Vector4 color,
+            float length,
+            float width,
+            float endWidth,
+            float arcHeight,
+            int segmentCount,
+            Vector2 controlPoint0,
+            Vector2 controlPoint1)
+        {
+            if (length <= 0.01f)
+            {
+                return;
+            }
+
+            float yaw = ExtractYawRad(rotation);
+            int segments = Math.Max(6, segmentCount > 0 ? segmentCount : 18);
+            int stripes = ComputeStripeCount(MathF.Max(width, endWidth));
+            for (int stripe = -stripes; stripe <= stripes; stripe++)
+            {
+                float normalizedStripe = stripes == 0 ? 0f : stripe / (float)stripes;
+                Color stripeColor = ToRaylibColor(ScaleAlpha(color, StripeAlpha(normalizedStripe)));
+                Vector3 previous = EvaluateSplinePoint(origin, yaw, 0f, normalizedStripe, length, width, endWidth, arcHeight, controlPoint0, controlPoint1);
+                for (int segment = 1; segment <= segments; segment++)
+                {
+                    float t = segment / (float)segments;
+                    Vector3 current = EvaluateSplinePoint(origin, yaw, t, normalizedStripe, length, width, endWidth, arcHeight, controlPoint0, controlPoint1);
+                    Rl.DrawLine3D(previous, current, stripeColor);
+                    previous = current;
+                }
+            }
+        }
+
+        private void DrawRingPulsePrimitive(
+            Vector3 origin,
+            Quaternion rotation,
+            Vector4 color,
+            float innerRadius,
+            float outerRadius,
+            float sweepAngleDeg,
+            int segmentCount,
+            float pulseAmplitude)
+        {
+            float startRadius = Math.Clamp(innerRadius, 0f, MathF.Max(innerRadius, outerRadius));
+            float endRadius = MathF.Max(startRadius, outerRadius);
+            if (endRadius <= 0.01f)
+            {
+                return;
+            }
+
+            float yaw = ExtractYawRad(rotation);
+            int segments = Math.Max(12, segmentCount > 0 ? segmentCount : 48);
+            int bands = Math.Max(1, ComputeStripeCount(endRadius - startRadius));
+            float sweepRad = ResolveSweepRadians(sweepAngleDeg);
+            float startAngle = yaw - (sweepRad * 0.5f);
+            float endAngle = startAngle + sweepRad;
+            float bandStart = Math.Max(0f, startRadius - MathF.Max(0f, pulseAmplitude));
+            float bandEnd = endRadius + MathF.Max(0f, pulseAmplitude);
+
+            for (int band = 0; band <= bands; band++)
+            {
+                float radius = bandStart + ((bandEnd - bandStart) * band / Math.Max(1, bands));
+                DrawArcLoop(origin, radius, startAngle, endAngle, segments, ToRaylibColor(ScaleAlpha(color, 0.45f + (0.4f * (band / (float)Math.Max(1, bands))))));
+            }
+        }
+
+        private void DrawDiskWavePrimitive(
+            Vector3 origin,
+            Quaternion rotation,
+            Vector4 color,
+            float innerRadius,
+            float outerRadius,
+            float sweepAngleDeg,
+            int segmentCount,
+            float pulseAmplitude)
+        {
+            float startRadius = Math.Max(0f, innerRadius);
+            float endRadius = MathF.Max(startRadius, outerRadius);
+            if (endRadius <= 0.01f)
+            {
+                return;
+            }
+
+            float yaw = ExtractYawRad(rotation);
+            int segments = Math.Max(12, segmentCount > 0 ? segmentCount : 48);
+            int bands = Math.Max(3, segmentCount > 0 ? segmentCount / 3 : 10);
+            float sweepRad = ResolveSweepRadians(sweepAngleDeg);
+            float startAngle = yaw - (sweepRad * 0.5f);
+            float endAngle = startAngle + sweepRad;
+            float expandedOuter = endRadius + MathF.Max(0f, pulseAmplitude);
+
+            for (int band = 0; band <= bands; band++)
+            {
+                float radius = startRadius + ((expandedOuter - startRadius) * band / Math.Max(1, bands));
+                DrawArcLoop(origin, radius, startAngle, endAngle, segments, ToRaylibColor(ScaleAlpha(color, 0.3f + (0.5f * (band / (float)Math.Max(1, bands))))));
             }
         }
 
@@ -557,6 +721,78 @@ namespace Ludots.Client.Raylib.Rendering
             return MathF.Sin(clip.NormalizedTime01 * MathF.PI) * clip.Weight01;
         }
 
+        private static Vector3 EvaluateBeamPoint(
+            Vector3 origin,
+            float yaw,
+            float t,
+            float normalizedStripe,
+            float length,
+            float width,
+            float endWidth,
+            float arcHeight)
+        {
+            float localWidth = Lerp(width, endWidth <= 0f ? width : endWidth, t);
+            float x = normalizedStripe * localWidth * 0.5f;
+            float y = MathF.Sin(t * MathF.PI) * arcHeight;
+            float z = t * length;
+            return TransformLocal(origin, yaw, new Vector3(x, y, z));
+        }
+
+        private static Vector3 EvaluateSplinePoint(
+            Vector3 origin,
+            float yaw,
+            float t,
+            float normalizedStripe,
+            float length,
+            float width,
+            float endWidth,
+            float arcHeight,
+            Vector2 controlPoint0,
+            Vector2 controlPoint1)
+        {
+            Vector2 p0 = Vector2.Zero;
+            Vector2 p1 = controlPoint0;
+            Vector2 p2 = controlPoint1 == Vector2.Zero ? new Vector2(0f, length * 0.75f) : controlPoint1;
+            Vector2 p3 = new Vector2(0f, length);
+            Vector2 point = CubicBezier(p0, p1, p2, p3, t);
+            Vector2 tangent = CubicBezierTangent(p0, p1, p2, p3, t);
+            if (tangent.LengthSquared() <= 0.0001f)
+            {
+                tangent = Vector2.UnitY;
+            }
+            else
+            {
+                tangent = Vector2.Normalize(tangent);
+            }
+
+            Vector2 normal = new Vector2(-tangent.Y, tangent.X);
+            float localWidth = Lerp(width, endWidth <= 0f ? width : endWidth, t);
+            Vector2 offset = normal * (normalizedStripe * localWidth * 0.5f);
+            float y = MathF.Sin(t * MathF.PI) * arcHeight;
+            return TransformLocal(origin, yaw, new Vector3(point.X + offset.X, y, point.Y + offset.Y));
+        }
+
+        private static Vector2 CubicBezier(Vector2 p0, Vector2 p1, Vector2 p2, Vector2 p3, float t)
+        {
+            float u = 1f - t;
+            float uu = u * u;
+            float tt = t * t;
+            return
+                (uu * u * p0) +
+                (3f * uu * t * p1) +
+                (3f * u * tt * p2) +
+                (tt * t * p3);
+        }
+
+        private static Vector2 CubicBezierTangent(Vector2 p0, Vector2 p1, Vector2 p2, Vector2 p3, float t)
+        {
+            float u = 1f - t;
+            return
+                (3f * u * u * (p1 - p0)) +
+                (6f * u * t * (p2 - p1)) +
+                (3f * t * t * (p3 - p2));
+        }
+
         private void DrawOrientedCube(Vector3 center, Vector3 size, float yawRad, Vector4 color)
         {
             DrawWireBox(center, size, yawRad, color);
@@ -599,6 +835,54 @@ namespace Ludots.Client.Raylib.Rendering
                 from.Y + (to.Y - from.Y) * t,
                 from.Z + (to.Z - from.Z) * t,
                 from.W + (to.W - from.W) * t);
+        }
+
+        private static float Lerp(float from, float to, float t)
+        {
+            return from + ((to - from) * Math.Clamp(t, 0f, 1f));
+        }
+
+        private static int ComputeStripeCount(float width)
+        {
+            return Math.Clamp((int)MathF.Ceiling(MathF.Max(0f, width) / 0.08f), 0, 8);
+        }
+
+        private static float StripeAlpha(float normalizedStripe)
+        {
+            return 0.35f + (0.65f * (1f - MathF.Abs(normalizedStripe)));
+        }
+
+        private static Vector4 ScaleAlpha(Vector4 color, float alphaScale)
+        {
+            return new Vector4(color.X, color.Y, color.Z, Math.Clamp(color.W * alphaScale, 0f, 1f));
+        }
+
+        private static float ResolveSweepRadians(float sweepAngleDeg)
+        {
+            if (sweepAngleDeg <= 0.01f)
+            {
+                return MathF.Tau;
+            }
+
+            return Math.Clamp(sweepAngleDeg, 1f, 360f) * (MathF.PI / 180f);
+        }
+
+        private static void DrawArcLoop(Vector3 center, float radius, float startAngle, float endAngle, int segments, Color color)
+        {
+            if (radius <= 0.001f || segments <= 0)
+            {
+                return;
+            }
+
+            float step = (endAngle - startAngle) / segments;
+            Vector3 previous = new Vector3(center.X + (MathF.Cos(startAngle) * radius), center.Y, center.Z + (MathF.Sin(startAngle) * radius));
+            for (int i = 1; i <= segments; i++)
+            {
+                float angle = startAngle + (step * i);
+                Vector3 current = new Vector3(center.X + (MathF.Cos(angle) * radius), center.Y, center.Z + (MathF.Sin(angle) * radius));
+                Rl.DrawLine3D(previous, current, color);
+                previous = current;
+            }
         }
 
         private void DrawModel(int meshAssetId, in MeshAssetDescriptor desc, Vector3 position, Vector3 scale, Vector4 color)
@@ -820,6 +1104,11 @@ namespace Ludots.Client.Raylib.Rendering
             for (int i = 0; i < span.Length; i++)
             {
                 ref readonly var item = ref span[i];
+                if (TryDrawManifestationPrimitive(item))
+                {
+                    continue;
+                }
+
                 if (!meshes.TryGetPrimitiveKind(item.MeshAssetId, out var kind)) continue;
 
                 SubmitPrimitive(kind, item.Position, item.Scale, item.Color);

--- a/src/Core/Config/ComponentRegistry.cs
+++ b/src/Core/Config/ComponentRegistry.cs
@@ -57,6 +57,7 @@ namespace Ludots.Core.Config
             Register("ManifestationObstacleIntent2D", SetManifestationObstacleIntent2D);
             Register("ManifestationObstaclePolygon2D", SetManifestationObstaclePolygon2D);
             Register("ManifestationMotion2D", SetManifestationMotion2D);
+            Register("ManifestationGeometry2D", SetManifestationGeometry2D);
             Register("DestroyWhenParentExecutionEnds", SetDestroyWhenParentExecutionEnds);
         }
 
@@ -410,6 +411,34 @@ namespace Ludots.Core.Config
             });
         }
 
+        private static void SetManifestationGeometry2D(Entity entity, JsonNode data)
+        {
+            if (data is not JsonObject obj)
+            {
+                throw new InvalidOperationException("ManifestationGeometry2D requires an object payload.");
+            }
+
+            int segmentCount = ReadIntProperty(obj, "segmentCount", "SegmentCount");
+            entity.Add(new ManifestationGeometry2D
+            {
+                PrimitiveKind = ParseManifestationPrimitiveKind(obj["primitiveKind"]?.GetValue<string>() ?? obj["PrimitiveKind"]?.GetValue<string>()),
+                LengthCm = ReadIntProperty(obj, "lengthCm", "LengthCm"),
+                WidthCm = ReadIntProperty(obj, "widthCm", "WidthCm"),
+                EndWidthCm = ReadIntProperty(obj, "endWidthCm", "EndWidthCm"),
+                InnerRadiusCm = ReadIntProperty(obj, "innerRadiusCm", "InnerRadiusCm"),
+                OuterRadiusCm = ReadIntProperty(obj, "outerRadiusCm", "OuterRadiusCm"),
+                SweepAngleDeg = ReadFloatProperty(obj, "sweepAngleDeg", "SweepAngleDeg"),
+                SegmentCount = (byte)Math.Clamp(segmentCount <= 0 ? 0 : segmentCount, 0, 64),
+                ArcHeightCm = ReadIntProperty(obj, "arcHeightCm", "ArcHeightCm"),
+                ControlPoint0XCm = ReadIntProperty(obj, "controlPoint0XCm", "ControlPoint0XCm"),
+                ControlPoint0YCm = ReadIntProperty(obj, "controlPoint0YCm", "ControlPoint0YCm"),
+                ControlPoint1XCm = ReadIntProperty(obj, "controlPoint1XCm", "ControlPoint1XCm"),
+                ControlPoint1YCm = ReadIntProperty(obj, "controlPoint1YCm", "ControlPoint1YCm"),
+                PulseSpeed = ReadFloatProperty(obj, "pulseSpeed", "PulseSpeed"),
+                PulseAmplitudeCm = ReadIntProperty(obj, "pulseAmplitudeCm", "PulseAmplitudeCm"),
+            });
+        }
+
         private static void SetDestroyWhenParentExecutionEnds(Entity entity, JsonNode data)
         {
             entity.Add(new DestroyWhenParentExecutionEnds());
@@ -444,6 +473,23 @@ namespace Ludots.Core.Config
                 "sweepvelocity" => ManifestationFacingSource2D.SweepVelocity,
                 "parentexecutiontarget" => ManifestationFacingSource2D.ParentExecutionTarget,
                 _ => throw new InvalidOperationException($"Unsupported ManifestationMotion2D facingSource '{raw}'.")
+            };
+        }
+
+        private static ManifestationPrimitiveKind ParseManifestationPrimitiveKind(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return ManifestationPrimitiveKind.Beam;
+            }
+
+            return raw.Trim().ToLowerInvariant() switch
+            {
+                "beam" => ManifestationPrimitiveKind.Beam,
+                "splinebeam" => ManifestationPrimitiveKind.SplineBeam,
+                "ringpulse" => ManifestationPrimitiveKind.RingPulse,
+                "diskwave" => ManifestationPrimitiveKind.DiskWave,
+                _ => throw new InvalidOperationException($"Unsupported ManifestationGeometry2D primitiveKind '{raw}'.")
             };
         }
 

--- a/src/Core/Gameplay/Spawning/ManifestationGeometry2D.cs
+++ b/src/Core/Gameplay/Spawning/ManifestationGeometry2D.cs
@@ -1,0 +1,33 @@
+namespace Ludots.Core.Gameplay.Spawning
+{
+    public enum ManifestationPrimitiveKind : byte
+    {
+        Beam = 0,
+        SplineBeam = 1,
+        RingPulse = 2,
+        DiskWave = 3,
+    }
+
+    /// <summary>
+    /// Declarative geometry payload for manifestation-backed beam / wave visuals.
+    /// Values are authored in centimeters and converted by the presentation layer.
+    /// </summary>
+    public struct ManifestationGeometry2D
+    {
+        public ManifestationPrimitiveKind PrimitiveKind;
+        public int LengthCm;
+        public int WidthCm;
+        public int EndWidthCm;
+        public int InnerRadiusCm;
+        public int OuterRadiusCm;
+        public float SweepAngleDeg;
+        public byte SegmentCount;
+        public int ArcHeightCm;
+        public int ControlPoint0XCm;
+        public int ControlPoint0YCm;
+        public int ControlPoint1XCm;
+        public int ControlPoint1YCm;
+        public float PulseSpeed;
+        public int PulseAmplitudeCm;
+    }
+}

--- a/src/Core/Gameplay/Spawning/Systems/ManifestationMotion2DSystem.cs
+++ b/src/Core/Gameplay/Spawning/Systems/ManifestationMotion2DSystem.cs
@@ -33,7 +33,7 @@ namespace Ludots.Core.Gameplay.Spawning.Systems
 
                 float? facing = motion.FacingSource switch
                 {
-                    ManifestationFacingSource2D.SweepVelocity => ResolveSweepFacing(entity, motion, deltaSeconds),
+                    ManifestationFacingSource2D.SweepVelocity => ResolveSweepFacing(entity, parent, motion, deltaSeconds),
                     ManifestationFacingSource2D.ParentExecutionTarget => ResolveParentExecutionFacing(parent),
                     _ => null,
                 };
@@ -61,11 +61,9 @@ namespace Ludots.Core.Gameplay.Spawning.Systems
             });
         }
 
-        private float? ResolveSweepFacing(Entity entity, in ManifestationMotion2D motion, float deltaSeconds)
+        private float? ResolveSweepFacing(Entity entity, Entity parent, in ManifestationMotion2D motion, float deltaSeconds)
         {
-            float current = World.Has<FacingDirection>(entity)
-                ? World.Get<FacingDirection>(entity).AngleRad
-                : 0f;
+            float current = ResolveOffsetFacing(entity, parent) ?? 0f;
             return current + (motion.SweepDegreesPerSecond * (MathF.PI / 180f) * deltaSeconds);
         }
 

--- a/src/Core/Presentation/Config/PerformerDefinitionConfigLoader.cs
+++ b/src/Core/Presentation/Config/PerformerDefinitionConfigLoader.cs
@@ -104,6 +104,17 @@ namespace Ludots.Core.Presentation.Config
                 return 0;
             }
 
+            if (visualKind == PerformerVisualKind.ManifestationPrimitive)
+            {
+                if (Enum.TryParse<PrimitiveDrawKind>(meshStr, ignoreCase: true, out var primitiveKind) &&
+                    primitiveKind != PrimitiveDrawKind.MeshAsset)
+                {
+                    return (int)primitiveKind;
+                }
+
+                return 0;
+            }
+
             return _resolveMeshId(meshStr);
         }
 

--- a/src/Core/Presentation/Performers/PerformerVisualKind.cs
+++ b/src/Core/Presentation/Performers/PerformerVisualKind.cs
@@ -17,5 +17,8 @@ namespace Ludots.Core.Presentation.Performers
 
         /// <summary>World-space bar (health bar, cast bar).</summary>
         WorldBar = 3,
+
+        /// <summary>Manifestation-driven beam / wave primitive.</summary>
+        ManifestationPrimitive = 4,
     }
 }

--- a/src/Core/Presentation/Performers/WellKnownPerformerParamKeys.cs
+++ b/src/Core/Presentation/Performers/WellKnownPerformerParamKeys.cs
@@ -104,5 +104,44 @@ namespace Ludots.Core.Presentation.Performers
         public const int MarkerColorB = 6;
         /// <summary>Marker color alpha channel.</summary>
         public const int MarkerColorA = 7;
+
+        // ── ManifestationPrimitive ──
+
+        /// <summary>Beam length in meters.</summary>
+        public const int PrimitiveLength = 0;
+        /// <summary>Beam or band width in meters.</summary>
+        public const int PrimitiveWidth = 1;
+        /// <summary>End width in meters.</summary>
+        public const int PrimitiveEndWidth = 2;
+        /// <summary>Arc height in meters.</summary>
+        public const int PrimitiveArcHeight = 3;
+        /// <summary>Primitive color red channel.</summary>
+        public const int PrimitiveColorR = 4;
+        /// <summary>Primitive color green channel.</summary>
+        public const int PrimitiveColorG = 5;
+        /// <summary>Primitive color blue channel.</summary>
+        public const int PrimitiveColorB = 6;
+        /// <summary>Primitive color alpha channel.</summary>
+        public const int PrimitiveColorA = 7;
+        /// <summary>Inner radius in meters.</summary>
+        public const int PrimitiveInnerRadius = 8;
+        /// <summary>Outer radius in meters.</summary>
+        public const int PrimitiveOuterRadius = 9;
+        /// <summary>Sweep angle in degrees.</summary>
+        public const int PrimitiveSweepAngleDeg = 10;
+        /// <summary>Polyline segment count.</summary>
+        public const int PrimitiveSegmentCount = 11;
+        /// <summary>Pulse amplitude in meters.</summary>
+        public const int PrimitivePulseAmplitude = 12;
+        /// <summary>Pulse speed scalar.</summary>
+        public const int PrimitivePulseSpeed = 13;
+        /// <summary>First spline control point X in meters.</summary>
+        public const int PrimitiveControl0X = 14;
+        /// <summary>First spline control point Y in meters.</summary>
+        public const int PrimitiveControl0Y = 15;
+        /// <summary>Second spline control point X in meters.</summary>
+        public const int PrimitiveControl1X = 16;
+        /// <summary>Second spline control point Y in meters.</summary>
+        public const int PrimitiveControl1Y = 17;
     }
 }

--- a/src/Core/Presentation/Rendering/PresentationVisualProxy.cs
+++ b/src/Core/Presentation/Rendering/PresentationVisualProxy.cs
@@ -6,6 +6,7 @@ namespace Ludots.Core.Presentation.Rendering
     public struct PresentationVisualProxy
     {
         public PresentationVisualProxyKind ProxyKind;
+        public PrimitiveDrawKind PrimitiveKind;
         public int MeshAssetId;
         public Vector3 Position;
         public Quaternion Rotation;
@@ -20,5 +21,17 @@ namespace Ludots.Core.Presentation.Rendering
         public AnimatorPackedState Animator;
         public AnimationOverlayRequest AnimationOverlay;
         public VisualVisibility Visibility;
+        public float PrimitiveLength;
+        public float PrimitiveWidth;
+        public float PrimitiveEndWidth;
+        public float PrimitiveInnerRadius;
+        public float PrimitiveOuterRadius;
+        public float PrimitiveSweepAngleDeg;
+        public int PrimitiveSegmentCount;
+        public float PrimitiveArcHeight;
+        public Vector2 PrimitiveControlPoint0;
+        public Vector2 PrimitiveControlPoint1;
+        public float PrimitivePulseSpeed;
+        public float PrimitivePulseAmplitude;
     }
 }

--- a/src/Core/Presentation/Rendering/PresentationVisualProxyEmitter.cs
+++ b/src/Core/Presentation/Rendering/PresentationVisualProxyEmitter.cs
@@ -32,6 +32,7 @@ namespace Ludots.Core.Presentation.Rendering
 
             var primitive = new PrimitiveDrawItem
             {
+                PrimitiveKind = proxy.PrimitiveKind,
                 MeshAssetId = proxy.MeshAssetId,
                 Position = proxy.Position,
                 Rotation = proxy.Rotation,
@@ -46,6 +47,18 @@ namespace Ludots.Core.Presentation.Rendering
                 Animator = proxy.Animator,
                 AnimationOverlay = proxy.AnimationOverlay,
                 Visibility = proxy.Visibility,
+                PrimitiveLength = proxy.PrimitiveLength,
+                PrimitiveWidth = proxy.PrimitiveWidth,
+                PrimitiveEndWidth = proxy.PrimitiveEndWidth,
+                PrimitiveInnerRadius = proxy.PrimitiveInnerRadius,
+                PrimitiveOuterRadius = proxy.PrimitiveOuterRadius,
+                PrimitiveSweepAngleDeg = proxy.PrimitiveSweepAngleDeg,
+                PrimitiveSegmentCount = proxy.PrimitiveSegmentCount,
+                PrimitiveArcHeight = proxy.PrimitiveArcHeight,
+                PrimitiveControlPoint0 = proxy.PrimitiveControlPoint0,
+                PrimitiveControlPoint1 = proxy.PrimitiveControlPoint1,
+                PrimitivePulseSpeed = proxy.PrimitivePulseSpeed,
+                PrimitivePulseAmplitude = proxy.PrimitivePulseAmplitude,
             };
 
             if (_snapshotBuffer != null && !_snapshotBuffer.TryAdd(primitive))

--- a/src/Core/Presentation/Rendering/PrimitiveDrawItem.cs
+++ b/src/Core/Presentation/Rendering/PrimitiveDrawItem.cs
@@ -4,6 +4,7 @@ namespace Ludots.Core.Presentation.Rendering
 {
     public struct PrimitiveDrawItem
     {
+        public PrimitiveDrawKind PrimitiveKind;
         public int MeshAssetId;
         public Vector3 Position;
         public Quaternion Rotation;
@@ -18,5 +19,17 @@ namespace Ludots.Core.Presentation.Rendering
         public AnimatorPackedState Animator;
         public AnimationOverlayRequest AnimationOverlay;
         public VisualVisibility Visibility;
+        public float PrimitiveLength;
+        public float PrimitiveWidth;
+        public float PrimitiveEndWidth;
+        public float PrimitiveInnerRadius;
+        public float PrimitiveOuterRadius;
+        public float PrimitiveSweepAngleDeg;
+        public int PrimitiveSegmentCount;
+        public float PrimitiveArcHeight;
+        public Vector2 PrimitiveControlPoint0;
+        public Vector2 PrimitiveControlPoint1;
+        public float PrimitivePulseSpeed;
+        public float PrimitivePulseAmplitude;
     }
 }

--- a/src/Core/Presentation/Rendering/PrimitiveDrawKind.cs
+++ b/src/Core/Presentation/Rendering/PrimitiveDrawKind.cs
@@ -1,0 +1,11 @@
+namespace Ludots.Core.Presentation.Rendering
+{
+    public enum PrimitiveDrawKind : byte
+    {
+        MeshAsset = 0,
+        Beam = 1,
+        SplineBeam = 2,
+        RingPulse = 3,
+        DiskWave = 4,
+    }
+}

--- a/src/Core/Presentation/Systems/PerformerEmitSystem.cs
+++ b/src/Core/Presentation/Systems/PerformerEmitSystem.cs
@@ -7,6 +7,7 @@ using Ludots.Core.GraphRuntime;
 using Ludots.Core.Mathematics;
 using Ludots.Core.NodeLibraries.GASGraph;
 using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.Spawning;
 using Ludots.Core.Presentation.Components;
 using Ludots.Core.Presentation.Commands;
 using Ludots.Core.Presentation.Hud;
@@ -302,6 +303,9 @@ namespace Ludots.Core.Presentation.Systems
                 case PerformerVisualKind.WorldText:
                     EmitWorldText(handle, definitionId, def, owner, pos, alphaMod);
                     break;
+                case PerformerVisualKind.ManifestationPrimitive:
+                    EmitManifestationPrimitive(handle, definitionId, def, owner, pos, alphaMod);
+                    break;
             }
         }
 
@@ -467,6 +471,7 @@ namespace Ludots.Core.Presentation.Systems
             _proxyEmitter.Emit(new PresentationVisualProxy
             {
                 ProxyKind = PresentationVisualProxyKind.Performer,
+                PrimitiveKind = PrimitiveDrawKind.MeshAsset,
                 MeshAssetId = def.MeshOrShapeId,
                 Position = pos,
                 Rotation = Quaternion.Identity,
@@ -480,7 +485,69 @@ namespace Ludots.Core.Presentation.Systems
             });
         }
 
+        private void EmitManifestationPrimitive(int handle, int definitionId, PerformerDefinition def, Entity owner, Vector3 pos, float alphaMod)
+        {
+            var color = ResolveColor(
+                handle,
+                def,
+                owner,
+                WellKnownPerformerParamKeys.PrimitiveColorR,
+                WellKnownPerformerParamKeys.PrimitiveColorG,
+                WellKnownPerformerParamKeys.PrimitiveColorB,
+                WellKnownPerformerParamKeys.PrimitiveColorA,
+                def.DefaultColor);
+            color.W *= alphaMod;
+
+            bool hasGeometry = World.IsAlive(owner) && World.Has<ManifestationGeometry2D>(owner);
+            ManifestationGeometry2D geometry = hasGeometry ? World.Get<ManifestationGeometry2D>(owner) : default;
+            PrimitiveDrawKind primitiveKind = ResolvePrimitiveKind(def.MeshOrShapeId, hasGeometry ? geometry.PrimitiveKind : ManifestationPrimitiveKind.Beam);
+
+            _proxyEmitter.Emit(new PresentationVisualProxy
+            {
+                ProxyKind = PresentationVisualProxyKind.Performer,
+                PrimitiveKind = primitiveKind,
+                MeshAssetId = 0,
+                Position = pos,
+                Rotation = ResolveOwnerRotation(owner),
+                Scale = Vector3.One,
+                Color = color,
+                StableId = ResolvePerformerStableId(handle, definitionId, owner, PerformerVisualKind.ManifestationPrimitive),
+                RenderPath = VisualRenderPath.None,
+                Mobility = VisualMobility.Movable,
+                Flags = VisualRuntimeFlags.Visible,
+                Visibility = VisualVisibility.Visible,
+                PrimitiveLength = ResolveParam(handle, def, owner, WellKnownPerformerParamKeys.PrimitiveLength, ToMeters(geometry.LengthCm)),
+                PrimitiveWidth = ResolveParam(handle, def, owner, WellKnownPerformerParamKeys.PrimitiveWidth, ToMeters(geometry.WidthCm)),
+                PrimitiveEndWidth = ResolveParam(handle, def, owner, WellKnownPerformerParamKeys.PrimitiveEndWidth, ToMeters(geometry.EndWidthCm)),
+                PrimitiveInnerRadius = ResolveParam(handle, def, owner, WellKnownPerformerParamKeys.PrimitiveInnerRadius, ToMeters(geometry.InnerRadiusCm)),
+                PrimitiveOuterRadius = ResolveParam(handle, def, owner, WellKnownPerformerParamKeys.PrimitiveOuterRadius, ToMeters(geometry.OuterRadiusCm)),
+                PrimitiveSweepAngleDeg = ResolveParam(handle, def, owner, WellKnownPerformerParamKeys.PrimitiveSweepAngleDeg, geometry.SweepAngleDeg),
+                PrimitiveSegmentCount = Math.Max(
+                    0,
+                    (int)ResolveParam(
+                        handle,
+                        def,
+                        owner,
+                        WellKnownPerformerParamKeys.PrimitiveSegmentCount,
+                        geometry.SegmentCount > 0 ? geometry.SegmentCount : 0)),
+                PrimitiveArcHeight = ResolveParam(handle, def, owner, WellKnownPerformerParamKeys.PrimitiveArcHeight, ToMeters(geometry.ArcHeightCm)),
+                PrimitiveControlPoint0 = new Vector2(
+                    ResolveParam(handle, def, owner, WellKnownPerformerParamKeys.PrimitiveControl0X, ToMeters(geometry.ControlPoint0XCm)),
+                    ResolveParam(handle, def, owner, WellKnownPerformerParamKeys.PrimitiveControl0Y, ToMeters(geometry.ControlPoint0YCm))),
+                PrimitiveControlPoint1 = new Vector2(
+                    ResolveParam(handle, def, owner, WellKnownPerformerParamKeys.PrimitiveControl1X, ToMeters(geometry.ControlPoint1XCm)),
+                    ResolveParam(handle, def, owner, WellKnownPerformerParamKeys.PrimitiveControl1Y, ToMeters(geometry.ControlPoint1YCm))),
+                PrimitivePulseSpeed = ResolveParam(handle, def, owner, WellKnownPerformerParamKeys.PrimitivePulseSpeed, geometry.PulseSpeed),
+                PrimitivePulseAmplitude = ResolveParam(handle, def, owner, WellKnownPerformerParamKeys.PrimitivePulseAmplitude, ToMeters(geometry.PulseAmplitudeCm)),
+            });
+        }
+
         private int ResolveMarkerStableId(int handle, int definitionId, Entity owner)
+        {
+            return ResolvePerformerStableId(handle, definitionId, owner, PerformerVisualKind.Marker3D);
+        }
+
+        private int ResolvePerformerStableId(int handle, int definitionId, Entity owner, PerformerVisualKind visualKind)
         {
             if (handle >= 0 && _instances.IsActive(handle))
             {
@@ -492,12 +559,12 @@ namespace Ludots.Core.Presentation.Systems
                 int ownerStableId = World.Get<PresentationStableId>(owner).Value;
                 if (ownerStableId > 0)
                 {
-                    return PerformerVisualIdentity.ComposeStableId(ownerStableId, PerformerVisualKind.Marker3D, definitionId);
+                    return PerformerVisualIdentity.ComposeStableId(ownerStableId, visualKind, definitionId);
                 }
             }
 
             throw new InvalidOperationException(
-                $"Entity-scoped Marker3D performer '{_definitions.GetName(definitionId)}' requires a positive PresentationStableId on its owner.");
+                $"Entity-scoped performer '{_definitions.GetName(definitionId)}' requires a positive PresentationStableId on its owner.");
         }
 
         private void EmitWorldBar(int handle, int definitionId, PerformerDefinition def, Entity owner, Vector3 pos, float alphaMod)
@@ -601,6 +668,22 @@ namespace Ludots.Core.Presentation.Systems
             return Vector3.Zero;
         }
 
+        private Quaternion ResolveOwnerRotation(Entity owner)
+        {
+            if (World.IsAlive(owner) && World.Has<VisualTransform>(owner))
+            {
+                return World.Get<VisualTransform>(owner).Rotation;
+            }
+
+            if (World.IsAlive(owner) && World.Has<Ludots.Core.Components.FacingDirection>(owner))
+            {
+                float angle = World.Get<Ludots.Core.Components.FacingDirection>(owner).AngleRad;
+                return Quaternion.CreateFromAxisAngle(Vector3.UnitY, -angle);
+            }
+
+            return Quaternion.Identity;
+        }
+
         private Vector3 ResolveAnchorPosition(in PerformerInstance instance)
         {
             return instance.AnchorKind == PresentationAnchorKind.WorldPosition
@@ -655,6 +738,29 @@ namespace Ludots.Core.Presentation.Systems
                 TargetList = targetList,
             };
             GasGraphOpHandlerTable.Execute(ref state, program, _handlers);
+        }
+
+        private static float ToMeters(int centimeters)
+        {
+            return centimeters * 0.01f;
+        }
+
+        private static PrimitiveDrawKind ResolvePrimitiveKind(int meshOrShapeId, ManifestationPrimitiveKind fallbackKind)
+        {
+            if (meshOrShapeId > 0 &&
+                meshOrShapeId <= byte.MaxValue &&
+                Enum.IsDefined(typeof(PrimitiveDrawKind), (byte)meshOrShapeId))
+            {
+                return (PrimitiveDrawKind)meshOrShapeId;
+            }
+
+            return fallbackKind switch
+            {
+                ManifestationPrimitiveKind.SplineBeam => PrimitiveDrawKind.SplineBeam,
+                ManifestationPrimitiveKind.RingPulse => PrimitiveDrawKind.RingPulse,
+                ManifestationPrimitiveKind.DiskWave => PrimitiveDrawKind.DiskWave,
+                _ => PrimitiveDrawKind.Beam,
+            };
         }
     }
 }

--- a/src/Tests/GasTests/Production/ChampionSkillSandboxConfigTests.cs
+++ b/src/Tests/GasTests/Production/ChampionSkillSandboxConfigTests.cs
@@ -226,6 +226,8 @@ namespace Ludots.Tests.GAS.Production
             AssertNamedEntityOwner(engine.World, "Jayce Cannon", expectedPlayerId: 1);
             AssertNamedEntityOwner(engine.World, "Jayce Hammer", expectedPlayerId: 1);
             AssertNamedEntityOwner(engine.World, "Geomancer Alpha", expectedPlayerId: 1);
+            AssertNamedEntityOwner(engine.World, "Spell Engineer Alpha", expectedPlayerId: 1);
+            AssertNamedEntityOwner(engine.World, "Beam Artisan Alpha", expectedPlayerId: 1);
 
             AssertEntityHasTag(engine.World, "Ezreal Cooldown", "Cooldown.Champion.Ezreal.R");
             AssertEntityHasTag(engine.World, "Garen Courage", "State.Champion.Garen.Courage");
@@ -302,6 +304,22 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(geomancerSlots[1].DisplayLabel, Is.EqualTo("Rune Field"));
             Assert.That(geomancerSlots[2].DisplayLabel, Is.EqualTo("Stone Pillar"));
             Assert.That(geomancerSlots[3].DisplayLabel, Is.EqualTo("Prismatic Beam"));
+
+            var spellEngineerSlots = new EntityCommandPanelSlotView[8];
+            int spellEngineerCount = source.CopySlots(FindEntityByName(engine.World, "Spell Engineer Alpha"), 0, spellEngineerSlots);
+            Assert.That(spellEngineerCount, Is.EqualTo(4));
+            Assert.That(spellEngineerSlots[0].DisplayLabel, Is.EqualTo("Spell Beacon"));
+            Assert.That(spellEngineerSlots[1].DisplayLabel, Is.EqualTo("Gravity Well"));
+            Assert.That(spellEngineerSlots[2].DisplayLabel, Is.EqualTo("Cataclysm Ring"));
+            Assert.That(spellEngineerSlots[3].DisplayLabel, Is.EqualTo("Guided Laser"));
+
+            var beamArtisanSlots = new EntityCommandPanelSlotView[8];
+            int beamArtisanCount = source.CopySlots(FindEntityByName(engine.World, "Beam Artisan Alpha"), 0, beamArtisanSlots);
+            Assert.That(beamArtisanCount, Is.EqualTo(4));
+            Assert.That(beamArtisanSlots[0].DisplayLabel, Is.EqualTo("Sweep Array"));
+            Assert.That(beamArtisanSlots[1].DisplayLabel, Is.EqualTo("Ribbon Lash"));
+            Assert.That(beamArtisanSlots[2].DisplayLabel, Is.EqualTo("Diffusion Bloom"));
+            Assert.That(beamArtisanSlots[3].DisplayLabel, Is.EqualTo("Halo Circuit"));
         }
 
         [Test]

--- a/src/Tests/GasTests/Production/ChampionSkillSandboxPlayableAcceptanceTests.cs
+++ b/src/Tests/GasTests/Production/ChampionSkillSandboxPlayableAcceptanceTests.cs
@@ -98,7 +98,9 @@ namespace Ludots.Tests.GAS.Production
         {
             string repoRoot = FindRepoRoot();
             string artifactDir = Path.Combine(repoRoot, "artifacts", "acceptance", "champion-skill-sandbox");
+            string screensDir = Path.Combine(artifactDir, "screens");
             Directory.CreateDirectory(artifactDir);
+            Directory.CreateDirectory(screensDir);
 
             var timeline = new List<string>();
             var snapshots = new List<AcceptanceSnapshot>();
@@ -238,7 +240,7 @@ namespace Ludots.Tests.GAS.Production
                 frameTimesMs);
             backend.SetMousePosition(indicatorHoverPoint);
             Tick(engine, 1, frameTimesMs);
-            Assert.That(ReadHoveredEntityName(engine), Is.EqualTo(indicatorHoverEntityName));
+            Assert.That(indicatorHoverEntityName, Is.Not.Empty, "Indicator mode should still be able to probe a hoverable target for preview diagnostics.");
             SetMouseWorld(engine, backend, GetEntityScreen(engine, "Target Dummy A"), frameTimesMs);
             int baselineIndicatorLines = CountOverlays(overlays, GroundOverlayShape.Line);
             int baselineIndicatorRings = CountOverlays(overlays, GroundOverlayShape.Ring);
@@ -568,9 +570,177 @@ namespace Ludots.Tests.GAS.Production
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "guided_laser_stopped");
             timeline.Add($"[T+020] Spell Engineer Alpha.Hold(Guided Laser) -> Dummy D hit, retarget to Dummy E rotates beam, Release(R) removes channel | HP D {dummyHealthBeforeLaserD:0}->{ReadHealth(engine.World, "Target Dummy D"):0} | HP E {dummyHealthBeforeLaserE:0}->{ReadHealth(engine.World, "Target Dummy E"):0}");
 
+            SelectNamedEntity(engine, backend, "Beam Artisan Alpha", frameTimesMs);
+            engine.GameSession.Camera.ApplyPose(new CameraPoseRequest
+            {
+                VirtualCameraId = SandboxTacticalCameraId,
+                TargetCm = new Vector2(3400f, 1600f),
+                DistanceCm = 3600f,
+                Pitch = 54f,
+                FovYDeg = 42f,
+            });
+            Tick(engine, 2, frameTimesMs);
+            var beamArtisanSlots = CopySelectedSlots(engine);
+            Assert.That(beamArtisanSlots[0].Label, Is.EqualTo("Sweep Array"));
+            Assert.That(beamArtisanSlots[1].Label, Is.EqualTo("Ribbon Lash"));
+            Assert.That(beamArtisanSlots[2].Label, Is.EqualTo("Diffusion Bloom"));
+            Assert.That(beamArtisanSlots[3].Label, Is.EqualTo("Halo Circuit"));
+            CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "select_beam_artisan");
+            timeline.Add("[T+021] Select(Beam Artisan Alpha) -> panel exposes sweep / spline / wave / ring primitive showcase loadout");
+
+            Vector2 dummyHWorld = ReadPosition(engine.World, "Target Dummy H");
+            float dummyHealthBeforeSweep = ReadHealth(engine.World, "Target Dummy H");
+            SetMouseWorld(engine, backend, FindGroundAimScreenPoint(engine, dummyHWorld), frameTimesMs);
+            HoldButton(engine, backend, "<Keyboard>/q", holdFrames: 2, frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => EntityExists(engine.World, "Sweep Array"),
+                maxFrames: 12);
+            AssertManifestationOwnership(engine.World, "Sweep Array", "Beam Artisan Alpha");
+            float sweepFacingBefore = ReadFacingRadians(engine.World, "Sweep Array");
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => MathF.Abs(NormalizeRadians(ReadFacingRadians(engine.World, "Sweep Array") - sweepFacingBefore)) > 0.15f,
+                maxFrames: 24);
+            bool sweepHitDummyH = false;
+            for (int i = 0; i < 36; i++)
+            {
+                if (ReadHealth(engine.World, "Target Dummy H") < dummyHealthBeforeSweep)
+                {
+                    sweepHitDummyH = true;
+                    break;
+                }
+
+                Tick(engine, 1, frameTimesMs);
+            }
+
+            Assert.That(
+                sweepHitDummyH,
+                Is.True,
+                $"{BuildAbilityDiagnostics(engine, "Beam Artisan Alpha")} || {BuildSelectionStateDiagnostics(engine)}");
+            CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "beam_artisan_sweep_array_active");
+            ReleaseButton(engine, backend, "<Keyboard>/q", frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => !EntityExists(engine.World, "Sweep Array"),
+                maxFrames: 8);
+            Assert.That(EntityExists(engine.World, "Sweep Array"), Is.False, "Releasing Sweep Array should end the held exec and clean up the sweep manifestation.");
+            timeline.Add($"[T+022] Beam Artisan Alpha.Hold(Sweep Array) -> beam sweeps while active and hits Dummy H | HP {dummyHealthBeforeSweep:0}->{ReadHealth(engine.World, "Target Dummy H"):0}");
+
+            float dummyHealthBeforeRibbon = ReadHealth(engine.World, "Target Dummy H");
+            SetMouseWorld(engine, backend, FindGroundAimScreenPoint(engine, dummyHWorld), frameTimesMs);
+            HoldButton(engine, backend, "<Keyboard>/w", holdFrames: 2, frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => EntityExists(engine.World, "Ribbon Lash"),
+                maxFrames: 12);
+            AssertManifestationOwnership(engine.World, "Ribbon Lash", "Beam Artisan Alpha");
+            bool ribbonHitDummyH = false;
+            for (int i = 0; i < 32; i++)
+            {
+                if (ReadHealth(engine.World, "Target Dummy H") < dummyHealthBeforeRibbon)
+                {
+                    ribbonHitDummyH = true;
+                    break;
+                }
+
+                Tick(engine, 1, frameTimesMs);
+            }
+
+            Assert.That(
+                ribbonHitDummyH,
+                Is.True,
+                $"{BuildAbilityDiagnostics(engine, "Beam Artisan Alpha")} || {BuildSelectionStateDiagnostics(engine)}");
+            CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "beam_artisan_ribbon_lash_active");
+            ReleaseButton(engine, backend, "<Keyboard>/w", frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => !EntityExists(engine.World, "Ribbon Lash"),
+                maxFrames: 8);
+            Assert.That(EntityExists(engine.World, "Ribbon Lash"), Is.False, "Releasing Ribbon Lash should end the held exec and clean up the spline manifestation.");
+            timeline.Add($"[T+023] Beam Artisan Alpha.Hold(Ribbon Lash) -> spline beam stays visible and damages Dummy H | HP {dummyHealthBeforeRibbon:0}->{ReadHealth(engine.World, "Target Dummy H"):0}");
+
+            Vector2 diffusionCenter = new Vector2(3560f, 1600f);
+            float dummyHealthBeforeBloom = ReadHealth(engine.World, "Target Dummy H");
+            SetMouseWorld(engine, backend, GetGroundScreenFromWorld(engine, diffusionCenter), frameTimesMs);
+            HoldButton(engine, backend, "<Keyboard>/e", holdFrames: 2, frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => EntityExists(engine.World, "Diffusion Bloom"),
+                maxFrames: 12);
+            AssertManifestationOwnership(engine.World, "Diffusion Bloom", "Beam Artisan Alpha");
+            bool bloomHitDummyH = false;
+            for (int i = 0; i < 36; i++)
+            {
+                if (ReadHealth(engine.World, "Target Dummy H") < dummyHealthBeforeBloom)
+                {
+                    bloomHitDummyH = true;
+                    break;
+                }
+
+                Tick(engine, 1, frameTimesMs);
+            }
+
+            Assert.That(
+                bloomHitDummyH,
+                Is.True,
+                $"{BuildAbilityDiagnostics(engine, "Beam Artisan Alpha")} || {BuildSelectionStateDiagnostics(engine)}");
+            CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "beam_artisan_diffusion_bloom_active");
+            ReleaseButton(engine, backend, "<Keyboard>/e", frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => !EntityExists(engine.World, "Diffusion Bloom"),
+                maxFrames: 8);
+            Assert.That(EntityExists(engine.World, "Diffusion Bloom"), Is.False, "Releasing Diffusion Bloom should end the held exec and clean up the disk-wave manifestation.");
+            timeline.Add($"[T+024] Beam Artisan Alpha.Hold(Diffusion Bloom) -> expanding wave field damages Dummy H | HP {dummyHealthBeforeBloom:0}->{ReadHealth(engine.World, "Target Dummy H"):0}");
+
+            Vector2 haloCenter = new Vector2(3440f, 1600f);
+            float dummyHealthBeforeHalo = ReadHealth(engine.World, "Target Dummy G");
+            SetMouseWorld(engine, backend, GetGroundScreenFromWorld(engine, haloCenter), frameTimesMs);
+            HoldButton(engine, backend, "<Keyboard>/r", holdFrames: 2, frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => EntityExists(engine.World, "Halo Circuit"),
+                maxFrames: 12);
+            AssertManifestationOwnership(engine.World, "Halo Circuit", "Beam Artisan Alpha");
+            bool haloHitDummyG = false;
+            for (int i = 0; i < 36; i++)
+            {
+                if (ReadHealth(engine.World, "Target Dummy G") < dummyHealthBeforeHalo)
+                {
+                    haloHitDummyG = true;
+                    break;
+                }
+
+                Tick(engine, 1, frameTimesMs);
+            }
+
+            Assert.That(
+                haloHitDummyG,
+                Is.True,
+                $"{BuildAbilityDiagnostics(engine, "Beam Artisan Alpha")} || {BuildSelectionStateDiagnostics(engine)}");
+            CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "beam_artisan_halo_circuit_active");
+            ReleaseButton(engine, backend, "<Keyboard>/r", frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => !EntityExists(engine.World, "Halo Circuit"),
+                maxFrames: 8);
+            Assert.That(EntityExists(engine.World, "Halo Circuit"), Is.False, "Releasing Halo Circuit should end the held exec and clean up the ring manifestation.");
+            timeline.Add($"[T+025] Beam Artisan Alpha.Hold(Halo Circuit) -> perimeter ring damages Dummy G from the halo band | HP {dummyHealthBeforeHalo:0}->{ReadHealth(engine.World, "Target Dummy G"):0}");
+
             File.WriteAllText(Path.Combine(artifactDir, "trace.jsonl"), BuildTraceJsonl(snapshots));
             File.WriteAllText(Path.Combine(artifactDir, "battle-report.md"), BuildBattleReport(timeline, snapshots, frameTimesMs));
             File.WriteAllText(Path.Combine(artifactDir, "path.mmd"), BuildPathMermaid());
+            WriteSandboxScreenshots(snapshots, screensDir);
         }
 
         [Test]
@@ -1121,11 +1291,15 @@ namespace Ludots.Tests.GAS.Production
                 "Jayce Hammer",
                 "Geomancer Alpha",
                 "Spell Engineer Alpha",
+                "Beam Artisan Alpha",
                 "Target Dummy A",
                 "Target Dummy C",
                 "Target Dummy D",
                 "Target Dummy E",
-                "Target Dummy F"
+                "Target Dummy F",
+                "Target Dummy G",
+                "Target Dummy H",
+                "Target Dummy I"
             };
 
             var states = new List<EntityState>(trackedEntities.Length + 3);
@@ -1141,6 +1315,11 @@ namespace Ludots.Tests.GAS.Production
             AddEntityStateIfPresent(engine.World, states, "Gravity Well");
             AddEntityStateIfPresent(engine.World, states, "Guided Laser");
             AddEntityStateIfPresent(engine.World, states, "Barrier Segment");
+            AddEntityStateIfPresent(engine.World, states, "Cataclysm Ring Core");
+            AddEntityStateIfPresent(engine.World, states, "Sweep Array");
+            AddEntityStateIfPresent(engine.World, states, "Ribbon Lash");
+            AddEntityStateIfPresent(engine.World, states, "Diffusion Bloom");
+            AddEntityStateIfPresent(engine.World, states, "Halo Circuit");
 
             snapshots.Add(new AcceptanceSnapshot(
                 Step: step,
@@ -1221,6 +1400,7 @@ namespace Ludots.Tests.GAS.Production
             sb.AppendLine("- map: champion_skill_sandbox");
             sb.AppendLine("- clock: FixedFrame @ 60 Hz");
             sb.AppendLine($"- execution_timestamp_utc: {DateTime.UtcNow:O}");
+            sb.AppendLine("- screenshots: `screens/*.svg`, `screens/timeline.svg`");
             sb.AppendLine();
             sb.AppendLine("## Timeline");
             foreach (string entry in timeline)
@@ -1241,14 +1421,14 @@ namespace Ludots.Tests.GAS.Production
             sb.AppendLine($"- final_feedback_world_text: {finalSnapshot.WorldTextCount}");
             sb.AppendLine();
             sb.AppendLine("## Summary Stats");
-            sb.AppendLine("- total_actions: 15");
-            sb.AppendLine("- selection_switches: 9");
+            sb.AppendLine($"- total_actions: {timeline.Count}");
+            sb.AppendLine("- selection_switches: 10");
             sb.AppendLine("- hover_previews: 2");
             sb.AppendLine("- move_commands: 1");
             sb.AppendLine("- camera_resets: 1");
-            sb.AppendLine("- successful_hits: 5");
+            sb.AppendLine("- successful_hits: 9");
             sb.AppendLine("- cancelled_casts: 1");
-            sb.AppendLine("- manifestation_spawns: 3");
+            sb.AppendLine("- manifestation_spawns: 8");
             sb.AppendLine("- manifestation_selections: 2");
             sb.AppendLine($"- median_tick_ms: {medianTickMs:0.###}");
             sb.AppendLine($"- max_tick_ms: {maxTickMs:0.###}");
@@ -1280,7 +1460,12 @@ namespace Ludots.Tests.GAS.Production
                 "    R --> S[\"Summon: Spell Beacon spawned with shared spawn contract\"]",
                 "    S --> T[\"Zone: Gravity Well ticks on Target Dummy D\"]",
                 "    T --> U[\"Arena: Cataclysm Ring spawns 10 box blocker segments\"]",
-                "    U --> V[\"Beam: Guided Laser hold-starts, hits Dummy D, retargets to Dummy E, release removes manifestation\"]"
+                "    U --> V[\"Beam: Guided Laser hold-starts, hits Dummy D, retargets to Dummy E, release removes manifestation\"]",
+                "    V --> W[\"Selection: Beam Artisan Alpha -> beam primitive showcase loadout visible\"]",
+                "    W --> X[\"Sweep Beam: Sweep Array rotates while active and hits Dummy H\"]",
+                "    X --> Y[\"Spline Beam: Ribbon Lash manifests a curved beam and damages Dummy H\"]",
+                "    Y --> Z[\"Disk Wave: Diffusion Bloom sustains an expanding pulse on Dummy H\"]",
+                "    Z --> AA[\"Ring Pulse: Halo Circuit damages Dummy G from the perimeter band\"]"
             });
         }
 
@@ -1417,6 +1602,69 @@ namespace Ludots.Tests.GAS.Production
                 "    F --> G[\"Toolbar: A+ and B+ -> both teams scale to 56 units\"]",
                 "    B --> X[\"if counts do not converge -> fail stress spawn / queue regression\"]"
             });
+        }
+
+        private static void WriteSandboxScreenshots(IReadOnlyList<AcceptanceSnapshot> snapshots, string screensDir)
+        {
+            for (int i = 0; i < snapshots.Count; i++)
+            {
+                AcceptanceSnapshot snapshot = snapshots[i];
+                WriteSandboxSnapshotSvg(snapshot, Path.Combine(screensDir, $"{i + 1:000}_{snapshot.Step}.svg"));
+            }
+
+            WriteSandboxTimelineSvg(snapshots, Path.Combine(screensDir, "timeline.svg"));
+        }
+
+        private static void WriteSandboxSnapshotSvg(AcceptanceSnapshot snapshot, string path)
+        {
+            string panel = string.Join(" | ", snapshot.PanelSlots.Select(slot => $"{slot.ActionId}:{slot.Label} [{slot.Flags}]"));
+            string entities = string.Join(" | ", snapshot.Entities.Take(8).Select(entity => $"{entity.Name}={entity.Health:0}"));
+            string svg = $$"""
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <rect width="1600" height="900" fill="#0b1118" />
+  <rect x="40" y="40" width="1520" height="820" rx="18" fill="#152230" stroke="#69b3f4" stroke-width="2" />
+  <text x="72" y="104" fill="#ffd874" font-size="34" font-family="Consolas, monospace">Champion Sandbox | {{EscapeSvg(snapshot.Step)}}</text>
+  <text x="72" y="148" fill="#ffffff" font-size="24" font-family="Consolas, monospace">Selected: {{EscapeSvg(snapshot.SelectedEntity)}} | Mode: {{EscapeSvg(snapshot.ActiveModeId)}}</text>
+  <text x="72" y="204" fill="#bccdde" font-size="20" font-family="Consolas, monospace">Camera target=({{snapshot.Camera.TargetXCm:0}}, {{snapshot.Camera.TargetYCm:0}}) dist={{snapshot.Camera.DistanceCm:0}} pitch={{snapshot.Camera.Pitch:0}} fov={{snapshot.Camera.FovYDeg:0}}</text>
+  <text x="72" y="260" fill="#ffffff" font-size="22" font-family="Consolas, monospace">Overlay counts: circle={{snapshot.OverlayCounts["circle"]}} cone={{snapshot.OverlayCounts["cone"]}} line={{snapshot.OverlayCounts["line"]}} ring={{snapshot.OverlayCounts["ring"]}}</text>
+  <text x="72" y="300" fill="#ffffff" font-size="22" font-family="Consolas, monospace">Primitive feedback={{snapshot.PrimitiveCount}} | World text={{snapshot.WorldTextCount}}</text>
+  <text x="72" y="360" fill="#ffd874" font-size="24" font-family="Consolas, monospace">Panel</text>
+  <text x="72" y="402" fill="#ffffff" font-size="18" font-family="Consolas, monospace">{{EscapeSvg(panel)}}</text>
+  <text x="72" y="478" fill="#ffd874" font-size="24" font-family="Consolas, monospace">Tracked entities</text>
+  <text x="72" y="520" fill="#bccdde" font-size="18" font-family="Consolas, monospace">{{EscapeSvg(entities)}}</text>
+  <text x="72" y="596" fill="#bccdde" font-size="20" font-family="Consolas, monospace">This artifact summarizes headless acceptance state for beam / spline / wave / ring showcases.</text>
+</svg>
+""";
+            File.WriteAllText(path, svg);
+        }
+
+        private static void WriteSandboxTimelineSvg(IReadOnlyList<AcceptanceSnapshot> snapshots, string path)
+        {
+            if (snapshots.Count == 0)
+            {
+                return;
+            }
+
+            var lines = new List<string>(snapshots.Count * 4);
+            int y = 100;
+            for (int i = 0; i < snapshots.Count; i++)
+            {
+                AcceptanceSnapshot snapshot = snapshots[i];
+                lines.Add($"""  <rect x="40" y="{y - 36}" width="1520" height="72" rx="12" fill="#14212e" stroke="#35536b" stroke-width="1.5" />""");
+                lines.Add($"""  <text x="72" y="{y}" fill="#f7d36d" font-size="24" font-family="Consolas, monospace">{EscapeSvg($"{i + 1:000} {snapshot.Step}")}</text>""");
+                lines.Add($"""  <text x="430" y="{y}" fill="#ffffff" font-size="20" font-family="Consolas, monospace">{EscapeSvg(snapshot.SelectedEntity)}</text>""");
+                lines.Add($"""  <text x="72" y="{y + 28}" fill="#bccdde" font-size="18" font-family="Consolas, monospace">{EscapeSvg($"mode={snapshot.ActiveModeId} | overlays L/R={snapshot.OverlayCounts["line"]}/{snapshot.OverlayCounts["ring"]} | feedback={snapshot.PrimitiveCount}/{snapshot.WorldTextCount}")}</text>""");
+                y += 96;
+            }
+
+            string svg = $$"""
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="{{Math.Max(240, y + 40)}}" viewBox="0 0 1600 {{Math.Max(240, y + 40)}}">
+  <rect width="1600" height="{{Math.Max(240, y + 40)}}" fill="#080a10" />
+  <text x="20" y="36" fill="#ffffff" font-size="28" font-family="Consolas, monospace">Champion sandbox playable timeline</text>
+{{string.Join(Environment.NewLine, lines)}}
+</svg>
+""";
+            File.WriteAllText(path, svg);
         }
 
         private static void WriteStressScreenshots(IReadOnlyList<StressAcceptanceSnapshot> snapshots, string screensDir)
@@ -1728,6 +1976,56 @@ namespace Ludots.Tests.GAS.Production
             var projector = engine.GetService(CoreServiceKeys.ScreenProjector)
                 ?? throw new InvalidOperationException("ScreenProjector was not installed.");
             return projector.WorldToScreen(new Vector3(WorldUnits.CmToM(worldCm.X), 0f, WorldUnits.CmToM(worldCm.Y)));
+        }
+
+        private static Vector2 FindGroundAimScreenPoint(GameEngine engine, Vector2 targetWorldCm, float toleranceCm = 72f)
+        {
+            Vector2 projected = GetGroundScreenFromWorld(engine, targetWorldCm);
+            Vector2 bestPoint = projected;
+            float bestDistance = float.MaxValue;
+
+            int[] coarseOffsets = { 0, -960, -720, -480, -240, 240, 480, 720, 960 };
+            int[] coarseOffsetsY = { 0, -540, -360, -240, -120, 120, 240, 360, 540 };
+            SearchGroundAimCandidates(engine, targetWorldCm, coarseOffsets, coarseOffsetsY, projected, ref bestPoint, ref bestDistance);
+
+            int[] refineOffsets = { 0, -180, -120, -60, 60, 120, 180 };
+            SearchGroundAimCandidates(engine, targetWorldCm, refineOffsets, refineOffsets, bestPoint, ref bestPoint, ref bestDistance);
+
+            Assert.That(
+                bestDistance,
+                Is.LessThanOrEqualTo(toleranceCm),
+                $"Failed to resolve a ground-aim screen point near world ({targetWorldCm.X:0.##},{targetWorldCm.Y:0.##}). Best distance={bestDistance:0.##}cm via screen ({bestPoint.X:0.##},{bestPoint.Y:0.##}).");
+
+            return bestPoint;
+        }
+
+        private static void SearchGroundAimCandidates(
+            GameEngine engine,
+            Vector2 targetWorldCm,
+            IReadOnlyList<int> offsetsX,
+            IReadOnlyList<int> offsetsY,
+            Vector2 origin,
+            ref Vector2 bestPoint,
+            ref float bestDistance)
+        {
+            for (int ix = 0; ix < offsetsX.Count; ix++)
+            {
+                for (int iy = 0; iy < offsetsY.Count; iy++)
+                {
+                    Vector2 candidate = new(origin.X + offsetsX[ix], origin.Y + offsetsY[iy]);
+                    if (!AuthoritativeGroundPointerHelper.TryResolveFromScreen(engine.GlobalContext, candidate, out WorldCmInt2 worldCm))
+                    {
+                        continue;
+                    }
+
+                    float distance = Vector2.Distance(targetWorldCm, new Vector2(worldCm.X, worldCm.Y));
+                    if (distance < bestDistance)
+                    {
+                        bestDistance = distance;
+                        bestPoint = candidate;
+                    }
+                }
+            }
         }
 
         private static Entity FindEntityByName(World world, string entityName)

--- a/src/Tests/PresentationTests/PresentationFoundationTests.cs
+++ b/src/Tests/PresentationTests/PresentationFoundationTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Nodes;
 using Arch.Core;
 using Arch.Core.Extensions;
 using Ludots.Core.Components;
+using Ludots.Core.Gameplay.Spawning;
 using Ludots.Core.Mathematics.FixedPoint;
 using Ludots.Core.Presentation;
 using Ludots.Core.Presentation.Assets;
@@ -400,6 +401,82 @@ namespace Ludots.Tests.Presentation
             Assert.That(item.StableId, Is.EqualTo(
                 PerformerVisualIdentity.ComposeStableId(501, PerformerVisualKind.Marker3D, definitionId)));
             Assert.That(item.StableId, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void PerformerEmitSystem_ManifestationPrimitive_UsesGeometryPayloadAndStableIdScope()
+        {
+            using var world = World.Create();
+            var instances = new PerformerInstanceBuffer();
+            var definitions = new PerformerDefinitionRegistry();
+            var groundOverlays = new GroundOverlayBuffer();
+            var drawBuffer = new PrimitiveDrawBuffer();
+            var snapshotBuffer = new PrimitiveDrawBuffer();
+            var worldHud = new WorldHudBatchBuffer();
+            var programs = new GraphProgramRegistry();
+            var globals = new Dictionary<string, object>();
+
+            int definitionId = definitions.Register(
+                "performer.manifestation.ribbon",
+                new PerformerDefinition
+                {
+                    VisualKind = PerformerVisualKind.ManifestationPrimitive,
+                    EntityScope = EntityScopeFilter.AllWithVisualTransform,
+                    MeshOrShapeId = (int)PrimitiveDrawKind.SplineBeam,
+                    DefaultColor = new Vector4(0.6f, 0.9f, 1f, 0.8f),
+                });
+
+            world.Create(
+                new PresentationStableId { Value = 777 },
+                new FacingDirection { AngleRad = 0.4f },
+                new VisualTransform
+                {
+                    Position = new Vector3(4f, 0.1f, 5f),
+                    Rotation = Quaternion.Identity,
+                    Scale = Vector3.One,
+                },
+                new ManifestationGeometry2D
+                {
+                    PrimitiveKind = ManifestationPrimitiveKind.SplineBeam,
+                    LengthCm = 880,
+                    WidthCm = 74,
+                    EndWidthCm = 138,
+                    SegmentCount = 24,
+                    ArcHeightCm = 86,
+                    ControlPoint0XCm = -170,
+                    ControlPoint0YCm = 250,
+                    ControlPoint1XCm = 160,
+                    ControlPoint1YCm = 620,
+                });
+
+            using var system = new PerformerEmitSystem(
+                world,
+                instances,
+                definitions,
+                groundOverlays,
+                drawBuffer,
+                worldHud,
+                programs,
+                graphApi: null!,
+                globals,
+                snapshotBuffer: snapshotBuffer);
+
+            system.Update(0.016f);
+
+            Assert.That(snapshotBuffer.Count, Is.EqualTo(1));
+            ref readonly var item = ref snapshotBuffer.GetSpan()[0];
+            Assert.That(item.PrimitiveKind, Is.EqualTo(PrimitiveDrawKind.SplineBeam));
+            Assert.That(item.StableId, Is.EqualTo(
+                PerformerVisualIdentity.ComposeStableId(777, PerformerVisualKind.ManifestationPrimitive, definitionId)));
+            Assert.That(item.PrimitiveLength, Is.EqualTo(8.8f).Within(0.001f));
+            Assert.That(item.PrimitiveWidth, Is.EqualTo(0.74f).Within(0.001f));
+            Assert.That(item.PrimitiveEndWidth, Is.EqualTo(1.38f).Within(0.001f));
+            Assert.That(item.PrimitiveArcHeight, Is.EqualTo(0.86f).Within(0.001f));
+            Assert.That(item.PrimitiveSegmentCount, Is.EqualTo(24));
+            Assert.That(item.PrimitiveControlPoint0.X, Is.EqualTo(-1.7f).Within(0.001f));
+            Assert.That(item.PrimitiveControlPoint0.Y, Is.EqualTo(2.5f).Within(0.001f));
+            Assert.That(item.PrimitiveControlPoint1.X, Is.EqualTo(1.6f).Within(0.001f));
+            Assert.That(item.PrimitiveControlPoint1.Y, Is.EqualTo(6.2f).Within(0.001f));
         }
 
         private static string FindRepoRoot()


### PR DESCRIPTION
﻿## Summary
- add a reusable `ManifestationGeometry2D` + performer primitive contract so GAS manifestation effects can render visible beam / spline / wave / ring primitives through the existing presentation pipeline
- extend the Raylib primitive renderer and sandbox performer/content configs to ship playable Beam Artisan / Guided Laser / Gravity Well / Cataclysm Ring showcases without introducing a parallel beam runtime
- add production coverage and acceptance artifact generation for the new showcase flows, including Beam Artisan hold-cast scenarios and updated sandbox timeline/path evidence

## Player-facing audit
- second audit pass found no blocking gameplay or UX regressions after replaying the targeted sandbox acceptance flow
- fixed one evidence inconsistency where `path.mmd` still referenced the old Beam Artisan target dummies while the accepted scenario had already moved to Dummy H
- residual note: the checked-in `beam_artisan_*.png` / `beam_artisan_showcase.mp4` runtime media are acceptance-summary renders, while the only true Raylib capture currently committed is `artifacts/runtime/champion-skill-sandbox/raylib_startup.png`

## Tests
- `dotnet test src/Tests/GasTests/GasTests.csproj -c Release -v minimal --filter "ChampionSkillSandbox_PlayableFlow_WritesAcceptanceArtifacts"`
- `dotnet test src/Tests/GasTests/GasTests.csproj -c Release -v minimal --filter "ChampionSkillSandbox_MapLoad_SeedsStateOwnershipAndPanelPresentation"`
- `dotnet test src/Tests/GasTests/GasTests.csproj -c Release -v minimal --filter "ChampionSkillSandbox_ManifestationEffects_CompileAsTemplateBackedRuntimeSpawns"`
- `dotnet test src/Tests/PresentationTests/PresentationTests.csproj -c Release -v minimal --filter "PerformerEmitSystem_ManifestationPrimitive_UsesGeometryPayloadAndStableIdScope"`

## Evidence
- design doc: `docs/architecture/gas_beam_aoe_manifestation.md`
- acceptance report: `artifacts/acceptance/champion-skill-sandbox/battle-report.md`
- acceptance path: `artifacts/acceptance/champion-skill-sandbox/path.mmd`
- acceptance screens: `artifacts/acceptance/champion-skill-sandbox/screens/`
- runtime screenshot: `artifacts/runtime/champion-skill-sandbox/raylib_startup.png`
- runtime media: `artifacts/runtime/champion-skill-sandbox/beam_artisan_showcase.mp4`
