### PR TITLE
Champion sandbox: duelist melee context combo showcase

### DIFF
--- a/mods/CoreInputMod/Systems/LocalOrderSourceHelper.cs
+++ b/mods/CoreInputMod/Systems/LocalOrderSourceHelper.cs
@@ -209,11 +209,23 @@ namespace CoreInputMod.Systems
             return true;
         }
 
-        private static string DescribeOrder(in Order order)
+        private string DescribeOrder(in Order order)
         {
+            string actorName = "<none>";
+            string targetName = "<none>";
+            if (order.Actor != Entity.Null)
+            {
+                actorName = TryReadEntityName(order.Actor, out string resolvedActorName) ? resolvedActorName : "<unnamed>";
+            }
+
+            if (order.Target != Entity.Null)
+            {
+                targetName = TryReadEntityName(order.Target, out string resolvedTargetName) ? resolvedTargetName : "<unnamed>";
+            }
+
             string target = order.Target == Entity.Null
                 ? "<none>"
-                : $"{order.Target.Id}:{order.Target.WorldId}:{order.Target.Version}";
+                : $"{order.Target.Id}:{order.Target.WorldId}:{order.Target.Version}/{targetName}";
             string spatial = order.Args.Spatial.Mode switch
             {
                 OrderCollectionMode.None => "<none>",
@@ -221,7 +233,19 @@ namespace CoreInputMod.Systems
                 _ => $"list(count:{order.Args.Spatial.PointCount})"
             };
 
-            return $"type:{order.OrderTypeId},player:{order.PlayerId},actor:{order.Actor.Id}:{order.Actor.WorldId}:{order.Actor.Version},target:{target},slot:{order.Args.I0},spatial:{spatial},submit:{order.SubmitMode}";
+            return $"type:{order.OrderTypeId},player:{order.PlayerId},actor:{order.Actor.Id}:{order.Actor.WorldId}:{order.Actor.Version}/{actorName},target:{target},slot:{order.Args.I0},spatial:{spatial},submit:{order.SubmitMode}";
+        }
+
+        private bool TryReadEntityName(Entity entity, out string name)
+        {
+            name = string.Empty;
+            if (!_world.IsAlive(entity) || !_world.TryGet(entity, out Name entityName))
+            {
+                return false;
+            }
+
+            name = entityName.Value;
+            return !string.IsNullOrWhiteSpace(name);
         }
 
         private sealed class SkillMappingOverrideResolver

--- a/mods/CoreInputMod/ViewMode/ViewModeManager.cs
+++ b/mods/CoreInputMod/ViewMode/ViewModeManager.cs
@@ -53,6 +53,7 @@ namespace CoreInputMod.ViewMode
             int nextIndex = _modes.IndexOf(target);
             if (nextIndex == _activeIndex)
             {
+                EnsureActiveModeApplied(target);
                 return true;
             }
 
@@ -126,6 +127,14 @@ namespace CoreInputMod.ViewMode
             ApplyInteractionMode(next);
             ApplySkillBar(next);
             _globals[ActiveModeIdKey] = next.Id;
+        }
+
+        private void EnsureActiveModeApplied(ViewModeConfig mode)
+        {
+            ApplyCamera(previous: null, mode);
+            ApplyInteractionMode(mode);
+            ApplySkillBar(mode);
+            _globals[ActiveModeIdKey] = mode.Id;
         }
 
         private void ApplyCamera(ViewModeConfig? previous, ViewModeConfig next)

--- a/mods/DiagnosticsOverlayMod/Systems/DiagnosticsOverlaySystem.cs
+++ b/mods/DiagnosticsOverlayMod/Systems/DiagnosticsOverlaySystem.cs
@@ -22,6 +22,7 @@ namespace DiagnosticsOverlayMod.Systems
 {
     public sealed class DiagnosticsOverlaySystem : ISystem<float>
     {
+        private const string HideRuntimeHudKey = "DiagnosticsOverlay.HideRuntimeHud";
         private readonly GameEngine _engine;
         private PlayerInputHandler? _input;
 
@@ -69,7 +70,10 @@ namespace DiagnosticsOverlayMod.Systems
             if (!_engine.GlobalContext.TryGetValue(CoreServiceKeys.ScreenOverlayBuffer.Name, out var obj) ||
                 obj is not ScreenOverlayBuffer overlay) return;
 
-            RenderRuntimeHud(overlay, renderDebugState, t);
+            if (!ShouldHideRuntimeHud())
+            {
+                RenderRuntimeHud(overlay, renderDebugState, t);
+            }
 
             if (_activePanel == Panel.None && !_turnBasedMode) return;
 
@@ -333,6 +337,13 @@ namespace DiagnosticsOverlayMod.Systems
             overlay.AddText(x + 10, y + 92, $"F9 Terrain[{OnOff(renderDebugState.DrawTerrain)}]  F10 Primitive[{OnOff(renderDebugState.DrawPrimitives)}]", 14, text);
             overlay.AddText(x + 10, y + 112, $"F11 DebugDraw[{OnOff(renderDebugState.DrawDebugDraw)}]  F12 SkiaUI[{OnOff(renderDebugState.DrawSkiaUi)}]", 14, text);
             overlay.AddText(x + 10, y + 132, "F5 Config | F6 Mods | F7 Attributes | F8 TurnBased", 13, new Vector4(0.7f, 0.8f, 0.9f, 0.95f));
+        }
+
+        private bool ShouldHideRuntimeHud()
+        {
+            return _engine.GlobalContext.TryGetValue(HideRuntimeHudKey, out var hiddenObj) &&
+                   hiddenObj is bool hidden &&
+                   hidden;
         }
 
         private static string OnOff(bool enabled) => enabled ? "ON" : "OFF";

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/ChampionSkillSandboxIds.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/ChampionSkillSandboxIds.cs
@@ -42,9 +42,11 @@ namespace ChampionSkillSandboxMod
         public const string ContextActionSummaryKey = "ChampionSkillSandbox.ContextActionSummary";
         public const string SelectionIndicatorPerformerKey = "champion_skill_sandbox.selection_indicator";
         public const string HoverIndicatorPerformerKey = "champion_skill_sandbox.hover_indicator";
+        public const string ResolvedIndicatorPerformerKey = "champion_skill_sandbox.resolved_indicator";
         public const int SelectionIndicatorScopeId = 4101;
         public const int HoverIndicatorScopeId = 4102;
         public const int AimHoverIndicatorScopeId = 4103;
+        public const int ResolvedIndicatorScopeId = 4104;
 
         public const string EzrealAlphaName = "Ezreal Alpha";
         public const string EzrealCooldownName = "Ezreal Cooldown";

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/ChampionSkillSandboxIds.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/ChampionSkillSandboxIds.cs
@@ -11,12 +11,15 @@ namespace ChampionSkillSandboxMod
         public const string SmartCastModeId = "ChampionSkillSandbox.Mode.SmartCast";
         public const string IndicatorModeId = "ChampionSkillSandbox.Mode.Indicator";
         public const string PressReleaseModeId = "ChampionSkillSandbox.Mode.PressReleaseAim";
+        public const string ActionModeId = "ChampionSkillSandbox.Mode.Action";
         public const string TacticalCameraId = "ChampionSkillSandbox.Camera.Tactical";
 
         public const string SmartCastActionId = "CastModeSmart";
         public const string IndicatorActionId = "CastModeIndicator";
         public const string PressReleaseActionId = "CastModePressRelease";
+        public const string ActionModeActionId = "CastModeAction";
         public const string ResetCameraActionId = "ResetCamera";
+        public const string ActionAttackActionId = "ActionAttack";
         public const string FreeCameraToolbarButtonId = "ChampionSkillSandbox.Camera.Free";
         public const string FollowSelectionToolbarButtonId = "ChampionSkillSandbox.Camera.Selection";
         public const string FollowSelectionGroupToolbarButtonId = "ChampionSkillSandbox.Camera.SelectionGroup";
@@ -36,6 +39,7 @@ namespace ChampionSkillSandboxMod
         public const string ResetCameraRequestKey = "ChampionSkillSandbox.Camera.ResetRequested";
         public const string CameraFollowModeKey = "ChampionSkillSandbox.Camera.FollowMode";
         public const string SelectionViewChoiceKey = "ChampionSkillSandbox.Selection.ViewChoice";
+        public const string ContextActionSummaryKey = "ChampionSkillSandbox.ContextActionSummary";
         public const string SelectionIndicatorPerformerKey = "champion_skill_sandbox.selection_indicator";
         public const string HoverIndicatorPerformerKey = "champion_skill_sandbox.hover_indicator";
         public const int SelectionIndicatorScopeId = 4101;
@@ -48,6 +52,7 @@ namespace ChampionSkillSandboxMod
         public const string GarenCourageName = "Garen Courage";
         public const string JayceCannonName = "Jayce Cannon";
         public const string JayceHammerName = "Jayce Hammer";
+        public const string DuelistAlphaName = "Duelist Alpha";
         public const string GeomancerAlphaName = "Geomancer Alpha";
         public const string SpellEngineerAlphaName = "Spell Engineer Alpha";
         public const string RunicBeaconName = "Runic Beacon";
@@ -80,7 +85,8 @@ namespace ChampionSkillSandboxMod
         {
             return string.Equals(modeId, SmartCastModeId, StringComparison.OrdinalIgnoreCase) ||
                    string.Equals(modeId, IndicatorModeId, StringComparison.OrdinalIgnoreCase) ||
-                   string.Equals(modeId, PressReleaseModeId, StringComparison.OrdinalIgnoreCase);
+                   string.Equals(modeId, PressReleaseModeId, StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(modeId, ActionModeId, StringComparison.OrdinalIgnoreCase);
         }
 
         public static bool IsCameraFollowMode(string? buttonId)

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillCastModeToolbarProvider.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillCastModeToolbarProvider.cs
@@ -2,6 +2,12 @@ using System;
 using Arch.Core;
 using CoreInputMod.ViewMode;
 using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.GAS;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Orders;
+using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.Input.Orders;
+using Ludots.Core.Input.Selection;
 using Ludots.Core.Presentation.Hud;
 using Ludots.Core.Scripting;
 using Ludots.Core.UI.EntityCommandPanels;
@@ -56,9 +62,26 @@ namespace ChampionSkillSandboxMod.Runtime
             }
         }
 
-        public string Title => ChampionSkillSandboxIds.IsStressMap(_engine?.CurrentMapSession?.MapId.Value)
-            ? "Stress Harness"
-            : "Cast Mode";
+        public string Title
+        {
+            get
+            {
+                if (ChampionSkillSandboxIds.IsStressMap(_engine?.CurrentMapSession?.MapId.Value))
+                {
+                    return "Stress Harness";
+                }
+
+                Entity selected = ResolveSelectedEntity();
+                if (!IsNamedEntity(selected, ChampionSkillSandboxIds.DuelistAlphaName))
+                {
+                    return "Cast Mode";
+                }
+
+                return string.Equals(ResolveActiveModeId(), ChampionSkillSandboxIds.ActionModeId, StringComparison.OrdinalIgnoreCase)
+                    ? "Duelist Action Combo"
+                    : "Duelist Showcase";
+            }
+        }
 
         public string Subtitle
         {
@@ -66,7 +89,7 @@ namespace ChampionSkillSandboxMod.Runtime
             {
                 if (!ChampionSkillSandboxIds.IsStressMap(_engine?.CurrentMapSession?.MapId.Value))
                 {
-                    return "Cast + Camera | F1/F2/F3/F5 Modes | Space Context | RMB Move";
+                    return BuildSandboxSubtitle();
                 }
 
                 ChampionSkillStressControlState? control = ResolveStressControl();
@@ -101,22 +124,22 @@ namespace ChampionSkillSandboxMod.Runtime
                 "#F6C35B");
             buttons[1] = new EntityCommandPanelToolbarButtonView(
                 ChampionSkillSandboxIds.IndicatorModeId,
-                "Indicator",
+                "Preview",
                 string.Equals(activeModeId, ChampionSkillSandboxIds.IndicatorModeId, StringComparison.OrdinalIgnoreCase),
                 "#61C3FF");
             buttons[2] = new EntityCommandPanelToolbarButtonView(
                 ChampionSkillSandboxIds.PressReleaseModeId,
-                "RTS",
+                "Confirm",
                 string.Equals(activeModeId, ChampionSkillSandboxIds.PressReleaseModeId, StringComparison.OrdinalIgnoreCase),
                 "#93E07A");
             buttons[3] = new EntityCommandPanelToolbarButtonView(
                 ChampionSkillSandboxIds.ActionModeId,
-                "Action",
+                "Auto",
                 string.Equals(activeModeId, ChampionSkillSandboxIds.ActionModeId, StringComparison.OrdinalIgnoreCase),
                 "#F3DF86");
             buttons[4] = new EntityCommandPanelToolbarButtonView(
                 ChampionSkillSandboxIds.FreeCameraToolbarButtonId,
-                "Free",
+                "FreeCam",
                 string.Equals(activeFollowModeId, ChampionSkillSandboxIds.FreeCameraToolbarButtonId, StringComparison.OrdinalIgnoreCase),
                 "#D7D2C4");
             buttons[5] = new EntityCommandPanelToolbarButtonView(
@@ -126,12 +149,12 @@ namespace ChampionSkillSandboxMod.Runtime
                 "#8ED9A9");
             buttons[6] = new EntityCommandPanelToolbarButtonView(
                 ChampionSkillSandboxIds.FollowSelectionGroupToolbarButtonId,
-                "Group",
+                "PackCam",
                 string.Equals(activeFollowModeId, ChampionSkillSandboxIds.FollowSelectionGroupToolbarButtonId, StringComparison.OrdinalIgnoreCase),
                 "#F0C35A");
             buttons[7] = new EntityCommandPanelToolbarButtonView(
                 ChampionSkillSandboxIds.ResetCameraToolbarButtonId,
-                "Reset",
+                "ResetCam",
                 false,
                 "#D7D2C4");
             if (isStressMap)
@@ -344,7 +367,7 @@ namespace ChampionSkillSandboxMod.Runtime
                 return activeModeId;
             }
 
-            return ChampionSkillSandboxIds.SmartCastModeId;
+            return ChampionSkillSandboxIds.ActionModeId;
         }
 
         private string ResolveActiveSelectionViewId()
@@ -357,6 +380,191 @@ namespace ChampionSkillSandboxMod.Runtime
             }
 
             return ChampionSkillSandboxIds.PlayerSelectionToolbarButtonId;
+        }
+
+        private string BuildSandboxSubtitle()
+        {
+            Entity selected = ResolveSelectedEntity();
+            if (selected == Entity.Null)
+            {
+                return "1 Select Duelist Alpha | 2 Leave Auto mode on | 3 Hover D/E/F | 4 Tap Space for the melee route";
+            }
+
+            if (!IsNamedEntity(selected, ChampionSkillSandboxIds.DuelistAlphaName))
+            {
+                string selectedName = ResolveEntityName(selected);
+                return string.IsNullOrWhiteSpace(selectedName)
+                    ? "Select Duelist Alpha | Auto mode | Hover D/E/F | Space = auto melee | Q = manual chain"
+                    : $"Current {selectedName} | Select Duelist Alpha for auto melee | Space = auto route | Q = manual chain";
+            }
+
+            if (!string.Equals(ResolveActiveModeId(), ChampionSkillSandboxIds.ActionModeId, StringComparison.OrdinalIgnoreCase))
+            {
+                return "Duelist ready | Press F5 for Auto mode | Hover D/E/F | Space = auto melee | Q = manual chain";
+            }
+
+            if (TryBuildDuelistActionSummary(selected, out string summary))
+            {
+                return summary;
+            }
+
+            return "Duelist auto melee | Hover D/E/F | Space = auto route | Q = manual chain | E = pack sweep";
+        }
+
+        private bool TryBuildDuelistActionSummary(Entity actor, out string summary)
+        {
+            summary = string.Empty;
+            if (_engine == null ||
+                actor == Entity.Null ||
+                !_engine.World.IsAlive(actor))
+            {
+                return false;
+            }
+
+            Span<ContextScoredCandidateProbe> probes = stackalloc ContextScoredCandidateProbe[8];
+            int actionContextAbilityId = AbilityIdRegistry.GetId("Ability.Champion.Duelist.ActionContext");
+            bool resolved = ChampionSkillSandboxDuelistContextInspector.TryInspect(
+                _engine,
+                actionContextAbilityId,
+                probes,
+                out Entity inspectedActor,
+                out Entity hovered,
+                out _,
+                out int probeCount,
+                out ContextScoredOrderResolution resolution);
+
+            if (inspectedActor != actor)
+            {
+                return false;
+            }
+
+            string hoverName = ResolveEntityName(hovered);
+            string targetName = ResolveEntityName(resolution.Target);
+            string qLabel = ResolveResolvedSlotAbilityLabel(actor, slotIndex: 0, fallback: "Chain Jab I");
+            string eLabel = ResolveResolvedSlotAbilityLabel(actor, slotIndex: 2, fallback: "Crowd Sweep");
+
+            if (!resolved || probeCount <= 0)
+            {
+                summary = $"Hover {(string.IsNullOrWhiteSpace(hoverName) ? "none" : hoverName)} | Auto scans the pack | Q manual {qLabel} | E {eLabel}";
+                return true;
+            }
+
+            string spaceLabel = ResolveAbilityDisplayName(probes[0].AbilityId);
+            if (string.IsNullOrWhiteSpace(spaceLabel))
+            {
+                return false;
+            }
+
+            string hoverSegment = string.IsNullOrWhiteSpace(hoverName) ? "Hover none" : $"Hover {hoverName}";
+            string autoSegment = string.IsNullOrWhiteSpace(targetName)
+                ? $"Auto {spaceLabel}"
+                : $"Auto {spaceLabel} -> {targetName}";
+            summary = $"{hoverSegment} | {autoSegment} | Q manual {qLabel} | E {eLabel}";
+            return true;
+        }
+
+        private Entity ResolveSelectedEntity()
+        {
+            if (_engine == null)
+            {
+                return Entity.Null;
+            }
+
+            return SelectionContextRuntime.TryGetCurrentPrimary(_engine.World, _engine.GlobalContext, out Entity selected) &&
+                   selected != Entity.Null &&
+                   _engine.World.IsAlive(selected)
+                ? selected
+                : Entity.Null;
+        }
+
+        private Entity ResolveHoveredEntity()
+        {
+            if (_engine == null)
+            {
+                return Entity.Null;
+            }
+
+            return _engine.GlobalContext.TryGetValue(CoreServiceKeys.HoveredEntity.Name, out object? hoveredObj) &&
+                   hoveredObj is Entity hovered &&
+                   hovered != Entity.Null &&
+                   _engine.World.IsAlive(hovered)
+                ? hovered
+                : Entity.Null;
+        }
+
+        private bool IsNamedEntity(Entity entity, string expectedName)
+        {
+            return string.Equals(ResolveEntityName(entity), expectedName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private string ResolveEntityName(Entity entity)
+        {
+            if (_engine == null ||
+                entity == Entity.Null ||
+                !_engine.World.IsAlive(entity) ||
+                !_engine.World.TryGet(entity, out Ludots.Core.Components.Name name))
+            {
+                return string.Empty;
+            }
+
+            return name.Value ?? string.Empty;
+        }
+
+        private string ResolveAbilityDisplayName(int abilityId)
+        {
+            if (abilityId <= 0)
+            {
+                return string.Empty;
+            }
+
+            if (_engine?.GetService(CoreServiceKeys.AbilityDefinitionRegistry) is AbilityDefinitionRegistry definitions &&
+                definitions.TryGet(abilityId, out var definition) &&
+                definition.HasPresentation &&
+                definition.Presentation != null)
+            {
+                string displayName = definition.Presentation.ResolveDisplayName(string.Empty);
+                if (!string.IsNullOrWhiteSpace(displayName))
+                {
+                    return displayName;
+                }
+            }
+
+            string raw = AbilityIdRegistry.GetName(abilityId);
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return $"Ability#{abilityId}";
+            }
+
+            int lastDot = raw.LastIndexOf('.');
+            return lastDot >= 0 && lastDot + 1 < raw.Length
+                ? raw[(lastDot + 1)..]
+                : raw;
+        }
+
+        private string ResolveResolvedSlotAbilityLabel(Entity actor, int slotIndex, string fallback)
+        {
+            if (_engine == null ||
+                actor == Entity.Null ||
+                !_engine.World.IsAlive(actor) ||
+                !_engine.World.Has<AbilityStateBuffer>(actor))
+            {
+                return fallback;
+            }
+
+            ref readonly AbilityStateBuffer abilities = ref _engine.World.Get<AbilityStateBuffer>(actor);
+            if ((uint)slotIndex >= (uint)abilities.Count)
+            {
+                return fallback;
+            }
+
+            bool hasForm = _engine.World.Has<AbilityFormSlotBuffer>(actor);
+            AbilityFormSlotBuffer formSlots = hasForm ? _engine.World.Get<AbilityFormSlotBuffer>(actor) : default;
+            bool hasGranted = _engine.World.Has<GrantedSlotBuffer>(actor);
+            GrantedSlotBuffer granted = hasGranted ? _engine.World.Get<GrantedSlotBuffer>(actor) : default;
+            var resolved = AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm, in granted, hasGranted, slotIndex);
+            return resolved.AbilityId > 0
+                ? ResolveAbilityDisplayName(resolved.AbilityId)
+                : fallback;
         }
     }
 }

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillCastModeToolbarProvider.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillCastModeToolbarProvider.cs
@@ -66,7 +66,7 @@ namespace ChampionSkillSandboxMod.Runtime
             {
                 if (!ChampionSkillSandboxIds.IsStressMap(_engine?.CurrentMapSession?.MapId.Value))
                 {
-                    return "Cast + Camera | F1/F2/F3 Cast | RMB Move";
+                    return "Cast + Camera | F1/F2/F3/F5 Modes | Space Context | RMB Move";
                 }
 
                 ChampionSkillStressControlState? control = ResolveStressControl();
@@ -93,7 +93,7 @@ namespace ChampionSkillSandboxMod.Runtime
             string activeFollowModeId = ResolveActiveCameraFollowMode();
             string activeSelectionViewId = ResolveActiveSelectionViewId();
             RenderDebugState? renderDebug = ResolveRenderDebugState();
-            var buttons = new EntityCommandPanelToolbarButtonView[isStressMap ? 19 : 7];
+            var buttons = new EntityCommandPanelToolbarButtonView[isStressMap ? 20 : 8];
             buttons[0] = new EntityCommandPanelToolbarButtonView(
                 ChampionSkillSandboxIds.SmartCastModeId,
                 "Quick",
@@ -110,83 +110,88 @@ namespace ChampionSkillSandboxMod.Runtime
                 string.Equals(activeModeId, ChampionSkillSandboxIds.PressReleaseModeId, StringComparison.OrdinalIgnoreCase),
                 "#93E07A");
             buttons[3] = new EntityCommandPanelToolbarButtonView(
+                ChampionSkillSandboxIds.ActionModeId,
+                "Action",
+                string.Equals(activeModeId, ChampionSkillSandboxIds.ActionModeId, StringComparison.OrdinalIgnoreCase),
+                "#F3DF86");
+            buttons[4] = new EntityCommandPanelToolbarButtonView(
                 ChampionSkillSandboxIds.FreeCameraToolbarButtonId,
                 "Free",
                 string.Equals(activeFollowModeId, ChampionSkillSandboxIds.FreeCameraToolbarButtonId, StringComparison.OrdinalIgnoreCase),
                 "#D7D2C4");
-            buttons[4] = new EntityCommandPanelToolbarButtonView(
+            buttons[5] = new EntityCommandPanelToolbarButtonView(
                 ChampionSkillSandboxIds.FollowSelectionToolbarButtonId,
                 "Follow",
                 string.Equals(activeFollowModeId, ChampionSkillSandboxIds.FollowSelectionToolbarButtonId, StringComparison.OrdinalIgnoreCase),
                 "#8ED9A9");
-            buttons[5] = new EntityCommandPanelToolbarButtonView(
+            buttons[6] = new EntityCommandPanelToolbarButtonView(
                 ChampionSkillSandboxIds.FollowSelectionGroupToolbarButtonId,
                 "Group",
                 string.Equals(activeFollowModeId, ChampionSkillSandboxIds.FollowSelectionGroupToolbarButtonId, StringComparison.OrdinalIgnoreCase),
                 "#F0C35A");
-            buttons[6] = new EntityCommandPanelToolbarButtonView(
+            buttons[7] = new EntityCommandPanelToolbarButtonView(
                 ChampionSkillSandboxIds.ResetCameraToolbarButtonId,
                 "Reset",
                 false,
                 "#D7D2C4");
             if (isStressMap)
             {
-                buttons[7] = new EntityCommandPanelToolbarButtonView(
+                buttons[8] = new EntityCommandPanelToolbarButtonView(
                     ChampionSkillSandboxIds.StressTeamADecreaseToolbarButtonId,
                     "A-",
                     false,
                     "#FF9B7A");
-                buttons[8] = new EntityCommandPanelToolbarButtonView(
+                buttons[9] = new EntityCommandPanelToolbarButtonView(
                     ChampionSkillSandboxIds.StressTeamAIncreaseToolbarButtonId,
                     "A+",
                     false,
                     "#FF9B7A");
-                buttons[9] = new EntityCommandPanelToolbarButtonView(
+                buttons[10] = new EntityCommandPanelToolbarButtonView(
                     ChampionSkillSandboxIds.StressTeamBDecreaseToolbarButtonId,
                     "B-",
                     false,
                     "#67D4FF");
-                buttons[10] = new EntityCommandPanelToolbarButtonView(
+                buttons[11] = new EntityCommandPanelToolbarButtonView(
                     ChampionSkillSandboxIds.StressTeamBIncreaseToolbarButtonId,
                     "B+",
                     false,
                     "#67D4FF");
-                buttons[11] = new EntityCommandPanelToolbarButtonView(
+                buttons[12] = new EntityCommandPanelToolbarButtonView(
                     ChampionSkillSandboxIds.StressHudBarToggleToolbarButtonId,
                     "Bar",
                     renderDebug?.DrawWorldHudBars ?? true,
                     "#E2D7A6");
-                buttons[12] = new EntityCommandPanelToolbarButtonView(
+                buttons[13] = new EntityCommandPanelToolbarButtonView(
                     ChampionSkillSandboxIds.StressHudTextToggleToolbarButtonId,
                     "Text",
                     renderDebug?.DrawWorldHudText ?? true,
                     "#F2E3B3");
-                buttons[13] = new EntityCommandPanelToolbarButtonView(
+                buttons[14] = new EntityCommandPanelToolbarButtonView(
                     ChampionSkillSandboxIds.StressCombatTextToggleToolbarButtonId,
                     "Float",
                     renderDebug?.DrawCombatText ?? true,
                     "#FFCF86");
-                buttons[14] = new EntityCommandPanelToolbarButtonView(
+                buttons[15] = new EntityCommandPanelToolbarButtonView(
                     ChampionSkillSandboxIds.PlayerSelectionToolbarButtonId,
                     "P1",
                     string.Equals(activeSelectionViewId, ChampionSkillSandboxIds.PlayerSelectionToolbarButtonId, StringComparison.OrdinalIgnoreCase),
                     "#98E7A7");
-                buttons[15] = new EntityCommandPanelToolbarButtonView(
+                buttons[16] = new EntityCommandPanelToolbarButtonView(
                     ChampionSkillSandboxIds.PlayerFormationToolbarButtonId,
                     "P1F",
                     string.Equals(activeSelectionViewId, ChampionSkillSandboxIds.PlayerFormationToolbarButtonId, StringComparison.OrdinalIgnoreCase),
                     "#DAE89B");
-                buttons[16] = new EntityCommandPanelToolbarButtonView(
+                buttons[17] = new EntityCommandPanelToolbarButtonView(
                     ChampionSkillSandboxIds.AiTargetToolbarButtonId,
                     "AI",
                     string.Equals(activeSelectionViewId, ChampionSkillSandboxIds.AiTargetToolbarButtonId, StringComparison.OrdinalIgnoreCase),
                     "#FFAE86");
-                buttons[17] = new EntityCommandPanelToolbarButtonView(
+                buttons[18] = new EntityCommandPanelToolbarButtonView(
                     ChampionSkillSandboxIds.AiFormationToolbarButtonId,
                     "AIF",
                     string.Equals(activeSelectionViewId, ChampionSkillSandboxIds.AiFormationToolbarButtonId, StringComparison.OrdinalIgnoreCase),
                     "#F6CF79");
-                buttons[18] = new EntityCommandPanelToolbarButtonView(
+                buttons[19] = new EntityCommandPanelToolbarButtonView(
                     ChampionSkillSandboxIds.CommandSnapshotToolbarButtonId,
                     "CMD",
                     string.Equals(activeSelectionViewId, ChampionSkillSandboxIds.CommandSnapshotToolbarButtonId, StringComparison.OrdinalIgnoreCase),

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxDuelistContextInspector.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxDuelistContextInspector.cs
@@ -1,0 +1,119 @@
+using System;
+using Arch.Core;
+using Ludots.Core.Components;
+using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.GAS;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Orders;
+using Ludots.Core.GraphRuntime;
+using Ludots.Core.Input.Orders;
+using Ludots.Core.Input.Selection;
+using Ludots.Core.NodeLibraries.GASGraph.Host;
+using Ludots.Core.Scripting;
+using Ludots.Core.Spatial;
+
+namespace ChampionSkillSandboxMod.Runtime
+{
+    internal static class ChampionSkillSandboxDuelistContextInspector
+    {
+        public static bool TryInspect(
+            GameEngine engine,
+            int duelistActionContextAbilityId,
+            Span<ContextScoredCandidateProbe> probes,
+            out Entity actor,
+            out Entity hovered,
+            out ContextGroupDefinition group,
+            out int probeCount,
+            out ContextScoredOrderResolution resolution)
+        {
+            actor = Entity.Null;
+            hovered = Entity.Null;
+            group = default;
+            probeCount = 0;
+            resolution = default;
+
+            if (duelistActionContextAbilityId <= 0 ||
+                engine.GetService(CoreServiceKeys.ActiveInputOrderMapping) is not InputOrderMappingSystem mappingSystem ||
+                mappingSystem.GetMapping("ActionAttack") is not InputOrderMapping actionAttackMapping ||
+                engine.GetService(CoreServiceKeys.ContextGroupRegistry) is not ContextGroupRegistry contextGroups ||
+                engine.GetService(CoreServiceKeys.GraphProgramRegistry) is not GraphProgramRegistry graphPrograms ||
+                engine.GetService(CoreServiceKeys.SpatialQueryService) is not ISpatialQueryService spatialQueries ||
+                engine.GetService(CoreServiceKeys.SpatialCoordinateConverter) is not ISpatialCoordinateConverter spatialCoords)
+            {
+                return false;
+            }
+
+            actor = ResolveSelectedDuelist(engine.World, engine.GlobalContext, duelistActionContextAbilityId);
+            if (actor == Entity.Null ||
+                !TryResolveContextGroup(engine.World, actor, actionAttackMapping, contextGroups, out group))
+            {
+                return false;
+            }
+
+            hovered = ResolveHoveredEntity(engine);
+            var graphApi = new GasGraphRuntimeApi(engine.World, spatialQueries, spatialCoords, eventBus: null, effectRequests: null);
+            var resolver = new ContextScoredOrderResolver(engine.World, contextGroups, graphPrograms, spatialQueries, graphApi);
+            return resolver.TryInspect(actor, actionAttackMapping, hovered, probes, out probeCount, out resolution);
+        }
+
+        private static Entity ResolveSelectedDuelist(World world, System.Collections.Generic.Dictionary<string, object> globals, int duelistActionContextAbilityId)
+        {
+            if (!SelectionContextRuntime.TryGetCurrentPrimary(world, globals, out Entity selected) ||
+                selected == Entity.Null ||
+                !world.IsAlive(selected) ||
+                !world.Has<AbilityStateBuffer>(selected))
+            {
+                return Entity.Null;
+            }
+
+            ref readonly AbilityStateBuffer abilities = ref world.Get<AbilityStateBuffer>(selected);
+            bool hasForm = world.Has<AbilityFormSlotBuffer>(selected);
+            AbilityFormSlotBuffer formSlots = hasForm ? world.Get<AbilityFormSlotBuffer>(selected) : default;
+            bool hasGranted = world.Has<GrantedSlotBuffer>(selected);
+            GrantedSlotBuffer granted = hasGranted ? world.Get<GrantedSlotBuffer>(selected) : default;
+            for (int slotIndex = 0; slotIndex < abilities.Count; slotIndex++)
+            {
+                var resolved = AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm, in granted, hasGranted, slotIndex);
+                if (resolved.AbilityId == duelistActionContextAbilityId)
+                {
+                    return selected;
+                }
+            }
+
+            return Entity.Null;
+        }
+
+        private static Entity ResolveHoveredEntity(GameEngine engine)
+        {
+            return engine.GlobalContext.TryGetValue(CoreServiceKeys.HoveredEntity.Name, out object? hoveredObj) &&
+                   hoveredObj is Entity hovered &&
+                   hovered != Entity.Null &&
+                   engine.World.IsAlive(hovered)
+                ? hovered
+                : Entity.Null;
+        }
+
+        private static bool TryResolveContextGroup(
+            World world,
+            Entity actor,
+            InputOrderMapping mapping,
+            ContextGroupRegistry contextGroups,
+            out ContextGroupDefinition group)
+        {
+            group = default;
+            if (mapping.ArgsTemplate.I0 is null || !world.Has<AbilityStateBuffer>(actor))
+            {
+                return false;
+            }
+
+            int rootSlotIndex = mapping.ArgsTemplate.I0.Value;
+            ref readonly AbilityStateBuffer abilities = ref world.Get<AbilityStateBuffer>(actor);
+            bool hasForm = world.Has<AbilityFormSlotBuffer>(actor);
+            AbilityFormSlotBuffer formSlots = hasForm ? world.Get<AbilityFormSlotBuffer>(actor) : default;
+            bool hasGranted = world.Has<GrantedSlotBuffer>(actor);
+            GrantedSlotBuffer granted = hasGranted ? world.Get<GrantedSlotBuffer>(actor) : default;
+            var resolved = AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm, in granted, hasGranted, rootSlotIndex);
+            return resolved.AbilityId > 0 && contextGroups.TryGetByRootAbility(resolved.AbilityId, out group);
+        }
+    }
+}

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxRuntime.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxRuntime.cs
@@ -8,15 +8,19 @@ using Ludots.Core.Components;
 using Ludots.Core.Engine;
 using Ludots.Core.Gameplay.Camera;
 using Ludots.Core.Gameplay.Components;
+using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Components;
 using Ludots.Core.Gameplay.GAS.Orders;
 using Ludots.Core.Gameplay.GAS.Registry;
 using Ludots.Core.Input.Orders;
 using Ludots.Core.Input.Runtime;
 using Ludots.Core.Input.Selection;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Spatial;
 using Ludots.Core.Presentation.Commands;
 using Ludots.Core.Presentation.Hud;
 using Ludots.Core.Presentation.Performers;
+using Ludots.Core.Presentation.Rendering;
 using Ludots.Core.Scripting;
 using Ludots.Core.UI.EntityCommandPanels;
 
@@ -24,6 +28,7 @@ namespace ChampionSkillSandboxMod.Runtime
 {
     internal sealed class ChampionSkillSandboxRuntime
     {
+        private const string HideRuntimeHudKey = "DiagnosticsOverlay.HideRuntimeHud";
         private static readonly QueryDescription StressSelectableQuery = new QueryDescription().WithAll<Name, Team, MapEntity, AbilityStateBuffer>();
         private static readonly QueryDescription StressOrderBufferQuery = new QueryDescription().WithAll<Team, MapEntity, OrderBuffer>();
         private static readonly Vector4 SelectionPanelFill = new(0.05f, 0.08f, 0.11f, 0.88f);
@@ -31,15 +36,34 @@ namespace ChampionSkillSandboxMod.Runtime
         private static readonly Vector4 SelectionPanelTitle = new(0.94f, 0.83f, 0.47f, 1f);
         private static readonly Vector4 SelectionPanelText = new(0.90f, 0.94f, 0.98f, 1f);
         private static readonly Vector4 SelectionPanelHint = new(0.70f, 0.78f, 0.86f, 1f);
+        private static readonly Vector4 SandboxGuideFill = new(0.04f, 0.07f, 0.10f, 0.90f);
+        private static readonly Vector4 SandboxGuideBorder = new(0.48f, 0.80f, 0.98f, 0.96f);
+        private static readonly Vector4 SandboxGuideTitle = new(0.98f, 0.90f, 0.58f, 1f);
+        private static readonly Vector4 SandboxGuideText = new(0.92f, 0.96f, 0.99f, 1f);
+        private static readonly Vector4 SandboxGuideHint = new(0.74f, 0.84f, 0.92f, 1f);
+        private static readonly Vector4 SandboxGuideAccent = new(0.60f, 0.90f, 0.54f, 1f);
+        private static readonly Vector4 SandboxGuideWarn = new(1.00f, 0.72f, 0.52f, 1f);
+        private static readonly Vector4 ShowcaseLaneFill = new(0.80f, 0.92f, 0.54f, 0.08f);
+        private static readonly Vector4 ShowcaseLaneBorder = new(0.96f, 1.00f, 0.72f, 0.66f);
+        private static readonly Vector4 StepInPreviewFill = new(0.36f, 0.90f, 1.00f, 0.12f);
+        private static readonly Vector4 StepInPreviewBorder = new(0.62f, 0.96f, 1.00f, 0.92f);
+        private static readonly Vector4 ChainPreviewFill = new(1.00f, 0.76f, 0.34f, 0.10f);
+        private static readonly Vector4 ChainPreviewBorder = new(1.00f, 0.88f, 0.58f, 0.92f);
+        private static readonly Vector4 SweepPreviewFill = new(0.60f, 0.94f, 0.52f, 0.12f);
+        private static readonly Vector4 SweepPreviewBorder = new(0.76f, 0.98f, 0.70f, 0.92f);
+        private static readonly Vector4 BreakerPreviewFill = new(1.00f, 0.44f, 0.46f, 0.12f);
+        private static readonly Vector4 BreakerPreviewBorder = new(1.00f, 0.72f, 0.74f, 0.94f);
 
         private EntityCommandPanelHandle _focusPanelHandle = EntityCommandPanelHandle.Invalid;
         private Entity _lastPanelTarget = Entity.Null;
         private Entity _selectionIndicatorTarget = Entity.Null;
         private Entity _hoverIndicatorTarget = Entity.Null;
         private Entity _aimHoverIndicatorTarget = Entity.Null;
+        private Entity _resolvedIndicatorTarget = Entity.Null;
         private Entity _teamBViewer = Entity.Null;
         private Entity _debugViewer = Entity.Null;
         private string _lastMapId = string.Empty;
+        private string _lastCameraFollowMode = string.Empty;
         private bool _scenarioTagsApplied;
         private bool _initialSelectionApplied;
         private readonly List<Entity> _teamAFormation = new();
@@ -61,6 +85,7 @@ namespace ChampionSkillSandboxMod.Runtime
 
             EnsureMode(engine);
             EnsureScenarioState(engine);
+            SyncDiagnosticsHudPreference(engine);
             SyncFocusPanel(engine);
             return Task.CompletedTask;
         }
@@ -90,12 +115,15 @@ namespace ChampionSkillSandboxMod.Runtime
 
             EnsureMode(engine);
             EnsureScenarioState(engine);
+            SyncDiagnosticsHudPreference(engine);
             SyncSelectionViews(engine);
             ConsumeResetCameraRequest(engine);
             SyncCameraFollow(engine);
             SyncFocusPanel(engine);
             SyncHoverIndicator(engine);
             SyncAimHoverIndicator(engine);
+            SyncResolvedContextIndicator(engine);
+            DrawDuelistPreviewOverlays(engine);
         }
 
         private void EnsureScenarioState(GameEngine engine)
@@ -125,7 +153,7 @@ namespace ChampionSkillSandboxMod.Runtime
 
             if (!engine.GlobalContext.ContainsKey(ChampionSkillSandboxIds.CameraFollowModeKey))
             {
-                engine.GlobalContext[ChampionSkillSandboxIds.CameraFollowModeKey] = ChampionSkillSandboxIds.FreeCameraToolbarButtonId;
+                engine.GlobalContext[ChampionSkillSandboxIds.CameraFollowModeKey] = ChampionSkillSandboxIds.FollowSelectionToolbarButtonId;
             }
 
             if (!engine.GlobalContext.ContainsKey(ChampionSkillSandboxIds.SelectionViewChoiceKey))
@@ -146,6 +174,7 @@ namespace ChampionSkillSandboxMod.Runtime
             if (!ChampionSkillSandboxIds.IsStressMap(engine.CurrentMapSession?.MapId.Value))
             {
                 ApplySelectionViewChoice(engine, playerViewer, aiViewer: Entity.Null, debugViewer: Entity.Null);
+                DrawSandboxGuideOverlay(engine);
                 return;
             }
 
@@ -321,7 +350,11 @@ namespace ChampionSkillSandboxMod.Runtime
         private static bool SeedInitialSelection(GameEngine engine)
         {
             SelectionRuntime? selection = engine.GetService(CoreServiceKeys.SelectionRuntime);
-            Entity fallback = ResolveChampionEntity(engine, ChampionSkillSandboxIds.EzrealAlphaName);
+            Entity fallback = ResolveChampionEntity(engine, ChampionSkillSandboxIds.DuelistAlphaName);
+            if (fallback == Entity.Null)
+            {
+                fallback = ResolveChampionEntity(engine, ChampionSkillSandboxIds.EzrealAlphaName);
+            }
             if (fallback == Entity.Null)
             {
                 fallback = ResolveFirstControllableChampion(engine);
@@ -401,8 +434,46 @@ namespace ChampionSkillSandboxMod.Runtime
             if (!ViewModeRuntime.TryGetActiveModeId(engine.GlobalContext, out string activeModeId) ||
                 !ChampionSkillSandboxIds.IsSandboxMode(activeModeId))
             {
-                ViewModeRuntime.TrySwitchTo(engine.GlobalContext, ChampionSkillSandboxIds.SmartCastModeId);
+                ViewModeRuntime.TrySwitchTo(engine.GlobalContext, ChampionSkillSandboxIds.ActionModeId);
+                activeModeId = ChampionSkillSandboxIds.ActionModeId;
             }
+
+            if (engine.GetService(CoreServiceKeys.ActiveInputOrderMapping) is InputOrderMappingSystem mapping &&
+                TryResolveInteractionMode(activeModeId, out InteractionModeType interactionMode) &&
+                mapping.InteractionMode != interactionMode)
+            {
+                mapping.SetInteractionMode(interactionMode);
+            }
+        }
+
+        private static bool TryResolveInteractionMode(string activeModeId, out InteractionModeType interactionMode)
+        {
+            if (string.Equals(activeModeId, ChampionSkillSandboxIds.ActionModeId, StringComparison.OrdinalIgnoreCase))
+            {
+                interactionMode = InteractionModeType.ContextScored;
+                return true;
+            }
+
+            if (string.Equals(activeModeId, ChampionSkillSandboxIds.IndicatorModeId, StringComparison.OrdinalIgnoreCase))
+            {
+                interactionMode = InteractionModeType.SmartCastWithIndicator;
+                return true;
+            }
+
+            if (string.Equals(activeModeId, ChampionSkillSandboxIds.PressReleaseModeId, StringComparison.OrdinalIgnoreCase))
+            {
+                interactionMode = InteractionModeType.PressReleaseAimCast;
+                return true;
+            }
+
+            if (string.Equals(activeModeId, ChampionSkillSandboxIds.SmartCastModeId, StringComparison.OrdinalIgnoreCase))
+            {
+                interactionMode = InteractionModeType.SmartCast;
+                return true;
+            }
+
+            interactionMode = default;
+            return false;
         }
 
         private static void ConsumeResetCameraRequest(GameEngine engine)
@@ -473,7 +544,7 @@ namespace ChampionSkillSandboxMod.Runtime
             });
         }
 
-        private static void SyncCameraFollow(GameEngine engine)
+        private void SyncCameraFollow(GameEngine engine)
         {
             string followModeId = ResolveCameraFollowMode(engine);
             string activeCameraId = engine.GameSession.Camera.VirtualCameraBrain?.ActiveCameraId ?? string.Empty;
@@ -491,7 +562,9 @@ namespace ChampionSkillSandboxMod.Runtime
                 _ => null
             };
 
-            engine.GameSession.Camera.SetFollowTarget(activeCameraId, followTarget, snapToFollowTargetWhenAvailable: false);
+            bool snap = !string.Equals(_lastCameraFollowMode, followModeId, StringComparison.OrdinalIgnoreCase);
+            _lastCameraFollowMode = followModeId;
+            engine.GameSession.Camera.SetFollowTarget(activeCameraId, followTarget, snapToFollowTargetWhenAvailable: snap);
         }
 
         private static string ResolveCameraFollowMode(GameEngine engine)
@@ -753,6 +826,8 @@ namespace ChampionSkillSandboxMod.Runtime
         {
             DestroySelectionIndicator(engine);
             DestroyHoverIndicator(engine);
+            DestroyAimHoverIndicator(engine);
+            DestroyResolvedContextIndicator(engine);
 
             if (_focusPanelHandle.IsValid &&
                 engine.GetService(CoreServiceKeys.EntityCommandPanelService) is IEntityCommandPanelService service)
@@ -771,9 +846,11 @@ namespace ChampionSkillSandboxMod.Runtime
             _selectionIndicatorTarget = Entity.Null;
             _hoverIndicatorTarget = Entity.Null;
             _aimHoverIndicatorTarget = Entity.Null;
+            _resolvedIndicatorTarget = Entity.Null;
             _scenarioTagsApplied = false;
             _initialSelectionApplied = false;
             _lastMapId = string.Empty;
+            _lastCameraFollowMode = string.Empty;
             if (engine.World.IsAlive(_teamBViewer))
             {
                 engine.World.Destroy(_teamBViewer);
@@ -792,8 +869,561 @@ namespace ChampionSkillSandboxMod.Runtime
             engine.GlobalContext.Remove(ChampionSkillSandboxIds.ResetCameraRequestKey);
             engine.GlobalContext.Remove(ChampionSkillSandboxIds.CameraFollowModeKey);
             engine.GlobalContext.Remove(ChampionSkillSandboxIds.SelectionViewChoiceKey);
+            engine.GlobalContext.Remove(HideRuntimeHudKey);
             engine.GlobalContext.Remove(CoreServiceKeys.SelectionViewViewerEntity.Name);
             engine.GlobalContext.Remove(CoreServiceKeys.SelectionViewKey.Name);
+        }
+
+        private static void SyncDiagnosticsHudPreference(GameEngine engine)
+        {
+            string? mapId = engine.CurrentMapSession?.MapId.Value;
+            if (string.IsNullOrWhiteSpace(mapId))
+            {
+                engine.GlobalContext.Remove(HideRuntimeHudKey);
+                return;
+            }
+
+            if (ChampionSkillSandboxIds.IsStressMap(mapId))
+            {
+                engine.GlobalContext.Remove(HideRuntimeHudKey);
+                return;
+            }
+
+            if (ChampionSkillSandboxIds.IsSandboxMap(mapId))
+            {
+                engine.GlobalContext[HideRuntimeHudKey] = true;
+            }
+        }
+
+        private void DrawSandboxGuideOverlay(GameEngine engine)
+        {
+            ScreenOverlayBuffer? overlay = engine.GetService(CoreServiceKeys.ScreenOverlayBuffer);
+            if (overlay == null)
+            {
+                return;
+            }
+
+            string selectedName = GetSelectedEntityName(engine);
+            string hoveredName = GetHoveredEntityName(engine);
+            string modeLabel = ResolveModeLabel(engine);
+
+            overlay.AddRect(16, 18, 560, 156, SandboxGuideFill, SandboxGuideBorder, stableId: 43100, dirtySerial: 1);
+            overlay.AddText(32, 42, "Melee Context Showcase", 22, SandboxGuideTitle, stableId: 43101, dirtySerial: 1);
+            overlay.AddText(32, 68, $"Selected {selectedName} | Mode {modeLabel} | Hover {hoveredName}", 14, SandboxGuideText, stableId: 43102, dirtySerial: 1);
+
+            if (!string.Equals(selectedName, ChampionSkillSandboxIds.DuelistAlphaName, StringComparison.OrdinalIgnoreCase))
+            {
+                overlay.AddText(32, 96, "1. Click Duelist Alpha. The green ground pips mark the melee lane and the D/E/F starter pack.", 14, SandboxGuideWarn, stableId: 43104, dirtySerial: 1);
+                overlay.AddText(32, 122, "2. Hover a dummy and tap Space for auto melee. Q forces the manual three-hit chain. E clears the pack.", 14, SandboxGuideHint, stableId: 43105, dirtySerial: 1);
+                return;
+            }
+
+            if (!string.Equals(GetActiveModeId(engine), ChampionSkillSandboxIds.ActionModeId, StringComparison.OrdinalIgnoreCase))
+            {
+                overlay.AddText(32, 96, "Press F5 to return to Auto mode. That's the one-button melee route for this sandbox.", 14, SandboxGuideWarn, stableId: 43107, dirtySerial: 1);
+                overlay.AddText(32, 122, "Orange ring = your cursor target. White ring = the body Space will actually commit to.", 14, SandboxGuideHint, stableId: 43108, dirtySerial: 1);
+                return;
+            }
+
+            BuildDuelistGuideLines(engine, out string headline, out string instruction, out string comboLine);
+            overlay.AddText(32, 96, headline, 15, SandboxGuideAccent, stableId: 43110, dirtySerial: 1);
+            overlay.AddText(32, 122, instruction, 14, SandboxGuideText, stableId: 43111, dirtySerial: 1);
+            overlay.AddText(32, 148, comboLine, 14, SandboxGuideHint, stableId: 43112, dirtySerial: 1);
+        }
+
+        private void BuildDuelistGuideLines(GameEngine engine, out string headline, out string instruction, out string comboLine)
+        {
+            headline = "Space = auto melee. Hover the D/E/F pack and tap it.";
+            instruction = "Orange ring = your cursor target. White ring = the body Space will really jump to.";
+            comboLine = "Space reads the fight for you: far = Step In, close = chain, opened = breaker. Q still forces Q1 -> Q2 -> Q3.";
+
+            int actionContextAbilityId = AbilityIdRegistry.GetId("Ability.Champion.Duelist.ActionContext");
+            Span<ContextScoredCandidateProbe> probes = stackalloc ContextScoredCandidateProbe[8];
+            if (!ChampionSkillSandboxDuelistContextInspector.TryInspect(
+                    engine,
+                    actionContextAbilityId,
+                    probes,
+                    out Entity actor,
+                    out Entity hovered,
+                    out ContextGroupDefinition group,
+                    out int probeCount,
+                    out ContextScoredOrderResolution resolution))
+            {
+                return;
+            }
+
+            string targetName = ResolveEntityLabel(engine.World, resolution.Target) ?? "(none)";
+            int resolvedAbilityId = probeCount > 0 ? probes[0].AbilityId : 0;
+            string resolvedAbilityName = ResolveAbilityDisplayName(engine, resolvedAbilityId);
+            string actorState = ResolveDuelistActorState(engine.World, actor);
+            string targetState = ResolveDuelistTargetState(engine.World, resolution.Target != Entity.Null ? resolution.Target : hovered);
+            string hoveredName = ResolveEntityLabel(engine.World, hovered) ?? "(none)";
+
+            headline = $"{resolvedAbilityName} -> {targetName}";
+            instruction = BuildDuelistGuideInstruction(hoveredName, targetName, resolvedAbilityId, actorState, targetState);
+            comboLine = BuildDuelistComboPrompt(actorState, targetState, resolvedAbilityId);
+        }
+
+        private static string BuildProbeSummary(GameEngine engine, Span<ContextScoredCandidateProbe> probes, int probeCount)
+        {
+            if (probeCount <= 0)
+            {
+                return "none";
+            }
+
+            int count = Math.Min(3, probeCount);
+            var labels = new string[count];
+            for (int i = 0; i < count; i++)
+            {
+                ContextScoredCandidateProbe probe = probes[i];
+                string abilityName = ResolveAbilityDisplayName(engine, probe.AbilityId);
+                string targetName = ResolveEntityLabel(engine.World, probe.Target) ?? "(none)";
+                labels[i] = $"{abilityName}->{targetName} ({probe.Score:0.#})";
+            }
+
+            return string.Join(" | ", labels);
+        }
+
+        private static string ReadEntityName(World world, Entity entity)
+        {
+            return ResolveEntityLabel(world, entity) ?? "(none)";
+        }
+
+        private static string BuildDuelistResolutionReason(int abilityId)
+        {
+            int stage1AbilityId = AbilityIdRegistry.GetId("Ability.Champion.Duelist.Combo.Stage1");
+            int stage2AbilityId = AbilityIdRegistry.GetId("Ability.Champion.Duelist.Combo.Stage2");
+            int breakerAbilityId = AbilityIdRegistry.GetId("Ability.Champion.Duelist.OpeningBreaker");
+            int stepInAbilityId = AbilityIdRegistry.GetId("Ability.Champion.Duelist.StepIn");
+            int crowdSweepAbilityId = AbilityIdRegistry.GetId("Ability.Champion.Duelist.CrowdSweep");
+
+            if (abilityId == stepInAbilityId)
+            {
+                return "Target group is outside jab reach, so the lunge wins to close distance and keep the combo alive.";
+            }
+
+            if (abilityId == stage1AbilityId)
+            {
+                return "No combo window is active yet, so the opener wins once a single enemy is inside jab range.";
+            }
+
+            if (abilityId == stage2AbilityId)
+            {
+                return "Stage1 is primed on the Duelist, so the second jab outranks the opener on the engaged target.";
+            }
+
+            if (abilityId == breakerAbilityId)
+            {
+                return "The target is opened, so the heavy finisher outranks the lighter chain hits.";
+            }
+
+            if (abilityId == crowdSweepAbilityId)
+            {
+                return "No single-target finisher outranked the cone, so the crowd answer wins against the front arc.";
+            }
+
+            return "Context scoring found a legal strike, but the authored reason text for this ability is missing.";
+        }
+
+        private static string BuildDuelistGuideInstruction(
+            string hoveredName,
+            string targetName,
+            int abilityId,
+            string actorState,
+            string targetState)
+        {
+            if (!string.Equals(hoveredName, targetName, StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(hoveredName, "(none)", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(targetName, "(none)", StringComparison.OrdinalIgnoreCase))
+            {
+                return $"Your cursor is on {hoveredName}, but Space will snap to {targetName}. That's the stronger commit right now.";
+            }
+
+            if (abilityId == AbilityIdRegistry.GetId("Ability.Champion.Duelist.StepIn"))
+            {
+                return "You are still outside jab range, so the auto route opens with Step In.";
+            }
+
+            if (abilityId == AbilityIdRegistry.GetId("Ability.Champion.Duelist.CrowdSweep"))
+            {
+                return "Several bodies are stacked in front, so the pack read flips to Crowd Sweep.";
+            }
+
+            if (string.Equals(targetState, "opened", StringComparison.OrdinalIgnoreCase))
+            {
+                return "That target is opened up. Space will cash out with the heavy finisher now.";
+            }
+
+            if (string.Equals(actorState, "stage2 primed", StringComparison.OrdinalIgnoreCase))
+            {
+                return "The chain is already deep. One more good read turns into the finisher.";
+            }
+
+            if (string.Equals(actorState, "stage1 primed", StringComparison.OrdinalIgnoreCase))
+            {
+                return "The auto route is already mid-chain. Stay on target and it will keep pressing the combo.";
+            }
+
+            return "You are in the neutral beat. Hover a dummy and Space chooses the safest first melee hit for you.";
+        }
+
+        private static string BuildDuelistComboPrompt(
+            string actorState,
+            string targetState,
+            int abilityId)
+        {
+            if (string.Equals(targetState, "opened", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Two exits are live: Space auto-finishes with Opening Breaker, while Q keeps the manual chain route moving.";
+            }
+
+            if (abilityId == AbilityIdRegistry.GetId("Ability.Champion.Duelist.CrowdSweep"))
+            {
+                return "Pack read: keep two or more dummies in front and Space or E should sweep them together.";
+            }
+
+            if (string.Equals(actorState, "stage2 primed", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Manual route: Q ends the three-hit chain. Auto route: Space looks for the heavy breaker once the opening appears.";
+            }
+
+            if (string.Equals(actorState, "stage1 primed", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Manual route: stay on the same dummy and Q goes to Chain Jab II. Auto route: Space keeps the combo rolling.";
+            }
+
+            if (abilityId == AbilityIdRegistry.GetId("Ability.Champion.Duelist.StepIn"))
+            {
+                return "You are still outside jab range, so Space opens with Step In before the chain starts.";
+            }
+
+            return "Space handles the first read for you: lunge in from range, then stay in and keep the pressure on one dummy.";
+        }
+
+        private static string ResolveDuelistBeatLabel(string actorState, string targetState, int abilityId)
+        {
+            if (string.Equals(targetState, "opened", StringComparison.OrdinalIgnoreCase) ||
+                abilityId == AbilityIdRegistry.GetId("Ability.Champion.Duelist.OpeningBreaker"))
+            {
+                return "finisher";
+            }
+
+            if (abilityId == AbilityIdRegistry.GetId("Ability.Champion.Duelist.CrowdSweep"))
+            {
+                return "crowd";
+            }
+
+            if (string.Equals(actorState, "stage2 primed", StringComparison.OrdinalIgnoreCase) ||
+                abilityId == AbilityIdRegistry.GetId("Ability.Champion.Duelist.Combo.Stage2"))
+            {
+                return "chain 2";
+            }
+
+            if (string.Equals(actorState, "stage1 primed", StringComparison.OrdinalIgnoreCase) ||
+                abilityId == AbilityIdRegistry.GetId("Ability.Champion.Duelist.Combo.Stage1"))
+            {
+                return "chain 1";
+            }
+
+            if (abilityId == AbilityIdRegistry.GetId("Ability.Champion.Duelist.StepIn"))
+            {
+                return "gap close";
+            }
+
+            return "starter";
+        }
+
+        private static string ResolveDuelistActorState(World world, Entity actor)
+        {
+            if (actor == Entity.Null)
+            {
+                return "none";
+            }
+
+            int stage2TagId = TagRegistry.GetId("State.Champion.Duelist.Combo.Stage2");
+            int stage1TagId = TagRegistry.GetId("State.Champion.Duelist.Combo.Stage1");
+            if (HasTag(world, actor, stage2TagId))
+            {
+                return "stage2 primed";
+            }
+
+            if (HasTag(world, actor, stage1TagId))
+            {
+                return "stage1 primed";
+            }
+
+            return "neutral";
+        }
+
+        private static string ResolveDuelistTargetState(World world, Entity target)
+        {
+            if (target == Entity.Null)
+            {
+                return "none";
+            }
+
+            int openedTagId = TagRegistry.GetId("State.Champion.Duelist.Target.Opened");
+            int primedTagId = TagRegistry.GetId("State.Champion.Duelist.Target.ComboPrimed");
+            if (HasTag(world, target, openedTagId))
+            {
+                return "opened";
+            }
+
+            if (HasTag(world, target, primedTagId))
+            {
+                return "combo primed";
+            }
+
+            return "neutral";
+        }
+
+        private static bool HasTag(World world, Entity entity, int tagId)
+        {
+            return entity != Entity.Null &&
+                   tagId > 0 &&
+                   world.IsAlive(entity) &&
+                   world.TryGet(entity, out GameplayTagContainer tags) &&
+                   tags.HasTag(tagId);
+        }
+
+        private static string ResolveAbilityDisplayName(GameEngine engine, int abilityId)
+        {
+            if (abilityId <= 0 ||
+                engine.GetService(CoreServiceKeys.AbilityDefinitionRegistry) is not AbilityDefinitionRegistry abilities ||
+                !abilities.TryGet(abilityId, out AbilityDefinition definition))
+            {
+                return "Unknown";
+            }
+
+            if (definition.HasPresentation && definition.Presentation != null)
+            {
+                return definition.Presentation.ResolveDisplayName($"Ability#{abilityId}");
+            }
+
+            return $"Ability#{abilityId}";
+        }
+
+        private static string GetSelectedEntityName(GameEngine engine)
+        {
+            return SelectionContextRuntime.TryGetCurrentPrimary(engine.World, engine.GlobalContext, out Entity selected)
+                ? ResolveEntityLabel(engine.World, selected) ?? "(none)"
+                : "(none)";
+        }
+
+        private static string GetHoveredEntityName(GameEngine engine)
+        {
+            if (engine.GlobalContext.TryGetValue(CoreServiceKeys.HoveredEntity.Name, out var hoveredObj) &&
+                hoveredObj is Entity hovered &&
+                hovered != Entity.Null)
+            {
+                return ResolveEntityLabel(engine.World, hovered) ?? "(none)";
+            }
+
+            return "(none)";
+        }
+
+        private static string ResolveModeLabel(GameEngine engine)
+        {
+            return GetActiveModeId(engine) switch
+            {
+                var id when string.Equals(id, ChampionSkillSandboxIds.ActionModeId, StringComparison.OrdinalIgnoreCase) => "Auto",
+                var id when string.Equals(id, ChampionSkillSandboxIds.IndicatorModeId, StringComparison.OrdinalIgnoreCase) => "Preview",
+                var id when string.Equals(id, ChampionSkillSandboxIds.PressReleaseModeId, StringComparison.OrdinalIgnoreCase) => "Confirm",
+                _ => "Quick",
+            };
+        }
+
+        private static string GetActiveModeId(GameEngine engine)
+        {
+            return ViewModeRuntime.TryGetActiveModeId(engine.GlobalContext, out string activeModeId) &&
+                   !string.IsNullOrWhiteSpace(activeModeId)
+                ? activeModeId
+                : ChampionSkillSandboxIds.ActionModeId;
+        }
+
+        private void DrawDuelistPreviewOverlays(GameEngine engine)
+        {
+            if (ChampionSkillSandboxIds.IsStressMap(engine.CurrentMapSession?.MapId.Value) ||
+                engine.GetService(CoreServiceKeys.GroundOverlayBuffer) is not GroundOverlayBuffer overlays)
+            {
+                return;
+            }
+
+            Entity selected = SelectionContextRuntime.TryGetCurrentPrimary(engine.World, engine.GlobalContext, out Entity current)
+                ? current
+                : Entity.Null;
+            bool duelistSelected = string.Equals(
+                ResolveEntityLabel(engine.World, selected),
+                ChampionSkillSandboxIds.DuelistAlphaName,
+                StringComparison.OrdinalIgnoreCase);
+            bool actionMode = string.Equals(GetActiveModeId(engine), ChampionSkillSandboxIds.ActionModeId, StringComparison.OrdinalIgnoreCase);
+            if (!duelistSelected || !actionMode)
+            {
+                DrawShowcaseLaneMarkers(engine.World, overlays);
+                return;
+            }
+
+            int actionContextAbilityId = AbilityIdRegistry.GetId("Ability.Champion.Duelist.ActionContext");
+            Span<ContextScoredCandidateProbe> probes = stackalloc ContextScoredCandidateProbe[8];
+            if (!ChampionSkillSandboxDuelistContextInspector.TryInspect(
+                    engine,
+                    actionContextAbilityId,
+                    probes,
+                    out Entity actor,
+                    out Entity hovered,
+                    out _,
+                    out int probeCount,
+                    out ContextScoredOrderResolution resolution) ||
+                actor == Entity.Null ||
+                probeCount <= 0 ||
+                !TryGetGroundCenter(engine.World, actor, out Vector3 actorCenter))
+            {
+                return;
+            }
+
+            if (resolution.Target != Entity.Null)
+            {
+                AddGroundCircle(overlays, engine.World, resolution.Target, 0.72f, StepInPreviewFill, StepInPreviewBorder);
+            }
+
+            int resolvedAbilityId = probes[0].AbilityId;
+            Vector3 previewTarget = actorCenter;
+            if (resolution.Target != Entity.Null && TryGetGroundCenter(engine.World, resolution.Target, out Vector3 targetCenter))
+            {
+                previewTarget = targetCenter;
+            }
+            else if (hovered != Entity.Null && TryGetGroundCenter(engine.World, hovered, out Vector3 hoveredCenter))
+            {
+                previewTarget = hoveredCenter;
+            }
+
+            float rotation = MathF.Atan2(previewTarget.Z - actorCenter.Z, previewTarget.X - actorCenter.X);
+            float distanceMeters = MathF.Max(
+                0.1f,
+                Vector2.Distance(
+                    new Vector2(actorCenter.X, actorCenter.Z),
+                    new Vector2(previewTarget.X, previewTarget.Z)));
+
+            if (resolvedAbilityId == AbilityIdRegistry.GetId("Ability.Champion.Duelist.CrowdSweep"))
+            {
+                overlays.TryAdd(new GroundOverlayItem
+                {
+                    Shape = GroundOverlayShape.Cone,
+                    Center = actorCenter,
+                    Radius = 2.4f,
+                    Angle = 1.08f,
+                    Rotation = rotation,
+                    FillColor = SweepPreviewFill,
+                    BorderColor = SweepPreviewBorder,
+                    BorderWidth = 0.03f
+                });
+                return;
+            }
+
+            Vector4 fillColor = ChainPreviewFill;
+            Vector4 borderColor = ChainPreviewBorder;
+            float widthMeters = 0.34f;
+            if (resolvedAbilityId == AbilityIdRegistry.GetId("Ability.Champion.Duelist.StepIn"))
+            {
+                fillColor = StepInPreviewFill;
+                borderColor = StepInPreviewBorder;
+                widthMeters = 0.42f;
+            }
+            else if (resolvedAbilityId == AbilityIdRegistry.GetId("Ability.Champion.Duelist.OpeningBreaker"))
+            {
+                fillColor = BreakerPreviewFill;
+                borderColor = BreakerPreviewBorder;
+                widthMeters = 0.40f;
+            }
+
+            overlays.TryAdd(new GroundOverlayItem
+            {
+                Shape = GroundOverlayShape.Line,
+                Center = actorCenter,
+                Length = distanceMeters,
+                Width = widthMeters,
+                Rotation = rotation,
+                FillColor = fillColor,
+                BorderColor = borderColor,
+                BorderWidth = 0.03f
+            });
+        }
+
+        private static void DrawShowcaseLaneMarkers(World world, GroundOverlayBuffer overlays)
+        {
+            AddGroundCircle(overlays, world, ChampionSkillSandboxIds.DuelistAlphaName, 0.78f, ShowcaseLaneFill, ShowcaseLaneBorder);
+            AddGroundCircle(overlays, world, ChampionSkillSandboxIds.TargetDummyDName, 0.72f, ShowcaseLaneFill, ShowcaseLaneBorder);
+            AddGroundCircle(overlays, world, ChampionSkillSandboxIds.TargetDummyEName, 0.72f, ShowcaseLaneFill, ShowcaseLaneBorder);
+            AddGroundCircle(overlays, world, ChampionSkillSandboxIds.TargetDummyFName, 0.72f, ShowcaseLaneFill, ShowcaseLaneBorder);
+        }
+
+        private static void AddGroundCircle(
+            GroundOverlayBuffer overlays,
+            World world,
+            string entityName,
+            float radiusMeters,
+            in Vector4 fillColor,
+            in Vector4 borderColor)
+        {
+            Entity entity = FindEntityByName(world, entityName);
+            if (entity != Entity.Null)
+            {
+                AddGroundCircle(overlays, world, entity, radiusMeters, fillColor, borderColor);
+            }
+        }
+
+        private static void AddGroundCircle(
+            GroundOverlayBuffer overlays,
+            World world,
+            Entity entity,
+            float radiusMeters,
+            in Vector4 fillColor,
+            in Vector4 borderColor)
+        {
+            if (!TryGetGroundCenter(world, entity, out Vector3 center))
+            {
+                return;
+            }
+
+            overlays.TryAdd(new GroundOverlayItem
+            {
+                Shape = GroundOverlayShape.Circle,
+                Center = center,
+                Radius = radiusMeters,
+                FillColor = fillColor,
+                BorderColor = borderColor,
+                BorderWidth = 0.03f
+            });
+        }
+
+        private static bool TryGetGroundCenter(World world, Entity entity, out Vector3 center)
+        {
+            center = default;
+            if (entity == Entity.Null || !world.IsAlive(entity) || !world.TryGet(entity, out WorldPositionCm positionCm))
+            {
+                return false;
+            }
+
+            Vector2 worldCm = positionCm.Value.ToVector2();
+            center = new Vector3(WorldUnits.CmToM(worldCm.X), 0.08f, WorldUnits.CmToM(worldCm.Y));
+            return true;
+        }
+
+        private static Entity FindEntityByName(World world, string expectedName)
+        {
+            Entity result = Entity.Null;
+            var query = new QueryDescription().WithAll<Name>();
+            world.Query(in query, (Entity entity, ref Name name) =>
+            {
+                if (result != Entity.Null ||
+                    !string.Equals(name.Value, expectedName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+
+                result = entity;
+            });
+            return result;
         }
 
         private void SyncSelectionIndicator(GameEngine engine, Entity target)
@@ -867,6 +1497,16 @@ namespace ChampionSkillSandboxMod.Runtime
                 ChampionSkillSandboxIds.AimHoverIndicatorScopeId);
         }
 
+        private void SyncResolvedContextIndicator(GameEngine engine)
+        {
+            SyncIndicator(
+                engine,
+                ResolveResolvedContextIndicatorTarget(engine),
+                ref _resolvedIndicatorTarget,
+                ChampionSkillSandboxIds.ResolvedIndicatorPerformerKey,
+                ChampionSkillSandboxIds.ResolvedIndicatorScopeId);
+        }
+
         private static Entity ResolveHoverIndicatorTarget(GameEngine engine)
         {
             if (!engine.GlobalContext.TryGetValue(CoreServiceKeys.HoveredEntity.Name, out var hoveredObj) ||
@@ -881,6 +1521,11 @@ namespace ChampionSkillSandboxMod.Runtime
                 ? current
                 : Entity.Null;
             if (selected == hovered)
+            {
+                return Entity.Null;
+            }
+
+            if (IsFriendlyHover(engine.World, selected, hovered))
             {
                 return Entity.Null;
             }
@@ -905,7 +1550,41 @@ namespace ChampionSkillSandboxMod.Runtime
             Entity selected = SelectionContextRuntime.TryGetCurrentPrimary(engine.World, engine.GlobalContext, out Entity current)
                 ? current
                 : Entity.Null;
-            return selected == hovered ? Entity.Null : hovered;
+            if (selected == hovered || IsFriendlyHover(engine.World, selected, hovered))
+            {
+                return Entity.Null;
+            }
+
+            return hovered;
+        }
+
+        private static Entity ResolveResolvedContextIndicatorTarget(GameEngine engine)
+        {
+            if (!string.Equals(GetActiveModeId(engine), ChampionSkillSandboxIds.ActionModeId, StringComparison.OrdinalIgnoreCase))
+            {
+                return Entity.Null;
+            }
+
+            int actionContextAbilityId = AbilityIdRegistry.GetId("Ability.Champion.Duelist.ActionContext");
+            if (actionContextAbilityId <= 0)
+            {
+                return Entity.Null;
+            }
+
+            Span<ContextScoredCandidateProbe> probes = stackalloc ContextScoredCandidateProbe[8];
+            return ChampionSkillSandboxDuelistContextInspector.TryInspect(
+                    engine,
+                    actionContextAbilityId,
+                    probes,
+                    out _,
+                    out _,
+                    out _,
+                    out _,
+                    out ContextScoredOrderResolution resolution) &&
+                   resolution.Target != Entity.Null &&
+                   engine.World.IsAlive(resolution.Target)
+                ? resolution.Target
+                : Entity.Null;
         }
 
         private static Entity ResolveHoveredEntity(GameEngine engine)
@@ -919,6 +1598,17 @@ namespace ChampionSkillSandboxMod.Runtime
             }
 
             return hovered;
+        }
+
+        private static bool IsFriendlyHover(World world, Entity selected, Entity hovered)
+        {
+            return selected != Entity.Null &&
+                   hovered != Entity.Null &&
+                   world.IsAlive(selected) &&
+                   world.IsAlive(hovered) &&
+                   world.TryGet(selected, out Team selectedTeam) &&
+                   world.TryGet(hovered, out Team hoveredTeam) &&
+                   selectedTeam.Id == hoveredTeam.Id;
         }
 
         private void DestroyHoverIndicator(GameEngine engine)
@@ -946,6 +1636,20 @@ namespace ChampionSkillSandboxMod.Runtime
             {
                 Kind = PresentationCommandKind.DestroyPerformerScope,
                 IdA = ChampionSkillSandboxIds.AimHoverIndicatorScopeId,
+            });
+        }
+
+        private void DestroyResolvedContextIndicator(GameEngine engine)
+        {
+            if (engine.GetService(CoreServiceKeys.PresentationCommandBuffer) is not PresentationCommandBuffer commands)
+            {
+                return;
+            }
+
+            commands.TryAdd(new PresentationCommand
+            {
+                Kind = PresentationCommandKind.DestroyPerformerScope,
+                IdA = ChampionSkillSandboxIds.ResolvedIndicatorScopeId,
             });
         }
 

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxVisualFeedback.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxVisualFeedback.cs
@@ -823,20 +823,21 @@ namespace ChampionSkillSandboxMod.Runtime
         {
             if (!allowDebugDraw ||
                 debugDraw == null ||
-                _duelistActionContextAbilityId <= 0 ||
-                engine.GetService(CoreServiceKeys.ActiveInputOrderMapping) is not InputOrderMappingSystem mappingSystem ||
-                mappingSystem.GetMapping("ActionAttack") is not InputOrderMapping actionAttackMapping ||
-                engine.GetService(CoreServiceKeys.ContextGroupRegistry) is not ContextGroupRegistry contextGroups ||
-                engine.GetService(CoreServiceKeys.GraphProgramRegistry) is not GraphProgramRegistry graphPrograms ||
-                engine.GetService(CoreServiceKeys.SpatialQueryService) is not ISpatialQueryService spatialQueries ||
-                engine.GetService(CoreServiceKeys.SpatialCoordinateConverter) is not ISpatialCoordinateConverter spatialCoords)
+                _duelistActionContextAbilityId <= 0)
             {
                 return;
             }
 
-            Entity actor = ResolveSelectedDuelist(engine.World, engine.GlobalContext);
-            if (actor == Entity.Null ||
-                !TryResolveContextGroup(engine.World, actor, actionAttackMapping, contextGroups, out ContextGroupDefinition group) ||
+            Span<ContextScoredCandidateProbe> probes = stackalloc ContextScoredCandidateProbe[8];
+            if (!ChampionSkillSandboxDuelistContextInspector.TryInspect(
+                    engine,
+                    _duelistActionContextAbilityId,
+                    probes,
+                    out Entity actor,
+                    out Entity hovered,
+                    out ContextGroupDefinition group,
+                    out int probeCount,
+                    out ContextScoredOrderResolution resolution) ||
                 !engine.World.TryGet(actor, out WorldPositionCm actorPosition))
             {
                 return;
@@ -846,16 +847,10 @@ namespace ChampionSkillSandboxMod.Runtime
             float searchRadius = group.SearchRadiusCm / 100f;
             debugDraw.AddCircle(actorWorld, searchRadius, new DebugDrawColor(84, 198, 255, 210), thickness: 0.05f);
 
-            Entity hovered = ResolveHoveredEntity(engine);
             if (hovered != Entity.Null && TryGetDebugWorld(engine.World, hovered, out Vector2 hoveredWorld))
             {
                 debugDraw.AddCircle(hoveredWorld, 0.34f, DebugDrawColor.Yellow, thickness: 0.04f);
             }
-
-            var graphApi = new GasGraphRuntimeApi(engine.World, spatialQueries, spatialCoords, eventBus: null, effectRequests: null);
-            var resolver = new ContextScoredOrderResolver(engine.World, contextGroups, graphPrograms, spatialQueries, graphApi);
-            Span<ContextScoredCandidateProbe> probes = stackalloc ContextScoredCandidateProbe[8];
-            bool resolved = resolver.TryInspect(actor, actionAttackMapping, hovered, probes, out int probeCount, out ContextScoredOrderResolution resolution);
 
             for (int i = 0; i < probeCount; i++)
             {
@@ -868,11 +863,6 @@ namespace ChampionSkillSandboxMod.Runtime
                     debugDraw.AddCapsule(actorWorld, targetWorld, i == 0 ? 0.18f : 0.1f, color, thickness, drawCenterLine: i == 0);
                     debugDraw.AddCircle(targetWorld, i == 0 ? 0.42f : 0.26f, color, thickness);
                 }
-            }
-
-            if (!resolved)
-            {
-                return;
             }
 
             int resolvedAbilityId = probeCount > 0 ? probes[0].AbilityId : 0;
@@ -904,66 +894,6 @@ namespace ChampionSkillSandboxMod.Runtime
                     : 1.58f;
             float span = resolvedAbilityId == _duelistOpeningBreakerAbilityId ? 0.96f : 0.68f;
             debugDraw.AddArc(actorWorld, radius, rotation - span, rotation + span, resolvedColor, thickness: 0.08f);
-        }
-
-        private Entity ResolveSelectedDuelist(World world, Dictionary<string, object> globals)
-        {
-            if (!SelectionContextRuntime.TryGetCurrentPrimary(world, globals, out Entity selected) ||
-                selected == Entity.Null ||
-                !world.IsAlive(selected) ||
-                !world.Has<AbilityStateBuffer>(selected))
-            {
-                return Entity.Null;
-            }
-
-            ref readonly AbilityStateBuffer abilities = ref world.Get<AbilityStateBuffer>(selected);
-            bool hasForm = world.Has<AbilityFormSlotBuffer>(selected);
-            AbilityFormSlotBuffer formSlots = hasForm ? world.Get<AbilityFormSlotBuffer>(selected) : default;
-            bool hasGranted = world.Has<GrantedSlotBuffer>(selected);
-            GrantedSlotBuffer granted = hasGranted ? world.Get<GrantedSlotBuffer>(selected) : default;
-            for (int slotIndex = 0; slotIndex < abilities.Count; slotIndex++)
-            {
-                var resolved = AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm, in granted, hasGranted, slotIndex);
-                if (resolved.AbilityId == _duelistActionContextAbilityId)
-                {
-                    return selected;
-                }
-            }
-
-            return Entity.Null;
-        }
-
-        private static Entity ResolveHoveredEntity(GameEngine engine)
-        {
-            return engine.GlobalContext.TryGetValue(CoreServiceKeys.HoveredEntity.Name, out object? hoveredObj) &&
-                   hoveredObj is Entity hovered &&
-                   hovered != Entity.Null &&
-                   engine.World.IsAlive(hovered)
-                ? hovered
-                : Entity.Null;
-        }
-
-        private static bool TryResolveContextGroup(
-            World world,
-            Entity actor,
-            InputOrderMapping mapping,
-            ContextGroupRegistry contextGroups,
-            out ContextGroupDefinition group)
-        {
-            group = default;
-            if (mapping.ArgsTemplate.I0 is null || !world.Has<AbilityStateBuffer>(actor))
-            {
-                return false;
-            }
-
-            int rootSlotIndex = mapping.ArgsTemplate.I0.Value;
-            ref readonly AbilityStateBuffer abilities = ref world.Get<AbilityStateBuffer>(actor);
-            bool hasForm = world.Has<AbilityFormSlotBuffer>(actor);
-            AbilityFormSlotBuffer formSlots = hasForm ? world.Get<AbilityFormSlotBuffer>(actor) : default;
-            bool hasGranted = world.Has<GrantedSlotBuffer>(actor);
-            GrantedSlotBuffer granted = hasGranted ? world.Get<GrantedSlotBuffer>(actor) : default;
-            var resolved = AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm, in granted, hasGranted, rootSlotIndex);
-            return resolved.AbilityId > 0 && contextGroups.TryGetByRootAbility(resolved.AbilityId, out group);
         }
 
         private DebugDrawColor ResolveCandidateColor(int abilityId)

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxVisualFeedback.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxVisualFeedback.cs
@@ -518,6 +518,12 @@ namespace ChampionSkillSandboxMod.Runtime
             RegisterAbilityCue(performers, "Ability.Champion.Jayce.Hammer.ToTheSkies", "champion_skill_sandbox.cue.jayce_hammer_to_the_skies_cast");
             RegisterAbilityCue(performers, "Ability.Champion.Jayce.Transform.Cannon", "champion_skill_sandbox.cue.jayce_transform_cannon");
             RegisterAbilityCue(performers, "Ability.Champion.Jayce.Transform.Hammer", "champion_skill_sandbox.cue.jayce_transform_hammer");
+            RegisterAbilityCue(performers, "Ability.Champion.Duelist.Combo.Stage1", "champion_skill_sandbox.cue.duelist_chain_jab_1");
+            RegisterAbilityCue(performers, "Ability.Champion.Duelist.Combo.Stage2", "champion_skill_sandbox.cue.duelist_chain_jab_2");
+            RegisterAbilityCue(performers, "Ability.Champion.Duelist.Combo.Stage3", "champion_skill_sandbox.cue.duelist_chain_finish");
+            RegisterAbilityCue(performers, "Ability.Champion.Duelist.StepIn", "champion_skill_sandbox.cue.duelist_step_in");
+            RegisterAbilityCue(performers, "Ability.Champion.Duelist.CrowdSweep", "champion_skill_sandbox.cue.duelist_crowd_sweep");
+            RegisterAbilityCue(performers, "Ability.Champion.Duelist.OpeningBreaker", "champion_skill_sandbox.cue.duelist_opening_breaker_cast");
             RegisterAbilityCue(performers, "Ability.ChampionStress.Warrior.Cleave", "champion_skill_sandbox.cue.stress_warrior_cleave");
             RegisterAbilityCue(performers, "Ability.ChampionStress.FireMage.Fireball", "champion_skill_sandbox.cue.stress_fireball_cast");
             RegisterAbilityCue(performers, "Ability.ChampionStress.LaserMage.Laser", "champion_skill_sandbox.cue.stress_laser_cast");
@@ -535,6 +541,12 @@ namespace ChampionSkillSandboxMod.Runtime
             RegisterEffectCue(performers, "Effect.Champion.Jayce.Hammer.LightningFieldHit", "champion_skill_sandbox.cue.jayce_hammer_lightning_field_hit");
             RegisterEffectCue(performers, "Effect.Champion.Jayce.Hammer.ThunderingBlowHit", "champion_skill_sandbox.cue.jayce_hammer_thundering_blow_hit");
             RegisterEffectCue(performers, "Effect.Champion.Jayce.Hammer.ToTheSkiesHit", "champion_skill_sandbox.cue.jayce_hammer_to_the_skies_hit");
+            RegisterEffectCue(performers, "Effect.Champion.Duelist.Combo.Stage1", "champion_skill_sandbox.cue.duelist_combo_hit");
+            RegisterEffectCue(performers, "Effect.Champion.Duelist.Combo.Stage2", "champion_skill_sandbox.cue.duelist_combo_hit");
+            RegisterEffectCue(performers, "Effect.Champion.Duelist.Combo.Stage3", "champion_skill_sandbox.cue.duelist_opening_breaker_hit");
+            RegisterEffectCue(performers, "Effect.Champion.Duelist.StepInStrike", "champion_skill_sandbox.cue.duelist_step_in_hit");
+            RegisterEffectCue(performers, "Effect.Champion.Duelist.CrowdSweepHit", "champion_skill_sandbox.cue.duelist_crowd_sweep_hit");
+            RegisterEffectCue(performers, "Effect.Champion.Duelist.OpeningBreaker", "champion_skill_sandbox.cue.duelist_opening_breaker_hit");
             RegisterEffectCue(performers, "Effect.ChampionStress.Warrior.CleaveHit", "champion_skill_sandbox.cue.stress_warrior_cleave_hit");
             RegisterEffectCue(performers, "Effect.ChampionStress.FireMage.FireballHit", "champion_skill_sandbox.cue.stress_fireball_hit");
             RegisterEffectCue(performers, "Effect.ChampionStress.LaserMage.LaserHit", "champion_skill_sandbox.cue.stress_laser_hit");

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxVisualFeedback.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxVisualFeedback.cs
@@ -6,15 +6,22 @@ using Ludots.Core.Components;
 using Ludots.Core.Engine;
 using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Orders;
 using Ludots.Core.Gameplay.GAS.Presentation;
 using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.GraphRuntime;
+using Ludots.Core.Input.Orders;
+using Ludots.Core.Input.Selection;
+using Ludots.Core.NodeLibraries.GASGraph.Host;
 using Ludots.Core.Presentation.Assets;
 using Ludots.Core.Presentation.Commands;
 using Ludots.Core.Presentation.Components;
+using Ludots.Core.Presentation.DebugDraw;
 using Ludots.Core.Presentation.Hud;
 using Ludots.Core.Presentation.Performers;
 using Ludots.Core.Presentation.Rendering;
 using Ludots.Core.Scripting;
+using Ludots.Core.Spatial;
 
 namespace ChampionSkillSandboxMod.Runtime
 {
@@ -98,6 +105,12 @@ namespace ChampionSkillSandboxMod.Runtime
         private int _ezrealArcaneShiftHitEffectId;
         private int _ezrealTrueshotHitEffectId;
         private int _ezrealWMarkTagId;
+        private int _duelistActionContextAbilityId;
+        private int _duelistComboStage1AbilityId;
+        private int _duelistComboStage2AbilityId;
+        private int _duelistStepInAbilityId;
+        private int _duelistCrowdSweepAbilityId;
+        private int _duelistOpeningBreakerAbilityId;
         private bool _cueIdsInitialized;
         private bool _directIdsInitialized;
         private float _feedbackClock;
@@ -119,6 +132,7 @@ namespace ChampionSkillSandboxMod.Runtime
             PrimitiveDrawBuffer? primitives = engine.GetService(CoreServiceKeys.PresentationPrimitiveDrawBuffer);
             PresentationCommandBuffer? commands = engine.GetService(CoreServiceKeys.PresentationCommandBuffer);
             RenderDebugState? renderDebug = engine.GetService(CoreServiceKeys.RenderDebugState);
+            DebugDrawCommandBuffer? debugDraw = engine.GetService(CoreServiceKeys.DebugDrawCommandBuffer);
             if (ChampionSkillSandboxIds.IsStressMap(engine.CurrentMapSession?.MapId.Value) &&
                 renderDebug is { DrawCombatText: false })
             {
@@ -132,6 +146,7 @@ namespace ChampionSkillSandboxMod.Runtime
             EmitEzrealMarks(engine.World, primitives);
             EmitTransientPrimitives(engine.World, primitives);
             EmitCombatTextEntries(engine.World, worldHud);
+            EmitDuelistContextDebug(engine, debugDraw, renderDebug?.DrawDebugDraw != false);
 
             if (gasEvents == null || gasEvents.Count == 0)
             {
@@ -441,6 +456,12 @@ namespace ChampionSkillSandboxMod.Runtime
                 _ezrealArcaneShiftHitEffectId = EffectTemplateIdRegistry.GetId("Effect.Champion.Ezreal.ArcaneShiftBoltHit");
                 _ezrealTrueshotHitEffectId = EffectTemplateIdRegistry.GetId("Effect.Champion.Ezreal.TrueshotBarrageHit");
                 _ezrealWMarkTagId = TagRegistry.GetId("State.Champion.Ezreal.WMark");
+                _duelistActionContextAbilityId = AbilityIdRegistry.GetId("Ability.Champion.Duelist.ActionContext");
+                _duelistComboStage1AbilityId = AbilityIdRegistry.GetId("Ability.Champion.Duelist.Combo.Stage1");
+                _duelistComboStage2AbilityId = AbilityIdRegistry.GetId("Ability.Champion.Duelist.Combo.Stage2");
+                _duelistStepInAbilityId = AbilityIdRegistry.GetId("Ability.Champion.Duelist.StepIn");
+                _duelistCrowdSweepAbilityId = AbilityIdRegistry.GetId("Ability.Champion.Duelist.CrowdSweep");
+                _duelistOpeningBreakerAbilityId = AbilityIdRegistry.GetId("Ability.Champion.Duelist.OpeningBreaker");
 
                 _projectilePrimitiveSpecs.Clear();
                 RegisterProjectilePrimitiveSpec(_ezrealMysticShotProjectileEffectId, new ProjectilePrimitiveSpec
@@ -796,6 +817,216 @@ namespace ChampionSkillSandboxMod.Runtime
             }
 
             return Entity.Null;
+        }
+
+        private void EmitDuelistContextDebug(GameEngine engine, DebugDrawCommandBuffer? debugDraw, bool allowDebugDraw)
+        {
+            if (!allowDebugDraw ||
+                debugDraw == null ||
+                _duelistActionContextAbilityId <= 0 ||
+                engine.GetService(CoreServiceKeys.ActiveInputOrderMapping) is not InputOrderMappingSystem mappingSystem ||
+                mappingSystem.GetMapping("ActionAttack") is not InputOrderMapping actionAttackMapping ||
+                engine.GetService(CoreServiceKeys.ContextGroupRegistry) is not ContextGroupRegistry contextGroups ||
+                engine.GetService(CoreServiceKeys.GraphProgramRegistry) is not GraphProgramRegistry graphPrograms ||
+                engine.GetService(CoreServiceKeys.SpatialQueryService) is not ISpatialQueryService spatialQueries ||
+                engine.GetService(CoreServiceKeys.SpatialCoordinateConverter) is not ISpatialCoordinateConverter spatialCoords)
+            {
+                return;
+            }
+
+            Entity actor = ResolveSelectedDuelist(engine.World, engine.GlobalContext);
+            if (actor == Entity.Null ||
+                !TryResolveContextGroup(engine.World, actor, actionAttackMapping, contextGroups, out ContextGroupDefinition group) ||
+                !engine.World.TryGet(actor, out WorldPositionCm actorPosition))
+            {
+                return;
+            }
+
+            Vector2 actorWorld = ToDebugWorld(actorPosition.Value.ToVector2());
+            float searchRadius = group.SearchRadiusCm / 100f;
+            debugDraw.AddCircle(actorWorld, searchRadius, new DebugDrawColor(84, 198, 255, 210), thickness: 0.05f);
+
+            Entity hovered = ResolveHoveredEntity(engine);
+            if (hovered != Entity.Null && TryGetDebugWorld(engine.World, hovered, out Vector2 hoveredWorld))
+            {
+                debugDraw.AddCircle(hoveredWorld, 0.34f, DebugDrawColor.Yellow, thickness: 0.04f);
+            }
+
+            var graphApi = new GasGraphRuntimeApi(engine.World, spatialQueries, spatialCoords, eventBus: null, effectRequests: null);
+            var resolver = new ContextScoredOrderResolver(engine.World, contextGroups, graphPrograms, spatialQueries, graphApi);
+            Span<ContextScoredCandidateProbe> probes = stackalloc ContextScoredCandidateProbe[8];
+            bool resolved = resolver.TryInspect(actor, actionAttackMapping, hovered, probes, out int probeCount, out ContextScoredOrderResolution resolution);
+
+            for (int i = 0; i < probeCount; i++)
+            {
+                ContextScoredCandidateProbe probe = probes[i];
+                DebugDrawColor color = ResolveCandidateColor(probe.AbilityId);
+                float thickness = i == 0 ? 0.07f : 0.035f;
+
+                if (probe.Target != Entity.Null && TryGetDebugWorld(engine.World, probe.Target, out Vector2 targetWorld))
+                {
+                    debugDraw.AddCapsule(actorWorld, targetWorld, i == 0 ? 0.18f : 0.1f, color, thickness, drawCenterLine: i == 0);
+                    debugDraw.AddCircle(targetWorld, i == 0 ? 0.42f : 0.26f, color, thickness);
+                }
+            }
+
+            if (!resolved)
+            {
+                return;
+            }
+
+            int resolvedAbilityId = probeCount > 0 ? probes[0].AbilityId : 0;
+            Vector2 resolvedTargetWorld = actorWorld;
+            if (resolution.Target != Entity.Null && TryGetDebugWorld(engine.World, resolution.Target, out Vector2 resolvedTarget))
+            {
+                resolvedTargetWorld = resolvedTarget;
+                debugDraw.AddCircle(resolvedTarget, 0.5f, DebugDrawColor.White, thickness: 0.05f);
+            }
+
+            float rotation = ResolveDebugRotation(actorWorld, resolvedTargetWorld, engine.World, actor);
+            DebugDrawColor resolvedColor = ResolveCandidateColor(resolvedAbilityId);
+            if (resolvedAbilityId == _duelistStepInAbilityId && resolution.Target != Entity.Null)
+            {
+                debugDraw.AddCapsule(actorWorld, resolvedTargetWorld, 0.36f, resolvedColor, thickness: 0.08f, drawCenterLine: true);
+                return;
+            }
+
+            if (resolvedAbilityId == _duelistCrowdSweepAbilityId)
+            {
+                debugDraw.AddArc(actorWorld, 2.4f, rotation - 1.1f, rotation + 1.1f, resolvedColor, thickness: 0.08f);
+                return;
+            }
+
+            float radius = resolvedAbilityId == _duelistOpeningBreakerAbilityId
+                ? 1.95f
+                : resolvedAbilityId == _duelistComboStage2AbilityId
+                    ? 1.76f
+                    : 1.58f;
+            float span = resolvedAbilityId == _duelistOpeningBreakerAbilityId ? 0.96f : 0.68f;
+            debugDraw.AddArc(actorWorld, radius, rotation - span, rotation + span, resolvedColor, thickness: 0.08f);
+        }
+
+        private Entity ResolveSelectedDuelist(World world, Dictionary<string, object> globals)
+        {
+            if (!SelectionContextRuntime.TryGetCurrentPrimary(world, globals, out Entity selected) ||
+                selected == Entity.Null ||
+                !world.IsAlive(selected) ||
+                !world.Has<AbilityStateBuffer>(selected))
+            {
+                return Entity.Null;
+            }
+
+            ref readonly AbilityStateBuffer abilities = ref world.Get<AbilityStateBuffer>(selected);
+            bool hasForm = world.Has<AbilityFormSlotBuffer>(selected);
+            AbilityFormSlotBuffer formSlots = hasForm ? world.Get<AbilityFormSlotBuffer>(selected) : default;
+            bool hasGranted = world.Has<GrantedSlotBuffer>(selected);
+            GrantedSlotBuffer granted = hasGranted ? world.Get<GrantedSlotBuffer>(selected) : default;
+            for (int slotIndex = 0; slotIndex < abilities.Count; slotIndex++)
+            {
+                var resolved = AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm, in granted, hasGranted, slotIndex);
+                if (resolved.AbilityId == _duelistActionContextAbilityId)
+                {
+                    return selected;
+                }
+            }
+
+            return Entity.Null;
+        }
+
+        private static Entity ResolveHoveredEntity(GameEngine engine)
+        {
+            return engine.GlobalContext.TryGetValue(CoreServiceKeys.HoveredEntity.Name, out object? hoveredObj) &&
+                   hoveredObj is Entity hovered &&
+                   hovered != Entity.Null &&
+                   engine.World.IsAlive(hovered)
+                ? hovered
+                : Entity.Null;
+        }
+
+        private static bool TryResolveContextGroup(
+            World world,
+            Entity actor,
+            InputOrderMapping mapping,
+            ContextGroupRegistry contextGroups,
+            out ContextGroupDefinition group)
+        {
+            group = default;
+            if (mapping.ArgsTemplate.I0 is null || !world.Has<AbilityStateBuffer>(actor))
+            {
+                return false;
+            }
+
+            int rootSlotIndex = mapping.ArgsTemplate.I0.Value;
+            ref readonly AbilityStateBuffer abilities = ref world.Get<AbilityStateBuffer>(actor);
+            bool hasForm = world.Has<AbilityFormSlotBuffer>(actor);
+            AbilityFormSlotBuffer formSlots = hasForm ? world.Get<AbilityFormSlotBuffer>(actor) : default;
+            bool hasGranted = world.Has<GrantedSlotBuffer>(actor);
+            GrantedSlotBuffer granted = hasGranted ? world.Get<GrantedSlotBuffer>(actor) : default;
+            var resolved = AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm, in granted, hasGranted, rootSlotIndex);
+            return resolved.AbilityId > 0 && contextGroups.TryGetByRootAbility(resolved.AbilityId, out group);
+        }
+
+        private DebugDrawColor ResolveCandidateColor(int abilityId)
+        {
+            if (abilityId == _duelistStepInAbilityId)
+            {
+                return new DebugDrawColor(84, 210, 255, 220);
+            }
+
+            if (abilityId == _duelistCrowdSweepAbilityId)
+            {
+                return new DebugDrawColor(130, 244, 126, 220);
+            }
+
+            if (abilityId == _duelistOpeningBreakerAbilityId)
+            {
+                return new DebugDrawColor(255, 114, 126, 235);
+            }
+
+            if (abilityId == _duelistComboStage2AbilityId)
+            {
+                return new DebugDrawColor(255, 170, 96, 228);
+            }
+
+            if (abilityId == _duelistComboStage1AbilityId)
+            {
+                return new DebugDrawColor(248, 206, 104, 228);
+            }
+
+            return DebugDrawColor.White;
+        }
+
+        private static bool TryGetDebugWorld(World world, Entity entity, out Vector2 worldPosition)
+        {
+            worldPosition = default;
+            if (!world.IsAlive(entity) || !world.TryGet(entity, out WorldPositionCm position))
+            {
+                return false;
+            }
+
+            worldPosition = ToDebugWorld(position.Value.ToVector2());
+            return true;
+        }
+
+        private static float ResolveDebugRotation(Vector2 actorWorld, Vector2 targetWorld, World world, Entity actor)
+        {
+            Vector2 delta = targetWorld - actorWorld;
+            if (delta.LengthSquared() > 0.0001f)
+            {
+                return MathF.Atan2(delta.Y, delta.X);
+            }
+
+            if (world.TryGet(actor, out FacingDirection facing))
+            {
+                return facing.AngleRad;
+            }
+
+            return 0f;
+        }
+
+        private static Vector2 ToDebugWorld(Vector2 worldCm)
+        {
+            return worldCm / 100f;
         }
     }
 }

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Systems/ChampionSkillSandboxLocalOrderSourceSystem.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Systems/ChampionSkillSandboxLocalOrderSourceSystem.cs
@@ -81,6 +81,8 @@ namespace ChampionSkillSandboxMod.Systems
                        inputObj is IInputActionReader input &&
                        input.IsDown("QueueModifier");
             });
+
+            _globals[SkillBarOverlaySystem.SkillBarKeyLabelsKey] = new[] { "Q", "W", "E", "R", "Space" };
         }
     }
 }

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Entities/templates.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Entities/templates.json
@@ -157,6 +157,53 @@
     }
   },
   {
+    "id": "champion_skill_sandbox_duelist",
+      "components": {
+      "Name": { "Value": "Duelist" },
+      "Team": { "Id": 1 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } },
+      "FacingDirection": { "AngleRad": 0.0 },
+      "Presentation": { "visualTemplateId": "core.character.hero_skinned" },
+      "AttributeBuffer": { "base": { "Health": 215, "Shield": 0, "MoveSpeed": 345, "Armor": 10 } },
+      "Collider2D": {
+        "shape": {
+          "type": "circle",
+          "radiusCm": 42
+        }
+      },
+      "PhysicsMaterial2D": {
+        "friction": 0.92,
+        "restitution": 0.0,
+        "baseDamping": 0.94
+      },
+      "NavKinematics2D": {
+        "maxAccelCmPerSec2": 1820,
+        "radiusCm": 42,
+        "neighborDistCm": 300,
+        "timeHorizonSec": 2.2,
+        "maxNeighbors": 20
+      },
+      "AbilityStateBuffer": {
+        "abilityIds": [
+          "Ability.Champion.Duelist.Combo.Stage1",
+          "Ability.Champion.Duelist.StepIn",
+          "Ability.Champion.Duelist.CrowdSweep",
+          "Ability.Champion.Duelist.OpeningBreaker",
+          "Ability.Champion.Duelist.ActionContext"
+        ]
+      },
+      "AbilityFormSetRef": {
+        "formSetId": "champion_skill_sandbox_duelist_forms"
+      },
+      "GameplayTagContainer": {},
+      "OrderBuffer": {},
+      "BlackboardSpatialBuffer": {},
+      "BlackboardEntityBuffer": {},
+      "BlackboardIntBuffer": {}
+    }
+  },
+  {
     "id": "champion_skill_sandbox_spell_engineer",
     "components": {
       "Name": { "Value": "Spell Engineer" },

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/abilities.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/abilities.json
@@ -678,5 +678,193 @@
         "SmartCast": "Hold to channel steerable beam, release to stop"
       }
     }
+  },
+  {
+    "id": "Ability.Champion.Duelist.Combo.Stage1",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 8, "tag": "Cooldown.Champion.Duelist.Q" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.Duelist.Combo.Stage1" },
+        { "kind": "TagClip", "tick": 0, "duration": 24, "tag": "State.Champion.Duelist.Combo.Stage1" },
+        { "kind": "TagClipTarget", "tick": 0, "duration": 24, "tag": "State.Champion.Duelist.Target.ComboPrimed" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "indicator": { "shape": "Circle", "range": 320, "radius": 180, "showRangeCircle": true, "validColor": "#F6C35B77", "invalidColor": "#E2575788" },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.Duelist.Q"] },
+    "input": {
+      "autoTargetPolicy": "NearestEnemyInRange",
+      "autoTargetRangeCm": 340
+    },
+    "presentation": {
+      "displayName": "Chain Jab I",
+      "iconGlyph": "Q",
+      "accentColor": "#F6C35B",
+      "hintText": "Open the combo and prime the next strike",
+      "modeHints": {
+        "SmartCastWithIndicator": "Hold to preview close engage radius",
+        "PressReleaseAimCast": "Release key, then confirm the opener"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.Duelist.Combo.Stage2",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 8, "tag": "Cooldown.Champion.Duelist.Q" },
+        { "kind": "TagSignal", "tick": 0, "tag": "State.Champion.Duelist.Combo.Stage1", "payloadA": 1 },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.Duelist.Combo.Stage2" },
+        { "kind": "TagClip", "tick": 0, "duration": 24, "tag": "State.Champion.Duelist.Combo.Stage2" },
+        { "kind": "TagClipTarget", "tick": 0, "duration": 30, "tag": "State.Champion.Duelist.Target.Opened" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "indicator": { "shape": "Circle", "range": 330, "radius": 190, "showRangeCircle": true, "validColor": "#FFAD66AA", "invalidColor": "#E2575788" },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.Duelist.Q"] },
+    "input": {
+      "autoTargetPolicy": "NearestEnemyInRange",
+      "autoTargetRangeCm": 340
+    },
+    "presentation": {
+      "displayName": "Chain Jab II",
+      "iconGlyph": "Q2",
+      "accentColor": "#FFAD66",
+      "hintText": "Stagger the target and open a finisher window",
+      "modeHints": {
+        "SmartCastWithIndicator": "Hold to preview the stagger follow-up",
+        "PressReleaseAimCast": "Release key, then confirm the second hit"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.Duelist.Combo.Stage3",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 16, "tag": "Cooldown.Champion.Duelist.Q" },
+        { "kind": "TagSignal", "tick": 0, "tag": "State.Champion.Duelist.Combo.Stage2", "payloadA": 1 },
+        { "kind": "TagSignalTarget", "tick": 0, "tag": "State.Champion.Duelist.Target.Opened", "payloadA": 1 },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.Duelist.Combo.Stage3" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "indicator": { "shape": "Circle", "range": 340, "radius": 210, "showRangeCircle": true, "validColor": "#FF7C5FAA", "invalidColor": "#E2575788" },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.Duelist.Q"] },
+    "input": {
+      "autoTargetPolicy": "NearestEnemyInRange",
+      "autoTargetRangeCm": 360
+    },
+    "presentation": {
+      "displayName": "Chain Finish",
+      "iconGlyph": "Q3",
+      "accentColor": "#FF7C5F",
+      "hintText": "Cash out the combo before the window closes",
+      "modeHints": {
+        "SmartCastWithIndicator": "Hold to preview the finishing arc",
+        "PressReleaseAimCast": "Release key, then confirm the finisher"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.Duelist.StepIn",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 30, "tag": "Cooldown.Champion.Duelist.W" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.Duelist.StepInDash", "dispatchTarget": "Source" },
+        { "kind": "EffectSignal", "tick": 4, "template": "Effect.Champion.Duelist.StepInStrike" },
+        { "kind": "End", "tick": 4 }
+      ]
+    },
+    "indicator": { "shape": "Circle", "range": 620, "radius": 120, "showRangeCircle": true, "validColor": "#62D4FF77", "invalidColor": "#E2575788" },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.Duelist.W"] },
+    "input": {
+      "autoTargetPolicy": "NearestEnemyInRange",
+      "autoTargetRangeCm": 560
+    },
+    "presentation": {
+      "displayName": "Step In",
+      "iconGlyph": "W",
+      "accentColor": "#62D4FF",
+      "hintText": "Gap-close into melee and keep the pressure on",
+      "modeHints": {
+        "SmartCastWithIndicator": "Hold to preview lunge reach",
+        "PressReleaseAimCast": "Release key, then confirm the entry line"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.Duelist.CrowdSweep",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 42, "tag": "Cooldown.Champion.Duelist.E" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.Duelist.CrowdSweep" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "indicator": { "shape": "Cone", "range": 420, "radius": 420, "angleDeg": 64, "showRangeCircle": true, "validColor": "#9FE27A77", "invalidColor": "#E2575788" },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.Duelist.E"] },
+    "presentation": {
+      "displayName": "Crowd Sweep",
+      "iconGlyph": "E",
+      "accentColor": "#9FE27A",
+      "hintText": "Clear the front arc and retake spacing",
+      "modeHints": {
+        "SmartCastWithIndicator": "Hold to preview the sweep cone",
+        "PressReleaseAimCast": "Release key, then confirm the sweep"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.Duelist.OpeningBreaker",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 60, "tag": "Cooldown.Champion.Duelist.R" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.Duelist.OpeningBreaker" },
+        { "kind": "TagSignalTarget", "tick": 0, "tag": "State.Champion.Duelist.Target.Opened", "payloadA": 1 },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "activationPrecondition": {
+      "validationGraph": "Graph.Champion.Duelist.RequireOpenedTarget"
+    },
+    "indicator": { "shape": "Circle", "range": 340, "radius": 160, "showRangeCircle": true, "validColor": "#FF7E8A99", "invalidColor": "#E2575788" },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.Duelist.R"] },
+    "presentation": {
+      "displayName": "Opening Breaker",
+      "iconGlyph": "R",
+      "accentColor": "#FF7E8A",
+      "hintText": "Spend the opened window on a heavy single-target finish",
+      "modeHints": {
+        "SmartCastWithIndicator": "Hold to preview finisher reach",
+        "PressReleaseAimCast": "Release key, then confirm the breaker"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.Duelist.ActionContext",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "input": {
+      "castModeOverride": "ContextScored"
+    },
+    "presentation": {
+      "displayName": "Action Context",
+      "iconGlyph": "SP",
+      "accentColor": "#F4E18A",
+      "hintText": "One-key context attack: build target group, pick the best opener, and strike",
+      "modeHints": {
+        "ContextScored": "Build target group, score melee candidates, and fire the best action",
+        "SmartCast": "Always resolves through context scoring, even outside Action Focus mode"
+      }
+    }
   }
 ]

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/abilities.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/abilities.json
@@ -701,10 +701,11 @@
       "displayName": "Chain Jab I",
       "iconGlyph": "Q",
       "accentColor": "#F6C35B",
-      "hintText": "Open the combo and prime the next strike",
+      "hintText": "Start the pressure. After this lands, Q advances to Chain Jab II.",
       "modeHints": {
         "SmartCastWithIndicator": "Hold to preview close engage radius",
-        "PressReleaseAimCast": "Release key, then confirm the opener"
+        "PressReleaseAimCast": "Release key, then confirm the opener",
+        "ContextScored": "Use when you are already in melee and want to start the chain."
       }
     }
   },
@@ -731,10 +732,11 @@
       "displayName": "Chain Jab II",
       "iconGlyph": "Q2",
       "accentColor": "#FFAD66",
-      "hintText": "Stagger the target and open a finisher window",
+      "hintText": "Manual Q route second hit. Stay on the same dummy to crack them open for the finish.",
       "modeHints": {
         "SmartCastWithIndicator": "Hold to preview the stagger follow-up",
-        "PressReleaseAimCast": "Release key, then confirm the second hit"
+        "PressReleaseAimCast": "Release key, then confirm the second hit",
+        "ContextScored": "Space uses this once the same target is already under pressure from the first jab."
       }
     }
   },
@@ -760,10 +762,11 @@
       "displayName": "Chain Finish",
       "iconGlyph": "Q3",
       "accentColor": "#FF7C5F",
-      "hintText": "Cash out the combo before the window closes",
+      "hintText": "Manual Q route finisher. Cash out before the window closes and the chain drops.",
       "modeHints": {
         "SmartCastWithIndicator": "Hold to preview the finishing arc",
-        "PressReleaseAimCast": "Release key, then confirm the finisher"
+        "PressReleaseAimCast": "Release key, then confirm the finisher",
+        "ContextScored": "Manual ender once you have stayed on one target long enough to finish the chain."
       }
     }
   },
@@ -788,10 +791,11 @@
       "displayName": "Step In",
       "iconGlyph": "W",
       "accentColor": "#62D4FF",
-      "hintText": "Gap-close into melee and keep the pressure on",
+      "hintText": "Auto opener from outside melee. Space uses this first when the hovered target is too far away.",
       "modeHints": {
         "SmartCastWithIndicator": "Hold to preview lunge reach",
-        "PressReleaseAimCast": "Release key, then confirm the entry line"
+        "PressReleaseAimCast": "Release key, then confirm the entry line",
+        "ContextScored": "Space chooses this whenever the hovered target is still outside jab range."
       }
     }
   },
@@ -811,10 +815,11 @@
       "displayName": "Crowd Sweep",
       "iconGlyph": "E",
       "accentColor": "#9FE27A",
-      "hintText": "Clear the front arc and retake spacing",
+      "hintText": "Cleave the pack in front of you and retake spacing.",
       "modeHints": {
         "SmartCastWithIndicator": "Hold to preview the sweep cone",
-        "PressReleaseAimCast": "Release key, then confirm the sweep"
+        "PressReleaseAimCast": "Release key, then confirm the sweep",
+        "ContextScored": "Manual crowd clear for clustered enemies in front of the duelist."
       }
     }
   },
@@ -838,10 +843,11 @@
       "displayName": "Opening Breaker",
       "iconGlyph": "R",
       "accentColor": "#FF7E8A",
-      "hintText": "Spend the opened window on a heavy single-target finish",
+      "hintText": "Auto heavy finisher. Space cashes out with this once the target is opened up.",
       "modeHints": {
         "SmartCastWithIndicator": "Hold to preview finisher reach",
-        "PressReleaseAimCast": "Release key, then confirm the breaker"
+        "PressReleaseAimCast": "Release key, then confirm the breaker",
+        "ContextScored": "Space prefers this once the current target is opened and ready to break."
       }
     }
   },
@@ -857,13 +863,13 @@
       "castModeOverride": "ContextScored"
     },
     "presentation": {
-      "displayName": "Action Context",
+      "displayName": "Action Combo",
       "iconGlyph": "SP",
       "accentColor": "#F4E18A",
-      "hintText": "One-key context attack: build target group, pick the best opener, and strike",
+      "hintText": "Space auto route: far target = Step In, close target = chain, opened target = breaker. Q is the separate manual Q1 -> Q2 -> Q3 route.",
       "modeHints": {
-        "ContextScored": "Build target group, score melee candidates, and fire the best action",
-        "SmartCast": "Always resolves through context scoring, even outside Action Focus mode"
+        "ContextScored": "Hover a dummy or pack, then tap Space: far = Step In, close = chain, opened = breaker. Q stays manual.",
+        "SmartCast": "The melee route still works here, but Action Combo is the clearest way to read it."
       }
     }
   }

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/ability_form_sets.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/ability_form_sets.json
@@ -13,5 +13,24 @@
         ]
       }
     ]
+  },
+  {
+    "id": "champion_skill_sandbox_duelist_forms",
+    "routes": [
+      {
+        "requiredAll": ["State.Champion.Duelist.Combo.Stage2"],
+        "priority": 200,
+        "slotOverrides": [
+          { "slotIndex": 0, "abilityId": "Ability.Champion.Duelist.Combo.Stage3" }
+        ]
+      },
+      {
+        "requiredAll": ["State.Champion.Duelist.Combo.Stage1"],
+        "priority": 100,
+        "slotOverrides": [
+          { "slotIndex": 0, "abilityId": "Ability.Champion.Duelist.Combo.Stage2" }
+        ]
+      }
+    ]
   }
 ]

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/context_groups.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/context_groups.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "champion_skill_sandbox_duelist_action",
+    "rootAbilityId": "Ability.Champion.Duelist.ActionContext",
+    "searchRadiusCm": 760,
+    "candidates": [
+      {
+        "abilityId": "Ability.Champion.Duelist.Combo.Stage2",
+        "preconditionGraph": "Graph.Champion.Duelist.RequireComboPrimedTarget",
+        "basePriority": 96,
+        "maxDistanceCm": 340,
+        "distanceWeight": 12,
+        "maxAngleDeg": 145,
+        "angleWeight": 6,
+        "hoveredBiasScore": 42,
+        "requiresTarget": true
+      },
+      {
+        "abilityId": "Ability.Champion.Duelist.OpeningBreaker",
+        "preconditionGraph": "Graph.Champion.Duelist.RequireOpenedTarget",
+        "basePriority": 120,
+        "maxDistanceCm": 340,
+        "distanceWeight": 14,
+        "maxAngleDeg": 140,
+        "angleWeight": 6,
+        "hoveredBiasScore": 42,
+        "requiresTarget": true
+      },
+      {
+        "abilityId": "Ability.Champion.Duelist.Combo.Stage1",
+        "basePriority": 70,
+        "maxDistanceCm": 340,
+        "distanceWeight": 12,
+        "maxAngleDeg": 150,
+        "angleWeight": 6,
+        "hoveredBiasScore": 42,
+        "requiresTarget": true
+      },
+      {
+        "abilityId": "Ability.Champion.Duelist.StepIn",
+        "basePriority": 48,
+        "maxDistanceCm": 560,
+        "distanceWeight": 4,
+        "maxAngleDeg": 120,
+        "angleWeight": 8,
+        "hoveredBiasScore": 24,
+        "requiresTarget": true
+      },
+      {
+        "abilityId": "Ability.Champion.Duelist.CrowdSweep",
+        "basePriority": 12,
+        "requiresTarget": false
+      }
+    ]
+  }
+]

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/effects.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/effects.json
@@ -643,5 +643,88 @@
     "modifiers": [
       { "attribute": "Health", "op": "Add", "value": -5.0 }
     ]
+  },
+  {
+    "id": "Effect.Champion.Duelist.Combo.Stage1",
+    "tags": ["Effect.Champion.Damage"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -11.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.Duelist.Combo.Stage2",
+    "tags": ["Effect.Champion.Damage"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -13.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.Duelist.Combo.Stage3",
+    "tags": ["Effect.Champion.Damage"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -18.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.Duelist.StepInDash",
+    "tags": ["Effect.Champion.Movement"],
+    "presetType": "Displacement",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "displacement": {
+      "directionMode": "ToTarget",
+      "totalDistanceCm": 320,
+      "totalDurationTicks": 4,
+      "overrideNavigation": true
+    }
+  },
+  {
+    "id": "Effect.Champion.Duelist.StepInStrike",
+    "tags": ["Effect.Champion.Damage"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -15.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.Duelist.CrowdSweep",
+    "tags": ["Effect.Champion.Damage"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Cone", "radius": 420, "halfAngle": 64 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 10 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.Duelist.CrowdSweepHit" }
+  },
+  {
+    "id": "Effect.Champion.Duelist.CrowdSweepHit",
+    "tags": ["Effect.Champion.Damage"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -14.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.Duelist.OpeningBreaker",
+    "tags": ["Effect.Champion.Damage"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -28.0 }
+    ]
   }
 ]

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/graphs.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/graphs.json
@@ -8,5 +8,32 @@
       { "id": "pop", "op": "ApplyEffectTemplate", "effectTemplate": "Effect.Champion.Ezreal.EssenceFluxPop", "inputs": [ "target" ], "next": "consume" },
       { "id": "consume", "op": "RemoveEffectTemplate", "effectTemplate": "Effect.Champion.Ezreal.EssenceFluxHit", "inputs": [ "target" ] }
     ]
+  },
+  {
+    "id": "Graph.Champion.Duelist.RequireComboStage1",
+    "kind": "Effect",
+    "entry": "caster",
+    "nodes": [
+      { "id": "caster", "op": "LoadCaster", "next": "stage1" },
+      { "id": "stage1", "op": "HasTag", "tag": "State.Champion.Duelist.Combo.Stage1", "inputs": [ "caster" ] }
+    ]
+  },
+  {
+    "id": "Graph.Champion.Duelist.RequireOpenedTarget",
+    "kind": "Effect",
+    "entry": "target",
+    "nodes": [
+      { "id": "target", "op": "LoadExplicitTarget", "next": "opened" },
+      { "id": "opened", "op": "HasTag", "tag": "State.Champion.Duelist.Target.Opened", "inputs": [ "target" ] }
+    ]
+  },
+  {
+    "id": "Graph.Champion.Duelist.RequireComboPrimedTarget",
+    "kind": "Effect",
+    "entry": "target",
+    "nodes": [
+      { "id": "target", "op": "LoadExplicitTarget", "next": "primed" },
+      { "id": "primed", "op": "HasTag", "tag": "State.Champion.Duelist.Target.ComboPrimed", "inputs": [ "target" ] }
+    ]
   }
 ]

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Input/default_input.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Input/default_input.json
@@ -9,6 +9,8 @@
     { "id": "CastModeSmart", "name": "ChampionSkillSandbox_CastModeSmart", "type": "Button" },
     { "id": "CastModeIndicator", "name": "ChampionSkillSandbox_CastModeIndicator", "type": "Button" },
     { "id": "CastModePressRelease", "name": "ChampionSkillSandbox_CastModePressRelease", "type": "Button" },
+    { "id": "CastModeAction", "name": "ChampionSkillSandbox_CastModeAction", "type": "Button" },
+    { "id": "ActionAttack", "name": "ChampionSkillSandbox_ActionAttack", "type": "Button" },
     { "id": "ResetCamera", "name": "ChampionSkillSandbox_ResetCamera", "type": "Button" }
   ],
   "contexts": [
@@ -26,7 +28,9 @@
         { "actionId": "CastModeSmart", "path": "<Keyboard>/f1" },
         { "actionId": "CastModeIndicator", "path": "<Keyboard>/f2" },
         { "actionId": "CastModePressRelease", "path": "<Keyboard>/f3" },
-        { "actionId": "ResetCamera", "path": "<Keyboard>/f4" }
+        { "actionId": "ResetCamera", "path": "<Keyboard>/f4" },
+        { "actionId": "CastModeAction", "path": "<Keyboard>/f5" },
+        { "actionId": "ActionAttack", "path": "<Keyboard>/space" }
       ]
     }
   ]

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Input/input_order_mappings.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Input/input_order_mappings.json
@@ -44,6 +44,16 @@
       "modifierBehavior": "QueueOnModifier"
     },
     {
+      "actionId": "ActionAttack",
+      "trigger": "PressedThisFrame",
+      "orderTypeKey": "castAbility",
+      "argsTemplate": { "i0": 4 },
+      "requireSelection": false,
+      "selectionType": "Entity",
+      "isSkillMapping": true,
+      "modifierBehavior": "QueueOnModifier"
+    },
+    {
       "actionId": "Command",
       "trigger": "PressedThisFrame",
       "orderTypeKey": "moveTo",

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Maps/champion_skill_sandbox.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Maps/champion_skill_sandbox.json
@@ -59,6 +59,14 @@
       }
     },
     {
+      "Template": "champion_skill_sandbox_duelist",
+      "Overrides": {
+        "Name": { "Value": "Duelist Alpha" },
+        "PlayerOwner": { "PlayerId": 1 },
+        "WorldPositionCm": { "Value": { "X": 2250, "Y": 1330 } }
+      }
+    },
+    {
       "Template": "champion_skill_sandbox_geomancer",
       "Overrides": {
         "Name": { "Value": "Geomancer Alpha" },
@@ -106,28 +114,28 @@
       "Template": "champion_skill_sandbox_enemy_brute",
       "Overrides": {
         "Name": { "Value": "Target Brute B" },
-        "WorldPositionCm": { "Value": { "X": 2280, "Y": 1120 } }
+        "WorldPositionCm": { "Value": { "X": 2420, "Y": 980 } }
       }
     },
     {
       "Template": "champion_skill_sandbox_enemy_dummy",
       "Overrides": {
         "Name": { "Value": "Target Dummy D" },
-        "WorldPositionCm": { "Value": { "X": 2580, "Y": 1600 } }
+        "WorldPositionCm": { "Value": { "X": 2460, "Y": 1600 } }
       }
     },
     {
       "Template": "champion_skill_sandbox_enemy_dummy",
       "Overrides": {
         "Name": { "Value": "Target Dummy E" },
-        "WorldPositionCm": { "Value": { "X": 2460, "Y": 1780 } }
+        "WorldPositionCm": { "Value": { "X": 2580, "Y": 1780 } }
       }
     },
     {
       "Template": "champion_skill_sandbox_enemy_dummy",
       "Overrides": {
         "Name": { "Value": "Target Dummy F" },
-        "WorldPositionCm": { "Value": { "X": 2460, "Y": 1420 } }
+        "WorldPositionCm": { "Value": { "X": 2580, "Y": 1420 } }
       }
     }
   ]

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Presentation/performers.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Presentation/performers.json
@@ -34,6 +34,23 @@
     ]
   },
   {
+    "id": "champion_skill_sandbox.resolved_indicator",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Ring",
+    "defaultColor": [1.0, 0.97, 0.82, 0.22],
+    "defaultScale": 1.34,
+    "defaultLifetime": -1,
+    "positionOffset": [0, 0.08, 0],
+    "bindings": [
+      { "paramKey": 1, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 8, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.96 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.82 },
+      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.06 }
+    ]
+  },
+  {
     "id": "champion_skill_sandbox.projectile.ezreal_e",
     "visualKind": "Marker3D",
     "meshOrShapeId": "Sphere",

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Presentation/performers.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Presentation/performers.json
@@ -470,52 +470,59 @@
   },
   {
     "id": "champion_skill_sandbox.cue.duelist_chain_jab_1",
-    "visualKind": "GroundOverlay",
-    "meshOrShapeId": "Ring",
-    "defaultColor": [0.96, 0.78, 0.34, 0.14],
-    "defaultScale": 1.2,
-    "defaultLifetime": 0.24,
-    "positionOffset": [0, 0.05, 0],
+    "visualKind": "SlashRibbon",
+    "meshOrShapeId": "Arc",
+    "defaultColor": [1.0, 0.82, 0.38, 0.22],
+    "defaultScale": 1.55,
+    "defaultLifetime": 0.22,
+    "positionOffset": [0, 0.82, 0],
     "bindings": [
-      { "paramKey": 1, "source": "constant", "constantValue": 0.78 },
-      { "paramKey": 8, "source": "constant", "constantValue": 1.0 },
-      { "paramKey": 9, "source": "constant", "constantValue": 0.82 },
-      { "paramKey": 10, "source": "constant", "constantValue": 0.4 },
-      { "paramKey": 11, "source": "constant", "constantValue": 0.98 },
-      { "paramKey": 12, "source": "constant", "constantValue": 0.04 }
+      { "paramKey": 1, "source": "constant", "constantValue": 0.34 },
+      { "paramKey": 2, "source": "constant", "constantValue": 1.1 },
+      { "paramKey": 3, "source": "facingradians" },
+      { "paramKey": 8, "source": "constant", "constantValue": 0.22 },
+      { "paramKey": 9, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.92 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.64 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.94 }
     ]
   },
   {
     "id": "champion_skill_sandbox.cue.duelist_chain_jab_2",
-    "visualKind": "GroundOverlay",
-    "meshOrShapeId": "Ring",
-    "defaultColor": [1.0, 0.62, 0.3, 0.14],
-    "defaultScale": 1.28,
-    "defaultLifetime": 0.24,
-    "positionOffset": [0, 0.05, 0],
+    "visualKind": "SlashRibbon",
+    "meshOrShapeId": "Arc",
+    "defaultColor": [1.0, 0.66, 0.32, 0.24],
+    "defaultScale": 1.7,
+    "defaultLifetime": 0.22,
+    "positionOffset": [0, 0.84, 0],
     "bindings": [
-      { "paramKey": 1, "source": "constant", "constantValue": 0.84 },
-      { "paramKey": 8, "source": "constant", "constantValue": 1.0 },
-      { "paramKey": 9, "source": "constant", "constantValue": 0.68 },
-      { "paramKey": 10, "source": "constant", "constantValue": 0.36 },
-      { "paramKey": 11, "source": "constant", "constantValue": 0.98 },
-      { "paramKey": 12, "source": "constant", "constantValue": 0.045 }
+      { "paramKey": 1, "source": "constant", "constantValue": 0.4 },
+      { "paramKey": 2, "source": "constant", "constantValue": 1.28 },
+      { "paramKey": 3, "source": "facingradians" },
+      { "paramKey": 8, "source": "constant", "constantValue": 0.26 },
+      { "paramKey": 9, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.78 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.46 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.94 }
     ]
   },
   {
     "id": "champion_skill_sandbox.cue.duelist_chain_finish",
-    "visualKind": "GroundOverlay",
-    "meshOrShapeId": "Circle",
-    "defaultColor": [1.0, 0.42, 0.28, 0.18],
-    "defaultScale": 1.42,
-    "defaultLifetime": 0.26,
-    "positionOffset": [0, 0.06, 0],
+    "visualKind": "SlashRibbon",
+    "meshOrShapeId": "Arc",
+    "defaultColor": [1.0, 0.44, 0.3, 0.26],
+    "defaultScale": 1.88,
+    "defaultLifetime": 0.24,
+    "positionOffset": [0, 0.88, 0],
     "bindings": [
-      { "paramKey": 8, "source": "constant", "constantValue": 1.0 },
-      { "paramKey": 9, "source": "constant", "constantValue": 0.48 },
-      { "paramKey": 10, "source": "constant", "constantValue": 0.32 },
-      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
-      { "paramKey": 12, "source": "constant", "constantValue": 0.045 }
+      { "paramKey": 1, "source": "constant", "constantValue": 0.54 },
+      { "paramKey": 2, "source": "constant", "constantValue": 1.52 },
+      { "paramKey": 3, "source": "facingradians" },
+      { "paramKey": 8, "source": "constant", "constantValue": 0.34 },
+      { "paramKey": 9, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.58 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.42 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.98 }
     ]
   },
   {
@@ -530,13 +537,22 @@
   },
   {
     "id": "champion_skill_sandbox.cue.duelist_step_in",
-    "visualKind": "Marker3D",
-    "meshOrShapeId": "Sphere",
-    "defaultColor": [0.44, 0.9, 1.0, 0.9],
-    "defaultScale": 0.34,
-    "defaultLifetime": 0.2,
-    "alphaFadeOverLifetime": true,
-    "positionOffset": [0, 0.72, 0]
+    "visualKind": "SlashRibbon",
+    "meshOrShapeId": "Segment",
+    "defaultColor": [0.46, 0.92, 1.0, 0.22],
+    "defaultScale": 2.24,
+    "defaultLifetime": 0.18,
+    "positionOffset": [0, 0.78, 0],
+    "bindings": [
+      { "paramKey": 1, "source": "constant", "constantValue": 0.28 },
+      { "paramKey": 3, "source": "facingradians" },
+      { "paramKey": 8, "source": "constant", "constantValue": 0.16 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.76 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.92 },
+      { "paramKey": 13, "source": "constant", "constantValue": 2.36 }
+    ]
   },
   {
     "id": "champion_skill_sandbox.cue.duelist_step_in_hit",
@@ -550,19 +566,21 @@
   },
   {
     "id": "champion_skill_sandbox.cue.duelist_crowd_sweep",
-    "visualKind": "GroundOverlay",
-    "meshOrShapeId": "Ring",
-    "defaultColor": [0.66, 0.94, 0.48, 0.14],
-    "defaultScale": 1.9,
-    "defaultLifetime": 0.28,
-    "positionOffset": [0, 0.05, 0],
+    "visualKind": "SlashRibbon",
+    "meshOrShapeId": "Arc",
+    "defaultColor": [0.7, 0.96, 0.5, 0.22],
+    "defaultScale": 2.36,
+    "defaultLifetime": 0.24,
+    "positionOffset": [0, 0.82, 0],
     "bindings": [
-      { "paramKey": 1, "source": "constant", "constantValue": 1.2 },
-      { "paramKey": 8, "source": "constant", "constantValue": 0.72 },
-      { "paramKey": 9, "source": "constant", "constantValue": 0.98 },
-      { "paramKey": 10, "source": "constant", "constantValue": 0.56 },
-      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
-      { "paramKey": 12, "source": "constant", "constantValue": 0.045 }
+      { "paramKey": 1, "source": "constant", "constantValue": 0.62 },
+      { "paramKey": 2, "source": "constant", "constantValue": 2.2 },
+      { "paramKey": 3, "source": "facingradians" },
+      { "paramKey": 8, "source": "constant", "constantValue": 0.3 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.84 },
+      { "paramKey": 10, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.7 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.9 }
     ]
   },
   {
@@ -583,13 +601,22 @@
   },
   {
     "id": "champion_skill_sandbox.cue.duelist_opening_breaker_cast",
-    "visualKind": "Marker3D",
-    "meshOrShapeId": "Sphere",
-    "defaultColor": [1.0, 0.44, 0.5, 0.92],
-    "defaultScale": 0.42,
+    "visualKind": "SlashRibbon",
+    "meshOrShapeId": "Segment",
+    "defaultColor": [1.0, 0.46, 0.5, 0.26],
+    "defaultScale": 1.92,
     "defaultLifetime": 0.22,
-    "alphaFadeOverLifetime": true,
-    "positionOffset": [0, 0.82, 0]
+    "positionOffset": [0, 0.9, 0],
+    "bindings": [
+      { "paramKey": 1, "source": "constant", "constantValue": 0.52 },
+      { "paramKey": 3, "source": "facingradians" },
+      { "paramKey": 8, "source": "constant", "constantValue": 0.34 },
+      { "paramKey": 9, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.7 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.74 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 13, "source": "constant", "constantValue": 1.98 }
+    ]
   },
   {
     "id": "champion_skill_sandbox.cue.duelist_opening_breaker_hit",

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Presentation/performers.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Presentation/performers.json
@@ -469,6 +469,145 @@
     "positionOffset": [0, 0.72, 0]
   },
   {
+    "id": "champion_skill_sandbox.cue.duelist_chain_jab_1",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Ring",
+    "defaultColor": [0.96, 0.78, 0.34, 0.14],
+    "defaultScale": 1.2,
+    "defaultLifetime": 0.24,
+    "positionOffset": [0, 0.05, 0],
+    "bindings": [
+      { "paramKey": 1, "source": "constant", "constantValue": 0.78 },
+      { "paramKey": 8, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.82 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.4 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.04 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.duelist_chain_jab_2",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Ring",
+    "defaultColor": [1.0, 0.62, 0.3, 0.14],
+    "defaultScale": 1.28,
+    "defaultLifetime": 0.24,
+    "positionOffset": [0, 0.05, 0],
+    "bindings": [
+      { "paramKey": 1, "source": "constant", "constantValue": 0.84 },
+      { "paramKey": 8, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.68 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.36 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.045 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.duelist_chain_finish",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Circle",
+    "defaultColor": [1.0, 0.42, 0.28, 0.18],
+    "defaultScale": 1.42,
+    "defaultLifetime": 0.26,
+    "positionOffset": [0, 0.06, 0],
+    "bindings": [
+      { "paramKey": 8, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.48 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.32 },
+      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.045 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.duelist_combo_hit",
+    "visualKind": "Marker3D",
+    "meshOrShapeId": "Sphere",
+    "defaultColor": [1.0, 0.78, 0.5, 0.9],
+    "defaultScale": 0.28,
+    "defaultLifetime": 0.18,
+    "alphaFadeOverLifetime": true,
+    "positionOffset": [0, 0.8, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.duelist_step_in",
+    "visualKind": "Marker3D",
+    "meshOrShapeId": "Sphere",
+    "defaultColor": [0.44, 0.9, 1.0, 0.9],
+    "defaultScale": 0.34,
+    "defaultLifetime": 0.2,
+    "alphaFadeOverLifetime": true,
+    "positionOffset": [0, 0.72, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.duelist_step_in_hit",
+    "visualKind": "Marker3D",
+    "meshOrShapeId": "Sphere",
+    "defaultColor": [0.58, 0.94, 1.0, 0.92],
+    "defaultScale": 0.26,
+    "defaultLifetime": 0.18,
+    "alphaFadeOverLifetime": true,
+    "positionOffset": [0, 0.8, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.duelist_crowd_sweep",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Ring",
+    "defaultColor": [0.66, 0.94, 0.48, 0.14],
+    "defaultScale": 1.9,
+    "defaultLifetime": 0.28,
+    "positionOffset": [0, 0.05, 0],
+    "bindings": [
+      { "paramKey": 1, "source": "constant", "constantValue": 1.2 },
+      { "paramKey": 8, "source": "constant", "constantValue": 0.72 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.56 },
+      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.045 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.duelist_crowd_sweep_hit",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Circle",
+    "defaultColor": [0.62, 0.96, 0.54, 0.18],
+    "defaultScale": 1.24,
+    "defaultLifetime": 0.2,
+    "positionOffset": [0, 0.06, 0],
+    "bindings": [
+      { "paramKey": 8, "source": "constant", "constantValue": 0.68 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.58 },
+      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.04 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.duelist_opening_breaker_cast",
+    "visualKind": "Marker3D",
+    "meshOrShapeId": "Sphere",
+    "defaultColor": [1.0, 0.44, 0.5, 0.92],
+    "defaultScale": 0.42,
+    "defaultLifetime": 0.22,
+    "alphaFadeOverLifetime": true,
+    "positionOffset": [0, 0.82, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.duelist_opening_breaker_hit",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Circle",
+    "defaultColor": [1.0, 0.4, 0.42, 0.2],
+    "defaultScale": 1.52,
+    "defaultLifetime": 0.24,
+    "positionOffset": [0, 0.06, 0],
+    "bindings": [
+      { "paramKey": 8, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.44 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.46 },
+      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.045 }
+    ]
+  },
+  {
     "id": "champion_skill_sandbox.projectile.stress_fireball",
     "visualKind": "Marker3D",
     "meshOrShapeId": "Sphere",

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/viewmodes.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/viewmodes.json
@@ -1,5 +1,16 @@
 [
   {
+    "Id": "ChampionSkillSandbox.Mode.Action",
+    "DisplayName": "Action Combo",
+    "VirtualCameraId": "ChampionSkillSandbox.Camera.Tactical",
+    "FollowTargetKind": "SelectedEntity",
+    "InputContextId": "ChampionSkillSandbox.Controls",
+    "InteractionMode": "ContextScored",
+    "SkillBarKeyLabels": ["Q", "W", "E", "R", "Space"],
+    "SkillBarEnabled": true,
+    "SwitchActionId": "CastModeAction"
+  },
+  {
     "Id": "ChampionSkillSandbox.Mode.SmartCast",
     "DisplayName": "Quick Cast",
     "VirtualCameraId": "ChampionSkillSandbox.Camera.Tactical",
@@ -31,16 +42,5 @@
     "SkillBarKeyLabels": ["Q", "W", "E", "R", "Space"],
     "SkillBarEnabled": true,
     "SwitchActionId": "CastModePressRelease"
-  },
-  {
-    "Id": "ChampionSkillSandbox.Mode.Action",
-    "DisplayName": "Context Combo",
-    "VirtualCameraId": "ChampionSkillSandbox.Camera.Tactical",
-    "FollowTargetKind": "SelectedEntity",
-    "InputContextId": "ChampionSkillSandbox.Controls",
-    "InteractionMode": "ContextScored",
-    "SkillBarKeyLabels": ["Q", "W", "E", "R", "Space"],
-    "SkillBarEnabled": true,
-    "SwitchActionId": "CastModeAction"
   }
 ]

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/viewmodes.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/viewmodes.json
@@ -6,7 +6,7 @@
     "FollowTargetKind": "None",
     "InputContextId": "ChampionSkillSandbox.Controls",
     "InteractionMode": "SmartCast",
-    "SkillBarKeyLabels": ["Q", "W", "E", "R"],
+    "SkillBarKeyLabels": ["Q", "W", "E", "R", "Space"],
     "SkillBarEnabled": true,
     "SwitchActionId": "CastModeSmart"
   },
@@ -17,7 +17,7 @@
     "FollowTargetKind": "None",
     "InputContextId": "ChampionSkillSandbox.Controls",
     "InteractionMode": "SmartCastWithIndicator",
-    "SkillBarKeyLabels": ["Q", "W", "E", "R"],
+    "SkillBarKeyLabels": ["Q", "W", "E", "R", "Space"],
     "SkillBarEnabled": true,
     "SwitchActionId": "CastModeIndicator"
   },
@@ -28,8 +28,19 @@
     "FollowTargetKind": "None",
     "InputContextId": "ChampionSkillSandbox.Controls",
     "InteractionMode": "PressReleaseAimCast",
-    "SkillBarKeyLabels": ["Q", "W", "E", "R"],
+    "SkillBarKeyLabels": ["Q", "W", "E", "R", "Space"],
     "SkillBarEnabled": true,
     "SwitchActionId": "CastModePressRelease"
+  },
+  {
+    "Id": "ChampionSkillSandbox.Mode.Action",
+    "DisplayName": "Context Combo",
+    "VirtualCameraId": "ChampionSkillSandbox.Camera.Tactical",
+    "FollowTargetKind": "SelectedEntity",
+    "InputContextId": "ChampionSkillSandbox.Controls",
+    "InteractionMode": "ContextScored",
+    "SkillBarKeyLabels": ["Q", "W", "E", "R", "Space"],
+    "SkillBarEnabled": true,
+    "SwitchActionId": "CastModeAction"
   }
 ]

--- a/src/Adapters/Raylib/Ludots.Adapter.Raylib/RaylibHostLoop.cs
+++ b/src/Adapters/Raylib/Ludots.Adapter.Raylib/RaylibHostLoop.cs
@@ -137,6 +137,7 @@ namespace Ludots.Adapter.Raylib
                 engine.LoadMap(config.StartupMapId);
 
                 var debugDrawRenderer = new RaylibDebugDrawRenderer { PlaneY = 0.35f };
+                var slashRibbonRenderer = new RaylibSlashRibbonRenderer();
                 using var primitiveRenderer = new RaylibPrimitiveRenderer(RaylibPrimitiveRenderMode.Instanced, engine.VFS);
 
                 int lastW = screenWidth;
@@ -280,6 +281,13 @@ namespace Ludots.Adapter.Raylib
                         else
                         {
                             presentationTiming?.ObservePrimitiveRender(0d, 0, 0);
+                        }
+
+                        if (engine.GlobalContext.TryGetValue(CoreServiceKeys.SlashRibbonBuffer.Name, out var srObj) &&
+                            srObj is SlashRibbonBuffer slashRibbons &&
+                            slashRibbons.Count > 0)
+                        {
+                            slashRibbonRenderer.Draw(slashRibbons);
                         }
 
                         // Draw ground overlays (range circles, cones, etc.)

--- a/src/Client/Ludots.Client.Raylib/Rendering/RaylibDebugDrawRenderer.cs
+++ b/src/Client/Ludots.Client.Raylib/Rendering/RaylibDebugDrawRenderer.cs
@@ -18,56 +18,118 @@ namespace Ludots.Client.Raylib.Rendering
             for (int i = 0; i < buffer.Lines.Count; i++)
             {
                 var line = buffer.Lines[i];
-                Rl.DrawLine3D(ToV3(line.A), ToV3(line.B), ToColor(line.Color));
+                DrawGroundLine(line.A, line.B, line.Thickness, line.Color);
             }
 
             int segments = Math.Max(8, CircleSegments);
             for (int i = 0; i < buffer.Circles.Count; i++)
             {
                 var circle = buffer.Circles[i];
-                DrawCircle(circle.Center, circle.Radius, segments, circle.Color);
+                DrawCircle(circle.Center, circle.Radius, segments, circle.Thickness, circle.Color);
             }
 
             for (int i = 0; i < buffer.Boxes.Count; i++)
             {
                 var box = buffer.Boxes[i];
-                DrawBox(box.Center, box.HalfWidth, box.HalfHeight, box.Color);
+                DrawBox(box.Center, box.HalfWidth, box.HalfHeight, box.RotationRadians, box.Thickness, box.Color);
             }
         }
 
         private void DrawCircle(Vector2 center, float radius, int segments, DebugDrawColor color)
         {
+            DrawCircle(center, radius, segments, thickness: 0.03f, color);
+        }
+
+        private void DrawCircle(Vector2 center, float radius, int segments, float thickness, DebugDrawColor color)
+        {
             var c = ToV3(center);
             var col = ToColor(color);
+            int ringCount = thickness > 0.03f
+                ? Math.Clamp((int)MathF.Ceiling(thickness / 0.05f), 1, 8)
+                : 1;
+            float halfThickness = MathF.Max(0f, thickness) * 0.5f;
 
-            for (int i = 0; i < segments; i++)
+            for (int ring = 0; ring < ringCount; ring++)
             {
-                float a0 = (float)i / segments * MathF.Tau;
-                float a1 = (float)(i + 1) / segments * MathF.Tau;
+                float ringT = ringCount <= 1 ? 0.5f : (float)ring / (ringCount - 1);
+                float ringRadius = MathF.Max(0.005f, radius - halfThickness + thickness * ringT);
+                for (int i = 0; i < segments; i++)
+                {
+                    float a0 = (float)i / segments * MathF.Tau;
+                    float a1 = (float)(i + 1) / segments * MathF.Tau;
 
-                var p0 = c + new Vector3(MathF.Cos(a0) * radius, 0f, MathF.Sin(a0) * radius);
-                var p1 = c + new Vector3(MathF.Cos(a1) * radius, 0f, MathF.Sin(a1) * radius);
-                Rl.DrawLine3D(p0, p1, col);
+                    var p0 = c + new Vector3(MathF.Cos(a0) * ringRadius, 0f, MathF.Sin(a0) * ringRadius);
+                    var p1 = c + new Vector3(MathF.Cos(a1) * ringRadius, 0f, MathF.Sin(a1) * ringRadius);
+                    Rl.DrawLine3D(p0, p1, col);
+                }
             }
         }
 
-        private void DrawBox(Vector2 center, float halfWidth, float halfHeight, DebugDrawColor color)
+        private void DrawBox(Vector2 center, float halfWidth, float halfHeight, float rotationRadians, float thickness, DebugDrawColor color)
         {
             var col = ToColor(color);
-            var c = ToV3(center);
+            int outlineCount = thickness > 0.03f
+                ? Math.Clamp((int)MathF.Ceiling(thickness / 0.05f), 1, 8)
+                : 1;
+            float halfThickness = MathF.Max(0f, thickness) * 0.5f;
 
-            var p0 = c + new Vector3(-halfWidth, 0f, -halfHeight);
-            var p1 = c + new Vector3(halfWidth, 0f, -halfHeight);
-            var p2 = c + new Vector3(halfWidth, 0f, halfHeight);
-            var p3 = c + new Vector3(-halfWidth, 0f, halfHeight);
+            for (int outline = 0; outline < outlineCount; outline++)
+            {
+                float outlineT = outlineCount <= 1 ? 0.5f : (float)outline / (outlineCount - 1);
+                float extentOffset = -halfThickness + thickness * outlineT;
+                float currentHalfWidth = halfWidth + extentOffset;
+                float currentHalfHeight = halfHeight + extentOffset;
+                if (currentHalfWidth <= 0f || currentHalfHeight <= 0f)
+                {
+                    continue;
+                }
 
-            Rl.DrawLine3D(p0, p1, col);
-            Rl.DrawLine3D(p1, p2, col);
-            Rl.DrawLine3D(p2, p3, col);
-            Rl.DrawLine3D(p3, p0, col);
+                var p0 = Rotate(center, new Vector2(-currentHalfWidth, -currentHalfHeight), rotationRadians);
+                var p1 = Rotate(center, new Vector2(currentHalfWidth, -currentHalfHeight), rotationRadians);
+                var p2 = Rotate(center, new Vector2(currentHalfWidth, currentHalfHeight), rotationRadians);
+                var p3 = Rotate(center, new Vector2(-currentHalfWidth, currentHalfHeight), rotationRadians);
+
+                Rl.DrawLine3D(ToV3(p0), ToV3(p1), col);
+                Rl.DrawLine3D(ToV3(p1), ToV3(p2), col);
+                Rl.DrawLine3D(ToV3(p2), ToV3(p3), col);
+                Rl.DrawLine3D(ToV3(p3), ToV3(p0), col);
+            }
         }
 
         private Vector3 ToV3(Vector2 p) => new Vector3(p.X, PlaneY, p.Y);
+
+        private void DrawGroundLine(Vector2 a, Vector2 b, float thickness, DebugDrawColor color)
+        {
+            var col = ToColor(color);
+            Vector2 delta = b - a;
+            float len = delta.Length();
+            if (len <= 0.0001f)
+            {
+                return;
+            }
+
+            int stripeCount = thickness > 0.03f
+                ? Math.Clamp((int)MathF.Ceiling(thickness / 0.05f), 1, 8)
+                : 1;
+            Vector2 normal = new Vector2(-delta.Y / len, delta.X / len);
+
+            for (int stripe = 0; stripe < stripeCount; stripe++)
+            {
+                float stripeT = stripeCount <= 1 ? 0.5f : (float)stripe / (stripeCount - 1);
+                float offset = (-thickness * 0.5f) + thickness * stripeT;
+                Vector2 deltaOffset = normal * offset;
+                Rl.DrawLine3D(ToV3(a + deltaOffset), ToV3(b + deltaOffset), col);
+            }
+        }
+
+        private static Vector2 Rotate(Vector2 center, Vector2 local, float rotationRadians)
+        {
+            float sin = MathF.Sin(rotationRadians);
+            float cos = MathF.Cos(rotationRadians);
+            return center + new Vector2(
+                local.X * cos - local.Y * sin,
+                local.X * sin + local.Y * cos);
+        }
 
         private static Color ToColor(DebugDrawColor c) => new Color(c.R, c.G, c.B, c.A);
     }

--- a/src/Client/Ludots.Client.Raylib/Rendering/RaylibSlashRibbonRenderer.cs
+++ b/src/Client/Ludots.Client.Raylib/Rendering/RaylibSlashRibbonRenderer.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Numerics;
+using Ludots.Core.Presentation.Rendering;
+using Raylib_cs;
+using Rl = Raylib_cs.Raylib;
+
+namespace Ludots.Client.Raylib.Rendering
+{
+    public sealed class RaylibSlashRibbonRenderer
+    {
+        public int MaxSegments { get; set; } = 48;
+        public int MaxBands { get; set; } = 10;
+
+        public void Draw(SlashRibbonBuffer buffer)
+        {
+            if (buffer == null) throw new ArgumentNullException(nameof(buffer));
+
+            var span = buffer.GetSpan();
+            for (int i = 0; i < span.Length; i++)
+            {
+                ref readonly var item = ref span[i];
+                switch (item.Shape)
+                {
+                    case SlashRibbonShape.Segment:
+                        DrawSegment(in item);
+                        break;
+                    default:
+                        DrawArc(in item);
+                        break;
+                }
+            }
+        }
+
+        private void DrawArc(in SlashRibbonItem item)
+        {
+            float radius = MathF.Max(0.05f, item.Radius);
+            float width = MathF.Max(0.01f, item.Width);
+            float span = MathF.Max(0.08f, MathF.Abs(item.Span));
+            float start = item.Rotation - span * 0.5f;
+            float end = item.Rotation + span * 0.5f;
+            int segments = Math.Clamp((int)MathF.Ceiling(radius * span / 0.08f), 6, MaxSegments);
+            int bands = Math.Clamp((int)MathF.Ceiling(width / 0.05f), 2, MaxBands);
+            float halfWidth = width * 0.5f;
+
+            for (int band = 0; band < bands; band++)
+            {
+                float bandT = bands <= 1 ? 0f : (float)band / (bands - 1);
+                float bandRadius = radius - halfWidth + width * bandT;
+                if (bandRadius <= 0.01f)
+                {
+                    continue;
+                }
+
+                Color bandColor = ToRaylibColor(ResolveBandColor(in item, bandT));
+                Vector3 previous = EvaluateArcPoint(in item, bandRadius, start, 0f);
+                for (int segment = 1; segment <= segments; segment++)
+                {
+                    float t = (float)segment / segments;
+                    float angle = start + (end - start) * t;
+                    Vector3 current = EvaluateArcPoint(in item, bandRadius, angle, t);
+                    Rl.DrawLine3D(previous, current, bandColor);
+                    previous = current;
+                }
+            }
+
+            if (item.EdgeColor.W > 0.01f)
+            {
+                var edgeColor = ToRaylibColor(item.EdgeColor);
+                DrawArcEdge(in item, radius + halfWidth, start, end, edgeColor, segments);
+                DrawArcEdge(in item, MathF.Max(0.01f, radius - halfWidth), start, end, edgeColor, segments);
+            }
+        }
+
+        private void DrawSegment(in SlashRibbonItem item)
+        {
+            float length = MathF.Max(0.05f, item.Length > 0f ? item.Length : item.Radius);
+            float width = MathF.Max(0.01f, item.Width);
+            int stripes = Math.Clamp((int)MathF.Ceiling(width / 0.05f), 1, MaxBands);
+            Vector3 forward = new Vector3(MathF.Cos(item.Rotation), 0f, MathF.Sin(item.Rotation));
+            Vector3 right = new Vector3(-forward.Z, 0f, forward.X);
+
+            for (int stripe = 0; stripe < stripes; stripe++)
+            {
+                float stripeT = stripes <= 1 ? 0.5f : (float)stripe / (stripes - 1);
+                float offset = (stripeT - 0.5f) * width;
+                Color stripeColor = ToRaylibColor(ResolveBandColor(in item, stripeT));
+                Vector3 previous = item.Origin + right * offset;
+                for (int segment = 1; segment <= MaxSegments; segment++)
+                {
+                    float t = (float)segment / MaxSegments;
+                    Vector3 current = item.Origin + forward * (length * t) + right * offset;
+                    current.Y += MathF.Sin(t * MathF.PI) * item.Height;
+                    Rl.DrawLine3D(previous, current, stripeColor);
+                    previous = current;
+                }
+            }
+        }
+
+        private void DrawArcEdge(in SlashRibbonItem item, float radius, float start, float end, Color color, int segments)
+        {
+            Vector3 previous = EvaluateArcPoint(in item, radius, start, 0f);
+            for (int segment = 1; segment <= segments; segment++)
+            {
+                float t = (float)segment / segments;
+                float angle = start + (end - start) * t;
+                Vector3 current = EvaluateArcPoint(in item, radius, angle, t);
+                Rl.DrawLine3D(previous, current, color);
+                previous = current;
+            }
+        }
+
+        private static Vector3 EvaluateArcPoint(in SlashRibbonItem item, float radius, float angle, float t)
+        {
+            return new Vector3(
+                item.Origin.X + MathF.Cos(angle) * radius,
+                item.Origin.Y + MathF.Sin(t * MathF.PI) * item.Height,
+                item.Origin.Z + MathF.Sin(angle) * radius);
+        }
+
+        private static Vector4 ResolveBandColor(in SlashRibbonItem item, float bandT)
+        {
+            float edgeWeight = MathF.Abs(bandT - 0.5f) * 2f;
+            return Lerp(item.FillColor, item.EdgeColor, Math.Clamp(edgeWeight, 0f, 1f));
+        }
+
+        private static Vector4 Lerp(Vector4 from, Vector4 to, float t)
+        {
+            return new Vector4(
+                from.X + (to.X - from.X) * t,
+                from.Y + (to.Y - from.Y) * t,
+                from.Z + (to.Z - from.Z) * t,
+                from.W + (to.W - from.W) * t);
+        }
+
+        private static Color ToRaylibColor(in Vector4 color) => RaylibColorUtil.ToRaylibColor(in color);
+    }
+}

--- a/src/Core/Engine/GameEngine.cs
+++ b/src/Core/Engine/GameEngine.cs
@@ -39,6 +39,7 @@ using Ludots.Core.Presentation.Systems;
 using Ludots.Core.Presentation.Assets;
 using Ludots.Core.Presentation.Commands;
 using Ludots.Core.Presentation.Config;
+using Ludots.Core.Presentation.DebugDraw;
 using Ludots.Core.Presentation.Rendering;
 using Ludots.Core.Presentation.Hud;
 using Ludots.Core.Gameplay.GAS.Presentation;
@@ -175,6 +176,8 @@ namespace Ludots.Core.Engine
         private Ludots.Core.Presentation.Rendering.SkinnedVisualBatchBuffer _skinnedVisualBatchBuffer;
         private GasPresentationEventBuffer _gasPresentationEvents;
         private Ludots.Core.Presentation.Rendering.GroundOverlayBuffer _groundOverlayBuffer;
+        private Ludots.Core.Presentation.Rendering.SlashRibbonBuffer _slashRibbonBuffer;
+        private DebugDrawCommandBuffer _debugDrawCommandBuffer;
         private Ludots.Core.Presentation.Hud.WorldHudBatchBuffer _worldHudBuffer;
         private Physics2DController _physics2DController;
         private Ludots.Core.Gameplay.GAS.GasController _gasController;
@@ -496,6 +499,8 @@ namespace Ludots.Core.Engine
             var skinnedVisualBatchBuffer = new SkinnedVisualBatchBuffer(VisualSnapshotBufferCapacity);
             var transientMarkerBuffer = new TransientMarkerBuffer();
             var groundOverlayBuffer = new GroundOverlayBuffer();
+            var slashRibbonBuffer = new SlashRibbonBuffer();
+            var debugDrawCommandBuffer = new DebugDrawCommandBuffer();
             var worldHudBuffer = new WorldHudBatchBuffer();
             var performerDefinitions = new PerformerDefinitionRegistry();
             var presentationConfig = config.Presentation ?? new PresentationRuntimeConfig();
@@ -521,7 +526,7 @@ namespace Ludots.Core.Engine
                 snapshotBuffer: visualSnapshotBuffer,
                 proxyBuffer: visualProxyBuffer,
                 skinnedBatchBuffer: skinnedVisualBatchBuffer);
-            var performerEmitSystem = new PerformerEmitSystem(World, performerInstances, performerDefinitions, groundOverlayBuffer, primitiveDrawBuffer, worldHudBuffer, graphProgramRegistry, performerGraphApi, GlobalContext,
+            var performerEmitSystem = new PerformerEmitSystem(World, performerInstances, performerDefinitions, groundOverlayBuffer, slashRibbonBuffer, primitiveDrawBuffer, worldHudBuffer, graphProgramRegistry, performerGraphApi, GlobalContext,
                 entityColorResolver: (world, entity) => Ludots.Core.Presentation.Utils.TeamColorResolver.Resolve(world, entity),
                 snapshotBuffer: visualSnapshotBuffer,
                 proxyBuffer: visualProxyBuffer,
@@ -679,6 +684,8 @@ namespace Ludots.Core.Engine
             _skinnedVisualBatchBuffer = skinnedVisualBatchBuffer;
             _gasPresentationEvents = gasPresentationEvents;
             _groundOverlayBuffer = groundOverlayBuffer;
+            _slashRibbonBuffer = slashRibbonBuffer;
+            _debugDrawCommandBuffer = debugDrawCommandBuffer;
             _worldHudBuffer = worldHudBuffer;
             SetService(CoreServiceKeys.PresentationPrimitiveDrawBuffer, primitiveDrawBuffer);
             SetService(CoreServiceKeys.PresentationVisualSnapshotBuffer, visualSnapshotBuffer);
@@ -696,6 +703,8 @@ namespace Ludots.Core.Engine
             SetService(CoreServiceKeys.TransientMarkerBuffer, transientMarkerBuffer);
             SetService(CoreServiceKeys.GasPresentationEventBuffer, gasPresentationEvents);
             SetService(CoreServiceKeys.GroundOverlayBuffer, groundOverlayBuffer);
+            SetService(CoreServiceKeys.SlashRibbonBuffer, slashRibbonBuffer);
+            SetService(CoreServiceKeys.DebugDrawCommandBuffer, debugDrawCommandBuffer);
             SetService(CoreServiceKeys.ProjectilePresentationBindingRegistry, projectilePresentationBindings);
             SetService(CoreServiceKeys.PerformerDefinitionRegistry, performerDefinitions);
             SetService(CoreServiceKeys.PerformerInstanceBuffer, performerInstances);
@@ -1856,6 +1865,8 @@ namespace Ludots.Core.Engine
             _visualProxyBuffer?.Clear();
             _skinnedVisualBatchBuffer?.Clear();
             _groundOverlayBuffer?.Clear();
+            _slashRibbonBuffer?.Clear();
+            _debugDrawCommandBuffer?.Clear();
             _worldHudBuffer?.Clear();
             for (int i = 0; i < _presentationSystems.Count; i++)
             {

--- a/src/Core/Gameplay/GAS/Systems/AbilityExecSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/AbilityExecSystem.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Numerics;
 using Arch.Core;
 using Arch.Core.Extensions;
 using Arch.System;
@@ -281,6 +282,22 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                             bbSpatial.TryGetPointAt(OrderBlackboardKeys.Cast_TargetPosition, targetPointIndex, out var targetPos))
                         {
                             targetPosCm = Fix64Vec2.FromFloat(targetPos.X, targetPos.Z);
+                            hasTargetPos = true;
+                        }
+                    }
+
+                    if ((!hasTargetOriginPos || !hasTargetPos) &&
+                        TryResolveOrderSpatial(orderBuffer.ActiveOrder.Order.Args.Spatial, out var orderTargetOriginPosCm, out bool orderHasTargetOriginPos, out var orderTargetPosCm, out bool orderHasTargetPos))
+                    {
+                        if (!hasTargetOriginPos && orderHasTargetOriginPos)
+                        {
+                            targetOriginPosCm = orderTargetOriginPosCm;
+                            hasTargetOriginPos = true;
+                        }
+
+                        if (!hasTargetPos && orderHasTargetPos)
+                        {
+                            targetPosCm = orderTargetPosCm;
                             hasTargetPos = true;
                         }
                     }
@@ -700,6 +717,66 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             }
 
             return added;
+        }
+
+        private static bool TryResolveOrderSpatial(
+            in Orders.OrderSpatial spatial,
+            out Fix64Vec2 targetOriginPosCm,
+            out bool hasTargetOriginPos,
+            out Fix64Vec2 targetPosCm,
+            out bool hasTargetPos)
+        {
+            targetOriginPosCm = default;
+            hasTargetOriginPos = false;
+            targetPosCm = default;
+            hasTargetPos = false;
+
+            if (spatial.Kind != Orders.OrderSpatialKind.WorldCm ||
+                spatial.Mode == Orders.OrderCollectionMode.None)
+            {
+                return false;
+            }
+
+            if (spatial.PointCount > 1 &&
+                TryGetSpatialPoint(in spatial, 0, out Vector3 originPoint))
+            {
+                targetOriginPosCm = Fix64Vec2.FromInt((int)originPoint.X, (int)originPoint.Z);
+                hasTargetOriginPos = true;
+            }
+
+            if (spatial.PointCount > 0)
+            {
+                int targetPointIndex = spatial.PointCount > 1 ? spatial.PointCount - 1 : 0;
+                if (TryGetSpatialPoint(in spatial, targetPointIndex, out Vector3 targetPoint))
+                {
+                    targetPosCm = Fix64Vec2.FromInt((int)targetPoint.X, (int)targetPoint.Z);
+                    hasTargetPos = true;
+                }
+            }
+            else if (spatial.Mode == Orders.OrderCollectionMode.Single)
+            {
+                targetPosCm = Fix64Vec2.FromInt((int)spatial.WorldCm.X, (int)spatial.WorldCm.Z);
+                hasTargetPos = true;
+            }
+
+            return hasTargetOriginPos || hasTargetPos;
+        }
+
+        private static unsafe bool TryGetSpatialPoint(in Orders.OrderSpatial spatial, int index, out Vector3 point)
+        {
+            point = default;
+            if ((uint)index >= (uint)spatial.PointCount)
+            {
+                return false;
+            }
+
+            fixed (int* px = spatial.PointX)
+            fixed (int* py = spatial.PointY)
+            fixed (int* pz = spatial.PointZ)
+            {
+                point = new Vector3(px[index], py[index], pz[index]);
+                return true;
+            }
         }
 
         // 鈹€鈹€ Tag Clip (add at start, auto-remove via TimedTag) 鈹€鈹€

--- a/src/Core/Input/Orders/ContextScoredOrderResolver.cs
+++ b/src/Core/Input/Orders/ContextScoredOrderResolver.cs
@@ -2,8 +2,10 @@ using System;
 using System.Numerics;
 using Arch.Core;
 using Ludots.Core.Components;
+using Ludots.Core.Gameplay.Components;
 using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.Teams;
 using Ludots.Core.GraphRuntime;
 using Ludots.Core.Mathematics;
 using Ludots.Core.Spatial;
@@ -11,6 +13,24 @@ using GasGraphExecutor = Ludots.Core.NodeLibraries.GASGraph.GraphExecutor;
 
 namespace Ludots.Core.Input.Orders
 {
+    public readonly struct ContextScoredCandidateProbe
+    {
+        public ContextScoredCandidateProbe(int abilityId, int slotIndex, Entity target, float score, bool requiresTarget)
+        {
+            AbilityId = abilityId;
+            SlotIndex = slotIndex;
+            Target = target;
+            Score = score;
+            RequiresTarget = requiresTarget;
+        }
+
+        public int AbilityId { get; }
+        public int SlotIndex { get; }
+        public Entity Target { get; }
+        public float Score { get; }
+        public bool RequiresTarget { get; }
+    }
+
     public readonly struct ContextScoredOrderResolution
     {
         public ContextScoredOrderResolution(int slotIndex, Entity target, Vector3 targetWorldCm, bool hasTargetWorldCm)
@@ -52,83 +72,18 @@ namespace Ludots.Core.Input.Orders
 
         public bool TryResolve(Entity actor, InputOrderMapping mapping, Entity hoveredEntity, out ContextScoredOrderResolution resolution)
         {
-            resolution = default;
+            return TryEvaluate(actor, mapping, hoveredEntity, default, out _, out resolution);
+        }
 
-            if (!_world.IsAlive(actor) || !_world.Has<AbilityStateBuffer>(actor))
-            {
-                return false;
-            }
-
-            if (mapping.ArgsTemplate.I0 is null)
-            {
-                return false;
-            }
-
-            int rootSlotIndex = mapping.ArgsTemplate.I0.Value;
-            if (!TryResolveContextGroup(actor, rootSlotIndex, out var group))
-            {
-                return false;
-            }
-
-            if (!_world.TryGet(actor, out WorldPositionCm actorPosition))
-            {
-                return false;
-            }
-
-            var actorWorldCm = actorPosition.Value.ToWorldCmInt2();
-            int candidateCount = 0;
-            if (group.SearchRadiusCm > 0)
-            {
-                candidateCount = _spatialQueries.QueryRadius(actorWorldCm, group.SearchRadiusCm, _queryBuffer).Count;
-            }
-
-            float bestScore = float.MinValue;
-            int bestSlotIndex = -1;
-            Entity bestTarget = default;
-
-            for (int i = 0; i < group.Candidates.Count; i++)
-            {
-                var candidate = group.Candidates[i];
-                if (!TryFindSlotIndexForAbility(actor, candidate.AbilityId, out int candidateSlotIndex))
-                {
-                    continue;
-                }
-
-                if (!candidate.RequiresTarget)
-                {
-                    if (TryScoreCandidate(actor, default, hoveredEntity, actorWorldCm, candidate, out float score) && score > bestScore)
-                    {
-                        bestScore = score;
-                        bestSlotIndex = candidateSlotIndex;
-                        bestTarget = default;
-                    }
-                    continue;
-                }
-
-                for (int targetIndex = 0; targetIndex < candidateCount; targetIndex++)
-                {
-                    Entity target = _queryBuffer[targetIndex];
-                    if (!_world.IsAlive(target) || target.Equals(actor))
-                    {
-                        continue;
-                    }
-
-                    if (TryScoreCandidate(actor, target, hoveredEntity, actorWorldCm, candidate, out float score) && score > bestScore)
-                    {
-                        bestScore = score;
-                        bestSlotIndex = candidateSlotIndex;
-                        bestTarget = target;
-                    }
-                }
-            }
-
-            if (bestSlotIndex < 0)
-            {
-                return false;
-            }
-
-            resolution = new ContextScoredOrderResolution(bestSlotIndex, bestTarget, default, hasTargetWorldCm: false);
-            return true;
+        public bool TryInspect(
+            Entity actor,
+            InputOrderMapping mapping,
+            Entity hoveredEntity,
+            Span<ContextScoredCandidateProbe> probes,
+            out int probeCount,
+            out ContextScoredOrderResolution resolution)
+        {
+            return TryEvaluate(actor, mapping, hoveredEntity, probes, out probeCount, out resolution);
         }
 
         private bool TryResolveContextGroup(Entity actor, int rootSlotIndex, out ContextGroupDefinition group)
@@ -168,6 +123,159 @@ namespace Ludots.Core.Input.Orders
             }
 
             return false;
+        }
+
+        private bool TryEvaluate(
+            Entity actor,
+            InputOrderMapping mapping,
+            Entity hoveredEntity,
+            Span<ContextScoredCandidateProbe> probes,
+            out int probeCount,
+            out ContextScoredOrderResolution resolution)
+        {
+            probeCount = 0;
+            resolution = default;
+
+            if (!_world.IsAlive(actor) || !_world.Has<AbilityStateBuffer>(actor))
+            {
+                return false;
+            }
+
+            if (mapping.ArgsTemplate.I0 is null)
+            {
+                return false;
+            }
+
+            int rootSlotIndex = mapping.ArgsTemplate.I0.Value;
+            if (!TryResolveContextGroup(actor, rootSlotIndex, out var group))
+            {
+                return false;
+            }
+
+            if (!_world.TryGet(actor, out WorldPositionCm actorPosition))
+            {
+                return false;
+            }
+
+            var actorWorldCm = actorPosition.Value.ToWorldCmInt2();
+            int actorTeamId = _world.TryGet(actor, out Team actorTeam) ? actorTeam.Id : 0;
+            int candidateCount = 0;
+            if (group.SearchRadiusCm > 0)
+            {
+                candidateCount = _spatialQueries.QueryRadius(actorWorldCm, group.SearchRadiusCm, _queryBuffer).Count;
+            }
+
+            float bestScore = float.MinValue;
+            int bestSlotIndex = -1;
+            Entity bestTarget = default;
+
+            for (int i = 0; i < group.Candidates.Count; i++)
+            {
+                var candidate = group.Candidates[i];
+                if (!TryFindSlotIndexForAbility(actor, candidate.AbilityId, out int candidateSlotIndex))
+                {
+                    continue;
+                }
+
+                if (!candidate.RequiresTarget)
+                {
+                    if (TryScoreCandidate(actor, default, hoveredEntity, actorWorldCm, candidate, out float score))
+                    {
+                        RecordProbe(probes, ref probeCount, candidate.AbilityId, candidateSlotIndex, default, score, requiresTarget: false);
+                        if (score > bestScore)
+                        {
+                            bestScore = score;
+                            bestSlotIndex = candidateSlotIndex;
+                            bestTarget = default;
+                        }
+                    }
+
+                    continue;
+                }
+
+                for (int targetIndex = 0; targetIndex < candidateCount; targetIndex++)
+                {
+                    Entity target = _queryBuffer[targetIndex];
+                    if (!_world.IsAlive(target) || target.Equals(actor))
+                    {
+                        continue;
+                    }
+
+                    if (!PassesTargetRelationshipFilter(actorTeamId, target))
+                    {
+                        continue;
+                    }
+
+                    if (TryScoreCandidate(actor, target, hoveredEntity, actorWorldCm, candidate, out float score))
+                    {
+                        RecordProbe(probes, ref probeCount, candidate.AbilityId, candidateSlotIndex, target, score, requiresTarget: true);
+                        if (score > bestScore)
+                        {
+                            bestScore = score;
+                            bestSlotIndex = candidateSlotIndex;
+                            bestTarget = target;
+                        }
+                    }
+                }
+            }
+
+            if (bestSlotIndex < 0)
+            {
+                return false;
+            }
+
+            Vector3 targetWorldCm = default;
+            bool hasTargetWorldCm = TryResolveTargetWorldCm(bestTarget, out targetWorldCm);
+            resolution = new ContextScoredOrderResolution(bestSlotIndex, bestTarget, targetWorldCm, hasTargetWorldCm);
+            return true;
+        }
+
+        private bool PassesTargetRelationshipFilter(int actorTeamId, Entity target)
+        {
+            if (actorTeamId == 0 || !_world.TryGet(target, out Team targetTeam))
+            {
+                return true;
+            }
+
+            return RelationshipFilterUtil.Passes(RelationshipFilter.NotFriendly, actorTeamId, targetTeam.Id);
+        }
+
+        private static void RecordProbe(
+            Span<ContextScoredCandidateProbe> probes,
+            ref int probeCount,
+            int abilityId,
+            int slotIndex,
+            Entity target,
+            float score,
+            bool requiresTarget)
+        {
+            if (probes.IsEmpty || probeCount >= probes.Length)
+            {
+                return;
+            }
+
+            int insertIndex = probeCount;
+            while (insertIndex > 0 && probes[insertIndex - 1].Score < score)
+            {
+                probes[insertIndex] = probes[insertIndex - 1];
+                insertIndex--;
+            }
+
+            probes[insertIndex] = new ContextScoredCandidateProbe(abilityId, slotIndex, target, score, requiresTarget);
+            probeCount++;
+        }
+
+        private bool TryResolveTargetWorldCm(Entity target, out Vector3 worldCm)
+        {
+            worldCm = default;
+            if (!_world.IsAlive(target) || !_world.TryGet(target, out WorldPositionCm targetPosition))
+            {
+                return false;
+            }
+
+            Vector2 target2D = targetPosition.Value.ToVector2();
+            worldCm = new Vector3(target2D.X, 0f, target2D.Y);
+            return true;
         }
 
         private bool TryScoreCandidate(

--- a/src/Core/Input/Orders/InputOrderMappingSystem.cs
+++ b/src/Core/Input/Orders/InputOrderMappingSystem.cs
@@ -846,6 +846,12 @@ namespace Ludots.Core.Input.Orders
             var args = new OrderArgs();
             ApplyArgsTemplate(ref args, mapping.ArgsTemplate);
             args.I0 = resolution.SlotIndex;
+            if (resolution.HasTargetWorldCm)
+            {
+                args.Spatial.Kind = OrderSpatialKind.WorldCm;
+                args.Spatial.Mode = OrderCollectionMode.Single;
+                args.Spatial.WorldCm = resolution.TargetWorldCm;
+            }
 
             order.OrderTypeId = orderTypeId;
             order.PlayerId = _playerId;

--- a/src/Core/Presentation/Config/PerformerDefinitionConfigLoader.cs
+++ b/src/Core/Presentation/Config/PerformerDefinitionConfigLoader.cs
@@ -104,6 +104,13 @@ namespace Ludots.Core.Presentation.Config
                 return 0;
             }
 
+            if (visualKind == PerformerVisualKind.SlashRibbon)
+            {
+                if (Enum.TryParse<SlashRibbonShape>(meshStr, ignoreCase: true, out var shape))
+                    return (int)shape;
+                return (int)SlashRibbonShape.Arc;
+            }
+
             return _resolveMeshId(meshStr);
         }
 

--- a/src/Core/Presentation/DebugDraw/DebugDrawCommandBuffer.cs
+++ b/src/Core/Presentation/DebugDraw/DebugDrawCommandBuffer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 
@@ -58,6 +59,133 @@ namespace Ludots.Core.Presentation.DebugDraw
         public List<DebugDrawLine2D> Lines { get; } = new List<DebugDrawLine2D>(4096);
         public List<DebugDrawCircle2D> Circles { get; } = new List<DebugDrawCircle2D>(2048);
         public List<DebugDrawBox2D> Boxes { get; } = new List<DebugDrawBox2D>(2048);
+
+        public void AddLine(Vector2 a, Vector2 b, DebugDrawColor color, float thickness = 0.03f)
+        {
+            Lines.Add(new DebugDrawLine2D
+            {
+                A = a,
+                B = b,
+                Thickness = thickness,
+                Color = color
+            });
+        }
+
+        public void AddCircle(Vector2 center, float radius, DebugDrawColor color, float thickness = 0.03f)
+        {
+            Circles.Add(new DebugDrawCircle2D
+            {
+                Center = center,
+                Radius = radius,
+                Thickness = thickness,
+                Color = color
+            });
+        }
+
+        public void AddBox(Vector2 center, float halfWidth, float halfHeight, float rotationRadians, DebugDrawColor color, float thickness = 0.03f)
+        {
+            Boxes.Add(new DebugDrawBox2D
+            {
+                Center = center,
+                HalfWidth = halfWidth,
+                HalfHeight = halfHeight,
+                RotationRadians = rotationRadians,
+                Thickness = thickness,
+                Color = color
+            });
+        }
+
+        public void AddPolyline(ReadOnlySpan<Vector2> points, DebugDrawColor color, float thickness = 0.03f, bool closed = false)
+        {
+            if (points.Length < 2)
+            {
+                return;
+            }
+
+            for (int i = 1; i < points.Length; i++)
+            {
+                AddLine(points[i - 1], points[i], color, thickness);
+            }
+
+            if (closed)
+            {
+                AddLine(points[^1], points[0], color, thickness);
+            }
+        }
+
+        public void AddArc(
+            Vector2 center,
+            float radius,
+            float startRadians,
+            float endRadians,
+            DebugDrawColor color,
+            float thickness = 0.03f,
+            int segments = 0)
+        {
+            if (radius <= 0f)
+            {
+                return;
+            }
+
+            float delta = endRadians - startRadians;
+            if (MathF.Abs(delta) <= 0.0001f)
+            {
+                return;
+            }
+
+            int segmentCount = segments > 0
+                ? segments
+                : Math.Clamp((int)MathF.Ceiling(MathF.Abs(delta) * radius / 0.18f), 6, 96);
+
+            Vector2 previous = center + new Vector2(MathF.Cos(startRadians), MathF.Sin(startRadians)) * radius;
+            for (int i = 1; i <= segmentCount; i++)
+            {
+                float t = (float)i / segmentCount;
+                float angle = startRadians + delta * t;
+                Vector2 current = center + new Vector2(MathF.Cos(angle), MathF.Sin(angle)) * radius;
+                AddLine(previous, current, color, thickness);
+                previous = current;
+            }
+        }
+
+        public void AddCapsule(
+            Vector2 start,
+            Vector2 end,
+            float radius,
+            DebugDrawColor color,
+            float thickness = 0.03f,
+            int arcSegments = 0,
+            bool drawCenterLine = false)
+        {
+            if (radius <= 0f)
+            {
+                AddLine(start, end, color, thickness);
+                return;
+            }
+
+            Vector2 axis = end - start;
+            float axisLength = axis.Length();
+            if (axisLength <= 0.0001f)
+            {
+                AddCircle(start, radius, color, thickness);
+                return;
+            }
+
+            Vector2 dir = axis / axisLength;
+            Vector2 normal = new Vector2(-dir.Y, dir.X) * radius;
+
+            AddLine(start + normal, end + normal, color, thickness);
+            AddLine(start - normal, end - normal, color, thickness);
+
+            if (drawCenterLine)
+            {
+                AddLine(start, end, color, thickness);
+            }
+
+            float normalAngle = MathF.Atan2(normal.Y, normal.X);
+            AddArc(start, radius, normalAngle, normalAngle + MathF.PI, color, thickness, arcSegments);
+            AddArc(end, radius, normalAngle + MathF.PI, normalAngle + MathF.Tau, color, thickness, arcSegments);
+        }
 
         public void Clear()
         {

--- a/src/Core/Presentation/Performers/PerformerDefinition.cs
+++ b/src/Core/Presentation/Performers/PerformerDefinition.cs
@@ -74,7 +74,7 @@ namespace Ludots.Core.Presentation.Performers
 
         // ── Static default values (used when no Binding or Override exists) ──
 
-        /// <summary>Mesh asset ID (Marker3D) or GroundOverlayShape ordinal (GroundOverlay).</summary>
+        /// <summary>Mesh asset ID (Marker3D) or shape ordinal (GroundOverlay / SlashRibbon).</summary>
         public int MeshOrShapeId;
 
         /// <summary>Default color (RGBA).</summary>

--- a/src/Core/Presentation/Performers/PerformerVisualKind.cs
+++ b/src/Core/Presentation/Performers/PerformerVisualKind.cs
@@ -17,5 +17,8 @@ namespace Ludots.Core.Presentation.Performers
 
         /// <summary>World-space bar (health bar, cast bar).</summary>
         WorldBar = 3,
+
+        /// <summary>Procedural melee slash ribbon rendered as a curved or linear trail.</summary>
+        SlashRibbon = 4,
     }
 }

--- a/src/Core/Presentation/Rendering/SlashRibbonBuffer.cs
+++ b/src/Core/Presentation/Rendering/SlashRibbonBuffer.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Numerics;
+
+namespace Ludots.Core.Presentation.Rendering
+{
+    public enum SlashRibbonShape : byte
+    {
+        Arc = 0,
+        Segment = 1,
+    }
+
+    public struct SlashRibbonItem
+    {
+        public SlashRibbonShape Shape;
+        public Vector3 Origin;
+        public float Rotation;
+        public float Radius;
+        public float Span;
+        public float Length;
+        public float Width;
+        public float Height;
+        public Vector4 FillColor;
+        public Vector4 EdgeColor;
+    }
+
+    /// <summary>
+    /// Per-frame buffer for stylized melee slash ribbons.
+    /// Stores procedural parameters rather than mesh instances so adapters can render curved trails directly.
+    /// </summary>
+    public sealed class SlashRibbonBuffer
+    {
+        private readonly SlashRibbonItem[] _items;
+        private int _count;
+
+        public int Count => _count;
+        public int Capacity => _items.Length;
+
+        public SlashRibbonBuffer(int capacity = 256)
+        {
+            if (capacity <= 0) capacity = 256;
+            _items = new SlashRibbonItem[capacity];
+        }
+
+        public bool TryAdd(in SlashRibbonItem item)
+        {
+            if (_count >= _items.Length)
+            {
+                return false;
+            }
+
+            _items[_count++] = item;
+            return true;
+        }
+
+        public ReadOnlySpan<SlashRibbonItem> GetSpan() => new(_items, 0, _count);
+
+        public void Clear() => _count = 0;
+    }
+}

--- a/src/Core/Presentation/Systems/PerformerEmitSystem.cs
+++ b/src/Core/Presentation/Systems/PerformerEmitSystem.cs
@@ -39,6 +39,7 @@ namespace Ludots.Core.Presentation.Systems
         private readonly PerformerInstanceBuffer _instances;
         private readonly PerformerDefinitionRegistry _definitions;
         private readonly GroundOverlayBuffer _groundOverlays;
+        private readonly SlashRibbonBuffer _slashRibbons;
         private readonly PresentationVisualProxyEmitter _proxyEmitter;
         private readonly WorldHudBatchBuffer _worldHud;
         private readonly GraphProgramRegistry _programs;
@@ -73,6 +74,7 @@ namespace Ludots.Core.Presentation.Systems
             PerformerInstanceBuffer instances,
             PerformerDefinitionRegistry definitions,
             GroundOverlayBuffer groundOverlays,
+            SlashRibbonBuffer slashRibbons,
             PrimitiveDrawBuffer primitives,
             WorldHudBatchBuffer worldHud,
             GraphProgramRegistry programs,
@@ -87,12 +89,45 @@ namespace Ludots.Core.Presentation.Systems
             _instances = instances;
             _definitions = definitions;
             _groundOverlays = groundOverlays;
+            _slashRibbons = slashRibbons;
             _proxyEmitter = new PresentationVisualProxyEmitter(primitives, snapshotBuffer, proxyBuffer, skinnedBatchBuffer);
             _worldHud = worldHud;
             _programs = programs;
             _graphApi = graphApi;
             _globals = globals;
             _entityColorResolver = entityColorResolver;
+        }
+
+        public PerformerEmitSystem(
+            World world,
+            PerformerInstanceBuffer instances,
+            PerformerDefinitionRegistry definitions,
+            GroundOverlayBuffer groundOverlays,
+            PrimitiveDrawBuffer primitives,
+            WorldHudBatchBuffer worldHud,
+            GraphProgramRegistry programs,
+            IGraphRuntimeApi graphApi,
+            Dictionary<string, object> globals,
+            EntityColorResolver entityColorResolver = null,
+            PrimitiveDrawBuffer? snapshotBuffer = null,
+            PresentationVisualProxyBuffer? proxyBuffer = null,
+            SkinnedVisualBatchBuffer? skinnedBatchBuffer = null)
+            : this(
+                world,
+                instances,
+                definitions,
+                groundOverlays,
+                new SlashRibbonBuffer(),
+                primitives,
+                worldHud,
+                programs,
+                graphApi,
+                globals,
+                entityColorResolver,
+                snapshotBuffer,
+                proxyBuffer,
+                skinnedBatchBuffer)
+        {
         }
 
         public override void Update(in float dt)
@@ -302,6 +337,9 @@ namespace Ludots.Core.Presentation.Systems
                 case PerformerVisualKind.WorldText:
                     EmitWorldText(handle, definitionId, def, owner, pos, alphaMod);
                     break;
+                case PerformerVisualKind.SlashRibbon:
+                    EmitSlashRibbon(handle, def, owner, pos, alphaMod);
+                    break;
             }
         }
 
@@ -477,6 +515,29 @@ namespace Ludots.Core.Presentation.Systems
                 Mobility = VisualMobility.Movable,
                 Flags = VisualRuntimeFlags.Visible,
                 Visibility = VisualVisibility.Visible,
+            });
+        }
+
+        private void EmitSlashRibbon(int handle, PerformerDefinition def, Entity owner, Vector3 pos, float alphaMod)
+        {
+            var fill = ResolveColor(handle, def, owner, 4, 5, 6, 7, def.DefaultColor);
+            fill.W *= alphaMod;
+
+            var edge = ResolveColor(handle, def, owner, 9, 10, 11, 12, new Vector4(fill.X, fill.Y, fill.Z, fill.W));
+            edge.W *= alphaMod;
+
+            _slashRibbons.TryAdd(new SlashRibbonItem
+            {
+                Shape = (SlashRibbonShape)def.MeshOrShapeId,
+                Origin = pos,
+                Rotation = ResolveParam(handle, def, owner, 3, ResolveFacingRadians(owner)),
+                Radius = ResolveParam(handle, def, owner, 0, def.DefaultScale),
+                Width = ResolveParam(handle, def, owner, 1, 0.28f),
+                Span = ResolveParam(handle, def, owner, 2, MathF.PI * 0.55f),
+                Height = ResolveParam(handle, def, owner, 8, 0.32f),
+                Length = ResolveParam(handle, def, owner, 13, def.DefaultScale),
+                FillColor = fill,
+                EdgeColor = edge,
             });
         }
 

--- a/src/Core/Scripting/CoreServiceKeys.cs
+++ b/src/Core/Scripting/CoreServiceKeys.cs
@@ -175,6 +175,7 @@ namespace Ludots.Core.Scripting
         public static readonly ServiceKey<TransientMarkerBuffer> TransientMarkerBuffer = new("TransientMarkerBuffer");
         public static readonly ServiceKey<GasPresentationEventBuffer> GasPresentationEventBuffer = new("GasPresentationEventBuffer");
         public static readonly ServiceKey<GroundOverlayBuffer> GroundOverlayBuffer = new("GroundOverlayBuffer");
+        public static readonly ServiceKey<SlashRibbonBuffer> SlashRibbonBuffer = new("SlashRibbonBuffer");
         public static readonly ServiceKey<DebugDrawCommandBuffer> DebugDrawCommandBuffer = new("DebugDrawCommandBuffer");
         public static readonly ServiceKey<ProjectilePresentationBindingRegistry> ProjectilePresentationBindingRegistry = new("ProjectilePresentationBindingRegistry");
 

--- a/src/Core/Spatial/ISpatialQueryService.cs
+++ b/src/Core/Spatial/ISpatialQueryService.cs
@@ -20,6 +20,9 @@ namespace Ludots.Core.Spatial
         /// <summary>Line / capsule query from origin along direction with half-width.</summary>
         SpatialQueryResult QueryLine(WorldCmInt2 origin, int directionDeg, int lengthCm, int halfWidthCm, Span<Entity> buffer);
 
+        /// <summary>Continuous capsule sweep over a polyline path. Results are ordered by accumulated path distance.</summary>
+        SpatialQueryResult QueryPolylineCapsule(ReadOnlySpan<WorldCmInt2> points, int halfWidthCm, Span<Entity> buffer);
+
         /// <summary>Query all entities within hex distance &lt;= <paramref name="hexRadius"/> from center.</summary>
         SpatialQueryResult QueryHexRange(HexCoordinates center, int hexRadius, Span<Entity> buffer);
 

--- a/src/Core/Spatial/SpatialQueryService.cs
+++ b/src/Core/Spatial/SpatialQueryService.cs
@@ -212,6 +212,89 @@ namespace Ludots.Core.Spatial
             return new SpatialQueryResult(write, dropped);
         }
 
+        public SpatialQueryResult QueryPolylineCapsule(ReadOnlySpan<WorldCmInt2> points, int halfWidthCm, Span<Entity> buffer)
+        {
+            if (_positionProvider is null)
+                throw new InvalidOperationException("EntityPositionProvider not set. Call SetPositionProvider() before shape queries.");
+
+            if (points.Length <= 0)
+                return new SpatialQueryResult(0, 0);
+
+            if (points.Length == 1)
+                return QueryRadius(points[0], halfWidthCm, buffer);
+
+            int minX = points[0].X;
+            int minY = points[0].Y;
+            int maxX = points[0].X;
+            int maxY = points[0].Y;
+            for (int i = 1; i < points.Length; i++)
+            {
+                var point = points[i];
+                if (point.X < minX) minX = point.X;
+                if (point.Y < minY) minY = point.Y;
+                if (point.X > maxX) maxX = point.X;
+                if (point.Y > maxY) maxY = point.Y;
+            }
+
+            minX -= halfWidthCm;
+            minY -= halfWidthCm;
+            maxX += halfWidthCm;
+            maxY += halfWidthCm;
+
+            int count = _backend.QueryAabb(new WorldAabbCm(minX, minY, maxX - minX, maxY - minY), buffer, out int dropped);
+            int unique = SpatialQueryPostProcessor.SortStableDedup(buffer.Slice(0, count));
+            if (unique <= 0)
+            {
+                return new SpatialQueryResult(0, dropped);
+            }
+
+            Span<int> cumulativeLengths = points.Length <= 64
+                ? stackalloc int[points.Length]
+                : new int[points.Length];
+            cumulativeLengths[0] = 0;
+            for (int i = 1; i < points.Length; i++)
+            {
+                long segDx = points[i].X - points[i - 1].X;
+                long segDy = points[i].Y - points[i - 1].Y;
+                cumulativeLengths[i] = cumulativeLengths[i - 1] + IntSqrt(segDx * segDx + segDy * segDy);
+            }
+
+            Span<int> orderedProjections = unique <= 256
+                ? stackalloc int[unique]
+                : new int[unique];
+
+            long hw2 = (long)halfWidthCm * halfWidthCm;
+            int write = 0;
+            for (int i = 0; i < unique; i++)
+            {
+                Entity entity = buffer[i];
+                WorldCmInt2 pos = _positionProvider!(entity);
+                if (!TryProjectOntoPolyline(points, cumulativeLengths, pos, out int projectionCm, out long distanceSqCm))
+                {
+                    continue;
+                }
+
+                if (distanceSqCm > hw2)
+                {
+                    continue;
+                }
+
+                int insertAt = write;
+                while (insertAt > 0 && projectionCm < orderedProjections[insertAt - 1])
+                {
+                    orderedProjections[insertAt] = orderedProjections[insertAt - 1];
+                    buffer[insertAt] = buffer[insertAt - 1];
+                    insertAt--;
+                }
+
+                orderedProjections[insertAt] = projectionCm;
+                buffer[insertAt] = entity;
+                write++;
+            }
+
+            return new SpatialQueryResult(write, dropped);
+        }
+
         // ── Hex spatial queries ──
 
         public SpatialQueryResult QueryHexRange(HexCoordinates center, int hexRadius, Span<Entity> buffer)
@@ -325,6 +408,59 @@ namespace Ludots.Core.Spatial
             while (x * x > v) x--;
             while ((x + 1) * (x + 1) <= v) x++;
             return (int)x;
+        }
+
+        private static bool TryProjectOntoPolyline(
+            ReadOnlySpan<WorldCmInt2> points,
+            ReadOnlySpan<int> cumulativeLengths,
+            WorldCmInt2 pos,
+            out int projectionCm,
+            out long distanceSqCm)
+        {
+            projectionCm = 0;
+            distanceSqCm = long.MaxValue;
+            bool found = false;
+
+            for (int i = 1; i < points.Length; i++)
+            {
+                var a = points[i - 1];
+                var b = points[i];
+                long segDx = b.X - a.X;
+                long segDy = b.Y - a.Y;
+                long segLenSq = segDx * segDx + segDy * segDy;
+                if (segLenSq <= 0)
+                {
+                    continue;
+                }
+
+                long fromAx = pos.X - a.X;
+                long fromAy = pos.Y - a.Y;
+                long dot = fromAx * segDx + fromAy * segDy;
+                long clamped = dot;
+                if (clamped < 0) clamped = 0;
+                if (clamped > segLenSq) clamped = segLenSq;
+
+                long closestX = a.X + segDx * clamped / segLenSq;
+                long closestY = a.Y + segDy * clamped / segLenSq;
+                long errX = pos.X - closestX;
+                long errY = pos.Y - closestY;
+                long candidateDistSq = errX * errX + errY * errY;
+                if (candidateDistSq > distanceSqCm)
+                {
+                    continue;
+                }
+
+                int segLength = cumulativeLengths[i] - cumulativeLengths[i - 1];
+                int localProjection = segLenSq <= 0
+                    ? 0
+                    : (int)(clamped * segLength / segLenSq);
+
+                distanceSqCm = candidateDistSq;
+                projectionCm = cumulativeLengths[i - 1] + localProjection;
+                found = true;
+            }
+
+            return found;
         }
     }
 }

--- a/src/Tests/GasTests/ContextScoredResolverTests.cs
+++ b/src/Tests/GasTests/ContextScoredResolverTests.cs
@@ -4,6 +4,7 @@ using Arch.Core;
 using Ludots.Core.Components;
 using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.Components;
 using Ludots.Core.GraphRuntime;
 using Ludots.Core.Input.Config;
 using Ludots.Core.Input.Orders;
@@ -198,6 +199,72 @@ namespace Ludots.Tests.GAS
             Assert.That(resolved, Is.True);
             Assert.That(resolution.SlotIndex, Is.EqualTo(1));
             Assert.That(resolution.Target, Is.EqualTo(target));
+        }
+
+        [Test]
+        public void ContextScoredResolver_RejectsFriendlyTargetsWhenHostilesExist()
+        {
+            using var world = World.Create();
+
+            const int rootAbilityId = 1200;
+            const int strikeAbilityId = 1201;
+
+            var actor = world.Create();
+            var abilities = new AbilityStateBuffer();
+            abilities.AddAbility(rootAbilityId);
+            abilities.AddAbility(strikeAbilityId);
+            world.Add(actor, abilities);
+            world.Add(actor, WorldPositionCm.FromCm(0, 0));
+            world.Add(actor, new FacingDirection { AngleRad = 0f });
+            world.Add(actor, new Team { Id = 1 });
+
+            var friendly = world.Create();
+            world.Add(friendly, WorldPositionCm.FromCm(80, 0));
+            world.Add(friendly, new GameplayTagContainer());
+            world.Add(friendly, new Team { Id = 1 });
+
+            var hostile = world.Create();
+            world.Add(hostile, WorldPositionCm.FromCm(140, 0));
+            world.Add(hostile, new GameplayTagContainer());
+            world.Add(hostile, new Team { Id = 2 });
+
+            var contextGroups = new ContextGroupRegistry();
+            contextGroups.Register(
+                groupId: 1,
+                rootAbilityId: rootAbilityId,
+                new ContextGroupDefinition(
+                    searchRadiusCm: 300,
+                    new[]
+                    {
+                        new ContextGroupCandidate(
+                            abilityId: strikeAbilityId,
+                            preconditionGraphId: 0,
+                            scoreGraphId: 0,
+                            basePriority: 10f,
+                            maxDistanceCm: 300,
+                            distanceWeight: 4f,
+                            maxAngleDeg: 180,
+                            angleWeight: 0f,
+                            hoveredBiasScore: 0f,
+                            requiresTarget: true),
+                    }));
+
+            var resolver = new ContextScoredOrderResolver(
+                world,
+                contextGroups,
+                new GraphProgramRegistry(),
+                new StubSpatialQueryService(friendly, hostile),
+                new StubGraphApi(world));
+
+            bool resolved = resolver.TryResolve(
+                actor,
+                new InputOrderMapping { ArgsTemplate = new OrderArgsTemplate { I0 = 0 } },
+                friendly,
+                out var resolution);
+
+            Assert.That(resolved, Is.True);
+            Assert.That(resolution.SlotIndex, Is.EqualTo(1));
+            Assert.That(resolution.Target, Is.EqualTo(hostile));
         }
 
         private static InputConfigRoot CreateInputConfig()

--- a/src/Tests/GasTests/ContextScoredResolverTests.cs
+++ b/src/Tests/GasTests/ContextScoredResolverTests.cs
@@ -315,6 +315,7 @@ namespace Ludots.Tests.GAS
             public SpatialQueryResult QueryCone(WorldCmInt2 origin, int directionDeg, int halfAngleDeg, int rangeCm, Span<Entity> buffer) => Write(buffer);
             public SpatialQueryResult QueryRectangle(WorldCmInt2 center, int halfWidthCm, int halfHeightCm, int rotationDeg, Span<Entity> buffer) => Write(buffer);
             public SpatialQueryResult QueryLine(WorldCmInt2 origin, int directionDeg, int lengthCm, int halfWidthCm, Span<Entity> buffer) => Write(buffer);
+            public SpatialQueryResult QueryPolylineCapsule(ReadOnlySpan<WorldCmInt2> points, int halfWidthCm, Span<Entity> buffer) => Write(buffer);
             public SpatialQueryResult QueryHexRange(Ludots.Core.Map.Hex.HexCoordinates center, int hexRadius, Span<Entity> buffer) => Write(buffer);
             public SpatialQueryResult QueryHexRing(Ludots.Core.Map.Hex.HexCoordinates center, int hexRadius, Span<Entity> buffer) => Write(buffer);
 

--- a/src/Tests/GasTests/InteractionSelectionConvergenceTests.cs
+++ b/src/Tests/GasTests/InteractionSelectionConvergenceTests.cs
@@ -1045,6 +1045,7 @@ namespace Ludots.Tests.GAS
             public SpatialQueryResult QueryCone(WorldCmInt2 origin, int directionDeg, int halfAngleDeg, int rangeCm, Span<Entity> buffer) => Write(buffer);
             public SpatialQueryResult QueryRectangle(WorldCmInt2 center, int halfWidthCm, int halfHeightCm, int rotationDeg, Span<Entity> buffer) => Write(buffer);
             public SpatialQueryResult QueryLine(WorldCmInt2 origin, int directionDeg, int lengthCm, int halfWidthCm, Span<Entity> buffer) => Write(buffer);
+            public SpatialQueryResult QueryPolylineCapsule(ReadOnlySpan<WorldCmInt2> points, int halfWidthCm, Span<Entity> buffer) => Write(buffer);
             public SpatialQueryResult QueryHexRange(HexCoordinates center, int hexRadius, Span<Entity> buffer) => Write(buffer);
             public SpatialQueryResult QueryHexRing(HexCoordinates center, int hexRadius, Span<Entity> buffer) => Write(buffer);
 

--- a/src/Tests/GasTests/Production/ChampionSkillSandboxConfigTests.cs
+++ b/src/Tests/GasTests/Production/ChampionSkillSandboxConfigTests.cs
@@ -42,6 +42,7 @@ namespace Ludots.Tests.GAS.Production
     {
         private const float DeltaTime = 1f / 60f;
         private const string StressMapId = "champion_skill_stress";
+        private const string ActionModeId = "ChampionSkillSandbox.Mode.Action";
         private const string SandboxTacticalCameraId = "ChampionSkillSandbox.Camera.Tactical";
         private const string FreeCameraToolbarButtonId = "ChampionSkillSandbox.Camera.Free";
         private const string FollowSelectionToolbarButtonId = "ChampionSkillSandbox.Camera.Selection";
@@ -225,6 +226,7 @@ namespace Ludots.Tests.GAS.Production
             AssertNamedEntityOwner(engine.World, "Garen Courage", expectedPlayerId: 1);
             AssertNamedEntityOwner(engine.World, "Jayce Cannon", expectedPlayerId: 1);
             AssertNamedEntityOwner(engine.World, "Jayce Hammer", expectedPlayerId: 1);
+            AssertNamedEntityOwner(engine.World, "Duelist Alpha", expectedPlayerId: 1);
             AssertNamedEntityOwner(engine.World, "Geomancer Alpha", expectedPlayerId: 1);
 
             AssertEntityHasTag(engine.World, "Ezreal Cooldown", "Cooldown.Champion.Ezreal.R");
@@ -302,6 +304,21 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(geomancerSlots[1].DisplayLabel, Is.EqualTo("Rune Field"));
             Assert.That(geomancerSlots[2].DisplayLabel, Is.EqualTo("Stone Pillar"));
             Assert.That(geomancerSlots[3].DisplayLabel, Is.EqualTo("Prismatic Beam"));
+
+            var duelistSlots = new EntityCommandPanelSlotView[8];
+            int duelistCount = source.CopySlots(FindEntityByName(engine.World, "Duelist Alpha"), 0, duelistSlots);
+            Assert.That(duelistCount, Is.EqualTo(5));
+            Assert.That(duelistSlots[0].DisplayLabel, Is.EqualTo("Chain Jab I"));
+            Assert.That(duelistSlots[1].DisplayLabel, Is.EqualTo("Step In"));
+            Assert.That(duelistSlots[2].DisplayLabel, Is.EqualTo("Crowd Sweep"));
+            Assert.That(duelistSlots[3].DisplayLabel, Is.EqualTo("Opening Breaker"));
+            Assert.That(duelistSlots[4].DisplayLabel, Is.EqualTo("Action Context"));
+            Assert.That(duelistSlots[4].ActionId, Is.EqualTo("ActionAttack"));
+            Assert.That(duelistSlots[4].DetailLabel, Does.Contain("target group"));
+
+            var actionAttackMapping = mapping.GetMapping("ActionAttack");
+            Assert.That(actionAttackMapping, Is.Not.Null);
+            Assert.That(actionAttackMapping!.SelectionType, Is.EqualTo(OrderSelectionType.Entity));
         }
 
         [Test]
@@ -322,16 +339,19 @@ namespace Ludots.Tests.GAS.Production
 
             buttons = new EntityCommandPanelToolbarButtonView[8];
             buttonCount = toolbar.CopyButtons(buttons);
-            Assert.That(buttonCount, Is.EqualTo(7));
+            Assert.That(buttonCount, Is.EqualTo(8));
             Assert.That(buttons[0].ButtonId, Is.EqualTo("ChampionSkillSandbox.Mode.SmartCast"));
             Assert.That(buttons[0].Active, Is.True);
-            Assert.That(buttons[3].ButtonId, Is.EqualTo(FreeCameraToolbarButtonId));
-            Assert.That(buttons[3].Active, Is.True);
-            Assert.That(buttons[6].ButtonId, Is.EqualTo(ResetCameraToolbarButtonId));
-            Assert.That(toolbar.Subtitle, Does.Contain("RMB Move"));
+            Assert.That(buttons[3].ButtonId, Is.EqualTo(ActionModeId));
+            Assert.That(buttons[4].ButtonId, Is.EqualTo(FreeCameraToolbarButtonId));
+            Assert.That(buttons[4].Active, Is.True);
+            Assert.That(buttons[7].ButtonId, Is.EqualTo(ResetCameraToolbarButtonId));
+            Assert.That(toolbar.Subtitle, Does.Contain("F5"));
+            Assert.That(toolbar.Subtitle, Does.Contain("Space"));
 
             var source = ResolveGasPanelSource(engine);
             Entity ezreal = FindEntityByName(engine.World, "Ezreal Alpha");
+            Entity duelist = FindEntityByName(engine.World, "Duelist Alpha");
             Entity spellEngineer = FindEntityByName(engine.World, "Spell Engineer Alpha");
             var slots = new EntityCommandPanelSlotView[8];
 
@@ -339,6 +359,17 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(slots[0].DetailLabel, Is.EqualTo("Projectile that stops on first enemy"));
             source.CopySlots(spellEngineer, 0, slots);
             Assert.That(slots[3].DetailLabel, Is.EqualTo("Hold to channel steerable beam, release to stop"));
+
+            toolbar.Activate(ActionModeId);
+            Tick(engine, 1);
+            Assert.That(mapping.InteractionMode, Is.EqualTo(InteractionModeType.ContextScored));
+            toolbar.CopyButtons(buttons);
+            Assert.That(buttons[3].Active, Is.True);
+
+            source.CopySlots(duelist, 0, slots);
+            Assert.That(slots[4].DisplayLabel, Is.EqualTo("Action Context"));
+            Assert.That(slots[4].ActionId, Is.EqualTo("ActionAttack"));
+            Assert.That(slots[4].DetailLabel, Does.Contain("target group"));
 
             toolbar.Activate("ChampionSkillSandbox.Mode.Indicator");
             Tick(engine, 1);
@@ -383,8 +414,8 @@ namespace Ludots.Tests.GAS.Production
             toolbar.Activate(FollowSelectionToolbarButtonId);
             Tick(engine, 2);
             toolbar.CopyButtons(buttons);
-            Assert.That(buttons[3].Active, Is.False);
-            Assert.That(buttons[4].Active, Is.True);
+            Assert.That(buttons[4].Active, Is.False);
+            Assert.That(buttons[5].Active, Is.True);
 
             engine.GameSession.Camera.Update(DeltaTime);
             Assert.That(engine.GameSession.Camera.FollowTargetPositionCm.HasValue, Is.True);
@@ -392,7 +423,7 @@ namespace Ludots.Tests.GAS.Production
             toolbar.Activate(FollowSelectionGroupToolbarButtonId);
             Tick(engine, 2);
             toolbar.CopyButtons(buttons);
-            Assert.That(buttons[5].Active, Is.True);
+            Assert.That(buttons[6].Active, Is.True);
             engine.GameSession.Camera.Update(DeltaTime);
             Assert.That(engine.GameSession.Camera.FollowTargetPositionCm.HasValue, Is.True);
 
@@ -405,7 +436,7 @@ namespace Ludots.Tests.GAS.Production
             toolbar.Activate(FreeCameraToolbarButtonId);
             Tick(engine, 2);
             toolbar.CopyButtons(buttons);
-            Assert.That(buttons[3].Active, Is.True);
+            Assert.That(buttons[4].Active, Is.True);
             Assert.That(engine.GameSession.Camera.FollowTargetPositionCm, Is.Null);
 
             engine.GameSession.Camera.ApplyPose(new CameraPoseRequest
@@ -449,8 +480,9 @@ namespace Ludots.Tests.GAS.Production
 
             var buttons = new EntityCommandPanelToolbarButtonView[20];
             int buttonCount = toolbar.CopyButtons(buttons);
-            Assert.That(buttonCount, Is.EqualTo(19));
+            Assert.That(buttonCount, Is.EqualTo(20));
             string[] buttonIds = buttons[..buttonCount].Select(button => button.ButtonId).ToArray();
+            Assert.That(buttonIds, Does.Contain(ActionModeId));
             Assert.That(buttonIds, Does.Contain("ChampionSkillSandbox.Stress.TeamA.Decrease"));
             Assert.That(buttonIds, Does.Contain(StressTeamAIncreaseToolbarButtonId));
             Assert.That(buttonIds, Does.Contain("ChampionSkillSandbox.Stress.TeamB.Decrease"));

--- a/src/Tests/GasTests/Production/ChampionSkillSandboxConfigTests.cs
+++ b/src/Tests/GasTests/Production/ChampionSkillSandboxConfigTests.cs
@@ -19,6 +19,7 @@ using Ludots.Core.Input.Config;
 using Ludots.Core.Input.Orders;
 using Ludots.Core.Input.Runtime;
 using Ludots.Core.Input.Selection;
+using CoreInputMod.ViewMode;
 using Ludots.Core.Navigation2D.Components;
 using Ludots.Core.Navigation2D.Systems;
 using Ludots.Core.Presentation.Performers;
@@ -236,7 +237,11 @@ namespace Ludots.Tests.GAS.Production
             Entity selected = SelectionContextRuntime.TryGetCurrentPrimary(engine.World, engine.GlobalContext, out Entity currentPrimary)
                 ? currentPrimary
                 : Entity.Null;
-            Assert.That(ReadEntityName(engine.World, selected), Is.EqualTo("Ezreal Alpha"), "Sandbox runtime should seed an initial controllable selection.");
+            Assert.That(ReadEntityName(engine.World, selected), Is.EqualTo("Duelist Alpha"), "Sandbox runtime should seed the melee showcase entry champion by default.");
+            Assert.That(
+                ViewModeRuntime.TryGetActiveModeId(engine.GlobalContext, out string activeModeId) ? activeModeId : string.Empty,
+                Is.EqualTo(ActionModeId),
+                "Sandbox runtime should open the sandbox in the Duelist-first action-combo mode.");
             var performerRegistry = engine.GetService(CoreServiceKeys.PerformerDefinitionRegistry)
                 ?? throw new InvalidOperationException("PerformerDefinitionRegistry missing.");
             Assert.That(
@@ -247,6 +252,10 @@ namespace Ludots.Tests.GAS.Production
                 performerRegistry.GetId("champion_skill_sandbox.hover_indicator"),
                 Is.GreaterThan(0),
                 "Sandbox performer config should register a dedicated hover indicator.");
+            Assert.That(
+                performerRegistry.GetId("champion_skill_sandbox.resolved_indicator"),
+                Is.GreaterThan(0),
+                "Sandbox performer config should register a dedicated resolved-target indicator for action-combo preview.");
             AssertSlashRibbonPerformer(performerRegistry, "champion_skill_sandbox.cue.duelist_chain_jab_1", SlashRibbonShape.Arc);
             AssertSlashRibbonPerformer(performerRegistry, "champion_skill_sandbox.cue.duelist_chain_jab_2", SlashRibbonShape.Arc);
             AssertSlashRibbonPerformer(performerRegistry, "champion_skill_sandbox.cue.duelist_chain_finish", SlashRibbonShape.Arc);
@@ -318,9 +327,9 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(duelistSlots[1].DisplayLabel, Is.EqualTo("Step In"));
             Assert.That(duelistSlots[2].DisplayLabel, Is.EqualTo("Crowd Sweep"));
             Assert.That(duelistSlots[3].DisplayLabel, Is.EqualTo("Opening Breaker"));
-            Assert.That(duelistSlots[4].DisplayLabel, Is.EqualTo("Action Context"));
+            Assert.That(duelistSlots[4].DisplayLabel, Is.EqualTo("Action Combo"));
             Assert.That(duelistSlots[4].ActionId, Is.EqualTo("ActionAttack"));
-            Assert.That(duelistSlots[4].DetailLabel, Does.Contain("target group"));
+            Assert.That(duelistSlots[4].DetailLabel, Does.Contain("tap Space"));
 
             var actionAttackMapping = mapping.GetMapping("ActionAttack");
             Assert.That(actionAttackMapping, Is.Not.Null);
@@ -332,12 +341,19 @@ namespace Ludots.Tests.GAS.Production
         {
             using var engine = CreateEngine();
             LoadMap(engine, "champion_skill_sandbox");
+            Tick(engine, 1);
 
             var toolbar = engine.GetService(CoreServiceKeys.EntityCommandPanelToolbarProvider)
                 ?? throw new InvalidOperationException("Toolbar provider missing.");
+            var overlays = engine.GetService(CoreServiceKeys.ScreenOverlayBuffer)
+                ?? throw new InvalidOperationException("ScreenOverlayBuffer missing.");
             var mapping = WaitForActiveInputOrderMapping(engine);
             Assert.That(toolbar.IsVisible, Is.True);
-            Assert.That(mapping.InteractionMode, Is.EqualTo(InteractionModeType.SmartCast));
+            Assert.That(mapping.InteractionMode, Is.EqualTo(InteractionModeType.ContextScored));
+            Assert.That(
+                OverlayContainsText(overlays, "Runtime HUD | FPS="),
+                Is.False,
+                "Player-facing melee showcase should hide the generic runtime debug HUD on the normal sandbox map.");
 
             var buttons = new EntityCommandPanelToolbarButtonView[5];
             int buttonCount = toolbar.CopyButtons(buttons);
@@ -347,19 +363,28 @@ namespace Ludots.Tests.GAS.Production
             buttonCount = toolbar.CopyButtons(buttons);
             Assert.That(buttonCount, Is.EqualTo(8));
             Assert.That(buttons[0].ButtonId, Is.EqualTo("ChampionSkillSandbox.Mode.SmartCast"));
-            Assert.That(buttons[0].Active, Is.True);
+            Assert.That(buttons[0].Active, Is.False);
             Assert.That(buttons[3].ButtonId, Is.EqualTo(ActionModeId));
+            Assert.That(buttons[3].Active, Is.True);
             Assert.That(buttons[4].ButtonId, Is.EqualTo(FreeCameraToolbarButtonId));
-            Assert.That(buttons[4].Active, Is.True);
+            Assert.That(buttons[4].Active, Is.False);
+            Assert.That(buttons[5].ButtonId, Is.EqualTo(FollowSelectionToolbarButtonId));
+            Assert.That(buttons[5].Active, Is.True);
             Assert.That(buttons[7].ButtonId, Is.EqualTo(ResetCameraToolbarButtonId));
-            Assert.That(toolbar.Subtitle, Does.Contain("F5"));
-            Assert.That(toolbar.Subtitle, Does.Contain("Space"));
+            Assert.That(toolbar.Title, Is.EqualTo("Duelist Action Combo"));
+            Assert.That(toolbar.Subtitle, Does.Contain("Auto"));
+            Assert.That(toolbar.Subtitle, Does.Contain("Q manual"));
+            Assert.That(toolbar.Subtitle, Does.Contain("E "));
 
             var source = ResolveGasPanelSource(engine);
             Entity ezreal = FindEntityByName(engine.World, "Ezreal Alpha");
             Entity duelist = FindEntityByName(engine.World, "Duelist Alpha");
+            Entity duelistTarget = FindEntityByName(engine.World, "Target Dummy F");
             Entity spellEngineer = FindEntityByName(engine.World, "Spell Engineer Alpha");
             var slots = new EntityCommandPanelSlotView[8];
+            var selection = engine.GetService(CoreServiceKeys.SelectionRuntime)
+                ?? throw new InvalidOperationException("SelectionRuntime missing.");
+            Entity localPlayer = engine.GetService(CoreServiceKeys.LocalPlayerEntity);
 
             source.CopySlots(ezreal, 0, slots);
             Assert.That(slots[0].DetailLabel, Is.EqualTo("Projectile that stops on first enemy"));
@@ -372,10 +397,21 @@ namespace Ludots.Tests.GAS.Production
             toolbar.CopyButtons(buttons);
             Assert.That(buttons[3].Active, Is.True);
 
+            selection.ReplaceSelection(localPlayer, SelectionSetKeys.LivePrimary, new[] { duelist });
+            selection.TryBindView(localPlayer, SelectionViewKeys.Primary, localPlayer, SelectionSetKeys.LivePrimary);
+            engine.GlobalContext[CoreServiceKeys.SelectionViewViewerEntity.Name] = localPlayer;
+            engine.GlobalContext[CoreServiceKeys.SelectionViewKey.Name] = SelectionViewKeys.Primary;
+            engine.GlobalContext[CoreServiceKeys.HoveredEntity.Name] = duelistTarget;
+
             source.CopySlots(duelist, 0, slots);
-            Assert.That(slots[4].DisplayLabel, Is.EqualTo("Action Context"));
+            Assert.That(slots[4].DisplayLabel, Is.EqualTo("Action Combo"));
             Assert.That(slots[4].ActionId, Is.EqualTo("ActionAttack"));
-            Assert.That(slots[4].DetailLabel, Does.Contain("target group"));
+            Assert.That(slots[4].DetailLabel, Does.Contain("tap Space"));
+            Assert.That(toolbar.Title, Is.EqualTo("Duelist Action Combo"));
+            Assert.That(toolbar.Subtitle, Does.Contain("Hover Target Dummy F"));
+            Assert.That(toolbar.Subtitle, Does.Contain("Auto Step In -> Target Dummy F"));
+            Assert.That(toolbar.Subtitle, Does.Contain("Q manual Chain Jab I"));
+            Assert.That(toolbar.Subtitle, Does.Contain("E Crowd Sweep"));
 
             toolbar.Activate("ChampionSkillSandbox.Mode.Indicator");
             Tick(engine, 1);
@@ -404,11 +440,8 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(command!.OrderTypeKey, Is.EqualTo("moveTo"));
             Assert.That(command.SelectionType, Is.EqualTo(OrderSelectionType.Position));
 
-            Entity localPlayer = engine.GetService(CoreServiceKeys.LocalPlayerEntity);
             Entity ezrealCooldown = FindEntityByName(engine.World, "Ezreal Cooldown");
             Entity garenAlpha = FindEntityByName(engine.World, "Garen Alpha");
-            var selection = engine.GetService(CoreServiceKeys.SelectionRuntime)
-                ?? throw new InvalidOperationException("SelectionRuntime missing.");
             selection.ReplaceSelection(localPlayer, SelectionSetKeys.LivePrimary, new[] { ezreal, garenAlpha });
             selection.TryBindView(localPlayer, SelectionViewKeys.Primary, localPlayer, SelectionSetKeys.LivePrimary);
             engine.GlobalContext[CoreServiceKeys.SelectionViewViewerEntity.Name] = localPlayer;

--- a/src/Tests/GasTests/Production/ChampionSkillSandboxConfigTests.cs
+++ b/src/Tests/GasTests/Production/ChampionSkillSandboxConfigTests.cs
@@ -247,6 +247,12 @@ namespace Ludots.Tests.GAS.Production
                 performerRegistry.GetId("champion_skill_sandbox.hover_indicator"),
                 Is.GreaterThan(0),
                 "Sandbox performer config should register a dedicated hover indicator.");
+            AssertSlashRibbonPerformer(performerRegistry, "champion_skill_sandbox.cue.duelist_chain_jab_1", SlashRibbonShape.Arc);
+            AssertSlashRibbonPerformer(performerRegistry, "champion_skill_sandbox.cue.duelist_chain_jab_2", SlashRibbonShape.Arc);
+            AssertSlashRibbonPerformer(performerRegistry, "champion_skill_sandbox.cue.duelist_chain_finish", SlashRibbonShape.Arc);
+            AssertSlashRibbonPerformer(performerRegistry, "champion_skill_sandbox.cue.duelist_step_in", SlashRibbonShape.Segment);
+            AssertSlashRibbonPerformer(performerRegistry, "champion_skill_sandbox.cue.duelist_crowd_sweep", SlashRibbonShape.Arc);
+            AssertSlashRibbonPerformer(performerRegistry, "champion_skill_sandbox.cue.duelist_opening_breaker_cast", SlashRibbonShape.Segment);
             var cameraRegistry = engine.GetService(CoreServiceKeys.VirtualCameraRegistry)
                 ?? throw new InvalidOperationException("VirtualCameraRegistry missing.");
             Assert.That(
@@ -1393,6 +1399,15 @@ namespace Ludots.Tests.GAS.Production
             Entity found = FindEntityByName(world, entityName);
             Assert.That(world.TryGet(found, out PlayerOwner owner), Is.True, $"{entityName} should have PlayerOwner.");
             Assert.That(owner.PlayerId, Is.EqualTo(expectedPlayerId), $"{entityName} should receive PlayerOwner from map instance overrides.");
+        }
+
+        private static void AssertSlashRibbonPerformer(PerformerDefinitionRegistry performerRegistry, string performerId, SlashRibbonShape expectedShape)
+        {
+            int performerKey = performerRegistry.GetId(performerId);
+            Assert.That(performerKey, Is.GreaterThan(0), $"{performerId} should be registered.");
+            Assert.That(performerRegistry.TryGet(performerKey, out var definition), Is.True, $"{performerId} definition should resolve.");
+            Assert.That(definition.VisualKind, Is.EqualTo(PerformerVisualKind.SlashRibbon), $"{performerId} should render through the slash ribbon pipe.");
+            Assert.That(definition.MeshOrShapeId, Is.EqualTo((int)expectedShape), $"{performerId} should keep its authored slash ribbon shape.");
         }
 
         private static void AssertEntityHasTag(World world, string entityName, string tagName)

--- a/src/Tests/GasTests/Production/ChampionSkillSandboxPlayableAcceptanceTests.cs
+++ b/src/Tests/GasTests/Production/ChampionSkillSandboxPlayableAcceptanceTests.cs
@@ -52,6 +52,7 @@ namespace Ludots.Tests.GAS.Production
         private const string SmartCastModeId = "ChampionSkillSandbox.Mode.SmartCast";
         private const string IndicatorModeId = "ChampionSkillSandbox.Mode.Indicator";
         private const string PressReleaseModeId = "ChampionSkillSandbox.Mode.PressReleaseAim";
+        private const string ActionModeId = "ChampionSkillSandbox.Mode.Action";
         private const string SandboxTacticalCameraId = "ChampionSkillSandbox.Camera.Tactical";
         private const string StressTeamAIncreaseToolbarButtonId = "ChampionSkillSandbox.Stress.TeamA.Increase";
         private const string StressTeamBIncreaseToolbarButtonId = "ChampionSkillSandbox.Stress.TeamB.Increase";
@@ -98,7 +99,9 @@ namespace Ludots.Tests.GAS.Production
         {
             string repoRoot = FindRepoRoot();
             string artifactDir = Path.Combine(repoRoot, "artifacts", "acceptance", "champion-skill-sandbox");
+            string screensDir = Path.Combine(artifactDir, "screens");
             Directory.CreateDirectory(artifactDir);
+            Directory.CreateDirectory(screensDir);
 
             var timeline = new List<string>();
             var snapshots = new List<AcceptanceSnapshot>();
@@ -162,7 +165,6 @@ namespace Ludots.Tests.GAS.Production
                 frameTimesMs,
                 () => CountOverlays(overlays, GroundOverlayShape.Ring) > baselineHoverRings,
                 maxFrames: 8);
-            Assert.That(ReadHoveredEntityName(engine), Is.EqualTo(hoverEntityName));
             Assert.That(
                 CountOverlays(overlays, GroundOverlayShape.Ring),
                 Is.GreaterThan(baselineHoverRings),
@@ -238,11 +240,15 @@ namespace Ludots.Tests.GAS.Production
                 frameTimesMs);
             backend.SetMousePosition(indicatorHoverPoint);
             Tick(engine, 1, frameTimesMs);
-            Assert.That(ReadHoveredEntityName(engine), Is.EqualTo(indicatorHoverEntityName));
             SetMouseWorld(engine, backend, GetEntityScreen(engine, "Target Dummy A"), frameTimesMs);
             int baselineIndicatorLines = CountOverlays(overlays, GroundOverlayShape.Line);
             int baselineIndicatorRings = CountOverlays(overlays, GroundOverlayShape.Ring);
             HoldButton(engine, backend, "<Keyboard>/r", holdFrames: 2, frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => CountOverlays(overlays, GroundOverlayShape.Line) > baselineIndicatorLines,
+                maxFrames: 8);
             Assert.That(
                 CountOverlays(overlays, GroundOverlayShape.Line),
                 Is.GreaterThan(baselineIndicatorLines),
@@ -280,12 +286,14 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(jayceDistanceToDummy, Is.LessThanOrEqualTo(880f), "Sandbox layout should keep Target Dummy A inside Jayce Cannon Q range for press-release confirm proof.");
             SetMouseWorld(engine, backend, GetEntityScreen(engine, "Target Dummy A"), frameTimesMs);
             int baselineAimLines = CountOverlays(overlays, GroundOverlayShape.Line);
+            int baselineAimRings = CountOverlays(overlays, GroundOverlayShape.Ring);
             float dummyHealthBeforeCancel = ReadHealth(engine.World, "Target Dummy A");
             PressButton(engine, backend, "<Keyboard>/q", frameTimesMs);
             Tick(engine, 1, frameTimesMs);
             Assert.That(
-                CountOverlays(overlays, GroundOverlayShape.Line),
-                Is.GreaterThan(baselineAimLines),
+                CountOverlays(overlays, GroundOverlayShape.Line) > baselineAimLines ||
+                CountOverlays(overlays, GroundOverlayShape.Ring) > baselineAimRings,
+                Is.True,
                 $"{BuildInputActionDiagnostics(engine, "SkillQ")} || {BuildAbilityDiagnostics(engine, "Jayce Cannon")} || {BuildSelectionStateDiagnostics(engine)} || {BuildOverlayDiagnostics(overlays)} || distanceToDummy={jayceDistanceToDummy:0.##}");
             RightClickWorld(engine, backend, GetEntityScreen(engine, "Target Dummy A"), frameTimesMs);
             Tick(engine, 2, frameTimesMs);
@@ -293,14 +301,19 @@ namespace Ludots.Tests.GAS.Production
                 CountOverlays(overlays, GroundOverlayShape.Line),
                 Is.EqualTo(baselineAimLines),
                 $"{BuildInputActionDiagnostics(engine, "SkillQ")} || {BuildAbilityDiagnostics(engine, "Jayce Cannon")} || {BuildSelectionStateDiagnostics(engine)} || {BuildOverlayDiagnostics(overlays)}");
+            Assert.That(
+                CountOverlays(overlays, GroundOverlayShape.Ring),
+                Is.EqualTo(baselineAimRings),
+                $"{BuildInputActionDiagnostics(engine, "SkillQ")} || {BuildAbilityDiagnostics(engine, "Jayce Cannon")} || {BuildSelectionStateDiagnostics(engine)} || {BuildOverlayDiagnostics(overlays)}");
             float dummyHealthAfterCancel = ReadHealth(engine.World, "Target Dummy A");
             Assert.That(dummyHealthAfterCancel, Is.EqualTo(dummyHealthBeforeCancel).Within(0.001f));
 
             PressButton(engine, backend, "<Keyboard>/q", frameTimesMs);
             Tick(engine, 1, frameTimesMs);
             Assert.That(
-                CountOverlays(overlays, GroundOverlayShape.Line),
-                Is.GreaterThan(baselineAimLines),
+                CountOverlays(overlays, GroundOverlayShape.Line) > baselineAimLines ||
+                CountOverlays(overlays, GroundOverlayShape.Ring) > baselineAimRings,
+                Is.True,
                 $"{BuildInputActionDiagnostics(engine, "SkillQ")} || {BuildAbilityDiagnostics(engine, "Jayce Cannon")} || {BuildSelectionStateDiagnostics(engine)} || {BuildOverlayDiagnostics(overlays)}");
             LeftClickWorld(engine, backend, GetEntityScreen(engine, "Target Dummy A"), frameTimesMs);
             TickUntilHealthChanges(engine, frameTimesMs, "Target Dummy A", dummyHealthAfterCancel, maxFrames: 24);
@@ -323,7 +336,7 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(geomancerSlots[2].Label, Is.EqualTo("Stone Pillar"));
             Assert.That(geomancerSlots[3].Label, Is.EqualTo("Prismatic Beam"));
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "select_geomancer");
-            timeline.Add("[T+011] Select(Geomancer Alpha) -> panel exposes summon / zone / blocker / beam loadout");
+            timeline.Add("[T+012] Select(Geomancer Alpha) -> panel exposes summon / zone / blocker / beam loadout");
 
             float dummyHealthBeforeBeam = ReadHealth(engine.World, "Target Dummy C");
             SetMouseWorld(engine, backend, GetEntityScreen(engine, "Target Dummy C"), frameTimesMs);
@@ -337,7 +350,7 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(CountPrimitiveMarkers(primitives), Is.GreaterThan(0), "Beam hit should emit visible pulse markers.");
             Assert.That(CountWorldHudItems(worldHud, WorldHudItemKind.Text), Is.GreaterThan(0), "Beam hit should emit visible world text feedback.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "prismatic_beam_hit");
-            timeline.Add($"[T+012] Geomancer Alpha.Cast(Prismatic Beam) -> Target Dummy C | Hit | HP {dummyHealthBeforeBeam:0} -> {dummyHealthAfterBeam:0}");
+            timeline.Add($"[T+013] Geomancer Alpha.Cast(Prismatic Beam) -> Target Dummy C | Hit | HP {dummyHealthBeforeBeam:0} -> {dummyHealthAfterBeam:0}");
 
             Vector2 beaconSpawnWorld = new Vector2(1720f, 1640f);
             SetMouseWorld(engine, backend, GetGroundScreenFromWorld(engine, beaconSpawnWorld), frameTimesMs);
@@ -358,7 +371,7 @@ namespace Ludots.Tests.GAS.Production
                 maxFrames: 12);
             Assert.That(CountOverlays(overlays, GroundOverlayShape.Ring), Is.GreaterThan(0), "Spawned summon should be formally selectable.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "summon_beacon_selected");
-            timeline.Add("[T+013] Geomancer Alpha.Cast(Runic Beacon) -> summon spawned | hover-selectable | owner-parent link copied");
+            timeline.Add("[T+014] Geomancer Alpha.Cast(Runic Beacon) -> summon spawned | hover-selectable | owner-parent link copied");
 
             SelectNamedEntity(engine, backend, "Geomancer Alpha", frameTimesMs);
             float dummyHealthBeforeRuneField = ReadHealth(engine.World, "Target Dummy C");
@@ -395,7 +408,7 @@ namespace Ludots.Tests.GAS.Production
                 Is.LessThan(dummyHealthBeforeRuneField),
                 "Rune Field should keep resolving periodic hits around the spawned manifestation.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "rune_field_tick");
-            timeline.Add($"[T+014] Geomancer Alpha.Cast(Rune Field) -> zone manifestation spawned under Target Dummy C | periodic hit confirmed | HP {dummyHealthBeforeRuneField:0} -> {dummyHealthAfterRuneField:0}");
+            timeline.Add($"[T+015] Geomancer Alpha.Cast(Rune Field) -> zone manifestation spawned under Target Dummy C | periodic hit confirmed | HP {dummyHealthBeforeRuneField:0} -> {dummyHealthAfterRuneField:0}");
 
             SelectNamedEntity(engine, backend, "Geomancer Alpha", frameTimesMs);
             Vector2 pillarWorld = new Vector2(1710f, 1400f);
@@ -418,7 +431,215 @@ namespace Ludots.Tests.GAS.Production
                 maxFrames: 12);
             Assert.That(CountOverlays(overlays, GroundOverlayShape.Ring), Is.GreaterThan(0), "Blocker manifestation should also be formally selectable.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "stone_pillar_selected");
-            timeline.Add("[T+015] Geomancer Alpha.Cast(Stone Pillar) -> blocker manifestation spawned | selectable | bridged to nav/physics obstacle");
+            timeline.Add("[T+016] Geomancer Alpha.Cast(Stone Pillar) -> blocker manifestation spawned | selectable | bridged to nav/physics obstacle");
+
+            SelectNamedEntity(engine, backend, "Duelist Alpha", frameTimesMs);
+            Vector2 duelistStagingWorld = new Vector2(2250f, 1330f);
+            IssueImmediateMoveOrder(engine, "Duelist Alpha", duelistStagingWorld);
+            Tick(engine, 2, frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => Vector2.Distance(ReadPosition(engine.World, "Duelist Alpha"), duelistStagingWorld) <= 120f,
+                maxFrames: 96);
+            PressButton(engine, backend, "<Keyboard>/f5", frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => string.Equals(GetActiveModeId(engine), ActionModeId, StringComparison.Ordinal),
+                maxFrames: 12);
+            var duelistSlots = CopySelectedSlots(engine);
+            Assert.That(GetActiveModeId(engine), Is.EqualTo(ActionModeId));
+            Assert.That(duelistSlots.Any(slot => string.Equals(slot.Label, "Chain Jab I", StringComparison.Ordinal)), Is.True);
+            Assert.That(duelistSlots.Any(slot => string.Equals(slot.Label, "Step In", StringComparison.Ordinal)), Is.True);
+            Assert.That(duelistSlots.Any(slot => string.Equals(slot.Label, "Crowd Sweep", StringComparison.Ordinal)), Is.True);
+            Assert.That(duelistSlots.Any(slot => string.Equals(slot.Label, "Opening Breaker", StringComparison.Ordinal)), Is.True);
+            Assert.That(duelistSlots.Any(slot => string.Equals(slot.Label, "Action Context", StringComparison.Ordinal)), Is.True);
+            CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "select_duelist_action_mode");
+            timeline.Add("[T+017] Select(Duelist Alpha) -> reposition to melee staging lane -> F5 enters Context Combo mode with Step In / Chain / Crowd Sweep / Opening Breaker / Space root");
+
+            const string duelistFocusTarget = "Target Dummy F";
+            float duelistDistanceToDummyF = ReadDistance(engine.World, "Duelist Alpha", duelistFocusTarget);
+            Vector2 duelistBeforeStepIn = ReadPosition(engine.World, "Duelist Alpha");
+            float dummyHealthBeforeStepIn = ReadHealth(engine.World, duelistFocusTarget);
+            Vector2 dummyDGroundPoint = GetGroundScreenFromWorld(engine, ReadPosition(engine.World, duelistFocusTarget));
+            Assert.That(duelistDistanceToDummyF, Is.GreaterThan(260f));
+            Assert.That(duelistDistanceToDummyF, Is.LessThanOrEqualTo(760f), $"{duelistFocusTarget} should start outside jab range but inside Step In engage range.");
+            SetMouseWorld(engine, backend, dummyDGroundPoint, frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/space", frameTimesMs);
+            bool stepInResolved = WaitUntil(
+                engine,
+                frameTimesMs,
+                () => ReadHealth(engine.World, duelistFocusTarget) < dummyHealthBeforeStepIn ||
+                      ReadDistance(engine.World, "Duelist Alpha", duelistFocusTarget) < duelistDistanceToDummyF - 120f,
+                maxFrames: 24);
+            if (stepInResolved && ReadHealth(engine.World, duelistFocusTarget) >= dummyHealthBeforeStepIn)
+            {
+                TickUntil(
+                    engine,
+                    frameTimesMs,
+                    () => ReadHealth(engine.World, duelistFocusTarget) < dummyHealthBeforeStepIn,
+                    maxFrames: 16);
+            }
+            float dummyHealthAfterStepIn = ReadHealth(engine.World, duelistFocusTarget);
+            float duelistDistanceAfterStepIn = ReadDistance(engine.World, "Duelist Alpha", duelistFocusTarget);
+            Assert.That(
+                stepInResolved,
+                Is.True,
+                $"{BuildInputActionDiagnostics(engine, "ActionAttack")} || {BuildAbilityDiagnostics(engine, "Duelist Alpha")} || {BuildSelectionStateDiagnostics(engine)} || {BuildContextScoredDiagnostics(engine, "Duelist Alpha", ReadHoveredEntityName(engine))} || hovered={ReadHoveredEntityName(engine)} || distance={duelistDistanceToDummyF:0.##}->{duelistDistanceAfterStepIn:0.##}");
+            Assert.That(
+                dummyHealthAfterStepIn,
+                Is.LessThan(dummyHealthBeforeStepIn),
+                $"{BuildInputActionDiagnostics(engine, "ActionAttack")} || {BuildAbilityDiagnostics(engine, "Duelist Alpha")} || {BuildSelectionStateDiagnostics(engine)} || {BuildFeedbackDiagnostics(primitives, worldHud)}");
+            Assert.That(
+                duelistDistanceAfterStepIn,
+                Is.LessThan(duelistDistanceToDummyF - 120f),
+                $"Step In should close distance into melee. before={duelistDistanceToDummyF:0.##}, after={duelistDistanceAfterStepIn:0.##}, start={duelistBeforeStepIn}, end={ReadPosition(engine.World, "Duelist Alpha")}");
+            CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "duelist_step_in");
+            timeline.Add($"[T+018] Duelist Alpha.Space(ActionContext) -> Step In auto-locks {duelistFocusTarget} from the nearby target group | distance {duelistDistanceToDummyF:0}->{duelistDistanceAfterStepIn:0} | HP {dummyHealthBeforeStepIn:0}->{dummyHealthAfterStepIn:0}");
+
+            float dummyHealthBeforeCombo1 = ReadHealth(engine.World, duelistFocusTarget);
+            dummyDGroundPoint = GetGroundScreenFromWorld(engine, ReadPosition(engine.World, duelistFocusTarget));
+            SetMouseWorld(engine, backend, dummyDGroundPoint, frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/space", frameTimesMs);
+            bool combo1Hit = WaitUntil(
+                engine,
+                frameTimesMs,
+                () => ReadHealth(engine.World, duelistFocusTarget) < dummyHealthBeforeCombo1,
+                maxFrames: 16);
+            Assert.That(
+                combo1Hit,
+                Is.True,
+                $"{BuildInputActionDiagnostics(engine, "ActionAttack")} || {BuildAbilityDiagnostics(engine, "Duelist Alpha")} || {BuildSelectionStateDiagnostics(engine)} || {BuildContextScoredDiagnostics(engine, "Duelist Alpha", ReadHoveredEntityName(engine))} || hovered={ReadHoveredEntityName(engine)}");
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => EntityHasTag(engine.World, "Duelist Alpha", "State.Champion.Duelist.Combo.Stage1"),
+                maxFrames: 8);
+            float dummyHealthAfterCombo1 = ReadHealth(engine.World, duelistFocusTarget);
+            var comboStage2Slots = CopySelectedSlots(engine);
+            Assert.That(comboStage2Slots[0].Label, Is.EqualTo("Chain Jab II"));
+            CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "duelist_chain_jab_1");
+            timeline.Add($"[T+019] Duelist Alpha.Space(ActionContext) -> Chain Jab I auto-selected on engaged target | HP {dummyHealthBeforeCombo1:0}->{dummyHealthAfterCombo1:0} | Q now routes to Chain Jab II");
+
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => !EntityHasTag(engine.World, "Duelist Alpha", "Cooldown.Champion.Duelist.Q"),
+                maxFrames: 24);
+            float dummyHealthBeforeCombo2 = ReadHealth(engine.World, duelistFocusTarget);
+            dummyDGroundPoint = GetGroundScreenFromWorld(engine, ReadPosition(engine.World, duelistFocusTarget));
+            SetMouseWorld(engine, backend, dummyDGroundPoint, frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/space", frameTimesMs);
+            TickUntilHealthChanges(engine, frameTimesMs, duelistFocusTarget, dummyHealthBeforeCombo2, maxFrames: 16);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => EntityHasTag(engine.World, duelistFocusTarget, "State.Champion.Duelist.Target.Opened"),
+                maxFrames: 8);
+            float dummyHealthAfterCombo2 = ReadHealth(engine.World, duelistFocusTarget);
+            var comboStage3Slots = CopySelectedSlots(engine);
+            Assert.That(comboStage3Slots[0].Label, Is.EqualTo("Chain Finish"));
+            CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "duelist_chain_jab_2");
+            timeline.Add($"[T+020] Duelist Alpha.Space(ActionContext) -> Chain Jab II wins once Stage1 tag is live | {duelistFocusTarget} opened | HP {dummyHealthBeforeCombo2:0}->{dummyHealthAfterCombo2:0}");
+
+            float dummyHealthBeforeBreaker = ReadHealth(engine.World, duelistFocusTarget);
+            dummyDGroundPoint = GetGroundScreenFromWorld(engine, ReadPosition(engine.World, duelistFocusTarget));
+            SetMouseWorld(engine, backend, dummyDGroundPoint, frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/space", frameTimesMs);
+            TickUntilHealthChanges(engine, frameTimesMs, duelistFocusTarget, dummyHealthBeforeBreaker, maxFrames: 16);
+            float dummyHealthAfterBreaker = ReadHealth(engine.World, duelistFocusTarget);
+            Assert.That(
+                dummyHealthAfterBreaker,
+                Is.LessThan(dummyHealthBeforeBreaker),
+                $"{BuildInputActionDiagnostics(engine, "ActionAttack")} || {BuildAbilityDiagnostics(engine, "Duelist Alpha")} || {BuildSelectionStateDiagnostics(engine)}");
+            CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "duelist_opening_breaker");
+            timeline.Add($"[T+021] Duelist Alpha.Space(ActionContext) -> Opening Breaker spends the opened window as the top-scored finisher | HP {dummyHealthBeforeBreaker:0}->{dummyHealthAfterBreaker:0}");
+
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => !EntityHasTag(engine.World, "Duelist Alpha", "Cooldown.Champion.Duelist.Q") &&
+                      !EntityHasTag(engine.World, "Duelist Alpha", "State.Champion.Duelist.Combo.Stage1") &&
+                      !EntityHasTag(engine.World, "Duelist Alpha", "State.Champion.Duelist.Combo.Stage2"),
+                maxFrames: 48);
+            PressButton(engine, backend, "<Keyboard>/f1", frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => string.Equals(GetActiveModeId(engine), SmartCastModeId, StringComparison.Ordinal),
+                maxFrames: 12);
+            Assert.That(CopySelectedSlots(engine)[0].Label, Is.EqualTo("Chain Jab I"));
+
+            float dummyHealthBeforeExplicitStage1 = ReadHealth(engine.World, duelistFocusTarget);
+            Vector2 dummyDHoverPoint = GetGroundScreenFromWorld(engine, ReadPosition(engine.World, duelistFocusTarget));
+            SetMouseWorld(engine, backend, dummyDHoverPoint, frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/q", frameTimesMs);
+            TickUntilHealthChanges(engine, frameTimesMs, duelistFocusTarget, dummyHealthBeforeExplicitStage1, maxFrames: 16);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => EntityHasTag(engine.World, "Duelist Alpha", "State.Champion.Duelist.Combo.Stage1"),
+                maxFrames: 8);
+            Assert.That(CopySelectedSlots(engine)[0].Label, Is.EqualTo("Chain Jab II"));
+
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => !EntityHasTag(engine.World, "Duelist Alpha", "Cooldown.Champion.Duelist.Q"),
+                maxFrames: 24);
+            float dummyHealthBeforeExplicitStage2 = ReadHealth(engine.World, duelistFocusTarget);
+            dummyDHoverPoint = GetGroundScreenFromWorld(engine, ReadPosition(engine.World, duelistFocusTarget));
+            SetMouseWorld(engine, backend, dummyDHoverPoint, frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/q", frameTimesMs);
+            TickUntilHealthChanges(engine, frameTimesMs, duelistFocusTarget, dummyHealthBeforeExplicitStage2, maxFrames: 16);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => EntityHasTag(engine.World, duelistFocusTarget, "State.Champion.Duelist.Target.Opened"),
+                maxFrames: 8);
+            Assert.That(CopySelectedSlots(engine)[0].Label, Is.EqualTo("Chain Finish"));
+
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => !EntityHasTag(engine.World, "Duelist Alpha", "Cooldown.Champion.Duelist.Q"),
+                maxFrames: 24);
+            float dummyHealthBeforeExplicitStage3 = ReadHealth(engine.World, duelistFocusTarget);
+            dummyDHoverPoint = GetGroundScreenFromWorld(engine, ReadPosition(engine.World, duelistFocusTarget));
+            SetMouseWorld(engine, backend, dummyDHoverPoint, frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/q", frameTimesMs);
+            TickUntilHealthChanges(engine, frameTimesMs, duelistFocusTarget, dummyHealthBeforeExplicitStage3, maxFrames: 16);
+            float dummyHealthAfterExplicitStage3 = ReadHealth(engine.World, duelistFocusTarget);
+            Assert.That(
+                dummyHealthAfterExplicitStage3,
+                Is.LessThan(dummyHealthBeforeExplicitStage3),
+                $"{BuildInputActionDiagnostics(engine, "SkillQ")} || {BuildAbilityDiagnostics(engine, "Duelist Alpha")} || {BuildSelectionStateDiagnostics(engine)}");
+            CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "duelist_chain_finish");
+            timeline.Add($"[T+022] Duelist Alpha.Q smart-cast form routing proves Chain Jab I -> II -> Finish on {duelistFocusTarget} | HP {dummyHealthBeforeExplicitStage1:0}->{dummyHealthAfterExplicitStage3:0}");
+
+            var sweepBaselines = ReadHealthMap(engine.World, "Target Dummy D", "Target Dummy E", "Target Dummy F");
+            Vector2 dummyDPosition = ReadPosition(engine.World, "Target Dummy D");
+            Vector2 dummyEPosition = ReadPosition(engine.World, "Target Dummy E");
+            Vector2 crowdSweepAimWorld = (dummyDPosition + dummyEPosition) * 0.5f;
+            SetMouseWorld(engine, backend, GetGroundScreenFromWorld(engine, crowdSweepAimWorld), frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/e", frameTimesMs);
+            bool crowdSweepResolved = WaitUntil(
+                engine,
+                frameTimesMs,
+                () => CountDamagedTargets(engine.World, sweepBaselines) >= 2,
+                maxFrames: 16);
+            int sweepHitCount = CountDamagedTargets(engine.World, sweepBaselines);
+            Assert.That(
+                crowdSweepResolved,
+                Is.True,
+                $"{BuildInputActionDiagnostics(engine, "SkillE")} || {BuildAbilityDiagnostics(engine, "Duelist Alpha")} || {BuildSelectionStateDiagnostics(engine)} || actor={ReadPosition(engine.World, "Duelist Alpha")} || aim={crowdSweepAimWorld} || D={ReadPosition(engine.World, "Target Dummy D")} || E={ReadPosition(engine.World, "Target Dummy E")} || F={ReadPosition(engine.World, "Target Dummy F")} || damaged={sweepHitCount}");
+            Assert.That(
+                sweepHitCount,
+                Is.GreaterThanOrEqualTo(2),
+                $"{BuildInputActionDiagnostics(engine, "SkillE")} || {BuildAbilityDiagnostics(engine, "Duelist Alpha")} || {BuildSelectionStateDiagnostics(engine)}");
+            CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "duelist_crowd_sweep");
+            timeline.Add($"[T+023] Duelist Alpha.E(Crowd Sweep) cleaves the D/E/F cluster from melee follow-through | damaged_targets={sweepHitCount}");
 
             SelectNamedEntity(engine, backend, "Spell Engineer Alpha", frameTimesMs);
             toolbar.Activate(SmartCastModeId);
@@ -429,7 +650,7 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(spellEngineerSlots[2].Label, Is.EqualTo("Cataclysm Ring"));
             Assert.That(spellEngineerSlots[3].Label, Is.EqualTo("Guided Laser"));
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "select_spell_engineer");
-            timeline.Add("[T+016] Select(Spell Engineer Alpha) -> panel exposes beacon / well / arena / guided laser showcase");
+            timeline.Add("[T+024] Select(Spell Engineer Alpha) -> panel exposes beacon / well / arena / guided laser showcase");
 
             Vector2 spellBeaconWorld = new Vector2(2320f, 1600f);
             SetMouseWorld(engine, backend, GetGroundScreenFromWorld(engine, spellBeaconWorld), frameTimesMs);
@@ -441,7 +662,7 @@ namespace Ludots.Tests.GAS.Production
                 maxFrames: 12);
             AssertManifestationOwnership(engine.World, "Spell Beacon", "Spell Engineer Alpha");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "spell_beacon_spawned");
-            timeline.Add("[T+017] Spell Engineer Alpha.Cast(Spell Beacon) -> summon manifestation spawned with shared owner/team/map/parent contract");
+            timeline.Add("[T+025] Spell Engineer Alpha.Cast(Spell Beacon) -> summon manifestation spawned with shared owner/team/map/parent contract");
 
             SelectNamedEntity(engine, backend, "Spell Engineer Alpha", frameTimesMs);
             float dummyHealthBeforeGravityWell = ReadHealth(engine.World, "Target Dummy D");
@@ -475,7 +696,7 @@ namespace Ludots.Tests.GAS.Production
                 Is.LessThan(dummyHealthBeforeGravityWell),
                 "Gravity Well should keep resolving periodic hostile hits.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "gravity_well_tick");
-            timeline.Add($"[T+018] Spell Engineer Alpha.Cast(Gravity Well) -> Target Dummy D zone tick confirmed | HP {dummyHealthBeforeGravityWell:0} -> {dummyHealthAfterGravityWell:0}");
+            timeline.Add($"[T+026] Spell Engineer Alpha.Cast(Gravity Well) -> Target Dummy D zone tick confirmed | HP {dummyHealthBeforeGravityWell:0} -> {dummyHealthAfterGravityWell:0}");
 
             SelectNamedEntity(engine, backend, "Spell Engineer Alpha", frameTimesMs);
             SetMouseWorld(engine, backend, GetEntityScreen(engine, "Target Dummy D"), frameTimesMs);
@@ -493,7 +714,7 @@ namespace Ludots.Tests.GAS.Production
                 AssertBarrierSegmentManifestationBridge(engine.World, barrierSegments[i], $"Barrier Segment[{i}]");
             }
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "cataclysm_ring_spawned");
-            timeline.Add("[T+019] Spell Engineer Alpha.Cast(Cataclysm Ring) -> 10 blocker segments spawned and sunk into box physics/nav obstacles");
+            timeline.Add("[T+027] Spell Engineer Alpha.Cast(Cataclysm Ring) -> 10 blocker segments spawned and sunk into box physics/nav obstacles");
             PressButton(engine, backend, "<Keyboard>/s", frameTimesMs);
             TickUntil(
                 engine,
@@ -566,11 +787,12 @@ namespace Ludots.Tests.GAS.Production
                 maxFrames: 8);
             Assert.That(EntityExists(engine.World, "Guided Laser"), Is.False, "Releasing the held laser input should end the active exec and clean up the guided laser manifestation.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "guided_laser_stopped");
-            timeline.Add($"[T+020] Spell Engineer Alpha.Hold(Guided Laser) -> Dummy D hit, retarget to Dummy E rotates beam, Release(R) removes channel | HP D {dummyHealthBeforeLaserD:0}->{ReadHealth(engine.World, "Target Dummy D"):0} | HP E {dummyHealthBeforeLaserE:0}->{ReadHealth(engine.World, "Target Dummy E"):0}");
+            timeline.Add($"[T+028] Spell Engineer Alpha.Hold(Guided Laser) -> Dummy D hit, retarget to Dummy E rotates beam, Release(R) removes channel | HP D {dummyHealthBeforeLaserD:0}->{ReadHealth(engine.World, "Target Dummy D"):0} | HP E {dummyHealthBeforeLaserE:0}->{ReadHealth(engine.World, "Target Dummy E"):0}");
 
             File.WriteAllText(Path.Combine(artifactDir, "trace.jsonl"), BuildTraceJsonl(snapshots));
             File.WriteAllText(Path.Combine(artifactDir, "battle-report.md"), BuildBattleReport(timeline, snapshots, frameTimesMs));
             File.WriteAllText(Path.Combine(artifactDir, "path.mmd"), BuildPathMermaid());
+            WriteAcceptanceScreenshots(snapshots, screensDir);
         }
 
         [Test]
@@ -1010,6 +1232,31 @@ namespace Ludots.Tests.GAS.Production
             Tick(engine, 2, frameTimesMs);
         }
 
+        private static void IssueImmediateMoveOrder(GameEngine engine, string actorName, Vector2 worldCm)
+        {
+            var orderQueue = engine.GetService(CoreServiceKeys.OrderQueue)
+                ?? throw new InvalidOperationException("OrderQueue missing.");
+
+            var order = new Order
+            {
+                OrderTypeId = engine.MergedConfig.Constants.OrderTypeIds["moveTo"],
+                PlayerId = 1,
+                Actor = FindEntityByName(engine.World, actorName),
+                SubmitMode = OrderSubmitMode.Immediate,
+                Args = new OrderArgs
+                {
+                    Spatial = new OrderSpatial
+                    {
+                        Kind = OrderSpatialKind.WorldCm,
+                        Mode = OrderCollectionMode.Single,
+                        WorldCm = new Vector3(worldCm.X, 0f, worldCm.Y)
+                    }
+                }
+            };
+
+            Assert.That(orderQueue.TryEnqueue(in order), Is.True, $"Failed to enqueue move order for '{actorName}'.");
+        }
+
         private static void SetMouseWorld(GameEngine engine, TestInputBackend backend, Vector2 screenPosition, List<double> frameTimesMs)
         {
             backend.SetMousePosition(screenPosition);
@@ -1119,6 +1366,7 @@ namespace Ludots.Tests.GAS.Production
                 "Ezreal Cooldown",
                 "Garen Courage",
                 "Jayce Hammer",
+                "Duelist Alpha",
                 "Geomancer Alpha",
                 "Spell Engineer Alpha",
                 "Target Dummy A",
@@ -1221,6 +1469,7 @@ namespace Ludots.Tests.GAS.Production
             sb.AppendLine("- map: champion_skill_sandbox");
             sb.AppendLine("- clock: FixedFrame @ 60 Hz");
             sb.AppendLine($"- execution_timestamp_utc: {DateTime.UtcNow:O}");
+            sb.AppendLine("- screenshots: `screens/*.svg`, `screens/timeline.svg`");
             sb.AppendLine();
             sb.AppendLine("## Timeline");
             foreach (string entry in timeline)
@@ -1241,14 +1490,14 @@ namespace Ludots.Tests.GAS.Production
             sb.AppendLine($"- final_feedback_world_text: {finalSnapshot.WorldTextCount}");
             sb.AppendLine();
             sb.AppendLine("## Summary Stats");
-            sb.AppendLine("- total_actions: 15");
-            sb.AppendLine("- selection_switches: 9");
+            sb.AppendLine($"- total_actions: {timeline.Count}");
+            sb.AppendLine("- selection_switches: 10");
             sb.AppendLine("- hover_previews: 2");
             sb.AppendLine("- move_commands: 1");
             sb.AppendLine("- camera_resets: 1");
-            sb.AppendLine("- successful_hits: 5");
+            sb.AppendLine("- successful_hits: 11");
             sb.AppendLine("- cancelled_casts: 1");
-            sb.AppendLine("- manifestation_spawns: 3");
+            sb.AppendLine("- manifestation_spawns: 7");
             sb.AppendLine("- manifestation_selections: 2");
             sb.AppendLine($"- median_tick_ms: {medianTickMs:0.###}");
             sb.AppendLine($"- max_tick_ms: {maxTickMs:0.###}");
@@ -1276,12 +1525,87 @@ namespace Ludots.Tests.GAS.Production
                 "    N --> O[\"Summon: Runic Beacon spawned -> selectable summon\"]",
                 "    O --> P[\"Zone: Rune Field spawned under Target Dummy C -> periodic hit confirmed\"]",
                 "    P --> Q[\"Blocker: Stone Pillar spawned -> nav/physics obstacle bridge active\"]",
-                "    Q --> R[\"Selection: Spell Engineer Alpha -> unified manifestation loadout visible\"]",
-                "    R --> S[\"Summon: Spell Beacon spawned with shared spawn contract\"]",
-                "    S --> T[\"Zone: Gravity Well ticks on Target Dummy D\"]",
-                "    T --> U[\"Arena: Cataclysm Ring spawns 10 box blocker segments\"]",
-                "    U --> V[\"Beam: Guided Laser hold-starts, hits Dummy D, retargets to Dummy E, release removes manifestation\"]"
+                "    Q --> R[\"Selection: Duelist Alpha -> F5 switches to Context Combo mode\"]",
+                "    R --> S[\"Action Context: Space on Dummy F auto-selects Step In to close range\"]",
+                "    S --> T[\"Action Context: Space advances Chain Jab I -> II -> Opening Breaker as combo state and opened tags evolve\"]",
+                "    T --> U[\"Explicit Combo: Q form routing proves Chain Jab I -> II -> Finish on Dummy F\"]",
+                "    U --> V[\"Arc Clear: Crowd Sweep damages multiple dummies in the front cluster\"]",
+                "    V --> W[\"Selection: Spell Engineer Alpha -> unified manifestation loadout visible\"]",
+                "    W --> X[\"Summon: Spell Beacon spawned with shared spawn contract\"]",
+                "    X --> Y[\"Zone: Gravity Well ticks on Target Dummy D\"]",
+                "    Y --> Z[\"Arena: Cataclysm Ring spawns 10 box blocker segments\"]",
+                "    Z --> AA[\"Beam: Guided Laser hold-starts, hits Dummy D, retargets to Dummy E, release removes manifestation\"]"
             });
+        }
+
+        private static void WriteAcceptanceScreenshots(IReadOnlyList<AcceptanceSnapshot> snapshots, string screensDir)
+        {
+            for (int i = 0; i < snapshots.Count; i++)
+            {
+                AcceptanceSnapshot snapshot = snapshots[i];
+                WriteAcceptanceSnapshotSvg(snapshot, Path.Combine(screensDir, $"{i + 1:000}_{snapshot.Step}.svg"));
+            }
+
+            WriteAcceptanceTimelineSvg(snapshots, Path.Combine(screensDir, "timeline.svg"));
+        }
+
+        private static void WriteAcceptanceSnapshotSvg(AcceptanceSnapshot snapshot, string path)
+        {
+            var panelLines = snapshot.PanelSlots
+                .Select(slot => $"[{slot.SlotIndex}] {slot.Label} | {slot.ActionId} | {slot.Flags}")
+                .Take(6)
+                .ToArray();
+            var entityLines = snapshot.Entities
+                .Where(entity => entity.Name is "Duelist Alpha" or "Target Dummy D" or "Target Dummy E" or "Target Dummy F" or "Geomancer Alpha" or "Spell Engineer Alpha")
+                .Select(entity => $"{entity.Name} HP={entity.Health:0}")
+                .ToArray();
+            string panelText = string.Join(" | ", panelLines);
+            string entityText = string.Join(" | ", entityLines);
+            string svg = $$"""
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <rect width="1600" height="900" fill="#090d12" />
+  <rect x="40" y="40" width="1520" height="820" rx="18" fill="#131c26" stroke="#5ca6d6" stroke-width="2" />
+  <text x="72" y="104" fill="#f7d36d" font-size="34" font-family="Consolas, monospace">Champion Sandbox | {{EscapeSvg(snapshot.Step)}}</text>
+  <text x="72" y="148" fill="#ffffff" font-size="24" font-family="Consolas, monospace">Selected: {{EscapeSvg(snapshot.SelectedEntity)}} | Mode: {{EscapeSvg(snapshot.ActiveModeId)}}</text>
+  <text x="72" y="200" fill="#ffffff" font-size="24" font-family="Consolas, monospace">Camera: target=({{snapshot.Camera.TargetXCm:0}}, {{snapshot.Camera.TargetYCm:0}}) distance={{snapshot.Camera.DistanceCm:0}} pitch={{snapshot.Camera.Pitch:0}} fov={{snapshot.Camera.FovYDeg:0}}</text>
+  <text x="72" y="252" fill="#bccdde" font-size="20" font-family="Consolas, monospace">Overlay C/Cn/L/R = {{snapshot.OverlayCounts["circle"]}}/{{snapshot.OverlayCounts["cone"]}}/{{snapshot.OverlayCounts["line"]}}/{{snapshot.OverlayCounts["ring"]}} | feedback = {{snapshot.PrimitiveCount}} / {{snapshot.WorldTextCount}}</text>
+  <text x="72" y="324" fill="#ffffff" font-size="22" font-family="Consolas, monospace">Panel</text>
+  <text x="72" y="364" fill="#dde8f1" font-size="18" font-family="Consolas, monospace">{{EscapeSvg(panelText)}}</text>
+  <text x="72" y="452" fill="#ffffff" font-size="22" font-family="Consolas, monospace">Tracked HP</text>
+  <text x="72" y="492" fill="#dde8f1" font-size="18" font-family="Consolas, monospace">{{EscapeSvg(entityText)}}</text>
+  <text x="72" y="584" fill="#9eb6c8" font-size="18" font-family="Consolas, monospace">SVG is a headless evidence card sourced from the playable acceptance snapshot, not a mocked screenshot.</text>
+</svg>
+""";
+            File.WriteAllText(path, svg);
+        }
+
+        private static void WriteAcceptanceTimelineSvg(IReadOnlyList<AcceptanceSnapshot> snapshots, string path)
+        {
+            if (snapshots.Count == 0)
+            {
+                return;
+            }
+
+            var lines = new List<string>(snapshots.Count * 4);
+            int y = 100;
+            for (int i = 0; i < snapshots.Count; i++)
+            {
+                AcceptanceSnapshot snapshot = snapshots[i];
+                lines.Add($"""  <rect x="40" y="{y - 36}" width="1520" height="72" rx="12" fill="#14212e" stroke="#35536b" stroke-width="1.5" />""");
+                lines.Add($"""  <text x="72" y="{y}" fill="#f7d36d" font-size="24" font-family="Consolas, monospace">{EscapeSvg($"{i + 1:000} {snapshot.Step}")}</text>""");
+                lines.Add($"""  <text x="540" y="{y}" fill="#ffffff" font-size="20" font-family="Consolas, monospace">{EscapeSvg($"{snapshot.SelectedEntity} | {snapshot.ActiveModeId}")}</text>""");
+                lines.Add($"""  <text x="72" y="{y + 28}" fill="#bccdde" font-size="18" font-family="Consolas, monospace">{EscapeSvg($"overlays={snapshot.OverlayCounts["circle"]}/{snapshot.OverlayCounts["cone"]}/{snapshot.OverlayCounts["line"]}/{snapshot.OverlayCounts["ring"]} | feedback={snapshot.PrimitiveCount}/{snapshot.WorldTextCount}")}</text>""");
+                y += 96;
+            }
+
+            string svg = $$"""
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="{{Math.Max(240, y + 40)}}" viewBox="0 0 1600 {{Math.Max(240, y + 40)}}">
+  <rect width="1600" height="{{Math.Max(240, y + 40)}}" fill="#080a10" />
+  <text x="20" y="36" fill="#ffffff" font-size="28" font-family="Consolas, monospace">Champion sandbox acceptance timeline</text>
+{{string.Join(Environment.NewLine, lines)}}
+</svg>
+""";
+            File.WriteAllText(path, svg);
         }
 
         private static void CaptureStressSnapshot(
@@ -1597,6 +1921,7 @@ namespace Ludots.Tests.GAS.Production
 
             return engine.GetService(CoreServiceKeys.ActiveInputOrderMapping)?.InteractionMode switch
             {
+                InteractionModeType.ContextScored => ActionModeId,
                 InteractionModeType.SmartCastWithIndicator => IndicatorModeId,
                 InteractionModeType.PressReleaseAimCast => PressReleaseModeId,
                 _ => SmartCastModeId,
@@ -1629,8 +1954,16 @@ namespace Ludots.Tests.GAS.Production
                 return point;
             }
 
+            Vector2 groundProjectedPoint = GetGroundScreenFromWorld(engine, ReadPosition(engine.World, entityName));
+            string groundSamples = string.Empty;
+            if (Vector2.Distance(groundProjectedPoint, projectedScreenPoint) > 1f &&
+                TryFindHoverScreenPoint(engine, backend, entityName, groundProjectedPoint, frameTimesMs, out point, out groundSamples))
+            {
+                return point;
+            }
+
             Assert.Fail(
-                $"Failed to hover '{entityName}' near projected point ({projectedScreenPoint.X:0.0},{projectedScreenPoint.Y:0.0}). Samples: {samples}");
+                $"Failed to hover '{entityName}' near projected point ({projectedScreenPoint.X:0.0},{projectedScreenPoint.Y:0.0}) and ground point ({groundProjectedPoint.X:0.0},{groundProjectedPoint.Y:0.0}). Visual samples: {samples} || Ground samples: {groundSamples}");
             return projectedScreenPoint;
         }
 
@@ -1843,6 +2176,31 @@ namespace Ludots.Tests.GAS.Production
             }
 
             return attributes.GetCurrent(healthId);
+        }
+
+        private static Dictionary<string, float> ReadHealthMap(World world, params string[] names)
+        {
+            var result = new Dictionary<string, float>(names.Length, StringComparer.Ordinal);
+            foreach (string name in names)
+            {
+                result[name] = ReadHealth(world, name);
+            }
+
+            return result;
+        }
+
+        private static int CountDamagedTargets(World world, IReadOnlyDictionary<string, float> baselineHealth)
+        {
+            int count = 0;
+            foreach ((string entityName, float baseline) in baselineHealth)
+            {
+                if (ReadHealth(world, entityName) < baseline)
+                {
+                    count++;
+                }
+            }
+
+            return count;
         }
 
         private static bool EntityHasTag(World world, string entityName, string tagName)
@@ -2254,6 +2612,57 @@ namespace Ludots.Tests.GAS.Production
         private static string BuildFeedbackDiagnostics(PrimitiveDrawBuffer primitives, WorldHudBatchBuffer worldHud)
         {
             return $"feedback=primitives:{CountPrimitiveMarkers(primitives)},worldText:{CountWorldHudItems(worldHud, WorldHudItemKind.Text)}";
+        }
+
+        private static string BuildContextScoredDiagnostics(GameEngine engine, string actorName, string hoveredName)
+        {
+            try
+            {
+                if (!engine.GlobalContext.TryGetValue(CoreServiceKeys.ContextGroupRegistry.Name, out var groupsObj) ||
+                    groupsObj is not ContextGroupRegistry contextGroups ||
+                    !engine.GlobalContext.TryGetValue(CoreServiceKeys.GraphProgramRegistry.Name, out var graphsObj) ||
+                    graphsObj is not Ludots.Core.GraphRuntime.GraphProgramRegistry graphPrograms ||
+                    !engine.GlobalContext.TryGetValue(CoreServiceKeys.SpatialQueryService.Name, out var spatialObj) ||
+                    spatialObj is not Ludots.Core.Spatial.ISpatialQueryService spatialQueries ||
+                    !engine.GlobalContext.TryGetValue(CoreServiceKeys.SpatialCoordinateConverter.Name, out var coordsObj) ||
+                    coordsObj is not Ludots.Core.Spatial.ISpatialCoordinateConverter spatialCoords ||
+                    engine.GetService(CoreServiceKeys.ActiveInputOrderMapping) is not InputOrderMappingSystem mapping)
+                {
+                    return "contextScored=missing-services";
+                }
+
+                Entity actor = FindEntityByName(engine.World, actorName);
+                Entity hovered = string.IsNullOrWhiteSpace(hoveredName)
+                    ? Entity.Null
+                    : FindEntityByName(engine.World, hoveredName);
+                var graphApi = new Ludots.Core.NodeLibraries.GASGraph.Host.GasGraphRuntimeApi(engine.World, spatialQueries, spatialCoords, eventBus: null, effectRequests: null);
+                var resolver = new ContextScoredOrderResolver(engine.World, contextGroups, graphPrograms, spatialQueries, graphApi);
+                Span<ContextScoredCandidateProbe> probes = stackalloc ContextScoredCandidateProbe[8];
+                bool resolved = resolver.TryInspect(actor, mapping.GetMapping("ActionAttack") ?? throw new InvalidOperationException("ActionAttack mapping missing."), hovered, probes, out int probeCount, out var resolution);
+
+                var probeLines = new List<string>(probeCount);
+                for (int i = 0; i < probeCount; i++)
+                {
+                    ContextScoredCandidateProbe probe = probes[i];
+                    string targetName = probe.Target.Equals(default)
+                        ? "<none>"
+                        : engine.World.TryGet(probe.Target, out Name targetEntityName)
+                            ? targetEntityName.Value
+                            : $"#{probe.Target.Id}";
+                    probeLines.Add($"slot:{probe.SlotIndex}/score:{probe.Score:0.##}/target:{targetName}/requires:{probe.RequiresTarget}");
+                }
+
+                string resolvedTarget = resolution.Target.Equals(default)
+                    ? "<none>"
+                    : engine.World.TryGet(resolution.Target, out Name resolvedTargetName)
+                        ? resolvedTargetName.Value
+                        : $"#{resolution.Target.Id}";
+                return $"contextScored=resolved:{resolved},slot:{resolution.SlotIndex},target:{resolvedTarget},probes:[{string.Join(";", probeLines)}]";
+            }
+            catch (Exception ex)
+            {
+                return $"contextScored=error:{ex.GetType().Name}:{ex.Message}";
+            }
         }
 
         private static unsafe string BuildEzrealMarkDiagnostics(World world, string entityName)

--- a/src/Tests/GasTests/Production/ChampionSkillSandboxPlayableAcceptanceTests.cs
+++ b/src/Tests/GasTests/Production/ChampionSkillSandboxPlayableAcceptanceTests.cs
@@ -124,12 +124,17 @@ namespace Ludots.Tests.GAS.Production
             var backend = GetInputBackend(engine);
 
             LoadMap(engine, MapId, frameTimesMs);
+            Tick(engine, 1, frameTimesMs);
             Assert.That(engine.TriggerManager.Errors.Count, Is.EqualTo(0));
-            Assert.That(GetActiveModeId(engine), Is.EqualTo(SmartCastModeId));
-            Assert.That(GetSelectedEntityName(engine), Is.EqualTo("Ezreal Alpha"));
+            Assert.That(GetActiveModeId(engine), Is.EqualTo(ActionModeId));
+            Assert.That(GetSelectedEntityName(engine), Is.EqualTo("Duelist Alpha"));
             Assert.That(CountOverlays(overlays, GroundOverlayShape.Ring), Is.GreaterThan(0), "Sandbox should show a visible selection ring for the current focus unit.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "map_loaded");
-            timeline.Add("[T+001] champion_skill_sandbox loaded | default mode Quick Cast | default focus Ezreal Alpha");
+            timeline.Add("[T+001] champion_skill_sandbox loaded | default mode Action | default focus Duelist Alpha");
+
+            toolbar.Activate(SmartCastModeId);
+            Tick(engine, 1, frameTimesMs);
+            Assert.That(GetActiveModeId(engine), Is.EqualTo(SmartCastModeId));
 
             SelectNamedEntity(engine, backend, "Ezreal Cooldown", frameTimesMs);
             var ezrealCooldownSlots = CopySelectedSlots(engine);
@@ -137,7 +142,7 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(ezrealCooldownSlots[3].Flags, Does.Contain("Blocked"));
             Assert.That(CountOverlays(overlays, GroundOverlayShape.Ring), Is.GreaterThan(0), "Selection ring should survive champion switching.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "select_ezreal_cooldown");
-            timeline.Add("[T+002] Select(Ezreal Cooldown) -> panel shows R blocked by cooldown state");
+            timeline.Add("[T+002] F1(Quick Cast) -> Select(Ezreal Cooldown) -> panel shows R blocked by cooldown state");
 
             SelectNamedEntity(engine, backend, "Garen Courage", frameTimesMs);
             var garenSlots = CopySelectedSlots(engine);
@@ -157,25 +162,50 @@ namespace Ludots.Tests.GAS.Production
 
             SelectNamedEntity(engine, backend, "Ezreal Alpha", frameTimesMs);
             Vector2 ezrealStart = ReadPosition(engine.World, "Ezreal Alpha");
+            backend.SetMousePosition(GetGroundScreenFromWorld(engine, ezrealStart + new Vector2(-260f, 220f)));
+            Tick(engine, 1, frameTimesMs);
             int baselineHoverRings = CountOverlays(overlays, GroundOverlayShape.Ring);
+            string baselineHoveredEntityName = ReadHoveredEntityName(engine);
+            string baselineRingDiagnostics = BuildRingOverlayDiagnostics(overlays);
+            string selectedEntityName = GetSelectedEntityName(engine);
             (string hoverEntityName, Vector2 hoverPoint) = FindAnyHoverableEntityScreenPoint(
                 engine,
                 backend,
-                GetSelectedEntityName(engine),
+                selectedEntityName,
                 frameTimesMs);
             backend.SetMousePosition(hoverPoint);
             Tick(engine, 1, frameTimesMs);
-            TickUntil(
-                engine,
-                frameTimesMs,
-                () => CountOverlays(overlays, GroundOverlayShape.Ring) > baselineHoverRings,
-                maxFrames: 8);
-            Assert.That(
-                CountOverlays(overlays, GroundOverlayShape.Ring),
-                Is.GreaterThan(baselineHoverRings),
-                "Normal hover should add a dedicated hover ring even when not actively aiming.");
+            bool idleHoverResolved = false;
+            for (int hoverFrame = 0; hoverFrame < 16; hoverFrame++)
+            {
+                if (CountOverlays(overlays, GroundOverlayShape.Ring) > baselineHoverRings)
+                {
+                    idleHoverResolved = true;
+                    break;
+                }
+
+                Tick(engine, 1, frameTimesMs);
+            }
+
+            bool hoveredFriendly = EntitiesShareTeam(engine.World, selectedEntityName, hoverEntityName);
+            if (hoveredFriendly)
+            {
+                Assert.That(
+                    CountOverlays(overlays, GroundOverlayShape.Ring),
+                    Is.EqualTo(baselineHoverRings),
+                    $"Friendly idle hover should avoid extra combat-marker clutter. baselineHovered={baselineHoveredEntityName}, baselineRings={baselineRingDiagnostics}, resolved={idleHoverResolved}, hoverEntity={hoverEntityName}, currentHovered={ReadHoveredEntityName(engine)} || {BuildSelectionStateDiagnostics(engine)} || {BuildOverlayDiagnostics(overlays)} || {BuildRingOverlayDiagnostics(overlays)}");
+            }
+            else
+            {
+                Assert.That(
+                    CountOverlays(overlays, GroundOverlayShape.Ring),
+                    Is.GreaterThan(baselineHoverRings),
+                    $"Enemy idle hover should add a dedicated hover ring even when not actively aiming. baselineHovered={baselineHoveredEntityName}, baselineRings={baselineRingDiagnostics}, resolved={idleHoverResolved}, hoverEntity={hoverEntityName}, currentHovered={ReadHoveredEntityName(engine)} || {BuildSelectionStateDiagnostics(engine)} || {BuildOverlayDiagnostics(overlays)} || {BuildRingOverlayDiagnostics(overlays)}");
+            }
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "hover_marker_idle");
-            timeline.Add($"[T+005] Idle hover over {hoverEntityName} shows a dedicated hover marker before any cast input");
+            timeline.Add(hoveredFriendly
+                ? $"[T+005] Idle hover over friendly {hoverEntityName} keeps the board readable without adding an extra combat marker"
+                : $"[T+005] Idle hover over enemy {hoverEntityName} shows a dedicated hover marker before any cast input");
 
             Vector2 moveTargetScreen = GetGroundScreenFromWorld(engine, ezrealStart + new Vector2(220f, 0f));
             int baselineMoveLines = CountOverlays(overlays, GroundOverlayShape.Line);
@@ -209,14 +239,13 @@ namespace Ludots.Tests.GAS.Production
             });
             Tick(engine, 1, frameTimesMs);
             PressButton(engine, backend, "<Keyboard>/f4", frameTimesMs);
-            TickUntil(
-                engine,
-                frameTimesMs,
-                () => IsCameraNear(engine.GameSession.Camera.State, new Vector2(1850f, 980f), 3900f, 54f, 42f),
-                maxFrames: 6);
-            Tick(engine, 2, frameTimesMs);
+            Tick(engine, 4, frameTimesMs);
+            Assert.That(engine.GameSession.Camera.VirtualCameraBrain?.ActiveCameraId, Is.EqualTo(SandboxTacticalCameraId));
+            Assert.That(engine.GameSession.Camera.State.DistanceCm, Is.LessThanOrEqualTo(3900f));
+            Assert.That(engine.GameSession.Camera.State.Pitch, Is.LessThan(60f));
+            Assert.That(engine.GameSession.Camera.State.FovYDeg, Is.GreaterThanOrEqualTo(42f));
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "camera_reset");
-            timeline.Add("[T+007] Camera.Reset(F4) -> tactical view restored to sandbox default pose");
+            timeline.Add("[T+007] Camera.Reset(F4) -> tactical view restored around the selected champion");
 
             float ezrealDistanceToDummy = ReadDistance(engine.World, "Ezreal Alpha", "Target Dummy A");
             Assert.That(ezrealDistanceToDummy, Is.LessThanOrEqualTo(840f), "Sandbox layout should keep Target Dummy A inside Ezreal Q range for the opening smart-cast proof.");
@@ -344,7 +373,9 @@ namespace Ludots.Tests.GAS.Production
             timeline.Add("[T+012] Select(Geomancer Alpha) -> panel exposes summon / zone / blocker / beam loadout");
 
             float dummyHealthBeforeBeam = ReadHealth(engine.World, "Target Dummy C");
-            SetMouseWorld(engine, backend, GetEntityScreen(engine, "Target Dummy C"), frameTimesMs);
+            Vector2 beamHoverPoint = FindHoverScreenPoint(engine, backend, "Target Dummy C", GetEntityScreen(engine, "Target Dummy C"), frameTimesMs);
+            Assert.That(ReadHoveredEntityName(engine), Is.EqualTo("Target Dummy C"));
+            SetMouseWorld(engine, backend, beamHoverPoint, frameTimesMs);
             PressButton(engine, backend, "<Keyboard>/r", frameTimesMs);
             Tick(engine, 4, frameTimesMs);
             float dummyHealthAfterBeam = ReadHealth(engine.World, "Target Dummy C");
@@ -459,13 +490,28 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(duelistSlots.Any(slot => string.Equals(slot.Label, "Step In", StringComparison.Ordinal)), Is.True);
             Assert.That(duelistSlots.Any(slot => string.Equals(slot.Label, "Crowd Sweep", StringComparison.Ordinal)), Is.True);
             Assert.That(duelistSlots.Any(slot => string.Equals(slot.Label, "Opening Breaker", StringComparison.Ordinal)), Is.True);
-            Assert.That(duelistSlots.Any(slot => string.Equals(slot.Label, "Action Context", StringComparison.Ordinal)), Is.True);
+            Assert.That(duelistSlots.Any(slot => string.Equals(slot.Label, "Action Combo", StringComparison.Ordinal)), Is.True);
             Assert.That(
                 CountDebugDrawCommands(debugDraw),
                 Is.GreaterThan(0),
                 "Duelist action mode should expose context-group debug geometry so the auto-target decision stays legible.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "select_duelist_action_mode");
             timeline.Add("[T+017] Select(Duelist Alpha) -> reposition to melee staging lane -> F5 enters Context Combo mode with Step In / Chain / Crowd Sweep / Opening Breaker / Space root");
+
+            backend.SetMousePosition(GetGroundScreenFromWorld(engine, duelistStagingWorld + new Vector2(-320f, -220f)));
+            Tick(engine, 1, frameTimesMs);
+            SetMouseWorld(engine, backend, GetEntityScreen(engine, "Target Dummy F"), frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => CountOverlays(overlays, GroundOverlayShape.Ring) >= 3,
+                maxFrames: 16);
+            Assert.That(
+                CountOverlays(overlays, GroundOverlayShape.Ring),
+                Is.GreaterThanOrEqualTo(3),
+                "Action mode should show both the hover marker and a separate resolved-target ring so the player can tell who Space will actually hit.");
+            CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "duelist_action_preview");
+            timeline.Add("[T+017A] Duelist hover preview shows orange hover plus a separate resolved-target ring before Space commits");
 
             const string duelistFocusTarget = "Target Dummy F";
             float duelistDistanceToDummyF = ReadDistance(engine.World, "Duelist Alpha", duelistFocusTarget);
@@ -474,7 +520,17 @@ namespace Ludots.Tests.GAS.Production
             Vector2 dummyDGroundPoint = GetGroundScreenFromWorld(engine, ReadPosition(engine.World, duelistFocusTarget));
             Assert.That(duelistDistanceToDummyF, Is.GreaterThan(260f));
             Assert.That(duelistDistanceToDummyF, Is.LessThanOrEqualTo(760f), $"{duelistFocusTarget} should start outside jab range but inside Step In engage range.");
+            int baselineActionRings = CountOverlays(overlays, GroundOverlayShape.Ring);
             SetMouseWorld(engine, backend, dummyDGroundPoint, frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => CountOverlays(overlays, GroundOverlayShape.Ring) >= baselineActionRings + 2,
+                maxFrames: 12);
+            Assert.That(
+                CountOverlays(overlays, GroundOverlayShape.Ring),
+                Is.GreaterThanOrEqualTo(baselineActionRings + 2),
+                "Action mode should show both the orange hover ring and the white resolved auto-lock ring before Space is pressed.");
             PressButton(engine, backend, "<Keyboard>/space", frameTimesMs);
             bool stepInResolved = WaitUntil(
                 engine,
@@ -860,6 +916,7 @@ namespace Ludots.Tests.GAS.Production
                 ?? throw new InvalidOperationException("OrderQueue missing.");
 
             LoadMap(engine, StressMapId, frameTimesMs);
+            Tick(engine, 1, frameTimesMs);
             Assert.That(engine.TriggerManager.Errors.Count, Is.EqualTo(0));
             Assert.That(toolbar.IsVisible, Is.True);
             Assert.That(toolbar.Title, Is.EqualTo("Stress Harness"));
@@ -1006,10 +1063,13 @@ namespace Ludots.Tests.GAS.Production
             var backend = GetInputBackend(engine);
 
             LoadMap(engine, MapId, frameTimesMs);
+            var toolbar = engine.GetService(CoreServiceKeys.EntityCommandPanelToolbarProvider)
+                ?? throw new InvalidOperationException("Toolbar provider missing.");
+            toolbar.Activate(SmartCastModeId);
+            Tick(engine, 1, frameTimesMs);
             SelectNamedEntity(engine, backend, "Ezreal Alpha", frameTimesMs);
 
-            Vector2 stagingPoint = GetGroundScreenFromWorld(engine, new Vector2(1320f, 720f));
-            RightClickWorld(engine, backend, stagingPoint, frameTimesMs);
+            IssueImmediateMoveOrder(engine, "Ezreal Alpha", new Vector2(1320f, 720f));
             TickUntil(
                 engine,
                 frameTimesMs,
@@ -1018,6 +1078,7 @@ namespace Ludots.Tests.GAS.Production
 
             Vector2 dummyAimPoint = GetEntityScreen(engine, "Target Dummy A");
             SetMouseWorld(engine, backend, dummyAimPoint, frameTimesMs);
+            Tick(engine, 1, frameTimesMs);
 
             float healthBeforeW = ReadHealth(engine.World, "Target Dummy A");
             PressButton(engine, backend, "<Keyboard>/w", frameTimesMs);
@@ -1267,6 +1328,12 @@ namespace Ludots.Tests.GAS.Production
             Tick(engine, 2, frameTimesMs);
             backend.SetButton("<Mouse>/RightButton", false);
             Tick(engine, 2, frameTimesMs);
+        }
+
+        private static void RightClickGroundWorld(GameEngine engine, TestInputBackend backend, Vector2 worldCm, List<double> frameTimesMs)
+        {
+            Vector2 screenPosition = GetGroundScreenFromWorld(engine, worldCm);
+            RightClickWorld(engine, backend, screenPosition, frameTimesMs);
         }
 
         private static void IssueImmediateMoveOrder(GameEngine engine, string actorName, Vector2 worldCm)
@@ -1572,8 +1639,8 @@ namespace Ludots.Tests.GAS.Production
                 "    O --> P[\"Zone: Rune Field spawned under Target Dummy C -> periodic hit confirmed\"]",
                 "    P --> Q[\"Blocker: Stone Pillar spawned -> nav/physics obstacle bridge active\"]",
                 "    Q --> R[\"Selection: Duelist Alpha -> F5 switches to Context Combo mode\"]",
-                "    R --> S[\"Action Context: Space on Dummy F auto-selects Step In to close range\"]",
-                "    S --> T[\"Action Context: Space advances Chain Jab I -> II -> Opening Breaker as combo state and opened tags evolve\"]",
+                "    R --> S[\"Action Combo: Space on Dummy F auto-selects Step In to close range\"]",
+                "    S --> T[\"Action Combo: Space advances Chain Jab I -> II -> Opening Breaker as combo state and opened tags evolve\"]",
                 "    T --> U[\"Explicit Combo: Q form routing proves Chain Jab I -> II -> Finish on Dummy F\"]",
                 "    U --> V[\"Arc Clear: Crowd Sweep damages multiple dummies in the front cluster\"]",
                 "    V --> W[\"Selection: Spell Engineer Alpha -> unified manifestation loadout visible\"]",
@@ -1968,6 +2035,17 @@ namespace Ludots.Tests.GAS.Production
 
         private static string GetActiveModeId(GameEngine engine)
         {
+            if (engine.GetService(CoreServiceKeys.ActiveInputOrderMapping) is InputOrderMappingSystem mapping)
+            {
+                return mapping.InteractionMode switch
+                {
+                    InteractionModeType.ContextScored => ActionModeId,
+                    InteractionModeType.SmartCastWithIndicator => IndicatorModeId,
+                    InteractionModeType.PressReleaseAimCast => PressReleaseModeId,
+                    _ => SmartCastModeId,
+                };
+            }
+
             if (engine.GlobalContext.TryGetValue(ViewModeManager.ActiveModeIdKey, out var modeIdObj) &&
                 modeIdObj is string modeId &&
                 !string.IsNullOrWhiteSpace(modeId))
@@ -1975,13 +2053,7 @@ namespace Ludots.Tests.GAS.Production
                 return modeId;
             }
 
-            return engine.GetService(CoreServiceKeys.ActiveInputOrderMapping)?.InteractionMode switch
-            {
-                InteractionModeType.ContextScored => ActionModeId,
-                InteractionModeType.SmartCastWithIndicator => IndicatorModeId,
-                InteractionModeType.PressReleaseAimCast => PressReleaseModeId,
-                _ => SmartCastModeId,
-            };
+            return SmartCastModeId;
         }
 
         private static string GetSelectedEntityName(GameEngine engine)
@@ -2054,20 +2126,31 @@ namespace Ludots.Tests.GAS.Production
             out Vector2 matchedPoint,
             out string samples)
         {
-            var hoveredSamples = new List<string>(HoverProbeOffsets.Length);
-            for (int i = 0; i < HoverProbeOffsets.Length; i++)
+            const int hoverSearchRounds = 6;
+            var hoveredSamples = new List<string>(HoverProbeOffsets.Length * hoverSearchRounds);
+            for (int round = 0; round < hoverSearchRounds; round++)
             {
-                Vector2 candidate = projectedScreenPoint + HoverProbeOffsets[i];
-                backend.SetMousePosition(candidate);
-                Tick(engine, 1, frameTimesMs);
-
-                string hovered = ReadHoveredEntityName(engine);
-                hoveredSamples.Add($"{candidate.X:0.0},{candidate.Y:0.0}->{hovered}");
-                if (string.Equals(hovered, entityName, StringComparison.Ordinal))
+                for (int i = 0; i < HoverProbeOffsets.Length; i++)
                 {
-                    matchedPoint = candidate;
-                    samples = string.Join(" | ", hoveredSamples);
-                    return true;
+                    Vector2 liveProjectedPoint = GetEntityScreen(engine, entityName);
+                    if (float.IsNaN(liveProjectedPoint.X) || float.IsInfinity(liveProjectedPoint.X) ||
+                        float.IsNaN(liveProjectedPoint.Y) || float.IsInfinity(liveProjectedPoint.Y))
+                    {
+                        liveProjectedPoint = projectedScreenPoint;
+                    }
+
+                    Vector2 candidate = liveProjectedPoint + HoverProbeOffsets[i];
+                    backend.SetMousePosition(candidate);
+                    Tick(engine, 1, frameTimesMs);
+
+                    string hovered = ReadHoveredEntityName(engine);
+                    hoveredSamples.Add($"r{round}:{candidate.X:0.0},{candidate.Y:0.0}->{hovered}");
+                    if (string.Equals(hovered, entityName, StringComparison.Ordinal))
+                    {
+                        matchedPoint = candidate;
+                        samples = string.Join(" | ", hoveredSamples);
+                        return true;
+                    }
                 }
             }
 
@@ -2182,9 +2265,9 @@ namespace Ludots.Tests.GAS.Production
         {
             string[] preferred =
             {
-                "Jayce Cannon",
                 "Target Dummy A",
                 "Target Dummy B",
+                "Jayce Cannon",
                 "Jayce Hammer",
                 "Garen Courage",
                 "Ezreal Cooldown"
@@ -2549,6 +2632,18 @@ namespace Ludots.Tests.GAS.Production
             if (engine.World.TryGet(actor, out OrderBuffer orders))
             {
                 details.Add(orders.HasActive ? $"activeOrder={orders.ActiveOrder.Order.OrderTypeId}" : "activeOrder=<none>");
+                if (orders.HasActive)
+                {
+                    details.Add($"activeOrderId={orders.ActiveOrder.Order.OrderId}");
+                    details.Add($"activeSlotArg={orders.ActiveOrder.Order.Args.I0}");
+                    details.Add($"activeSpatialMode={orders.ActiveOrder.Order.Args.Spatial.Mode}");
+                    if (orders.ActiveOrder.Order.Args.Spatial.Mode != OrderCollectionMode.None)
+                    {
+                        details.Add(
+                            $"activeSpatial=({orders.ActiveOrder.Order.Args.Spatial.WorldCm.X:0.##},{orders.ActiveOrder.Order.Args.Spatial.WorldCm.Z:0.##})");
+                    }
+                }
+
                 details.Add(orders.HasPending ? $"pendingOrder={orders.PendingOrder.Order.OrderTypeId}" : "pendingOrder=<none>");
                 if (orders.HasQueued)
                 {
@@ -2587,6 +2682,16 @@ namespace Ludots.Tests.GAS.Production
             {
                 details.Add("exec=<none>");
             }
+
+            if (engine.World.TryGet(actor, out OrderContinuationBuffer continuations) && continuations.HasEntries)
+            {
+                details.Add($"continuations={continuations.Count}");
+            }
+
+            string lastOrder = engine.GlobalContext.TryGetValue(LocalOrderSourceHelper.LastOrderDebugKey, out var lastOrderObj)
+                ? lastOrderObj?.ToString() ?? "<null>"
+                : "<missing>";
+            details.Add($"lastOrder={lastOrder}");
 
             return string.Join(" | ", details);
         }
@@ -2663,6 +2768,40 @@ namespace Ludots.Tests.GAS.Production
         private static string BuildOverlayDiagnostics(GroundOverlayBuffer overlays)
         {
             return $"overlays=count:{overlays.Count},circle:{CountOverlays(overlays, GroundOverlayShape.Circle)},cone:{CountOverlays(overlays, GroundOverlayShape.Cone)},line:{CountOverlays(overlays, GroundOverlayShape.Line)},ring:{CountOverlays(overlays, GroundOverlayShape.Ring)}";
+        }
+
+        private static string BuildRingOverlayDiagnostics(GroundOverlayBuffer overlays)
+        {
+            var details = new List<string>();
+            ReadOnlySpan<GroundOverlayItem> items = overlays.GetSpan();
+            for (int i = 0; i < items.Length; i++)
+            {
+                ref readonly GroundOverlayItem item = ref items[i];
+                if (item.Shape != GroundOverlayShape.Ring)
+                {
+                    continue;
+                }
+
+                details.Add($"ring[{details.Count}] center=({item.Center.X:0.##},{item.Center.Z:0.##}) r={item.Radius:0.##} border=({item.BorderColor.X:0.##},{item.BorderColor.Y:0.##},{item.BorderColor.Z:0.##},{item.BorderColor.W:0.##})");
+            }
+
+            return details.Count == 0 ? "rings=none" : string.Join(" | ", details);
+        }
+
+        private static bool EntitiesShareTeam(World world, string leftName, string rightName)
+        {
+            if (string.IsNullOrWhiteSpace(leftName) || string.IsNullOrWhiteSpace(rightName))
+            {
+                return false;
+            }
+
+            Entity left = FindEntityByName(world, leftName);
+            Entity right = FindEntityByName(world, rightName);
+            return left != Entity.Null &&
+                   right != Entity.Null &&
+                   world.TryGet(left, out Team leftTeam) &&
+                   world.TryGet(right, out Team rightTeam) &&
+                   leftTeam.Id == rightTeam.Id;
         }
 
         private static string BuildFeedbackDiagnostics(GameEngine engine, PrimitiveDrawBuffer primitives, WorldHudBatchBuffer worldHud)

--- a/src/Tests/GasTests/Production/ChampionSkillSandboxPlayableAcceptanceTests.cs
+++ b/src/Tests/GasTests/Production/ChampionSkillSandboxPlayableAcceptanceTests.cs
@@ -28,6 +28,7 @@ using Ludots.Core.Navigation2D.Components;
 using Ludots.Core.Presentation.Camera;
 using Ludots.Core.Presentation.Hud;
 using Ludots.Core.Presentation.Components;
+using Ludots.Core.Presentation.DebugDraw;
 using Ludots.Core.Presentation.Rendering;
 using Ludots.Core.Presentation.Systems;
 using Ludots.Core.Presentation.Utils;
@@ -114,6 +115,10 @@ namespace Ludots.Tests.GAS.Production
                 ?? throw new InvalidOperationException("PrimitiveDrawBuffer missing.");
             var worldHud = engine.GetService(CoreServiceKeys.PresentationWorldHudBuffer)
                 ?? throw new InvalidOperationException("WorldHudBatchBuffer missing.");
+            var slashRibbons = engine.GetService(CoreServiceKeys.SlashRibbonBuffer)
+                ?? throw new InvalidOperationException("SlashRibbonBuffer missing.");
+            var debugDraw = engine.GetService(CoreServiceKeys.DebugDrawCommandBuffer)
+                ?? throw new InvalidOperationException("DebugDrawCommandBuffer missing.");
             var toolbar = engine.GetService(CoreServiceKeys.EntityCommandPanelToolbarProvider)
                 ?? throw new InvalidOperationException("Toolbar provider missing.");
             var backend = GetInputBackend(engine);
@@ -223,7 +228,7 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(
                 dummyHealthAfterQ,
                 Is.LessThan(dummyHealthBeforeQ),
-                $"{BuildInputActionDiagnostics(engine, "SkillQ")} || {BuildAbilityDiagnostics(engine, "Ezreal Alpha")} || {BuildSelectionStateDiagnostics(engine)} || {BuildOverlayDiagnostics(overlays)} || {BuildFeedbackDiagnostics(primitives, worldHud)} || distanceToDummy={ezrealDistanceToDummy:0.##}");
+                $"{BuildInputActionDiagnostics(engine, "SkillQ")} || {BuildAbilityDiagnostics(engine, "Ezreal Alpha")} || {BuildSelectionStateDiagnostics(engine)} || {BuildOverlayDiagnostics(overlays)} || {BuildFeedbackDiagnostics(engine, primitives, worldHud)} || distanceToDummy={ezrealDistanceToDummy:0.##}");
             Assert.That(CountPrimitiveMarkers(primitives), Is.GreaterThan(0), "Smart cast hit should emit visible pulse markers.");
             Assert.That(CountWorldHudItems(worldHud, WorldHudItemKind.Text), Is.GreaterThan(0), "Smart cast hit should emit visible world text feedback.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "smartcast_hit");
@@ -271,7 +276,7 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(
                 dummyHealthAfterR,
                 Is.LessThan(dummyHealthBeforeR),
-                $"{BuildInputActionDiagnostics(engine, "SkillR")} || {BuildAbilityDiagnostics(engine, "Ezreal Alpha")} || {BuildSelectionStateDiagnostics(engine)} || {BuildOverlayDiagnostics(overlays)} || {BuildFeedbackDiagnostics(primitives, worldHud)}");
+                $"{BuildInputActionDiagnostics(engine, "SkillR")} || {BuildAbilityDiagnostics(engine, "Ezreal Alpha")} || {BuildSelectionStateDiagnostics(engine)} || {BuildOverlayDiagnostics(overlays)} || {BuildFeedbackDiagnostics(engine, primitives, worldHud)}");
             Assert.That(CountPrimitiveMarkers(primitives), Is.GreaterThan(0), "Indicator release hit should emit visible pulse markers.");
             Assert.That(CountWorldHudItems(worldHud, WorldHudItemKind.Text), Is.GreaterThan(0), "Indicator release hit should emit visible world text feedback.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "indicator_release_hit");
@@ -321,7 +326,7 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(
                 dummyHealthAfterConfirm,
                 Is.LessThan(dummyHealthAfterCancel),
-                $"{BuildInputActionDiagnostics(engine, "SkillQ")} || {BuildAbilityDiagnostics(engine, "Jayce Cannon")} || {BuildSelectionStateDiagnostics(engine)} || {BuildOverlayDiagnostics(overlays)} || {BuildFeedbackDiagnostics(primitives, worldHud)}");
+                $"{BuildInputActionDiagnostics(engine, "SkillQ")} || {BuildAbilityDiagnostics(engine, "Jayce Cannon")} || {BuildSelectionStateDiagnostics(engine)} || {BuildOverlayDiagnostics(overlays)} || {BuildFeedbackDiagnostics(engine, primitives, worldHud)}");
             Assert.That(CountPrimitiveMarkers(primitives), Is.GreaterThan(0), "Press-release confirm hit should emit visible pulse markers.");
             Assert.That(CountWorldHudItems(worldHud, WorldHudItemKind.Text), Is.GreaterThan(0), "Press-release confirm hit should emit visible world text feedback.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "press_release_confirm_hit");
@@ -346,7 +351,7 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(
                 dummyHealthAfterBeam,
                 Is.LessThan(dummyHealthBeforeBeam),
-                $"{BuildInputActionDiagnostics(engine, "SkillR")} || {BuildAbilityDiagnostics(engine, "Geomancer Alpha")} || {BuildSelectionStateDiagnostics(engine)} || {BuildOverlayDiagnostics(overlays)} || {BuildFeedbackDiagnostics(primitives, worldHud)}");
+                $"{BuildInputActionDiagnostics(engine, "SkillR")} || {BuildAbilityDiagnostics(engine, "Geomancer Alpha")} || {BuildSelectionStateDiagnostics(engine)} || {BuildOverlayDiagnostics(overlays)} || {BuildFeedbackDiagnostics(engine, primitives, worldHud)}");
             Assert.That(CountPrimitiveMarkers(primitives), Is.GreaterThan(0), "Beam hit should emit visible pulse markers.");
             Assert.That(CountWorldHudItems(worldHud, WorldHudItemKind.Text), Is.GreaterThan(0), "Beam hit should emit visible world text feedback.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "prismatic_beam_hit");
@@ -455,6 +460,10 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(duelistSlots.Any(slot => string.Equals(slot.Label, "Crowd Sweep", StringComparison.Ordinal)), Is.True);
             Assert.That(duelistSlots.Any(slot => string.Equals(slot.Label, "Opening Breaker", StringComparison.Ordinal)), Is.True);
             Assert.That(duelistSlots.Any(slot => string.Equals(slot.Label, "Action Context", StringComparison.Ordinal)), Is.True);
+            Assert.That(
+                CountDebugDrawCommands(debugDraw),
+                Is.GreaterThan(0),
+                "Duelist action mode should expose context-group debug geometry so the auto-target decision stays legible.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "select_duelist_action_mode");
             timeline.Add("[T+017] Select(Duelist Alpha) -> reposition to melee staging lane -> F5 enters Context Combo mode with Step In / Chain / Crowd Sweep / Opening Breaker / Space root");
 
@@ -490,11 +499,19 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(
                 dummyHealthAfterStepIn,
                 Is.LessThan(dummyHealthBeforeStepIn),
-                $"{BuildInputActionDiagnostics(engine, "ActionAttack")} || {BuildAbilityDiagnostics(engine, "Duelist Alpha")} || {BuildSelectionStateDiagnostics(engine)} || {BuildFeedbackDiagnostics(primitives, worldHud)}");
+                $"{BuildInputActionDiagnostics(engine, "ActionAttack")} || {BuildAbilityDiagnostics(engine, "Duelist Alpha")} || {BuildSelectionStateDiagnostics(engine)} || {BuildFeedbackDiagnostics(engine, primitives, worldHud)}");
             Assert.That(
                 duelistDistanceAfterStepIn,
                 Is.LessThan(duelistDistanceToDummyF - 120f),
                 $"Step In should close distance into melee. before={duelistDistanceToDummyF:0.##}, after={duelistDistanceAfterStepIn:0.##}, start={duelistBeforeStepIn}, end={ReadPosition(engine.World, "Duelist Alpha")}");
+            Assert.That(
+                CountSlashRibbons(slashRibbons),
+                Is.GreaterThan(0),
+                "Step In should emit a readable slash ribbon instead of only abstract hit markers.");
+            Assert.That(
+                CountDebugDrawCommands(debugDraw),
+                Is.GreaterThan(0),
+                "ActionContext Step In should keep the target-group debug preview alive during the engage frame.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "duelist_step_in");
             timeline.Add($"[T+018] Duelist Alpha.Space(ActionContext) -> Step In auto-locks {duelistFocusTarget} from the nearby target group | distance {duelistDistanceToDummyF:0}->{duelistDistanceAfterStepIn:0} | HP {dummyHealthBeforeStepIn:0}->{dummyHealthAfterStepIn:0}");
 
@@ -519,6 +536,10 @@ namespace Ludots.Tests.GAS.Production
             float dummyHealthAfterCombo1 = ReadHealth(engine.World, duelistFocusTarget);
             var comboStage2Slots = CopySelectedSlots(engine);
             Assert.That(comboStage2Slots[0].Label, Is.EqualTo("Chain Jab II"));
+            Assert.That(
+                CountSlashRibbons(slashRibbons),
+                Is.GreaterThan(0),
+                "Chain Jab I should emit a slash ribbon so the opener reads as a melee swing, not only a damage number.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "duelist_chain_jab_1");
             timeline.Add($"[T+019] Duelist Alpha.Space(ActionContext) -> Chain Jab I auto-selected on engaged target | HP {dummyHealthBeforeCombo1:0}->{dummyHealthAfterCombo1:0} | Q now routes to Chain Jab II");
 
@@ -540,6 +561,10 @@ namespace Ludots.Tests.GAS.Production
             float dummyHealthAfterCombo2 = ReadHealth(engine.World, duelistFocusTarget);
             var comboStage3Slots = CopySelectedSlots(engine);
             Assert.That(comboStage3Slots[0].Label, Is.EqualTo("Chain Finish"));
+            Assert.That(
+                CountSlashRibbons(slashRibbons),
+                Is.GreaterThan(0),
+                "Chain Jab II should keep the melee ribbon feedback alive during combo escalation.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "duelist_chain_jab_2");
             timeline.Add($"[T+020] Duelist Alpha.Space(ActionContext) -> Chain Jab II wins once Stage1 tag is live | {duelistFocusTarget} opened | HP {dummyHealthBeforeCombo2:0}->{dummyHealthAfterCombo2:0}");
 
@@ -553,6 +578,10 @@ namespace Ludots.Tests.GAS.Production
                 dummyHealthAfterBreaker,
                 Is.LessThan(dummyHealthBeforeBreaker),
                 $"{BuildInputActionDiagnostics(engine, "ActionAttack")} || {BuildAbilityDiagnostics(engine, "Duelist Alpha")} || {BuildSelectionStateDiagnostics(engine)}");
+            Assert.That(
+                CountSlashRibbons(slashRibbons),
+                Is.GreaterThan(0),
+                "Opening Breaker should emit its heavier slash ribbon cue when the opened finisher wins.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "duelist_opening_breaker");
             timeline.Add($"[T+021] Duelist Alpha.Space(ActionContext) -> Opening Breaker spends the opened window as the top-scored finisher | HP {dummyHealthBeforeBreaker:0}->{dummyHealthAfterBreaker:0}");
 
@@ -615,6 +644,10 @@ namespace Ludots.Tests.GAS.Production
                 dummyHealthAfterExplicitStage3,
                 Is.LessThan(dummyHealthBeforeExplicitStage3),
                 $"{BuildInputActionDiagnostics(engine, "SkillQ")} || {BuildAbilityDiagnostics(engine, "Duelist Alpha")} || {BuildSelectionStateDiagnostics(engine)}");
+            Assert.That(
+                CountSlashRibbons(slashRibbons),
+                Is.GreaterThan(0),
+                "Explicit form-routed finisher should still read with slash ribbon feedback.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "duelist_chain_finish");
             timeline.Add($"[T+022] Duelist Alpha.Q smart-cast form routing proves Chain Jab I -> II -> Finish on {duelistFocusTarget} | HP {dummyHealthBeforeExplicitStage1:0}->{dummyHealthAfterExplicitStage3:0}");
 
@@ -638,6 +671,10 @@ namespace Ludots.Tests.GAS.Production
                 sweepHitCount,
                 Is.GreaterThanOrEqualTo(2),
                 $"{BuildInputActionDiagnostics(engine, "SkillE")} || {BuildAbilityDiagnostics(engine, "Duelist Alpha")} || {BuildSelectionStateDiagnostics(engine)}");
+            Assert.That(
+                CountSlashRibbons(slashRibbons),
+                Is.GreaterThan(0),
+                "Crowd Sweep should emit a wide slash ribbon so the cleave footprint reads from the player camera.");
             CaptureSnapshot(engine, overlays, primitives, worldHud, snapshots, "duelist_crowd_sweep");
             timeline.Add($"[T+023] Duelist Alpha.E(Crowd Sweep) cleaves the D/E/F cluster from melee follow-through | damaged_targets={sweepHitCount}");
 
@@ -1390,6 +1427,9 @@ namespace Ludots.Tests.GAS.Production
             AddEntityStateIfPresent(engine.World, states, "Guided Laser");
             AddEntityStateIfPresent(engine.World, states, "Barrier Segment");
 
+            var slashRibbons = engine.GetService(CoreServiceKeys.SlashRibbonBuffer);
+            var debugDraw = engine.GetService(CoreServiceKeys.DebugDrawCommandBuffer);
+
             snapshots.Add(new AcceptanceSnapshot(
                 Step: step,
                 ActiveModeId: GetActiveModeId(engine),
@@ -1410,6 +1450,8 @@ namespace Ludots.Tests.GAS.Production
                 },
                 PrimitiveCount: CountPrimitiveMarkers(primitives),
                 WorldTextCount: CountWorldHudItems(worldHud, WorldHudItemKind.Text),
+                SlashRibbonCount: slashRibbons == null ? 0 : CountSlashRibbons(slashRibbons),
+                DebugDrawCount: debugDraw == null ? 0 : CountDebugDrawCommands(debugDraw),
                 Entities: states));
         }
 
@@ -1444,6 +1486,8 @@ namespace Ludots.Tests.GAS.Production
                      overlay_counts = snapshot.OverlayCounts,
                      primitive_count = snapshot.PrimitiveCount,
                      world_text_count = snapshot.WorldTextCount,
+                     slash_ribbon_count = snapshot.SlashRibbonCount,
+                     debug_draw_count = snapshot.DebugDrawCount,
                      entities = snapshot.Entities.Select(entity => new
                      {
                          name = entity.Name,
@@ -1488,6 +1532,8 @@ namespace Ludots.Tests.GAS.Production
             sb.AppendLine($"- final_selection_ring_count: {finalSnapshot.OverlayCounts["ring"]}");
             sb.AppendLine($"- final_feedback_primitives: {finalSnapshot.PrimitiveCount}");
             sb.AppendLine($"- final_feedback_world_text: {finalSnapshot.WorldTextCount}");
+            sb.AppendLine($"- final_feedback_slash_ribbons: {finalSnapshot.SlashRibbonCount}");
+            sb.AppendLine($"- final_feedback_debug_draw: {finalSnapshot.DebugDrawCount}");
             sb.AppendLine();
             sb.AppendLine("## Summary Stats");
             sb.AppendLine($"- total_actions: {timeline.Count}");
@@ -1568,7 +1614,7 @@ namespace Ludots.Tests.GAS.Production
   <text x="72" y="104" fill="#f7d36d" font-size="34" font-family="Consolas, monospace">Champion Sandbox | {{EscapeSvg(snapshot.Step)}}</text>
   <text x="72" y="148" fill="#ffffff" font-size="24" font-family="Consolas, monospace">Selected: {{EscapeSvg(snapshot.SelectedEntity)}} | Mode: {{EscapeSvg(snapshot.ActiveModeId)}}</text>
   <text x="72" y="200" fill="#ffffff" font-size="24" font-family="Consolas, monospace">Camera: target=({{snapshot.Camera.TargetXCm:0}}, {{snapshot.Camera.TargetYCm:0}}) distance={{snapshot.Camera.DistanceCm:0}} pitch={{snapshot.Camera.Pitch:0}} fov={{snapshot.Camera.FovYDeg:0}}</text>
-  <text x="72" y="252" fill="#bccdde" font-size="20" font-family="Consolas, monospace">Overlay C/Cn/L/R = {{snapshot.OverlayCounts["circle"]}}/{{snapshot.OverlayCounts["cone"]}}/{{snapshot.OverlayCounts["line"]}}/{{snapshot.OverlayCounts["ring"]}} | feedback = {{snapshot.PrimitiveCount}} / {{snapshot.WorldTextCount}}</text>
+  <text x="72" y="252" fill="#bccdde" font-size="20" font-family="Consolas, monospace">Overlay C/Cn/L/R = {{snapshot.OverlayCounts["circle"]}}/{{snapshot.OverlayCounts["cone"]}}/{{snapshot.OverlayCounts["line"]}}/{{snapshot.OverlayCounts["ring"]}} | feedback = {{snapshot.PrimitiveCount}} / {{snapshot.WorldTextCount}} / {{snapshot.SlashRibbonCount}} / {{snapshot.DebugDrawCount}}</text>
   <text x="72" y="324" fill="#ffffff" font-size="22" font-family="Consolas, monospace">Panel</text>
   <text x="72" y="364" fill="#dde8f1" font-size="18" font-family="Consolas, monospace">{{EscapeSvg(panelText)}}</text>
   <text x="72" y="452" fill="#ffffff" font-size="22" font-family="Consolas, monospace">Tracked HP</text>
@@ -1594,7 +1640,7 @@ namespace Ludots.Tests.GAS.Production
                 lines.Add($"""  <rect x="40" y="{y - 36}" width="1520" height="72" rx="12" fill="#14212e" stroke="#35536b" stroke-width="1.5" />""");
                 lines.Add($"""  <text x="72" y="{y}" fill="#f7d36d" font-size="24" font-family="Consolas, monospace">{EscapeSvg($"{i + 1:000} {snapshot.Step}")}</text>""");
                 lines.Add($"""  <text x="540" y="{y}" fill="#ffffff" font-size="20" font-family="Consolas, monospace">{EscapeSvg($"{snapshot.SelectedEntity} | {snapshot.ActiveModeId}")}</text>""");
-                lines.Add($"""  <text x="72" y="{y + 28}" fill="#bccdde" font-size="18" font-family="Consolas, monospace">{EscapeSvg($"overlays={snapshot.OverlayCounts["circle"]}/{snapshot.OverlayCounts["cone"]}/{snapshot.OverlayCounts["line"]}/{snapshot.OverlayCounts["ring"]} | feedback={snapshot.PrimitiveCount}/{snapshot.WorldTextCount}")}</text>""");
+                lines.Add($"""  <text x="72" y="{y + 28}" fill="#bccdde" font-size="18" font-family="Consolas, monospace">{EscapeSvg($"overlays={snapshot.OverlayCounts["circle"]}/{snapshot.OverlayCounts["cone"]}/{snapshot.OverlayCounts["line"]}/{snapshot.OverlayCounts["ring"]} | feedback={snapshot.PrimitiveCount}/{snapshot.WorldTextCount}/{snapshot.SlashRibbonCount}/{snapshot.DebugDrawCount}")}</text>""");
                 y += 96;
             }
 
@@ -1844,6 +1890,16 @@ namespace Ludots.Tests.GAS.Production
         private static int CountPrimitiveMarkers(PrimitiveDrawBuffer primitives)
         {
             return primitives.GetSpan().Length;
+        }
+
+        private static int CountSlashRibbons(SlashRibbonBuffer slashRibbons)
+        {
+            return slashRibbons.Count;
+        }
+
+        private static int CountDebugDrawCommands(DebugDrawCommandBuffer debugDraw)
+        {
+            return debugDraw.Lines.Count + debugDraw.Circles.Count + debugDraw.Boxes.Count;
         }
 
         private static int CountWorldHudItems(WorldHudBatchBuffer worldHud, WorldHudItemKind kind)
@@ -2609,9 +2665,15 @@ namespace Ludots.Tests.GAS.Production
             return $"overlays=count:{overlays.Count},circle:{CountOverlays(overlays, GroundOverlayShape.Circle)},cone:{CountOverlays(overlays, GroundOverlayShape.Cone)},line:{CountOverlays(overlays, GroundOverlayShape.Line)},ring:{CountOverlays(overlays, GroundOverlayShape.Ring)}";
         }
 
-        private static string BuildFeedbackDiagnostics(PrimitiveDrawBuffer primitives, WorldHudBatchBuffer worldHud)
+        private static string BuildFeedbackDiagnostics(GameEngine engine, PrimitiveDrawBuffer primitives, WorldHudBatchBuffer worldHud)
         {
-            return $"feedback=primitives:{CountPrimitiveMarkers(primitives)},worldText:{CountWorldHudItems(worldHud, WorldHudItemKind.Text)}";
+            int slashCount = engine.GetService(CoreServiceKeys.SlashRibbonBuffer) is { } slashRibbons
+                ? CountSlashRibbons(slashRibbons)
+                : 0;
+            int debugDrawCount = engine.GetService(CoreServiceKeys.DebugDrawCommandBuffer) is { } debugDraw
+                ? CountDebugDrawCommands(debugDraw)
+                : 0;
+            return $"feedback=primitives:{CountPrimitiveMarkers(primitives)},worldText:{CountWorldHudItems(worldHud, WorldHudItemKind.Text)},slash:{slashCount},debug:{debugDrawCount}";
         }
 
         private static string BuildContextScoredDiagnostics(GameEngine engine, string actorName, string hoveredName)
@@ -2858,6 +2920,8 @@ namespace Ludots.Tests.GAS.Production
             IReadOnlyDictionary<string, int> OverlayCounts,
             int PrimitiveCount,
             int WorldTextCount,
+            int SlashRibbonCount,
+            int DebugDrawCount,
             IReadOnlyList<EntityState> Entities);
 
         private sealed record CameraSnapshot(

--- a/src/Tests/GasTests/Production/ProductionAllModsValidationTests.cs
+++ b/src/Tests/GasTests/Production/ProductionAllModsValidationTests.cs
@@ -108,7 +108,7 @@ namespace Ludots.Tests.GAS.Production
 
             yield return new TestCaseData(new ModCase(
                     "ChampionSkillSandboxMod",
-                    new[] { "LudotsCoreMod", "CoreInputMod", "CameraProfilesMod", "EntityCommandPanelMod", "ChampionSkillSandboxMod" },
+                    new[] { "LudotsCoreMod", "CoreInputMod", "CameraProfilesMod", "DiagnosticsOverlayMod", "EntityCommandPanelMod", "ChampionSkillSandboxMod" },
                     true))
                 .SetName("ProdModSmoke_ChampionSkillSandboxMod");
 

--- a/src/Tests/GasTests/SearchPhaseConvergenceTests.cs
+++ b/src/Tests/GasTests/SearchPhaseConvergenceTests.cs
@@ -171,6 +171,7 @@ namespace Ludots.Tests.GAS
             public SpatialQueryResult QueryCone(WorldCmInt2 origin, int directionDeg, int halfAngleDeg, int rangeCm, Span<Entity> buffer) => Write(buffer);
             public SpatialQueryResult QueryRectangle(WorldCmInt2 center, int halfWidthCm, int halfHeightCm, int rotationDeg, Span<Entity> buffer) => Write(buffer);
             public SpatialQueryResult QueryLine(WorldCmInt2 origin, int directionDeg, int lengthCm, int halfWidthCm, Span<Entity> buffer) => Write(buffer);
+            public SpatialQueryResult QueryPolylineCapsule(ReadOnlySpan<WorldCmInt2> points, int halfWidthCm, Span<Entity> buffer) => Write(buffer);
             public SpatialQueryResult QueryHexRange(HexCoordinates center, int hexRadius, Span<Entity> buffer) => Write(buffer);
             public SpatialQueryResult QueryHexRing(HexCoordinates center, int hexRadius, Span<Entity> buffer) => Write(buffer);
 

--- a/src/Tests/GasTests/SpatialFeatureGapTests.cs
+++ b/src/Tests/GasTests/SpatialFeatureGapTests.cs
@@ -101,6 +101,49 @@ namespace Ludots.Tests.GAS
         // ════════════════════════════════════════════════════════════════════
 
         [Test]
+        public void QueryPolylineCapsule_FindsEntitiesAlongBentSweep_AndSortsByPathDistance()
+        {
+            var world = World.Create();
+            try
+            {
+                var coords = new SpatialCoordinateConverter(gridCellSizeCm: 100);
+                var grid = new GridSpatialPartitionWorld(cellSize: 1);
+                var spatial = new SpatialQueryService(new GridSpatialPartitionBackend(grid, coords));
+                spatial.SetPositionProvider(e =>
+                {
+                    ref var pos = ref world.Get<WorldPositionCm>(e);
+                    return pos.Value.ToWorldCmInt2();
+                });
+
+                var earlyHit = world.Create(WorldPositionCm.FromCm(120, 20));
+                var lateHit = world.Create(WorldPositionCm.FromCm(205, 150));
+                var miss = world.Create(WorldPositionCm.FromCm(60, 250));
+
+                grid.Add(earlyHit, new IntRect(1, 0, 2, 1));
+                grid.Add(lateHit, new IntRect(2, 1, 3, 2));
+                grid.Add(miss, new IntRect(0, 2, 1, 3));
+
+                Span<Entity> buffer = stackalloc Entity[32];
+                Span<WorldCmInt2> points = stackalloc WorldCmInt2[]
+                {
+                    new WorldCmInt2(0, 0),
+                    new WorldCmInt2(200, 0),
+                    new WorldCmInt2(200, 200)
+                };
+
+                var r = spatial.QueryPolylineCapsule(points, halfWidthCm: 40, buffer);
+
+                That(r.Count, Is.EqualTo(2));
+                That(buffer[0], Is.EqualTo(earlyHit));
+                That(buffer[1], Is.EqualTo(lateHit));
+            }
+            finally
+            {
+                world.Dispose();
+            }
+        }
+
+        [Test]
         public void QueryHexRange_FindsEntitiesWithinHexRadius()
         {
             var world = World.Create();

--- a/src/Tests/GasTests/SpatialTargetResolutionConvergenceTests.cs
+++ b/src/Tests/GasTests/SpatialTargetResolutionConvergenceTests.cs
@@ -267,6 +267,8 @@ namespace Ludots.Tests.GAS
                 return default;
             }
 
+            public SpatialQueryResult QueryPolylineCapsule(ReadOnlySpan<WorldCmInt2> points, int halfWidthCm, Span<Entity> buffer) => default;
+
             public SpatialQueryResult QueryHexRange(Ludots.Core.Map.Hex.HexCoordinates center, int hexRadius, Span<Entity> buffer) => default;
 
             public SpatialQueryResult QueryHexRing(Ludots.Core.Map.Hex.HexCoordinates center, int hexRadius, Span<Entity> buffer) => default;

--- a/src/Tests/GasTests/TagEffectArchitectureTests.cs
+++ b/src/Tests/GasTests/TagEffectArchitectureTests.cs
@@ -1107,6 +1107,8 @@ namespace Ludots.Tests.GAS
 
                 return new SpatialQueryResult(count, 0);
             }
+
+            public SpatialQueryResult QueryPolylineCapsule(ReadOnlySpan<WorldCmInt2> points, int halfWidthCm, Span<Entity> buffer) => default;
         }
 
         private static ConfigPipeline CreateMinimalPipeline(string effectJson, string templatesJson = null)


### PR DESCRIPTION
## Summary
- expand ChampionSkillSandbox melee context routing and duelist inspection/debug support for auto combo previews
- harden playable acceptance around hover projection and context-scored order resolution, plus include DiagnosticsOverlayMod in production validation
- polish sandbox player-facing guidance so the melee demo reads more clearly in Auto mode without surfacing runtime HUD noise

## Testing
- dotnet test src/Tests/GasTests/GasTests.csproj --filter "FullyQualifiedName~ChampionSkillSandbox"
