### PR TITLE
feat: add minimap showcase and upgrade skill panel sandbox

### DIFF
--- a/mods/EntityCommandPanelMod/Runtime/GasEntityCommandPanelSource.cs
+++ b/mods/EntityCommandPanelMod/Runtime/GasEntityCommandPanelSource.cs
@@ -243,6 +243,7 @@ namespace EntityCommandPanelMod.Runtime
                 string actionId = ResolvePrimarySkillActionId(inputMapping, slotIndex);
                 string displayLabel = string.Empty;
                 string detailLabel = BuildEmptyDetailLabel(actionId);
+                short cooldownPermille = 0;
                 if (effective.AbilityId > 0 &&
                     abilityDefinitions != null &&
                     abilityDefinitions.TryGet(effective.AbilityId, out var abilityDefinition))
@@ -261,6 +262,8 @@ namespace EntityCommandPanelMod.Runtime
                     {
                         flags |= EntityCommandSlotStateFlags.Active;
                     }
+
+                    cooldownPermille = ResolveCooldownPermille(target, in abilityDefinition);
 
                     string fallbackLabel = ResolveFallbackLabel(effective.AbilityId, effective.TemplateEntityId);
                     string fallbackDetail = BuildDefaultDetailLabel(actionId, abilityInteractionModeKey);
@@ -285,7 +288,7 @@ namespace EntityCommandPanelMod.Runtime
                     effective.AbilityId,
                     effective.TemplateEntityId,
                     flags,
-                    0,
+                    cooldownPermille,
                     0,
                     0,
                     displayLabel,
@@ -305,6 +308,72 @@ namespace EntityCommandPanelMod.Runtime
             }
 
             return interactionModeKey;
+        }
+
+        private short ResolveCooldownPermille(Entity target, in AbilityDefinition abilityDefinition)
+        {
+            if (!_engine.World.IsAlive(target) ||
+                !abilityDefinition.HasActivationBlockTags ||
+                abilityDefinition.ActivationBlockTags.BlockedAny.IsEmpty ||
+                !_engine.World.Has<TimedTagBuffer>(target))
+            {
+                return 0;
+            }
+
+            IClock? clock = _engine.GetService(CoreServiceKeys.Clock);
+            if (clock == null)
+            {
+                return 0;
+            }
+
+            ref var timed = ref _engine.World.Get<TimedTagBuffer>(target);
+            int bestPermille = 0;
+            for (int i = 0; i < timed.Count; i++)
+            {
+                int tagId = timed.GetTagId(i);
+                if (tagId <= 0 || !abilityDefinition.ActivationBlockTags.BlockedAny.HasTag(tagId))
+                {
+                    continue;
+                }
+
+                GasClockId clockId = timed.GetClockId(i);
+                int now = clock.Now(clockId.ToDomainId());
+                int remainingTicks = Math.Max(0, timed.GetExpireAt(i) - now);
+                if (remainingTicks <= 0)
+                {
+                    continue;
+                }
+
+                int totalTicks = ResolveCooldownDurationTicks(in abilityDefinition.ExecSpec, tagId);
+                int permille = totalTicks > 0
+                    ? Math.Clamp((int)Math.Round(remainingTicks * 1000d / totalTicks), 0, 1000)
+                    : 1000;
+                bestPermille = Math.Max(bestPermille, permille);
+            }
+
+            return (short)bestPermille;
+        }
+
+        private static int ResolveCooldownDurationTicks(in AbilityExecSpec execSpec, int tagId)
+        {
+            int durationTicks = 0;
+            for (int itemIndex = 0; itemIndex < execSpec.ItemCount; itemIndex++)
+            {
+                ExecItemKind kind = execSpec.GetKind(itemIndex);
+                if (kind != ExecItemKind.TagClip && kind != ExecItemKind.TagClipTarget)
+                {
+                    continue;
+                }
+
+                if (execSpec.GetTagId(itemIndex) != tagId)
+                {
+                    continue;
+                }
+
+                durationTicks = Math.Max(durationTicks, execSpec.GetDurationTicks(itemIndex));
+            }
+
+            return durationTicks;
         }
 
         public bool ActivateSlot(Entity target, int groupIndex, int slotIndex)

--- a/mods/EntityCommandPanelMod/UI/EntityCommandPanelController.cs
+++ b/mods/EntityCommandPanelMod/UI/EntityCommandPanelController.cs
@@ -22,6 +22,7 @@ namespace EntityCommandPanelMod.UI
         private readonly EntityCommandPanelRuntime _runtime;
         private readonly AbilityDefinitionRegistry? _abilityDefinitions;
         private readonly AbilityPresentationIconFactory _iconFactory = new();
+        private readonly EntityCommandPanelShowcaseArtFactory _showcaseArtFactory = new();
         private readonly Dictionary<int, string> _abilityLabelCache = new();
         private readonly ReactivePage<HostState> _page;
         private uint _lastRevision;
@@ -173,6 +174,17 @@ namespace EntityCommandPanelMod.UI
             float slotSectionHeight = ResolveSlotSectionHeight(state.Size.HeightPx, slotCount);
 
             ResolvePanelPosition(state.Anchor, state.Size, viewportWidth, viewportHeight, out float left, out float top);
+            string showcaseThemeId = ResolveShowcaseThemeId();
+            if (!string.Equals(showcaseThemeId, EntityCommandPanelShowcaseTheme.ClassicId, StringComparison.Ordinal))
+            {
+                var slotSnapshot = new EntityCommandPanelSlotView[slotCount];
+                for (int i = 0; i < slotCount; i++)
+                {
+                    slotSnapshot[i] = slots[i];
+                }
+
+                return BuildShowcasePanel(showcaseThemeId, state, group, groupCount, source, slotSnapshot, left, top);
+            }
 
             return Ui.Card(
                     BuildHeader(state, group, groupCount),
@@ -189,6 +201,516 @@ namespace EntityCommandPanelMod.UI
                 .Overflow(UiOverflow.Hidden)
                 .Absolute(left, top)
                 .ZIndex(40);
+        }
+
+        private UiElementBuilder BuildShowcasePanel(
+            string themeId,
+            EntityCommandPanelInstanceState state,
+            EntityCommandPanelGroupView group,
+            int groupCount,
+            IEntityCommandPanelSource? source,
+            EntityCommandPanelSlotView[] slots,
+            float left,
+            float top)
+        {
+            return themeId switch
+            {
+                var id when string.Equals(id, EntityCommandPanelShowcaseTheme.Dota2Id, StringComparison.Ordinal) => BuildDota2ShowcasePanel(state, group, groupCount, source, slots, left, top),
+                var id when string.Equals(id, EntityCommandPanelShowcaseTheme.Sc2Id, StringComparison.Ordinal) => BuildSc2ShowcasePanel(state, group, groupCount, source, slots, left, top),
+                _ => BuildLolShowcasePanel(state, group, groupCount, source, slots, left, top)
+            };
+        }
+
+        private UiElementBuilder BuildLolShowcasePanel(
+            EntityCommandPanelInstanceState state,
+            EntityCommandPanelGroupView group,
+            int groupCount,
+            IEntityCommandPanelSource? source,
+            EntityCommandPanelSlotView[] slots,
+            float left,
+            float top)
+        {
+            string themeId = EntityCommandPanelShowcaseTheme.LolId;
+            string title = _runtime.ResolveEntityTitle(state.TargetEntity);
+            string accent = ResolvePrimaryAccent(slots);
+            string interactionModeKey = ResolveInteractionModeKey();
+            var primarySlots = new UiElementBuilder[4];
+            for (int i = 0; i < primarySlots.Length; i++)
+            {
+                primarySlots[i] = i < slots.Length
+                    ? BuildShowcaseSlotCard(themeId, state.TargetEntity, state.GroupIndex, source, in slots[i], interactionModeKey, 124f, 12f, false)
+                    : BuildShowcasePlaceholderCard(themeId, "-", string.Empty, "Unbound", "#415060", 124f, 12f, false);
+            }
+
+            var utilitySlots = new[]
+            {
+                BuildShowcasePlaceholderCard(themeId, "D", "D", "Flash", "#F1C561", 88f, 10f, false),
+                BuildShowcasePlaceholderCard(themeId, "F", "F", "Heal", "#62C6FF", 88f, 10f, false),
+                BuildShowcasePlaceholderCard(themeId, "1", "1", "Active", "#8B6DF3", 88f, 10f, false),
+                BuildShowcasePlaceholderCard(themeId, "4", "4", "Ward", "#60CDB5", 88f, 10f, false)
+            };
+
+            return Ui.Card(
+                    Ui.Row(
+                            Ui.Image(_showcaseArtFactory.BuildPortraitArt(themeId, title, "Summoner Panel", accent))
+                                .Width(184f)
+                                .Height(160f)
+                                .FlexShrink(0f),
+                            Ui.Column(
+                                    Ui.Row(
+                                            Ui.Column(
+                                                    Ui.Text(title)
+                                                        .FontFamily("Segoe UI Semibold")
+                                                        .FontSize(24f)
+                                                        .Color("#F3E3A4")
+                                                        .TextShadow(0f, 1f, 2f, new UiColor(0x06, 0x09, 0x0E)),
+                                                    Ui.Text($"Theme LoL | {ResolveModeBadge(interactionModeKey)} | {ResolveGroupLine(group, groupCount, state.GroupIndex)}")
+                                                        .FontFamily("Segoe UI")
+                                                        .FontSize(11f)
+                                                        .Color("#C6D3DE"))
+                                                .Gap(4f),
+                                            Ui.Row(
+                                                    BuildShowcaseInfoPill("CAST", ResolveModeBadge(interactionModeKey), "#1A2430", "#ECD28B"),
+                                                    BuildShowcaseInfoPill("HUD", "LoL", "#1A2430", "#D9E6F2"))
+                                                .Gap(8f))
+                                        .Justify(UiJustifyContent.SpaceBetween)
+                                        .Align(UiAlignItems.Center),
+                                    BuildShowcaseBar("Resource", "Mana Ready", 0.84f, "#2C8CE4", "#102035", 564f),
+                                    BuildShowcaseBar("Cooldown Sync", ResolveModeBadge(interactionModeKey), ResolveModeProgress(interactionModeKey), "#D2A755", "#241C0D", 564f),
+                                    Ui.Row(primarySlots).Gap(8f),
+                                    Ui.Row(utilitySlots).Gap(8f))
+                                .Gap(10f)
+                                .FlexGrow(1f))
+                        .Gap(16f))
+                .Id($"entity-command-panel-showcase-lol-{state.Handle.Slot}")
+                .Width(Math.Max(948f, state.Size.WidthPx))
+                .Height(Math.Max(248f, state.Size.HeightPx))
+                .Padding(16f)
+                .Gap(12f)
+                .Radius(22f)
+                .BackgroundGradient(135f, new UiColor(0x0A, 0x0F, 0x16), new UiColor(0x12, 0x18, 0x21), new UiColor(0x08, 0x0C, 0x12))
+                .Border(2f, new UiColor(0x7A, 0x62, 0x33))
+                .BoxShadow(0f, 10f, 22f, new UiColor(0x02, 0x03, 0x06, 180))
+                .Absolute(left, top)
+                .ZIndex(44);
+        }
+
+        private UiElementBuilder BuildDota2ShowcasePanel(
+            EntityCommandPanelInstanceState state,
+            EntityCommandPanelGroupView group,
+            int groupCount,
+            IEntityCommandPanelSource? source,
+            EntityCommandPanelSlotView[] slots,
+            float left,
+            float top)
+        {
+            string themeId = EntityCommandPanelShowcaseTheme.Dota2Id;
+            string title = _runtime.ResolveEntityTitle(state.TargetEntity);
+            string accent = ResolvePrimaryAccent(slots);
+            string interactionModeKey = ResolveInteractionModeKey();
+            var abilitySlots = new UiElementBuilder[6];
+            for (int i = 0; i < abilitySlots.Length; i++)
+            {
+                abilitySlots[i] = i < slots.Length
+                    ? BuildShowcaseSlotCard(themeId, state.TargetEntity, state.GroupIndex, source, in slots[i], interactionModeKey, 116f, 11f, false)
+                    : BuildShowcasePlaceholderCard(themeId, "-", string.Empty, "Unbound", "#6A5647", 116f, 11f, false);
+            }
+
+            var inventorySlots = new[]
+            {
+                BuildShowcasePlaceholderCard(themeId, "T", "T", "Town", "#8C6A4E", 116f, 11f, false),
+                BuildShowcasePlaceholderCard(themeId, "1", "1", "Bottle", "#6C8396", 116f, 11f, false),
+                BuildShowcasePlaceholderCard(themeId, "2", "2", "Blade", "#5E8F78", 116f, 11f, false),
+                BuildShowcasePlaceholderCard(themeId, "3", "3", "Dust", "#8F7C57", 116f, 11f, false),
+                BuildShowcasePlaceholderCard(themeId, "4", "4", "Blink", "#6A69A4", 116f, 11f, false),
+                BuildShowcasePlaceholderCard(themeId, "5", "5", "Ward", "#4F8F79", 116f, 11f, false)
+            };
+
+            return Ui.Card(
+                    Ui.Row(
+                            Ui.Column(
+                                    Ui.Text(title)
+                                        .FontFamily("Georgia")
+                                        .FontSize(24f)
+                                        .Color("#F0D8AE"),
+                                    Ui.Text($"Theme Dota2 | {ResolveGroupLine(group, groupCount, state.GroupIndex)}")
+                                        .FontFamily("Georgia")
+                                        .FontSize(12f)
+                                        .Color("#CFB79B"),
+                                    Ui.Image(_showcaseArtFactory.BuildPortraitArt(themeId, title, "Ability Console", accent))
+                                        .Width(220f)
+                                        .Height(170f)
+                                        .FlexShrink(0f),
+                                    BuildShowcaseBar("Routing", ResolveModeBadge(interactionModeKey), ResolveModeProgress(interactionModeKey), "#A76B44", "#21140E", 220f))
+                                .Gap(10f)
+                                .FlexShrink(0f),
+                            Ui.Column(
+                                    Ui.Row(
+                                            BuildShowcaseInfoPill("CAST", ResolveModeBadge(interactionModeKey), "#2A1D16", "#F0D8AE"),
+                                            BuildShowcaseInfoPill("GROUP", groupCount <= 0 ? "0/0" : $"{state.GroupIndex + 1}/{groupCount}", "#2A1D16", "#D8C5B1"),
+                                            BuildShowcaseInfoPill("HUD", "Dota2", "#2A1D16", "#D6905B"))
+                                        .Gap(8f),
+                                    BuildShowcaseBar("Ability Ready", "Six-Slot Console", 0.92f, "#B76A44", "#21140E", 742f),
+                                    Ui.Row(abilitySlots).Gap(10f),
+                                    Ui.Row(inventorySlots).Gap(10f))
+                                .Gap(12f)
+                                .FlexGrow(1f))
+                        .Gap(18f))
+                .Id($"entity-command-panel-showcase-dota2-{state.Handle.Slot}")
+                .Width(Math.Max(1236f, state.Size.WidthPx))
+                .Height(Math.Max(332f, state.Size.HeightPx))
+                .Padding(18f)
+                .Radius(20f)
+                .BackgroundGradient(145f, new UiColor(0x12, 0x0D, 0x0A), new UiColor(0x21, 0x16, 0x11), new UiColor(0x0C, 0x08, 0x06))
+                .Border(2f, new UiColor(0x7A, 0x59, 0x3C))
+                .BoxShadow(0f, 12f, 28f, new UiColor(0x02, 0x01, 0x00, 190))
+                .Absolute(left, top)
+                .ZIndex(44);
+        }
+
+        private UiElementBuilder BuildSc2ShowcasePanel(
+            EntityCommandPanelInstanceState state,
+            EntityCommandPanelGroupView group,
+            int groupCount,
+            IEntityCommandPanelSource? source,
+            EntityCommandPanelSlotView[] slots,
+            float left,
+            float top)
+        {
+            string themeId = EntityCommandPanelShowcaseTheme.Sc2Id;
+            string title = _runtime.ResolveEntityTitle(state.TargetEntity);
+            string accent = ResolvePrimaryAccent(slots);
+            string interactionModeKey = ResolveInteractionModeKey();
+            var cells = new UiElementBuilder[15];
+            for (int i = 0; i < cells.Length; i++)
+            {
+                if (i < slots.Length)
+                {
+                    cells[i] = BuildShowcaseSlotCard(themeId, state.TargetEntity, state.GroupIndex, source, in slots[i], interactionModeKey, 82f, 9f, false);
+                    continue;
+                }
+
+                cells[i] = i switch
+                {
+                    4 => BuildShowcasePlaceholderCard(themeId, "A", "A", "Attack", "#E88A61", 82f, 9f, false),
+                    5 => BuildShowcasePlaceholderCard(themeId, "M", "M", "Move", "#69B8E8", 82f, 9f, false),
+                    6 => BuildShowcasePlaceholderCard(themeId, "S", "S", "Stop", "#E57957", 82f, 9f, false),
+                    7 => BuildShowcasePlaceholderCard(themeId, "P", "P", "Patrol", "#85D0BE", 82f, 9f, false),
+                    8 => BuildShowcasePlaceholderCard(themeId, "H", "H", "Hold", "#D7C56E", 82f, 9f, false),
+                    9 => BuildShowcasePlaceholderCard(themeId, "C", "C", "Cloak", "#9177F2", 82f, 9f, false),
+                    10 => BuildShowcasePlaceholderCard(themeId, "L", "L", "Lift", "#69D8F8", 82f, 9f, false),
+                    11 => BuildShowcasePlaceholderCard(themeId, "R", "R", "Rally", "#E8D06A", 82f, 9f, false),
+                    12 => BuildShowcasePlaceholderCard(themeId, "B", "B", "Build", "#6BCFB5", 82f, 9f, false),
+                    13 => BuildShowcasePlaceholderCard(themeId, "T", "T", "Tech", "#62A7FF", 82f, 9f, false),
+                    _ => BuildShowcasePlaceholderCard(themeId, "X", "X", "Cancel", "#9EB4C4", 82f, 9f, false)
+                };
+            }
+
+            return Ui.Card(
+                    Ui.Row(
+                            Ui.Column(
+                                    Ui.Image(_showcaseArtFactory.BuildPortraitArt(themeId, title, "Command Card", accent))
+                                        .Width(176f)
+                                        .Height(176f)
+                                        .FlexShrink(0f),
+                                    BuildShowcaseInfoPill("VIEW", "SC2", "#0A1824", "#92DEFF"),
+                                    BuildShowcaseInfoPill("GROUP", groupCount <= 0 ? "0/0" : $"{state.GroupIndex + 1}/{groupCount}", "#0A1824", "#D8EFF9"))
+                                .Gap(8f)
+                                .FlexShrink(0f),
+                            Ui.Column(
+                                    Ui.Row(
+                                            Ui.Column(
+                                                    Ui.Text(title)
+                                                        .FontFamily("Segoe UI Semibold")
+                                                        .FontSize(22f)
+                                                        .Color("#D7F6FF"),
+                                                    Ui.Text($"Theme SC2 | {ResolveGroupLine(group, groupCount, state.GroupIndex)} | {ResolveModeBadge(interactionModeKey)}")
+                                                        .FontFamily("Segoe UI")
+                                                        .FontSize(11f)
+                                                        .Color("#93BED7"))
+                                                .Gap(4f),
+                                            BuildShowcaseBar("Command Sync", ResolveModeBadge(interactionModeKey), ResolveModeProgress(interactionModeKey), "#4CB6E9", "#0D2131", 254f))
+                                        .Justify(UiJustifyContent.SpaceBetween)
+                                        .Align(UiAlignItems.Center),
+                                    Ui.Row(cells[0], cells[1], cells[2], cells[3], cells[4]).Gap(8f),
+                                    Ui.Row(cells[5], cells[6], cells[7], cells[8], cells[9]).Gap(8f),
+                                    Ui.Row(cells[10], cells[11], cells[12], cells[13], cells[14]).Gap(8f))
+                                .Gap(8f)
+                                .FlexGrow(1f))
+                        .Gap(16f))
+                .Id($"entity-command-panel-showcase-sc2-{state.Handle.Slot}")
+                .Width(Math.Max(744f, state.Size.WidthPx))
+                .Height(Math.Max(430f, state.Size.HeightPx))
+                .Padding(16f)
+                .Radius(14f)
+                .BackgroundGradient(135f, new UiColor(0x04, 0x0D, 0x15), new UiColor(0x0D, 0x1B, 0x2A), new UiColor(0x07, 0x10, 0x19))
+                .Border(2f, new UiColor(0x2A, 0x53, 0x70))
+                .BoxShadow(0f, 12f, 26f, new UiColor(0x00, 0x04, 0x09, 190))
+                .Absolute(left, top)
+                .ZIndex(44);
+        }
+
+        private UiElementBuilder BuildShowcaseSlotCard(
+            string themeId,
+            Entity target,
+            int groupIndex,
+            IEntityCommandPanelSource? source,
+            in EntityCommandPanelSlotView slot,
+            string interactionModeKey,
+            float width,
+            float labelFontSize,
+            bool showDetail)
+        {
+            string accent = ResolveAbilityAccent(in slot);
+            string glyph = ResolveAbilityGlyph(in slot, interactionModeKey);
+            string hotkey = ResolveActionKeyLabel(slot.ActionId);
+            string art = _showcaseArtFactory.BuildSlotArt(
+                themeId,
+                glyph,
+                hotkey,
+                accent,
+                slot.CooldownPermille,
+                slot.StateFlags.HasFlag(EntityCommandSlotStateFlags.Blocked),
+                slot.StateFlags.HasFlag(EntityCommandSlotStateFlags.Active),
+                slot.StateFlags.HasFlag(EntityCommandSlotStateFlags.Empty));
+            float artWidth = ResolveShowcaseArtWidth(themeId, width);
+            float artHeight = ResolveShowcaseArtHeight(themeId, artWidth);
+
+            UiElementBuilder card = Ui.Card(
+                    Ui.Image(art)
+                        .Width(artWidth)
+                        .Height(artHeight)
+                        .FlexShrink(0f),
+                    Ui.Text(ResolveAbilityLabel(in slot))
+                        .FontFamily(string.Equals(themeId, EntityCommandPanelShowcaseTheme.Dota2Id, StringComparison.Ordinal) ? "Georgia" : "Segoe UI")
+                        .FontSize(labelFontSize)
+                        .Bold()
+                        .Color(ResolveThemeTextColor(themeId))
+                        .Width(width - 4f),
+                    showDetail
+                        ? Ui.Text(ResolveDetailLabel(in slot))
+                            .FontSize(Math.Max(9f, labelFontSize - 1f))
+                            .Color(ResolveThemeSubTextColor(themeId))
+                            .Width(width - 4f)
+                        : Ui.Text(slot.CooldownPermille > 0 ? $"Cooldown {slot.CooldownPermille / 10f:0}%" : ResolveFlagSummary(slot.StateFlags))
+                            .FontSize(Math.Max(9f, labelFontSize - 1f))
+                            .Color(ResolveThemeSubTextColor(themeId))
+                            .Width(width - 4f))
+                .Width(width)
+                .Gap(4f)
+                .Padding(0f)
+                .Background(UiColor.Transparent);
+
+            if (source is IEntityCommandPanelActionSource actions &&
+                !slot.StateFlags.HasFlag(EntityCommandSlotStateFlags.Empty))
+            {
+                int slotIndex = slot.SlotIndex;
+                card.OnClick(_ => { actions.ActivateSlot(target, groupIndex, slotIndex); });
+            }
+
+            return card;
+        }
+
+        private UiElementBuilder BuildShowcasePlaceholderCard(
+            string themeId,
+            string glyph,
+            string hotkey,
+            string label,
+            string accentColorHex,
+            float width,
+            float labelFontSize,
+            bool showDetail)
+        {
+            string art = _showcaseArtFactory.BuildSlotArt(themeId, glyph, hotkey, accentColorHex, 0, blocked: false, active: false, empty: false);
+            float artWidth = ResolveShowcaseArtWidth(themeId, width);
+            float artHeight = ResolveShowcaseArtHeight(themeId, artWidth);
+            return Ui.Card(
+                    Ui.Image(art)
+                        .Width(artWidth)
+                        .Height(artHeight)
+                        .FlexShrink(0f),
+                    Ui.Text(label)
+                        .FontFamily(string.Equals(themeId, EntityCommandPanelShowcaseTheme.Dota2Id, StringComparison.Ordinal) ? "Georgia" : "Segoe UI")
+                        .FontSize(labelFontSize)
+                        .Bold()
+                        .Color(ResolveThemeTextColor(themeId))
+                        .Width(width - 4f),
+                    showDetail
+                        ? Ui.Text("Command")
+                            .FontSize(Math.Max(9f, labelFontSize - 1f))
+                            .Color(ResolveThemeSubTextColor(themeId))
+                            .Width(width - 4f)
+                        : Ui.Text("Showcase")
+                            .FontSize(Math.Max(9f, labelFontSize - 1f))
+                            .Color(ResolveThemeSubTextColor(themeId))
+                            .Width(width - 4f))
+                .Width(width)
+                .Gap(4f)
+                .Padding(0f)
+                .Background(UiColor.Transparent);
+        }
+
+        private static UiElementBuilder BuildShowcaseInfoPill(string label, string value, string background, string color)
+        {
+            return Ui.Column(
+                    Ui.Text(label)
+                        .FontSize(10f)
+                        .Bold()
+                        .Color("#7F95A8"),
+                    Ui.Text(value)
+                        .FontSize(11f)
+                        .Bold()
+                        .Color(color))
+                .Gap(3f)
+                .Padding(8f, 6f)
+                .Radius(10f)
+                .Background(background);
+        }
+
+        private static UiElementBuilder BuildShowcaseBar(string label, string value, float progress, string fillColor, string trackColor, float width)
+        {
+            float clampedWidth = Math.Max(120f, width);
+            float fillWidth = Math.Max(18f, clampedWidth * Math.Clamp(progress, 0.08f, 1f));
+            return Ui.Column(
+                    Ui.Row(
+                            Ui.Text(label)
+                                .FontSize(10f)
+                                .Bold()
+                                .Color("#8AA2B6"),
+                            Ui.Text(value)
+                                .FontSize(10f)
+                                .Bold()
+                                .Color("#E7F4FF"))
+                        .Justify(UiJustifyContent.SpaceBetween),
+                    Ui.Panel(
+                            Ui.Panel()
+                                .Width(fillWidth)
+                                .Height(10f)
+                                .Radius(999f)
+                                .Background(fillColor))
+                        .Width(clampedWidth)
+                        .Height(10f)
+                        .Radius(999f)
+                        .Background(trackColor)
+                        .Overflow(UiOverflow.Hidden))
+                .Gap(4f);
+        }
+
+        private static string ResolveThemeTextColor(string themeId)
+        {
+            if (string.Equals(themeId, EntityCommandPanelShowcaseTheme.Dota2Id, StringComparison.Ordinal))
+            {
+                return "#F2DDC0";
+            }
+
+            if (string.Equals(themeId, EntityCommandPanelShowcaseTheme.Sc2Id, StringComparison.Ordinal))
+            {
+                return "#D7F6FF";
+            }
+
+            return "#F5E8B1";
+        }
+
+        private static string ResolveThemeSubTextColor(string themeId)
+        {
+            if (string.Equals(themeId, EntityCommandPanelShowcaseTheme.Dota2Id, StringComparison.Ordinal))
+            {
+                return "#CBB69E";
+            }
+
+            if (string.Equals(themeId, EntityCommandPanelShowcaseTheme.Sc2Id, StringComparison.Ordinal))
+            {
+                return "#8FB9D1";
+            }
+
+            return "#C5D3DE";
+        }
+
+        private static string ResolveFlagSummary(EntityCommandSlotStateFlags flags)
+        {
+            if (flags.HasFlag(EntityCommandSlotStateFlags.Active))
+            {
+                return "Active";
+            }
+
+            if (flags.HasFlag(EntityCommandSlotStateFlags.Blocked))
+            {
+                return "Blocked";
+            }
+
+            if (flags.HasFlag(EntityCommandSlotStateFlags.FormOverride))
+            {
+                return "Form Override";
+            }
+
+            if (flags.HasFlag(EntityCommandSlotStateFlags.GrantedOverride))
+            {
+                return "Granted";
+            }
+
+            if (flags.HasFlag(EntityCommandSlotStateFlags.Empty))
+            {
+                return "Empty";
+            }
+
+            return "Ready";
+        }
+
+        private static string ResolveGroupLine(EntityCommandPanelGroupView group, int groupCount, int groupIndex)
+        {
+            string label = string.IsNullOrWhiteSpace(group.GroupLabel) ? "Unavailable" : group.GroupLabel;
+            string counter = groupCount <= 0 ? "0/0" : $"{groupIndex + 1}/{groupCount}";
+            return $"{label} | {counter}";
+        }
+
+        private static float ResolveShowcaseArtWidth(string themeId, float cardWidth)
+        {
+            if (string.Equals(themeId, EntityCommandPanelShowcaseTheme.Sc2Id, StringComparison.Ordinal))
+            {
+                return Math.Max(70f, Math.Min(cardWidth, 84f));
+            }
+
+            if (string.Equals(themeId, EntityCommandPanelShowcaseTheme.LolId, StringComparison.Ordinal))
+            {
+                return Math.Max(86f, Math.Min(cardWidth, 116f));
+            }
+
+            return Math.Max(88f, Math.Min(cardWidth, 112f));
+        }
+
+        private static float ResolveShowcaseArtHeight(string themeId, float artWidth)
+        {
+            return string.Equals(themeId, EntityCommandPanelShowcaseTheme.Sc2Id, StringComparison.Ordinal)
+                ? artWidth * 1.08f
+                : artWidth * 1.15625f;
+        }
+
+        private static float ResolveModeProgress(string interactionModeKey)
+        {
+            return interactionModeKey switch
+            {
+                nameof(InteractionModeType.SmartCast) => 0.96f,
+                nameof(InteractionModeType.SmartCastWithIndicator) => 0.72f,
+                nameof(InteractionModeType.PressReleaseAimCast) => 0.58f,
+                nameof(InteractionModeType.AimCast) => 0.51f,
+                _ => 0.42f
+            };
+        }
+
+        private string ResolvePrimaryAccent(IReadOnlyList<EntityCommandPanelSlotView> slots)
+        {
+            for (int i = 0; i < slots.Count; i++)
+            {
+                EntityCommandPanelSlotView slot = slots[i];
+                if (slot.StateFlags.HasFlag(EntityCommandSlotStateFlags.Empty))
+                {
+                    continue;
+                }
+
+                return ResolveAbilityAccent(in slot);
+            }
+
+            return "#59B7FF";
         }
 
         private UiElementBuilder BuildHeader(
@@ -561,6 +1083,17 @@ namespace EntityCommandPanelMod.UI
             }
 
             return nameof(InteractionModeType.TargetFirst);
+        }
+
+        private string ResolveShowcaseThemeId()
+        {
+            if (_engine.GlobalContext.TryGetValue(EntityCommandPanelShowcaseTheme.ContextKey, out object? themeObj) &&
+                themeObj is string themeId)
+            {
+                return EntityCommandPanelShowcaseTheme.Normalize(themeId, EntityCommandPanelShowcaseTheme.ClassicId);
+            }
+
+            return EntityCommandPanelShowcaseTheme.ClassicId;
         }
 
         private static string NormalizeColor(string? value, string fallback)

--- a/mods/EntityCommandPanelMod/UI/EntityCommandPanelShowcaseArtFactory.cs
+++ b/mods/EntityCommandPanelMod/UI/EntityCommandPanelShowcaseArtFactory.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Collections.Generic;
+
+namespace EntityCommandPanelMod.UI
+{
+    internal sealed class EntityCommandPanelShowcaseArtFactory
+    {
+        private readonly Dictionary<string, string> _cache = new(StringComparer.Ordinal);
+
+        public string BuildSlotArt(
+            string themeId,
+            string glyph,
+            string hotkey,
+            string accentColorHex,
+            short cooldownPermille,
+            bool blocked,
+            bool active,
+            bool empty)
+        {
+            string normalizedTheme = EntityCommandPanelShowcaseTheme.Normalize(themeId, EntityCommandPanelShowcaseTheme.LolId);
+            string normalizedGlyph = string.IsNullOrWhiteSpace(glyph) ? "-" : glyph.Trim();
+            string normalizedHotkey = string.IsNullOrWhiteSpace(hotkey) ? string.Empty : hotkey.Trim();
+            string normalizedAccent = NormalizeHex(accentColorHex, empty ? "#5E6B7C" : "#59B7FF");
+            string key = string.Concat(
+                normalizedTheme, "|",
+                normalizedGlyph, "|",
+                normalizedHotkey, "|",
+                normalizedAccent, "|",
+                cooldownPermille.ToString(System.Globalization.CultureInfo.InvariantCulture), "|",
+                blocked ? "1" : "0", "|",
+                active ? "1" : "0", "|",
+                empty ? "1" : "0");
+
+            if (_cache.TryGetValue(key, out string? cached))
+            {
+                return cached;
+            }
+
+            string svg = normalizedTheme switch
+            {
+                var theme when string.Equals(theme, EntityCommandPanelShowcaseTheme.Dota2Id, StringComparison.Ordinal) => BuildDotaSlotSvg(normalizedGlyph, normalizedHotkey, normalizedAccent, cooldownPermille, blocked, active, empty),
+                var theme when string.Equals(theme, EntityCommandPanelShowcaseTheme.Sc2Id, StringComparison.Ordinal) => BuildSc2SlotSvg(normalizedGlyph, normalizedHotkey, normalizedAccent, cooldownPermille, blocked, active, empty),
+                _ => BuildLolSlotSvg(normalizedGlyph, normalizedHotkey, normalizedAccent, cooldownPermille, blocked, active, empty)
+            };
+
+            string uri = "data:image/svg+xml;utf8," + Uri.EscapeDataString(svg);
+            _cache[key] = uri;
+            return uri;
+        }
+
+        public string BuildPortraitArt(string themeId, string title, string subtitle, string accentColorHex)
+        {
+            string normalizedTheme = EntityCommandPanelShowcaseTheme.Normalize(themeId, EntityCommandPanelShowcaseTheme.LolId);
+            string normalizedTitle = string.IsNullOrWhiteSpace(title) ? "Unknown" : title.Trim();
+            string normalizedSubtitle = string.IsNullOrWhiteSpace(subtitle) ? "Showcase" : subtitle.Trim();
+            string normalizedAccent = NormalizeHex(accentColorHex, "#59B7FF");
+            string key = string.Concat("portrait|", normalizedTheme, "|", normalizedTitle, "|", normalizedSubtitle, "|", normalizedAccent);
+            if (_cache.TryGetValue(key, out string? cached))
+            {
+                return cached;
+            }
+
+            string svg = normalizedTheme switch
+            {
+                var theme when string.Equals(theme, EntityCommandPanelShowcaseTheme.Dota2Id, StringComparison.Ordinal) => BuildDotaPortraitSvg(normalizedTitle, normalizedSubtitle, normalizedAccent),
+                var theme when string.Equals(theme, EntityCommandPanelShowcaseTheme.Sc2Id, StringComparison.Ordinal) => BuildSc2PortraitSvg(normalizedTitle, normalizedSubtitle, normalizedAccent),
+                _ => BuildLolPortraitSvg(normalizedTitle, normalizedSubtitle, normalizedAccent)
+            };
+
+            string uri = "data:image/svg+xml;utf8," + Uri.EscapeDataString(svg);
+            _cache[key] = uri;
+            return uri;
+        }
+
+        private static string BuildLolSlotSvg(string glyph, string hotkey, string accent, short cooldownPermille, bool blocked, bool active, bool empty)
+        {
+            string fill = empty ? "#1A222D" : "#0B1118";
+            string inner = empty ? "#202B38" : "#17222F";
+            string border = active ? "#D6B56A" : "#3B4D62";
+            string glow = active ? "0.95" : "0.42";
+            string cooldownOverlay = cooldownPermille > 0
+                ? $"<rect x='8' y='8' width='112' height='112' rx='14' fill='#020406' opacity='0.62'/>" +
+                  $"<text x='64' y='73' text-anchor='middle' font-family='Segoe UI, Microsoft YaHei, sans-serif' font-size='26' font-weight='800' fill='#F2F7FF'>{cooldownPermille / 10f:0}%</text>"
+                : string.Empty;
+            string blockedStroke = blocked ? "<path d='M20 104 L108 16' stroke='#FB5F69' stroke-width='8' stroke-linecap='round' opacity='0.9'/>" : string.Empty;
+            string hotkeyBadge = string.IsNullOrWhiteSpace(hotkey)
+                ? string.Empty
+                : $"<rect x='40' y='122' width='48' height='20' rx='10' fill='#0A0F15' stroke='#7B6840' stroke-width='1.4'/>" +
+                  $"<text x='64' y='136' text-anchor='middle' font-family='Segoe UI, Microsoft YaHei, sans-serif' font-size='11' font-weight='700' fill='#E7D18B'>{EscapeXml(hotkey)}</text>";
+
+            return
+                "<svg xmlns='http://www.w3.org/2000/svg' width='128' height='148' viewBox='0 0 128 148'>" +
+                "<defs>" +
+                $"<linearGradient id='g' x1='0' y1='0' x2='1' y2='1'><stop offset='0%' stop-color='{accent}' stop-opacity='0.96'/><stop offset='100%' stop-color='#1B2735' stop-opacity='0.88'/></linearGradient>" +
+                "</defs>" +
+                $"<rect x='6' y='6' width='116' height='116' rx='16' fill='{fill}' stroke='#8E7442' stroke-width='3'/>" +
+                $"<rect x='10' y='10' width='108' height='108' rx='14' fill='{inner}' stroke='{border}' stroke-width='2'/>" +
+                $"<rect x='16' y='16' width='96' height='96' rx='12' fill='url(#g)' opacity='0.96'/>" +
+                $"<rect x='16' y='16' width='96' height='96' rx='12' fill='none' stroke='{accent}' stroke-width='2.4' opacity='{glow}'/>" +
+                $"<text x='64' y='76' text-anchor='middle' font-family='Segoe UI, Microsoft YaHei, sans-serif' font-size='42' font-weight='900' fill='#F4F8FD'>{EscapeXml(glyph)}</text>" +
+                cooldownOverlay +
+                blockedStroke +
+                hotkeyBadge +
+                "</svg>";
+        }
+
+        private static string BuildDotaSlotSvg(string glyph, string hotkey, string accent, short cooldownPermille, bool blocked, bool active, bool empty)
+        {
+            string fill = empty ? "#201915" : "#16100C";
+            string inner = empty ? "#2B231D" : "#2A1A10";
+            string border = active ? "#D6B07A" : "#5C4632";
+            string cooldownOverlay = cooldownPermille > 0
+                ? $"<rect x='10' y='10' width='108' height='108' rx='10' fill='#020100' opacity='0.68'/>" +
+                  $"<text x='64' y='74' text-anchor='middle' font-family='Georgia, Times New Roman, serif' font-size='28' font-weight='700' fill='#F5E6CC'>{cooldownPermille / 10f:0}%</text>"
+                : string.Empty;
+            string blockedStroke = blocked ? "<path d='M18 106 L110 14' stroke='#9E3C31' stroke-width='9' stroke-linecap='round' opacity='0.88'/>" : string.Empty;
+            string hotkeyBadge = string.IsNullOrWhiteSpace(hotkey)
+                ? string.Empty
+                : $"<rect x='8' y='122' width='28' height='18' rx='4' fill='#271D17' stroke='#84654C' stroke-width='1.2'/>" +
+                  $"<text x='22' y='135' text-anchor='middle' font-family='Georgia, Times New Roman, serif' font-size='11' font-weight='700' fill='#E5D7B8'>{EscapeXml(hotkey)}</text>";
+
+            return
+                "<svg xmlns='http://www.w3.org/2000/svg' width='128' height='148' viewBox='0 0 128 148'>" +
+                "<defs>" +
+                $"<linearGradient id='g' x1='0' y1='0' x2='1' y2='1'><stop offset='0%' stop-color='{accent}' stop-opacity='0.9'/><stop offset='65%' stop-color='#413022' stop-opacity='0.96'/><stop offset='100%' stop-color='#100C09' stop-opacity='1'/></linearGradient>" +
+                "</defs>" +
+                $"<rect x='4' y='4' width='120' height='120' rx='12' fill='{fill}' stroke='#8A6A46' stroke-width='3'/>" +
+                $"<rect x='10' y='10' width='108' height='108' rx='10' fill='{inner}' stroke='{border}' stroke-width='2'/>" +
+                $"<rect x='14' y='14' width='100' height='100' rx='8' fill='url(#g)'/>" +
+                $"<rect x='14' y='14' width='100' height='100' rx='8' fill='none' stroke='#D2A264' stroke-width='1.8' opacity='0.72'/>" +
+                $"<text x='64' y='76' text-anchor='middle' font-family='Georgia, Times New Roman, serif' font-size='42' font-weight='700' fill='#F7E8D1'>{EscapeXml(glyph)}</text>" +
+                cooldownOverlay +
+                blockedStroke +
+                hotkeyBadge +
+                "</svg>";
+        }
+
+        private static string BuildSc2SlotSvg(string glyph, string hotkey, string accent, short cooldownPermille, bool blocked, bool active, bool empty)
+        {
+            string fill = empty ? "#101D2B" : "#09131F";
+            string inner = empty ? "#183043" : "#102437";
+            string border = active ? "#7FDBFF" : "#2D4C65";
+            string cooldownOverlay = cooldownPermille > 0
+                ? $"<rect x='8' y='8' width='112' height='112' rx='6' fill='#02060B' opacity='0.74'/>" +
+                  $"<text x='64' y='74' text-anchor='middle' font-family='Segoe UI, Microsoft YaHei, sans-serif' font-size='26' font-weight='800' fill='#CFEFFF'>{cooldownPermille / 10f:0}%</text>"
+                : string.Empty;
+            string blockedStroke = blocked ? "<path d='M18 108 L110 16' stroke='#E45B4F' stroke-width='8' stroke-linecap='round' opacity='0.92'/>" : string.Empty;
+            string hotkeyBadge = string.IsNullOrWhiteSpace(hotkey)
+                ? string.Empty
+                : $"<rect x='90' y='122' width='28' height='18' rx='3' fill='#071019' stroke='#4A84A8' stroke-width='1.2'/>" +
+                  $"<text x='104' y='135' text-anchor='middle' font-family='Segoe UI, Microsoft YaHei, sans-serif' font-size='11' font-weight='700' fill='#D6F3FF'>{EscapeXml(hotkey)}</text>";
+
+            return
+                "<svg xmlns='http://www.w3.org/2000/svg' width='128' height='148' viewBox='0 0 128 148'>" +
+                "<defs>" +
+                $"<linearGradient id='g' x1='0' y1='0' x2='1' y2='1'><stop offset='0%' stop-color='{accent}' stop-opacity='0.9'/><stop offset='60%' stop-color='#143A58' stop-opacity='0.95'/><stop offset='100%' stop-color='#08111B' stop-opacity='1'/></linearGradient>" +
+                "</defs>" +
+                $"<rect x='4' y='4' width='120' height='120' rx='8' fill='{fill}' stroke='#204059' stroke-width='3'/>" +
+                $"<rect x='9' y='9' width='110' height='110' rx='6' fill='{inner}' stroke='{border}' stroke-width='1.8'/>" +
+                $"<rect x='14' y='14' width='100' height='100' rx='4' fill='url(#g)' opacity='0.96'/>" +
+                $"<path d='M14 36 L114 36' stroke='#8BE9FF' stroke-width='1.2' opacity='0.45'/>" +
+                $"<path d='M14 92 L114 92' stroke='#8BE9FF' stroke-width='1.2' opacity='0.18'/>" +
+                $"<text x='64' y='76' text-anchor='middle' font-family='Segoe UI, Microsoft YaHei, sans-serif' font-size='42' font-weight='900' fill='#ECFBFF'>{EscapeXml(glyph)}</text>" +
+                cooldownOverlay +
+                blockedStroke +
+                hotkeyBadge +
+                "</svg>";
+        }
+
+        private static string BuildLolPortraitSvg(string title, string subtitle, string accent)
+        {
+            return
+                "<svg xmlns='http://www.w3.org/2000/svg' width='200' height='164' viewBox='0 0 200 164'>" +
+                "<defs>" +
+                $"<linearGradient id='g' x1='0' y1='0' x2='1' y2='1'><stop offset='0%' stop-color='{accent}' stop-opacity='0.95'/><stop offset='100%' stop-color='#0B1118' stop-opacity='1'/></linearGradient>" +
+                "</defs>" +
+                "<rect width='200' height='164' rx='18' fill='#081018' stroke='#8E7442' stroke-width='3'/>" +
+                "<rect x='10' y='10' width='180' height='98' rx='14' fill='url(#g)'/>" +
+                "<circle cx='100' cy='56' r='28' fill='#08131D' stroke='#E0C679' stroke-width='3'/>" +
+                $"<text x='100' y='66' text-anchor='middle' font-family='Segoe UI, Microsoft YaHei, sans-serif' font-size='28' font-weight='900' fill='#F4F8FD'>{EscapeXml(title[..1].ToUpperInvariant())}</text>" +
+                $"<text x='18' y='128' font-family='Segoe UI, Microsoft YaHei, sans-serif' font-size='16' font-weight='700' fill='#F1DC97'>{EscapeXml(title)}</text>" +
+                $"<text x='18' y='148' font-family='Segoe UI, Microsoft YaHei, sans-serif' font-size='11' font-weight='600' fill='#C5D3DE'>{EscapeXml(subtitle)}</text>" +
+                "</svg>";
+        }
+
+        private static string BuildDotaPortraitSvg(string title, string subtitle, string accent)
+        {
+            return
+                "<svg xmlns='http://www.w3.org/2000/svg' width='220' height='170' viewBox='0 0 220 170'>" +
+                "<defs>" +
+                $"<linearGradient id='g' x1='0' y1='0' x2='1' y2='1'><stop offset='0%' stop-color='{accent}' stop-opacity='0.92'/><stop offset='100%' stop-color='#17110C' stop-opacity='1'/></linearGradient>" +
+                "</defs>" +
+                "<rect width='220' height='170' rx='16' fill='#120E0B' stroke='#8A6A46' stroke-width='3'/>" +
+                "<rect x='12' y='12' width='196' height='108' rx='12' fill='url(#g)'/>" +
+                "<path d='M20 98 L110 26 L200 98' fill='none' stroke='#D6B07A' stroke-width='4' opacity='0.48'/>" +
+                $"<text x='110' y='72' text-anchor='middle' font-family='Georgia, Times New Roman, serif' font-size='32' font-weight='700' fill='#F5E6CC'>{EscapeXml(title[..1].ToUpperInvariant())}</text>" +
+                $"<text x='18' y='140' font-family='Georgia, Times New Roman, serif' font-size='18' font-weight='700' fill='#F4DEB7'>{EscapeXml(title)}</text>" +
+                $"<text x='18' y='158' font-family='Georgia, Times New Roman, serif' font-size='11' font-weight='700' fill='#C8B79F'>{EscapeXml(subtitle)}</text>" +
+                "</svg>";
+        }
+
+        private static string BuildSc2PortraitSvg(string title, string subtitle, string accent)
+        {
+            return
+                "<svg xmlns='http://www.w3.org/2000/svg' width='196' height='196' viewBox='0 0 196 196'>" +
+                "<defs>" +
+                $"<linearGradient id='g' x1='0' y1='0' x2='1' y2='1'><stop offset='0%' stop-color='{accent}' stop-opacity='0.92'/><stop offset='100%' stop-color='#07111A' stop-opacity='1'/></linearGradient>" +
+                "</defs>" +
+                "<rect width='196' height='196' rx='12' fill='#06121D' stroke='#2E5A79' stroke-width='3'/>" +
+                "<rect x='10' y='10' width='176' height='116' rx='8' fill='url(#g)'/>" +
+                "<path d='M10 44 L186 44' stroke='#8BE9FF' stroke-width='1.2' opacity='0.32'/>" +
+                "<path d='M10 94 L186 94' stroke='#8BE9FF' stroke-width='1.2' opacity='0.2'/>" +
+                "<circle cx='98' cy='68' r='28' fill='#08141E' stroke='#7FDBFF' stroke-width='3'/>" +
+                $"<text x='98' y='79' text-anchor='middle' font-family='Segoe UI, Microsoft YaHei, sans-serif' font-size='28' font-weight='900' fill='#ECFBFF'>{EscapeXml(title[..1].ToUpperInvariant())}</text>" +
+                $"<text x='16' y='150' font-family='Segoe UI, Microsoft YaHei, sans-serif' font-size='17' font-weight='700' fill='#D7F6FF'>{EscapeXml(title)}</text>" +
+                $"<text x='16' y='170' font-family='Segoe UI, Microsoft YaHei, sans-serif' font-size='11' font-weight='700' fill='#8FB9D1'>{EscapeXml(subtitle)}</text>" +
+                "</svg>";
+        }
+
+        private static string NormalizeHex(string? value, string fallback)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return fallback;
+            }
+
+            string trimmed = value.Trim();
+            if (trimmed.StartsWith('#'))
+            {
+                trimmed = trimmed[1..];
+            }
+
+            if (trimmed.Length == 3)
+            {
+                trimmed = string.Concat(
+                    trimmed[0], trimmed[0],
+                    trimmed[1], trimmed[1],
+                    trimmed[2], trimmed[2]);
+            }
+
+            if (trimmed.Length < 6)
+            {
+                return fallback;
+            }
+
+            string rgb = trimmed[..6];
+            for (int i = 0; i < rgb.Length; i++)
+            {
+                char ch = rgb[i];
+                bool isHex = (ch >= '0' && ch <= '9') ||
+                             (ch >= 'A' && ch <= 'F') ||
+                             (ch >= 'a' && ch <= 'f');
+                if (!isHex)
+                {
+                    return fallback;
+                }
+            }
+
+            return "#" + rgb.ToUpperInvariant();
+        }
+
+        private static string EscapeXml(string value)
+        {
+            return value
+                .Replace("&", "&amp;", StringComparison.Ordinal)
+                .Replace("<", "&lt;", StringComparison.Ordinal)
+                .Replace(">", "&gt;", StringComparison.Ordinal)
+                .Replace("\"", "&quot;", StringComparison.Ordinal)
+                .Replace("'", "&apos;", StringComparison.Ordinal);
+        }
+    }
+}

--- a/mods/EntityCommandPanelMod/UI/EntityCommandPanelShowcaseTheme.cs
+++ b/mods/EntityCommandPanelMod/UI/EntityCommandPanelShowcaseTheme.cs
@@ -1,0 +1,94 @@
+using System;
+using Ludots.Core.UI.EntityCommandPanels;
+
+namespace EntityCommandPanelMod.UI
+{
+    public static class EntityCommandPanelShowcaseTheme
+    {
+        public const string ContextKey = "EntityCommandPanel.ShowcaseTheme";
+        public const string ClassicId = "EntityCommandPanel.Showcase.Classic";
+        public const string Dota2Id = "EntityCommandPanel.Showcase.Dota2";
+        public const string LolId = "EntityCommandPanel.Showcase.LoL";
+        public const string Sc2Id = "EntityCommandPanel.Showcase.SC2";
+
+        public static bool IsThemeButton(string? buttonId)
+        {
+            return string.Equals(buttonId, Dota2Id, StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(buttonId, LolId, StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(buttonId, Sc2Id, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static string Normalize(string? themeId, string fallback = ClassicId)
+        {
+            if (string.Equals(themeId, Dota2Id, StringComparison.OrdinalIgnoreCase))
+            {
+                return Dota2Id;
+            }
+
+            if (string.Equals(themeId, LolId, StringComparison.OrdinalIgnoreCase))
+            {
+                return LolId;
+            }
+
+            if (string.Equals(themeId, Sc2Id, StringComparison.OrdinalIgnoreCase))
+            {
+                return Sc2Id;
+            }
+
+            return fallback;
+        }
+
+        public static string ResolveLabel(string? themeId)
+        {
+            string normalized = Normalize(themeId);
+            if (string.Equals(normalized, Dota2Id, StringComparison.Ordinal))
+            {
+                return "Dota2";
+            }
+
+            if (string.Equals(normalized, Sc2Id, StringComparison.Ordinal))
+            {
+                return "SC2";
+            }
+
+            if (string.Equals(normalized, LolId, StringComparison.Ordinal))
+            {
+                return "LoL";
+            }
+
+            return "Classic";
+        }
+
+        public static EntityCommandPanelAnchor ResolveSandboxAnchor(string? themeId)
+        {
+            string normalized = Normalize(themeId, LolId);
+            if (string.Equals(normalized, Sc2Id, StringComparison.Ordinal))
+            {
+                return new EntityCommandPanelAnchor(EntityCommandPanelAnchorPreset.BottomRight, 20f, 18f);
+            }
+
+            return new EntityCommandPanelAnchor(EntityCommandPanelAnchorPreset.BottomCenter, 0f, 18f);
+        }
+
+        public static EntityCommandPanelSize ResolveSandboxSize(string? themeId)
+        {
+            string normalized = Normalize(themeId, LolId);
+            if (string.Equals(normalized, Dota2Id, StringComparison.Ordinal))
+            {
+                return new EntityCommandPanelSize(1236f, 332f);
+            }
+
+            if (string.Equals(normalized, Sc2Id, StringComparison.Ordinal))
+            {
+                return new EntityCommandPanelSize(744f, 430f);
+            }
+
+            if (string.Equals(normalized, LolId, StringComparison.Ordinal))
+            {
+                return new EntityCommandPanelSize(948f, 248f);
+            }
+
+            return new EntityCommandPanelSize(460f, 276f);
+        }
+    }
+}

--- a/mods/capabilities/minimap/MinimapControlMod/MinimapControlMod.csproj
+++ b/mods/capabilities/minimap/MinimapControlMod/MinimapControlMod.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/mods/capabilities/minimap/MinimapControlMod/MinimapControlModEntry.cs
+++ b/mods/capabilities/minimap/MinimapControlMod/MinimapControlModEntry.cs
@@ -1,0 +1,18 @@
+using Ludots.Core.Modding;
+using Ludots.Core.Scripting;
+using MinimapControlMod.Triggers;
+
+namespace MinimapControlMod;
+
+public sealed class MinimapControlModEntry : IMod
+{
+    public void OnLoad(IModContext context)
+    {
+        context.Log("[MinimapControlMod] Loaded.");
+        context.OnEvent(GameEvents.GameStart, new InstallMinimapControlOnGameStartTrigger(context).ExecuteAsync);
+    }
+
+    public void OnUnload()
+    {
+    }
+}

--- a/mods/capabilities/minimap/MinimapControlMod/MinimapControlServiceKeys.cs
+++ b/mods/capabilities/minimap/MinimapControlMod/MinimapControlServiceKeys.cs
@@ -1,0 +1,10 @@
+using Ludots.Core.Scripting;
+using MinimapControlMod.Runtime;
+
+namespace MinimapControlMod;
+
+public static class MinimapControlServiceKeys
+{
+    public static readonly ServiceKey<MinimapControlRuntime> Runtime =
+        new("MinimapControlMod.Runtime");
+}

--- a/mods/capabilities/minimap/MinimapControlMod/Runtime/MinimapControlRuntime.cs
+++ b/mods/capabilities/minimap/MinimapControlMod/Runtime/MinimapControlRuntime.cs
@@ -1,0 +1,872 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Arch.Core;
+using Ludots.Core.Components;
+using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.Components;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.Gameplay.Teams;
+using Ludots.Core.Input.Selection;
+using Ludots.Core.Map;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Presentation.Hud;
+using Ludots.Core.Scripting;
+
+namespace MinimapControlMod.Runtime;
+
+public enum MinimapZoomBand : byte
+{
+    Strategic = 0,
+    Regional = 1,
+    Tactical = 2,
+}
+
+public enum MinimapSignalKind : byte
+{
+    Capital = 0,
+    Settlement = 1,
+    Fleet = 2,
+    Army = 3,
+    Scout = 4,
+    Objective = 5,
+    Resource = 6,
+    Hazard = 7,
+    Relay = 8,
+}
+
+[Flags]
+public enum MinimapSignalFlags : ushort
+{
+    None = 0,
+    Selected = 1 << 0,
+    Friendly = 1 << 1,
+    Hostile = 1 << 2,
+    Neutral = 1 << 3,
+    Structure = 1 << 4,
+    Mobile = 1 << 5,
+    Objective = 1 << 6,
+    Resource = 1 << 7,
+    Hazard = 1 << 8,
+    Alert = 1 << 9,
+    Frontier = 1 << 10,
+}
+
+public sealed record MinimapDebugSignal(
+    string Label,
+    int TeamId,
+    MinimapSignalKind Kind,
+    MinimapSignalFlags Flags,
+    float WorldXcm,
+    float WorldYcm,
+    float NormalizedX,
+    float NormalizedY);
+
+public sealed record MinimapDebugCell(
+    int CellX,
+    int CellY,
+    int Total,
+    int Friendly,
+    int Hostile,
+    int Neutral,
+    int Structures,
+    int Objectives,
+    int Resources,
+    int Hazards);
+
+public sealed record MinimapDebugSnapshot(
+    string MapId,
+    string SelectedLabel,
+    int PerspectiveTeamId,
+    MinimapZoomBand ZoomBand,
+    float CenterXcm,
+    float CenterYcm,
+    float HalfExtentCm,
+    float MinWorldXcm,
+    float MinWorldYcm,
+    float MaxWorldXcm,
+    float MaxWorldYcm,
+    IReadOnlyList<MinimapDebugSignal> VisibleSignals,
+    IReadOnlyList<MinimapDebugCell> StrategicCells);
+
+public sealed class MinimapControlRuntime
+{
+    private const int MaxSignals = 512;
+    private const int StrategicGridSide = 12;
+    private const int StrategicCellCount = StrategicGridSide * StrategicGridSide;
+
+    private const int PanelX = 1472;
+    private const int PanelY = 32;
+    private const int PanelWidth = 416;
+    private const int PanelHeight = 414;
+    private const int FieldX = PanelX + 18;
+    private const int FieldY = PanelY + 56;
+    private const int FieldSize = 272;
+    private const int LegendY = FieldY + FieldSize + 18;
+
+    private static readonly QueryDescription SignalQuery = new QueryDescription()
+        .WithAll<Name, WorldPositionCm, Team, MapEntity>();
+
+    private static readonly string[] BandLabels =
+    {
+        "Strategic",
+        "Regional",
+        "Tactical",
+    };
+
+    private static readonly string[] CountLabels =
+    {
+        string.Empty,
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9+",
+    };
+
+    private readonly int[] _entityIds = new int[MaxSignals];
+    private readonly int[] _entityVersions = new int[MaxSignals];
+    private readonly int[] _teamIds = new int[MaxSignals];
+    private readonly float[] _worldXcm = new float[MaxSignals];
+    private readonly float[] _worldYcm = new float[MaxSignals];
+    private readonly byte[] _kinds = new byte[MaxSignals];
+    private readonly ushort[] _flags = new ushort[MaxSignals];
+    private readonly byte[] _importance = new byte[MaxSignals];
+    private readonly string[] _labels = new string[MaxSignals];
+    private readonly int[] _visibleSignalIndices = new int[MaxSignals];
+
+    private readonly int[] _cellTotals = new int[StrategicCellCount];
+    private readonly int[] _cellFriendly = new int[StrategicCellCount];
+    private readonly int[] _cellHostile = new int[StrategicCellCount];
+    private readonly int[] _cellNeutral = new int[StrategicCellCount];
+    private readonly int[] _cellStructures = new int[StrategicCellCount];
+    private readonly int[] _cellObjectives = new int[StrategicCellCount];
+    private readonly int[] _cellResources = new int[StrategicCellCount];
+    private readonly int[] _cellHazards = new int[StrategicCellCount];
+
+    private readonly int _capitalTagId = TagRegistry.Register("State.Minimap.Capital");
+    private readonly int _objectiveTagId = TagRegistry.Register("State.Minimap.Objective");
+    private readonly int _resourceTagId = TagRegistry.Register("State.Minimap.Resource");
+    private readonly int _hazardTagId = TagRegistry.Register("State.Minimap.Hazard");
+    private readonly int _alertTagId = TagRegistry.Register("State.Minimap.Alert");
+    private readonly int _frontierTagId = TagRegistry.Register("State.Minimap.Frontier");
+
+    private int _signalCount;
+    private int _visibleSignalCount;
+    private int _perspectiveTeamId;
+    private string _selectedLabel = string.Empty;
+    private string _currentMapId = string.Empty;
+    private float _centerXcm;
+    private float _centerYcm;
+    private float _halfExtentCm = 22000f;
+    private float _minWorldXcm;
+    private float _minWorldYcm;
+    private float _maxWorldXcm;
+    private float _maxWorldYcm;
+    private bool _viewportInitialized;
+
+    public bool Visible { get; set; }
+    public MinimapZoomBand ZoomBand { get; private set; } = MinimapZoomBand.Strategic;
+    public string CurrentMapId => _currentMapId;
+    public string SelectedLabel => _selectedLabel;
+    public int PerspectiveTeamId => _perspectiveTeamId;
+    public int SignalCount => _signalCount;
+    public int VisibleSignalCount => _visibleSignalCount;
+    public float CenterXcm => _centerXcm;
+    public float CenterYcm => _centerYcm;
+    public float HalfExtentCm => _halfExtentCm;
+
+    public void Refresh(GameEngine engine)
+    {
+        ArgumentNullException.ThrowIfNull(engine);
+
+        _currentMapId = engine.CurrentMapSession?.MapId.Value ?? string.Empty;
+        if (!Visible || string.IsNullOrWhiteSpace(_currentMapId))
+        {
+            ResetTransientState();
+            return;
+        }
+
+        _signalCount = 0;
+        _visibleSignalCount = 0;
+        _selectedLabel = string.Empty;
+        _perspectiveTeamId = ResolvePerspectiveTeamId(engine);
+        _minWorldXcm = float.MaxValue;
+        _minWorldYcm = float.MaxValue;
+        _maxWorldXcm = float.MinValue;
+        _maxWorldYcm = float.MinValue;
+
+        Array.Clear(_cellTotals, 0, _cellTotals.Length);
+        Array.Clear(_cellFriendly, 0, _cellFriendly.Length);
+        Array.Clear(_cellHostile, 0, _cellHostile.Length);
+        Array.Clear(_cellNeutral, 0, _cellNeutral.Length);
+        Array.Clear(_cellStructures, 0, _cellStructures.Length);
+        Array.Clear(_cellObjectives, 0, _cellObjectives.Length);
+        Array.Clear(_cellResources, 0, _cellResources.Length);
+        Array.Clear(_cellHazards, 0, _cellHazards.Length);
+
+        MapId activeMapId = engine.CurrentMapSession?.MapId ?? default;
+        Entity selectedEntity = ResolveSelectedEntity(engine);
+
+        foreach (ref var chunk in engine.World.Query(in SignalQuery))
+        {
+            var names = chunk.GetSpan<Name>();
+            var positions = chunk.GetSpan<WorldPositionCm>();
+            var teams = chunk.GetSpan<Team>();
+            var mapEntities = chunk.GetSpan<MapEntity>();
+            bool hasTags = chunk.Has<GameplayTagContainer>();
+            var tags = hasTags ? chunk.GetSpan<GameplayTagContainer>() : default;
+
+            for (int i = 0; i < chunk.Count && _signalCount < MaxSignals; i++)
+            {
+                if (mapEntities[i].MapId != activeMapId)
+                {
+                    continue;
+                }
+
+                Entity entity = chunk.Entity(i);
+                string label = names[i].Value ?? string.Empty;
+                WorldCmInt2 world = positions[i].ToWorldCmInt2();
+                GameplayTagContainer tagContainer = hasTags ? tags[i] : default;
+
+                MinimapSignalKind kind = ClassifyKind(label, in tagContainer);
+                MinimapSignalFlags flagMask = BuildFlags(
+                    label,
+                    in tagContainer,
+                    kind,
+                    teams[i].Id,
+                    selectedEntity == entity,
+                    _perspectiveTeamId);
+
+                _entityIds[_signalCount] = entity.Id;
+                _entityVersions[_signalCount] = entity.Version;
+                _teamIds[_signalCount] = teams[i].Id;
+                _worldXcm[_signalCount] = world.X;
+                _worldYcm[_signalCount] = world.Y;
+                _kinds[_signalCount] = (byte)kind;
+                _flags[_signalCount] = (ushort)flagMask;
+                _importance[_signalCount] = ComputeImportance(kind, flagMask);
+                _labels[_signalCount] = label;
+
+                if ((flagMask & MinimapSignalFlags.Selected) != 0)
+                {
+                    _selectedLabel = label;
+                }
+
+                _minWorldXcm = MathF.Min(_minWorldXcm, world.X);
+                _minWorldYcm = MathF.Min(_minWorldYcm, world.Y);
+                _maxWorldXcm = MathF.Max(_maxWorldXcm, world.X);
+                _maxWorldYcm = MathF.Max(_maxWorldYcm, world.Y);
+
+                _signalCount++;
+            }
+        }
+
+        if (_signalCount == 0)
+        {
+            ResetTransientState();
+            return;
+        }
+
+        if (!_viewportInitialized)
+        {
+            FocusOnContent();
+        }
+
+        ClampViewportToContent();
+        ZoomBand = ResolveZoomBand(_halfExtentCm);
+        RebuildVisibleSet();
+    }
+
+    public void Render(ScreenOverlayBuffer overlay)
+    {
+        ArgumentNullException.ThrowIfNull(overlay);
+        if (!Visible || _signalCount == 0)
+        {
+            return;
+        }
+
+        overlay.AddRect(
+            PanelX,
+            PanelY,
+            PanelWidth,
+            PanelHeight,
+            new Vector4(0.03f, 0.06f, 0.09f, 0.90f),
+            new Vector4(0.34f, 0.49f, 0.62f, 0.90f));
+        overlay.AddText(PanelX + 18, PanelY + 24, "4X Minimap", 20, new Vector4(0.94f, 0.96f, 0.99f, 1f));
+        overlay.AddText(PanelX + 220, PanelY + 24, BandLabels[(int)ZoomBand], 16, new Vector4(0.95f, 0.78f, 0.43f, 1f));
+
+        overlay.AddRect(
+            FieldX,
+            FieldY,
+            FieldSize,
+            FieldSize,
+            new Vector4(0.04f, 0.08f, 0.12f, 0.96f),
+            new Vector4(0.22f, 0.35f, 0.43f, 0.95f));
+        RenderGrid(overlay);
+
+        if (ZoomBand == MinimapZoomBand.Strategic)
+        {
+            RenderStrategicCells(overlay);
+        }
+        else
+        {
+            RenderSignals(overlay);
+        }
+
+        overlay.AddText(PanelX + 18, LegendY, "Wheel/PageUp/PageDown zoom", 14, new Vector4(0.72f, 0.79f, 0.86f, 1f));
+        overlay.AddText(PanelX + 18, LegendY + 22, "Arrows pan  C center selected", 14, new Vector4(0.72f, 0.79f, 0.86f, 1f));
+        overlay.AddText(PanelX + 18, LegendY + 48, "Selected", 14, new Vector4(0.95f, 0.78f, 0.43f, 1f));
+        overlay.AddText(PanelX + 92, LegendY + 48, string.IsNullOrWhiteSpace(_selectedLabel) ? "None" : _selectedLabel, 14, new Vector4(0.97f, 0.98f, 1f, 1f));
+        overlay.AddText(PanelX + 18, LegendY + 72, "Empire / frontier / tactical layers switch by zoom band.", 13, new Vector4(0.60f, 0.69f, 0.76f, 1f));
+    }
+
+    public void SetViewport(float centerXcm, float centerYcm, float halfExtentCm)
+    {
+        _centerXcm = centerXcm;
+        _centerYcm = centerYcm;
+        _halfExtentCm = ClampHalfExtent(halfExtentCm);
+        _viewportInitialized = true;
+    }
+
+    public void FocusOnContent()
+    {
+        if (_signalCount <= 0)
+        {
+            return;
+        }
+
+        _centerXcm = (_minWorldXcm + _maxWorldXcm) * 0.5f;
+        _centerYcm = (_minWorldYcm + _maxWorldYcm) * 0.5f;
+        float spanX = MathF.Max(2400f, _maxWorldXcm - _minWorldXcm);
+        float spanY = MathF.Max(2400f, _maxWorldYcm - _minWorldYcm);
+        _halfExtentCm = ClampHalfExtent(MathF.Max(spanX, spanY) * 0.6f);
+        _viewportInitialized = true;
+    }
+
+    public void CenterOnSelected(GameEngine engine)
+    {
+        ArgumentNullException.ThrowIfNull(engine);
+
+        Entity selected = ResolveSelectedEntity(engine);
+        if (selected == Entity.Null || !engine.World.IsAlive(selected) || !engine.World.TryGet(selected, out WorldPositionCm position))
+        {
+            return;
+        }
+
+        WorldCmInt2 world = position.ToWorldCmInt2();
+        _centerXcm = world.X;
+        _centerYcm = world.Y;
+        _viewportInitialized = true;
+    }
+
+    public void ApplyWheelZoom(float wheelDelta)
+    {
+        if (wheelDelta == 0f)
+        {
+            return;
+        }
+
+        float factor = wheelDelta > 0f ? 0.85f : 1.18f;
+        _halfExtentCm = ClampHalfExtent(_halfExtentCm * factor);
+    }
+
+    public void CycleZoom(int delta)
+    {
+        if (delta == 0)
+        {
+            return;
+        }
+
+        MinimapZoomBand next = ZoomBand;
+        if (delta > 0 && next > MinimapZoomBand.Strategic)
+        {
+            next--;
+        }
+        else if (delta < 0 && next < MinimapZoomBand.Tactical)
+        {
+            next++;
+        }
+
+        _halfExtentCm = next switch
+        {
+            MinimapZoomBand.Strategic => 22000f,
+            MinimapZoomBand.Regional => 7000f,
+            _ => 1800f,
+        };
+    }
+
+    public void PanNormalized(float dx, float dy)
+    {
+        if (dx == 0f && dy == 0f)
+        {
+            return;
+        }
+
+        float step = _halfExtentCm * 1.1f;
+        _centerXcm += dx * step;
+        _centerYcm += dy * step;
+    }
+
+    public MinimapDebugSnapshot CaptureDebugSnapshot()
+    {
+        var visibleSignals = new List<MinimapDebugSignal>(_visibleSignalCount);
+        for (int i = 0; i < _visibleSignalCount; i++)
+        {
+            int index = _visibleSignalIndices[i];
+            visibleSignals.Add(new MinimapDebugSignal(
+                _labels[index] ?? string.Empty,
+                _teamIds[index],
+                (MinimapSignalKind)_kinds[index],
+                (MinimapSignalFlags)_flags[index],
+                _worldXcm[index],
+                _worldYcm[index],
+                NormalizeToField(_worldXcm[index], _centerXcm, _halfExtentCm),
+                NormalizeToField(_worldYcm[index], _centerYcm, _halfExtentCm)));
+        }
+
+        var cells = new List<MinimapDebugCell>(StrategicCellCount);
+        for (int i = 0; i < StrategicCellCount; i++)
+        {
+            if (_cellTotals[i] <= 0)
+            {
+                continue;
+            }
+
+            int cellX = i % StrategicGridSide;
+            int cellY = i / StrategicGridSide;
+            cells.Add(new MinimapDebugCell(
+                cellX,
+                cellY,
+                _cellTotals[i],
+                _cellFriendly[i],
+                _cellHostile[i],
+                _cellNeutral[i],
+                _cellStructures[i],
+                _cellObjectives[i],
+                _cellResources[i],
+                _cellHazards[i]));
+        }
+
+        return new MinimapDebugSnapshot(
+            _currentMapId,
+            _selectedLabel,
+            _perspectiveTeamId,
+            ZoomBand,
+            _centerXcm,
+            _centerYcm,
+            _halfExtentCm,
+            _minWorldXcm,
+            _minWorldYcm,
+            _maxWorldXcm,
+            _maxWorldYcm,
+            visibleSignals,
+            cells);
+    }
+
+    private void RenderGrid(ScreenOverlayBuffer overlay)
+    {
+        int step = FieldSize / 4;
+        for (int i = 1; i < 4; i++)
+        {
+            int offset = step * i;
+            overlay.AddRect(FieldX + offset, FieldY, 1, FieldSize, Vector4.Zero, new Vector4(0.15f, 0.25f, 0.30f, 0.70f));
+            overlay.AddRect(FieldX, FieldY + offset, FieldSize, 1, Vector4.Zero, new Vector4(0.15f, 0.25f, 0.30f, 0.70f));
+        }
+
+        overlay.AddRect(FieldX + (FieldSize / 2), FieldY, 1, FieldSize, Vector4.Zero, new Vector4(0.32f, 0.43f, 0.50f, 0.75f));
+        overlay.AddRect(FieldX, FieldY + (FieldSize / 2), FieldSize, 1, Vector4.Zero, new Vector4(0.32f, 0.43f, 0.50f, 0.75f));
+    }
+
+    private void RenderStrategicCells(ScreenOverlayBuffer overlay)
+    {
+        int cellSize = FieldSize / StrategicGridSide;
+        for (int index = 0; index < StrategicCellCount; index++)
+        {
+            int total = _cellTotals[index];
+            if (total <= 0)
+            {
+                continue;
+            }
+
+            int x = index % StrategicGridSide;
+            int y = index / StrategicGridSide;
+            Vector4 fill = ResolveCellColor(index);
+            overlay.AddRect(
+                FieldX + (x * cellSize) + 2,
+                FieldY + (y * cellSize) + 2,
+                cellSize - 4,
+                cellSize - 4,
+                fill,
+                new Vector4(0.10f, 0.17f, 0.23f, 0.80f));
+
+            if (_cellObjectives[index] > 0)
+            {
+                overlay.AddText(FieldX + (x * cellSize) + 6, FieldY + (y * cellSize) + 14, "O", 14, new Vector4(1f, 0.86f, 0.54f, 1f));
+            }
+            else if (_cellResources[index] > 0)
+            {
+                overlay.AddText(FieldX + (x * cellSize) + 6, FieldY + (y * cellSize) + 14, "R", 14, new Vector4(0.64f, 0.92f, 0.84f, 1f));
+            }
+            else if (_cellHazards[index] > 0)
+            {
+                overlay.AddText(FieldX + (x * cellSize) + 6, FieldY + (y * cellSize) + 14, "!", 14, new Vector4(1f, 0.57f, 0.50f, 1f));
+            }
+
+            overlay.AddText(
+                FieldX + (x * cellSize) + cellSize - 18,
+                FieldY + (y * cellSize) + cellSize - 8,
+                CountLabels[Math.Min(9, total)],
+                11,
+                new Vector4(0.97f, 0.98f, 1f, 1f));
+        }
+
+        RenderImportantSignals(overlay);
+    }
+
+    private void RenderSignals(ScreenOverlayBuffer overlay)
+    {
+        for (int i = 0; i < _visibleSignalCount; i++)
+        {
+            RenderSignal(overlay, _visibleSignalIndices[i], iconOnly: false);
+        }
+    }
+
+    private void RenderImportantSignals(ScreenOverlayBuffer overlay)
+    {
+        for (int i = 0; i < _visibleSignalCount; i++)
+        {
+            int index = _visibleSignalIndices[i];
+            if (_importance[index] >= 3)
+            {
+                RenderSignal(overlay, index, iconOnly: true);
+            }
+        }
+    }
+
+    private void RenderSignal(ScreenOverlayBuffer overlay, int index, bool iconOnly)
+    {
+        float normalizedX = NormalizeToField(_worldXcm[index], _centerXcm, _halfExtentCm);
+        float normalizedY = NormalizeToField(_worldYcm[index], _centerYcm, _halfExtentCm);
+        int screenX = FieldX + (int)MathF.Round(normalizedX * (FieldSize - 1));
+        int screenY = FieldY + (int)MathF.Round(normalizedY * (FieldSize - 1));
+        string icon = ResolveIcon((MinimapSignalKind)_kinds[index]);
+        Vector4 color = ResolveSignalColor((MinimapSignalFlags)_flags[index]);
+
+        if (((MinimapSignalFlags)_flags[index] & MinimapSignalFlags.Selected) != 0)
+        {
+            overlay.AddRect(
+                screenX - 8,
+                screenY - 8,
+                18,
+                18,
+                new Vector4(0.00f, 0.00f, 0.00f, 0.25f),
+                new Vector4(0.98f, 0.88f, 0.44f, 0.95f));
+        }
+
+        overlay.AddText(screenX - (iconOnly ? 3 : 4), screenY + 4, icon, iconOnly ? 12 : 14, color);
+        if (!iconOnly && ((MinimapSignalFlags)_flags[index] & MinimapSignalFlags.Alert) != 0)
+        {
+            overlay.AddRect(screenX + 8, screenY - 2, 5, 5, new Vector4(1f, 0.45f, 0.40f, 0.95f), new Vector4(1f, 0.64f, 0.61f, 1f));
+        }
+    }
+
+    private void RebuildVisibleSet()
+    {
+        float minX = _centerXcm - _halfExtentCm;
+        float maxX = _centerXcm + _halfExtentCm;
+        float minY = _centerYcm - _halfExtentCm;
+        float maxY = _centerYcm + _halfExtentCm;
+
+        for (int i = 0; i < _signalCount; i++)
+        {
+            if (_worldXcm[i] < minX || _worldXcm[i] > maxX || _worldYcm[i] < minY || _worldYcm[i] > maxY)
+            {
+                continue;
+            }
+
+            if (ShouldRenderSignalAtBand(i, ZoomBand))
+            {
+                _visibleSignalIndices[_visibleSignalCount++] = i;
+            }
+
+            int cellIndex = ResolveStrategicCellIndex(_worldXcm[i], _worldYcm[i], minX, minY, _halfExtentCm);
+            if ((uint)cellIndex >= (uint)StrategicCellCount)
+            {
+                continue;
+            }
+
+            _cellTotals[cellIndex]++;
+            MinimapSignalFlags flags = (MinimapSignalFlags)_flags[i];
+            if ((flags & MinimapSignalFlags.Friendly) != 0) _cellFriendly[cellIndex]++;
+            if ((flags & MinimapSignalFlags.Hostile) != 0) _cellHostile[cellIndex]++;
+            if ((flags & MinimapSignalFlags.Neutral) != 0) _cellNeutral[cellIndex]++;
+            if ((flags & MinimapSignalFlags.Structure) != 0) _cellStructures[cellIndex]++;
+            if ((flags & MinimapSignalFlags.Objective) != 0) _cellObjectives[cellIndex]++;
+            if ((flags & MinimapSignalFlags.Resource) != 0) _cellResources[cellIndex]++;
+            if ((flags & MinimapSignalFlags.Hazard) != 0) _cellHazards[cellIndex]++;
+        }
+    }
+
+    private bool ShouldRenderSignalAtBand(int index, MinimapZoomBand band)
+    {
+        return band switch
+        {
+            MinimapZoomBand.Strategic => _importance[index] >= 3,
+            MinimapZoomBand.Regional => _importance[index] >= 2,
+            _ => true,
+        };
+    }
+
+    private int ResolveStrategicCellIndex(float x, float y, float minX, float minY, float halfExtent)
+    {
+        float width = MathF.Max(1f, halfExtent * 2f);
+        int cellX = Math.Clamp((int)(((x - minX) / width) * StrategicGridSide), 0, StrategicGridSide - 1);
+        int cellY = Math.Clamp((int)(((y - minY) / width) * StrategicGridSide), 0, StrategicGridSide - 1);
+        return (cellY * StrategicGridSide) + cellX;
+    }
+
+    private void ClampViewportToContent()
+    {
+        float spanX = MathF.Max(2400f, _maxWorldXcm - _minWorldXcm);
+        float spanY = MathF.Max(2400f, _maxWorldYcm - _minWorldYcm);
+        float maxSpan = MathF.Max(spanX, spanY);
+        _halfExtentCm = MathF.Min(ClampHalfExtent(_halfExtentCm), MathF.Max(1400f, maxSpan * 0.8f));
+
+        float padding = _halfExtentCm * 0.35f;
+        _centerXcm = Math.Clamp(_centerXcm, _minWorldXcm - padding, _maxWorldXcm + padding);
+        _centerYcm = Math.Clamp(_centerYcm, _minWorldYcm - padding, _maxWorldYcm + padding);
+    }
+
+    private static MinimapZoomBand ResolveZoomBand(float halfExtentCm)
+    {
+        if (halfExtentCm > 11000f)
+        {
+            return MinimapZoomBand.Strategic;
+        }
+
+        return halfExtentCm > 3600f
+            ? MinimapZoomBand.Regional
+            : MinimapZoomBand.Tactical;
+    }
+
+    private static float ClampHalfExtent(float halfExtentCm)
+    {
+        return Math.Clamp(halfExtentCm, 750f, 36000f);
+    }
+
+    private static float NormalizeToField(float worldValue, float centerValue, float halfExtentCm)
+    {
+        float normalized = (worldValue - (centerValue - halfExtentCm)) / MathF.Max(1f, halfExtentCm * 2f);
+        return Math.Clamp(normalized, 0f, 1f);
+    }
+
+    private static Entity ResolveSelectedEntity(GameEngine engine)
+    {
+        return SelectionContextRuntime.TryGetCurrentPrimary(engine.World, engine.GlobalContext, out Entity selected)
+            ? selected
+            : Entity.Null;
+    }
+
+    private static int ResolvePerspectiveTeamId(GameEngine engine)
+    {
+        if (engine.GlobalContext.TryGetValue(CoreServiceKeys.LocalPlayerEntity.Name, out object? localObj) &&
+            localObj is Entity localPlayer &&
+            engine.World.IsAlive(localPlayer) &&
+            engine.World.TryGet(localPlayer, out Team localTeam))
+        {
+            return localTeam.Id;
+        }
+
+        Entity selected = ResolveSelectedEntity(engine);
+        if (selected != Entity.Null &&
+            engine.World.IsAlive(selected) &&
+            engine.World.TryGet(selected, out Team selectedTeam))
+        {
+            return selectedTeam.Id;
+        }
+
+        return 0;
+    }
+
+    private static byte ComputeImportance(MinimapSignalKind kind, MinimapSignalFlags flags)
+    {
+        if ((flags & MinimapSignalFlags.Selected) != 0)
+        {
+            return 4;
+        }
+
+        return kind switch
+        {
+            MinimapSignalKind.Capital => 4,
+            MinimapSignalKind.Objective => 4,
+            MinimapSignalKind.Hazard => 3,
+            MinimapSignalKind.Resource => 3,
+            MinimapSignalKind.Settlement => 3,
+            MinimapSignalKind.Fleet when (flags & MinimapSignalFlags.Alert) != 0 => 3,
+            MinimapSignalKind.Army when (flags & MinimapSignalFlags.Alert) != 0 => 3,
+            MinimapSignalKind.Scout => 1,
+            _ => 2,
+        };
+    }
+
+    private MinimapSignalFlags BuildFlags(
+        string label,
+        in GameplayTagContainer tags,
+        MinimapSignalKind kind,
+        int teamId,
+        bool selected,
+        int perspectiveTeamId)
+    {
+        MinimapSignalFlags flags = MinimapSignalFlags.None;
+        if (selected) flags |= MinimapSignalFlags.Selected;
+        if (kind is MinimapSignalKind.Capital or MinimapSignalKind.Settlement or MinimapSignalKind.Relay) flags |= MinimapSignalFlags.Structure;
+        if (kind is MinimapSignalKind.Fleet or MinimapSignalKind.Army or MinimapSignalKind.Scout) flags |= MinimapSignalFlags.Mobile;
+        if (HasTag(in tags, _objectiveTagId) || kind == MinimapSignalKind.Objective) flags |= MinimapSignalFlags.Objective;
+        if (HasTag(in tags, _resourceTagId) || kind == MinimapSignalKind.Resource) flags |= MinimapSignalFlags.Resource;
+        if (HasTag(in tags, _hazardTagId) || kind == MinimapSignalKind.Hazard) flags |= MinimapSignalFlags.Hazard;
+        if (HasTag(in tags, _alertTagId) || label.Contains("Frontier", StringComparison.OrdinalIgnoreCase)) flags |= MinimapSignalFlags.Alert;
+        if (HasTag(in tags, _frontierTagId)) flags |= MinimapSignalFlags.Frontier;
+
+        TeamRelationship relation = TeamManager.GetRelationship(perspectiveTeamId, teamId);
+        if (teamId == 0 || perspectiveTeamId == 0) flags |= MinimapSignalFlags.Neutral;
+        else if (relation == TeamRelationship.Friendly) flags |= MinimapSignalFlags.Friendly;
+        else if (relation == TeamRelationship.Hostile) flags |= MinimapSignalFlags.Hostile;
+        else flags |= MinimapSignalFlags.Neutral;
+
+        return flags;
+    }
+
+    private MinimapSignalKind ClassifyKind(string label, in GameplayTagContainer tags)
+    {
+        if (HasTag(in tags, _capitalTagId) ||
+            label.Contains("Capital", StringComparison.OrdinalIgnoreCase) ||
+            label.Contains("Prime", StringComparison.OrdinalIgnoreCase) ||
+            label.Contains("Nest", StringComparison.OrdinalIgnoreCase) ||
+            label.Contains("Enclave", StringComparison.OrdinalIgnoreCase))
+        {
+            return MinimapSignalKind.Capital;
+        }
+
+        if (HasTag(in tags, _objectiveTagId) || label.Contains("Gate", StringComparison.OrdinalIgnoreCase))
+        {
+            return MinimapSignalKind.Objective;
+        }
+
+        if (HasTag(in tags, _resourceTagId) ||
+            label.Contains("Crystal", StringComparison.OrdinalIgnoreCase) ||
+            label.Contains("Well", StringComparison.OrdinalIgnoreCase))
+        {
+            return MinimapSignalKind.Resource;
+        }
+
+        if (HasTag(in tags, _hazardTagId) ||
+            label.Contains("Rift", StringComparison.OrdinalIgnoreCase) ||
+            label.Contains("Storm", StringComparison.OrdinalIgnoreCase))
+        {
+            return MinimapSignalKind.Hazard;
+        }
+
+        if (label.Contains("Colony", StringComparison.OrdinalIgnoreCase) ||
+            label.Contains("Bastion", StringComparison.OrdinalIgnoreCase))
+        {
+            return MinimapSignalKind.Settlement;
+        }
+
+        if (label.Contains("Scout", StringComparison.OrdinalIgnoreCase) ||
+            label.Contains("Surveyor", StringComparison.OrdinalIgnoreCase))
+        {
+            return MinimapSignalKind.Scout;
+        }
+
+        if (label.Contains("Relay", StringComparison.OrdinalIgnoreCase))
+        {
+            return MinimapSignalKind.Relay;
+        }
+
+        if (label.Contains("Fleet", StringComparison.OrdinalIgnoreCase) ||
+            label.Contains("Carrier", StringComparison.OrdinalIgnoreCase) ||
+            label.Contains("Caravan", StringComparison.OrdinalIgnoreCase))
+        {
+            return MinimapSignalKind.Fleet;
+        }
+
+        if (label.Contains("Warpack", StringComparison.OrdinalIgnoreCase) ||
+            label.Contains("Wing", StringComparison.OrdinalIgnoreCase) ||
+            label.Contains("Watch", StringComparison.OrdinalIgnoreCase))
+        {
+            return MinimapSignalKind.Army;
+        }
+
+        return MinimapSignalKind.Settlement;
+    }
+
+    private bool HasTag(in GameplayTagContainer tags, int tagId)
+    {
+        return tagId > 0 && !tags.IsEmpty && tags.HasTag(tagId);
+    }
+
+    private static string ResolveIcon(MinimapSignalKind kind)
+    {
+        return kind switch
+        {
+            MinimapSignalKind.Capital => "C",
+            MinimapSignalKind.Settlement => "S",
+            MinimapSignalKind.Fleet => "F",
+            MinimapSignalKind.Army => "A",
+            MinimapSignalKind.Scout => "s",
+            MinimapSignalKind.Objective => "O",
+            MinimapSignalKind.Resource => "R",
+            MinimapSignalKind.Hazard => "!",
+            _ => "P",
+        };
+    }
+
+    private static Vector4 ResolveSignalColor(MinimapSignalFlags flags)
+    {
+        if ((flags & MinimapSignalFlags.Selected) != 0) return new Vector4(0.98f, 0.88f, 0.44f, 1f);
+        if ((flags & MinimapSignalFlags.Objective) != 0) return new Vector4(1f, 0.84f, 0.55f, 1f);
+        if ((flags & MinimapSignalFlags.Resource) != 0) return new Vector4(0.54f, 0.92f, 0.80f, 1f);
+        if ((flags & MinimapSignalFlags.Hazard) != 0) return new Vector4(1f, 0.55f, 0.50f, 1f);
+        if ((flags & MinimapSignalFlags.Hostile) != 0) return new Vector4(0.96f, 0.38f, 0.36f, 1f);
+        if ((flags & MinimapSignalFlags.Friendly) != 0) return new Vector4(0.42f, 0.82f, 1f, 1f);
+        return new Vector4(0.77f, 0.82f, 0.88f, 1f);
+    }
+
+    private Vector4 ResolveCellColor(int index)
+    {
+        if (_cellHostile[index] > _cellFriendly[index] && _cellHostile[index] >= _cellNeutral[index])
+        {
+            return new Vector4(0.44f, 0.12f, 0.11f, ResolveDensityAlpha(_cellTotals[index]));
+        }
+
+        if (_cellFriendly[index] >= _cellNeutral[index])
+        {
+            return new Vector4(0.09f, 0.28f, 0.39f, ResolveDensityAlpha(_cellTotals[index]));
+        }
+
+        return new Vector4(0.16f, 0.18f, 0.21f, ResolveDensityAlpha(_cellTotals[index]));
+    }
+
+    private static float ResolveDensityAlpha(int total)
+    {
+        return Math.Clamp(0.20f + (Math.Min(6, total) * 0.09f), 0.24f, 0.82f);
+    }
+
+    private void ResetTransientState()
+    {
+        _signalCount = 0;
+        _visibleSignalCount = 0;
+        _selectedLabel = string.Empty;
+        _currentMapId = string.Empty;
+        _minWorldXcm = 0f;
+        _minWorldYcm = 0f;
+        _maxWorldXcm = 0f;
+        _maxWorldYcm = 0f;
+    }
+}

--- a/mods/capabilities/minimap/MinimapControlMod/Systems/MinimapControlPresentationSystem.cs
+++ b/mods/capabilities/minimap/MinimapControlMod/Systems/MinimapControlPresentationSystem.cs
@@ -1,0 +1,116 @@
+using Arch.System;
+using Ludots.Core.Engine;
+using Ludots.Core.Input.Runtime;
+using Ludots.Core.Presentation.Hud;
+using Ludots.Core.Scripting;
+using MinimapControlMod.Runtime;
+
+namespace MinimapControlMod.Systems;
+
+internal sealed class MinimapControlPresentationSystem : ISystem<float>
+{
+    private readonly GameEngine _engine;
+    private readonly MinimapControlRuntime _runtime;
+    private float _lastWheel;
+    private bool _prevToggle;
+    private bool _prevCenterOnSelection;
+    private bool _prevZoomIn;
+    private bool _prevZoomOut;
+
+    public MinimapControlPresentationSystem(GameEngine engine, MinimapControlRuntime runtime)
+    {
+        _engine = engine;
+        _runtime = runtime;
+    }
+
+    public void Initialize()
+    {
+    }
+
+    public void BeforeUpdate(in float t)
+    {
+    }
+
+    public void Update(in float t)
+    {
+        if (_engine.GetService(CoreServiceKeys.ScreenOverlayBuffer) is not ScreenOverlayBuffer overlay)
+        {
+            return;
+        }
+
+        HandlePresentationInput(t);
+        _runtime.Refresh(_engine);
+        _runtime.Render(overlay);
+    }
+
+    public void AfterUpdate(in float t)
+    {
+    }
+
+    public void Dispose()
+    {
+    }
+
+    private void HandlePresentationInput(float deltaTime)
+    {
+        if (_engine.GetService(CoreServiceKeys.InputBackend) is not IInputBackend input)
+        {
+            return;
+        }
+
+        bool toggle = input.GetButton("<Keyboard>/m");
+        if (toggle && !_prevToggle)
+        {
+            _runtime.Visible = !_runtime.Visible;
+        }
+
+        _prevToggle = toggle;
+        if (!_runtime.Visible)
+        {
+            _lastWheel = input.GetMouseWheel();
+            return;
+        }
+
+        bool zoomIn = input.GetButton("<Keyboard>/pageUp") || input.GetButton("<Keyboard>/equals");
+        bool zoomOut = input.GetButton("<Keyboard>/pageDown") || input.GetButton("<Keyboard>/minus");
+        if (zoomIn && !_prevZoomIn)
+        {
+            _runtime.CycleZoom(-1);
+        }
+
+        if (zoomOut && !_prevZoomOut)
+        {
+            _runtime.CycleZoom(1);
+        }
+
+        _prevZoomIn = zoomIn;
+        _prevZoomOut = zoomOut;
+
+        bool centerOnSelection = input.GetButton("<Keyboard>/c");
+        if (centerOnSelection && !_prevCenterOnSelection)
+        {
+            _runtime.CenterOnSelected(_engine);
+        }
+
+        _prevCenterOnSelection = centerOnSelection;
+
+        float wheel = input.GetMouseWheel();
+        float wheelDelta = wheel - _lastWheel;
+        _lastWheel = wheel;
+        if (wheelDelta != 0f)
+        {
+            _runtime.ApplyWheelZoom(wheelDelta);
+        }
+
+        float panX = 0f;
+        float panY = 0f;
+        if (input.GetButton("<Keyboard>/leftArrow")) panX -= 1f;
+        if (input.GetButton("<Keyboard>/rightArrow")) panX += 1f;
+        if (input.GetButton("<Keyboard>/upArrow")) panY -= 1f;
+        if (input.GetButton("<Keyboard>/downArrow")) panY += 1f;
+        if (panX != 0f || panY != 0f)
+        {
+            _runtime.PanNormalized(panX * deltaTime * 0.9f, panY * deltaTime * 0.9f);
+        }
+    }
+}

--- a/mods/capabilities/minimap/MinimapControlMod/Triggers/InstallMinimapControlOnGameStartTrigger.cs
+++ b/mods/capabilities/minimap/MinimapControlMod/Triggers/InstallMinimapControlOnGameStartTrigger.cs
@@ -1,0 +1,45 @@
+using System.Threading.Tasks;
+using Ludots.Core.Engine;
+using Ludots.Core.Modding;
+using Ludots.Core.Scripting;
+using MinimapControlMod.Runtime;
+using MinimapControlMod.Systems;
+
+namespace MinimapControlMod.Triggers;
+
+internal sealed class InstallMinimapControlOnGameStartTrigger : Trigger
+{
+    private const string InstalledKey = "MinimapControlMod.Installed";
+    private readonly IModContext _context;
+
+    public InstallMinimapControlOnGameStartTrigger(IModContext context)
+    {
+        _context = context;
+        EventKey = GameEvents.GameStart;
+    }
+
+    public override Task ExecuteAsync(ScriptContext context)
+    {
+        GameEngine? engine = context.GetEngine();
+        if (engine == null)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (engine.GlobalContext.TryGetValue(InstalledKey, out object? installedObj) &&
+            installedObj is bool installed &&
+            installed)
+        {
+            return Task.CompletedTask;
+        }
+
+        engine.GlobalContext[InstalledKey] = true;
+
+        var runtime = new MinimapControlRuntime();
+        engine.SetService(MinimapControlServiceKeys.Runtime, runtime);
+        engine.RegisterPresentationSystem(new MinimapControlPresentationSystem(engine, runtime));
+
+        _context.Log("[MinimapControlMod] Runtime and presentation overlay installed.");
+        return Task.CompletedTask;
+    }
+}

--- a/mods/capabilities/minimap/MinimapControlMod/mod.json
+++ b/mods/capabilities/minimap/MinimapControlMod/mod.json
@@ -1,0 +1,12 @@
+{
+  "name": "MinimapControlMod",
+  "version": "1.0.0",
+  "description": "Reusable zero-allocation 4X minimap control with ECS/GAS-aware zoom bands and screen overlay rendering.",
+  "main": "bin/net8.0/MinimapControlMod.dll",
+  "priority": 0,
+  "dependencies": {
+    "LudotsCoreMod": "^1.0.0"
+  },
+  "author": "Ludots Team",
+  "tags": ["capability", "minimap", "overlay", "fourx"]
+}

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/ChampionSkillSandboxIds.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/ChampionSkillSandboxIds.cs
@@ -1,4 +1,5 @@
 using System;
+using EntityCommandPanelMod.UI;
 
 namespace ChampionSkillSandboxMod
 {
@@ -122,6 +123,11 @@ namespace ChampionSkillSandboxMod
             }
 
             return "P1 Live";
+        }
+
+        public static string ResolveDefaultShowcaseThemeId()
+        {
+            return EntityCommandPanelShowcaseTheme.LolId;
         }
     }
 }

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillCastModeToolbarProvider.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillCastModeToolbarProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using Arch.Core;
 using CoreInputMod.ViewMode;
+using EntityCommandPanelMod.UI;
 using Ludots.Core.Engine;
 using Ludots.Core.Presentation.Hud;
 using Ludots.Core.Scripting;
@@ -37,6 +38,12 @@ namespace ChampionSkillSandboxMod.Runtime
                     revision ^= (uint)activeSelectionViewId.GetHashCode(StringComparison.Ordinal);
                 }
 
+                string activeShowcaseThemeId = ResolveActiveShowcaseThemeId();
+                if (!string.IsNullOrWhiteSpace(activeShowcaseThemeId))
+                {
+                    revision ^= (uint)activeShowcaseThemeId.GetHashCode(StringComparison.Ordinal);
+                }
+
                 if (ChampionSkillSandboxIds.IsStressMap(_engine?.CurrentMapSession?.MapId.Value))
                 {
                     ChampionSkillStressControlState? control = ResolveStressControl();
@@ -58,7 +65,7 @@ namespace ChampionSkillSandboxMod.Runtime
 
         public string Title => ChampionSkillSandboxIds.IsStressMap(_engine?.CurrentMapSession?.MapId.Value)
             ? "Stress Harness"
-            : "Cast Mode";
+            : "Cast + Showcase";
 
         public string Subtitle
         {
@@ -66,7 +73,7 @@ namespace ChampionSkillSandboxMod.Runtime
             {
                 if (!ChampionSkillSandboxIds.IsStressMap(_engine?.CurrentMapSession?.MapId.Value))
                 {
-                    return "Cast + Camera | F1/F2/F3 Cast | RMB Move";
+                    return $"Theme {EntityCommandPanelShowcaseTheme.ResolveLabel(ResolveActiveShowcaseThemeId())} | Cast + Camera | F1/F2/F3 Cast | RMB Move";
                 }
 
                 ChampionSkillStressControlState? control = ResolveStressControl();
@@ -92,8 +99,9 @@ namespace ChampionSkillSandboxMod.Runtime
             string activeModeId = ResolveActiveModeId();
             string activeFollowModeId = ResolveActiveCameraFollowMode();
             string activeSelectionViewId = ResolveActiveSelectionViewId();
+            string activeShowcaseThemeId = ResolveActiveShowcaseThemeId();
             RenderDebugState? renderDebug = ResolveRenderDebugState();
-            var buttons = new EntityCommandPanelToolbarButtonView[isStressMap ? 19 : 7];
+            var buttons = new EntityCommandPanelToolbarButtonView[isStressMap ? 19 : 10];
             buttons[0] = new EntityCommandPanelToolbarButtonView(
                 ChampionSkillSandboxIds.SmartCastModeId,
                 "Quick",
@@ -129,6 +137,21 @@ namespace ChampionSkillSandboxMod.Runtime
                 "Reset",
                 false,
                 "#D7D2C4");
+            buttons[7] = new EntityCommandPanelToolbarButtonView(
+                EntityCommandPanelShowcaseTheme.Dota2Id,
+                "Dota2",
+                string.Equals(activeShowcaseThemeId, EntityCommandPanelShowcaseTheme.Dota2Id, StringComparison.OrdinalIgnoreCase),
+                "#D37A4B");
+            buttons[8] = new EntityCommandPanelToolbarButtonView(
+                EntityCommandPanelShowcaseTheme.LolId,
+                "LoL",
+                string.Equals(activeShowcaseThemeId, EntityCommandPanelShowcaseTheme.LolId, StringComparison.OrdinalIgnoreCase),
+                "#D5B25B");
+            buttons[9] = new EntityCommandPanelToolbarButtonView(
+                EntityCommandPanelShowcaseTheme.Sc2Id,
+                "SC2",
+                string.Equals(activeShowcaseThemeId, EntityCommandPanelShowcaseTheme.Sc2Id, StringComparison.OrdinalIgnoreCase),
+                "#59B7FF");
             if (isStressMap)
             {
                 buttons[7] = new EntityCommandPanelToolbarButtonView(
@@ -294,6 +317,16 @@ namespace ChampionSkillSandboxMod.Runtime
                 }
             }
 
+            if (EntityCommandPanelShowcaseTheme.IsThemeButton(buttonId))
+            {
+                if (_engine != null)
+                {
+                    _engine.GlobalContext[EntityCommandPanelShowcaseTheme.ContextKey] = EntityCommandPanelShowcaseTheme.Normalize(buttonId, ChampionSkillSandboxIds.ResolveDefaultShowcaseThemeId());
+                }
+
+                return;
+            }
+
             ViewModeRuntime.TrySwitchTo(_engine?.GlobalContext!, buttonId);
         }
 
@@ -307,6 +340,17 @@ namespace ChampionSkillSandboxMod.Runtime
             }
 
             return ChampionSkillSandboxIds.FreeCameraToolbarButtonId;
+        }
+
+        private string ResolveActiveShowcaseThemeId()
+        {
+            if (_engine?.GlobalContext.TryGetValue(EntityCommandPanelShowcaseTheme.ContextKey, out var themeObj) == true &&
+                themeObj is string themeId)
+            {
+                return EntityCommandPanelShowcaseTheme.Normalize(themeId, ChampionSkillSandboxIds.ResolveDefaultShowcaseThemeId());
+            }
+
+            return ChampionSkillSandboxIds.ResolveDefaultShowcaseThemeId();
         }
 
         private ChampionSkillStressControlState? ResolveStressControl()

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxRuntime.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxRuntime.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using System.Threading.Tasks;
 using Arch.Core;
 using CoreInputMod.ViewMode;
+using EntityCommandPanelMod.UI;
 using Ludots.Core.Components;
 using Ludots.Core.Engine;
 using Ludots.Core.Gameplay.Camera;
@@ -131,6 +132,11 @@ namespace ChampionSkillSandboxMod.Runtime
             if (!engine.GlobalContext.ContainsKey(ChampionSkillSandboxIds.SelectionViewChoiceKey))
             {
                 engine.GlobalContext[ChampionSkillSandboxIds.SelectionViewChoiceKey] = ChampionSkillSandboxIds.PlayerSelectionToolbarButtonId;
+            }
+
+            if (!engine.GlobalContext.ContainsKey(EntityCommandPanelShowcaseTheme.ContextKey))
+            {
+                engine.GlobalContext[EntityCommandPanelShowcaseTheme.ContextKey] = ChampionSkillSandboxIds.ResolveDefaultShowcaseThemeId();
             }
         }
 
@@ -525,8 +531,8 @@ namespace ChampionSkillSandboxMod.Runtime
                     TargetEntity = initialTarget,
                     SourceId = "gas.ability-slots",
                     InstanceKey = "champion-skill-sandbox.focus",
-                    Anchor = new EntityCommandPanelAnchor(EntityCommandPanelAnchorPreset.BottomCenter, 0f, 18f),
-                    Size = new EntityCommandPanelSize(460f, 276f),
+                    Anchor = ResolvePanelAnchor(engine),
+                    Size = ResolvePanelSize(engine),
                     InitialGroupIndex = 0,
                     StartVisible = visible
                 });
@@ -544,8 +550,31 @@ namespace ChampionSkillSandboxMod.Runtime
                 _lastPanelTarget = target;
             }
 
+            service.SetAnchor(_focusPanelHandle, ResolvePanelAnchor(engine));
+            service.SetSize(_focusPanelHandle, ResolvePanelSize(engine));
             service.SetVisible(_focusPanelHandle, visible);
             SyncSelectionIndicator(engine, visible ? target : Entity.Null);
+        }
+
+        private static EntityCommandPanelAnchor ResolvePanelAnchor(GameEngine engine)
+        {
+            return EntityCommandPanelShowcaseTheme.ResolveSandboxAnchor(ResolveShowcaseTheme(engine));
+        }
+
+        private static EntityCommandPanelSize ResolvePanelSize(GameEngine engine)
+        {
+            return EntityCommandPanelShowcaseTheme.ResolveSandboxSize(ResolveShowcaseTheme(engine));
+        }
+
+        private static string ResolveShowcaseTheme(GameEngine engine)
+        {
+            if (engine.GlobalContext.TryGetValue(EntityCommandPanelShowcaseTheme.ContextKey, out object? themeObj) &&
+                themeObj is string themeId)
+            {
+                return EntityCommandPanelShowcaseTheme.Normalize(themeId, ChampionSkillSandboxIds.ResolveDefaultShowcaseThemeId());
+            }
+
+            return ChampionSkillSandboxIds.ResolveDefaultShowcaseThemeId();
         }
 
         private static Entity ResolvePanelTarget(GameEngine engine)

--- a/mods/showcases/minimap/MinimapShowcaseMod/MinimapShowcaseIds.cs
+++ b/mods/showcases/minimap/MinimapShowcaseMod/MinimapShowcaseIds.cs
@@ -1,0 +1,6 @@
+namespace MinimapShowcaseMod;
+
+public static class MinimapShowcaseIds
+{
+    public const string MapId = "minimap_showcase";
+}

--- a/mods/showcases/minimap/MinimapShowcaseMod/MinimapShowcaseMod.csproj
+++ b/mods/showcases/minimap/MinimapShowcaseMod/MinimapShowcaseMod.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Core.csproj" />
+    <ProjectReference Include="..\..\..\CoreInputMod\CoreInputMod.csproj" />
+    <ProjectReference Include="..\..\..\FourXDemoMod\FourXDemoMod.csproj" />
+    <ProjectReference Include="..\..\..\capabilities\minimap\MinimapControlMod\MinimapControlMod.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/mods/showcases/minimap/MinimapShowcaseMod/MinimapShowcaseModEntry.cs
+++ b/mods/showcases/minimap/MinimapShowcaseMod/MinimapShowcaseModEntry.cs
@@ -1,0 +1,22 @@
+using Ludots.Core.Modding;
+using Ludots.Core.Scripting;
+using MinimapShowcaseMod.Triggers;
+
+namespace MinimapShowcaseMod;
+
+public sealed class MinimapShowcaseModEntry : IMod
+{
+    public void OnLoad(IModContext context)
+    {
+        context.Log("[MinimapShowcaseMod] Loaded.");
+        var trigger = new ConfigureMinimapShowcaseOnMapFocusTrigger();
+        context.OnEvent(GameEvents.MapLoaded, trigger.ExecuteAsync);
+        context.OnEvent(GameEvents.MapResumed, trigger.ExecuteAsync);
+        context.OnEvent(GameEvents.GameStart, trigger.ExecuteAsync);
+        context.OnEvent(GameEvents.MapUnloaded, trigger.HandleMapUnloadedAsync);
+    }
+
+    public void OnUnload()
+    {
+    }
+}

--- a/mods/showcases/minimap/MinimapShowcaseMod/Triggers/ConfigureMinimapShowcaseOnMapFocusTrigger.cs
+++ b/mods/showcases/minimap/MinimapShowcaseMod/Triggers/ConfigureMinimapShowcaseOnMapFocusTrigger.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Arch.Core;
+using Ludots.Core.Components;
+using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.GAS;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.Input.Selection;
+using Ludots.Core.Map;
+using Ludots.Core.Scripting;
+using MinimapControlMod;
+
+namespace MinimapShowcaseMod.Triggers;
+
+internal sealed class ConfigureMinimapShowcaseOnMapFocusTrigger : Trigger
+{
+    private static readonly QueryDescription NamedEntityQuery = new QueryDescription()
+        .WithAll<Name, MapEntity>();
+
+    private readonly int _capitalTagId = TagRegistry.Register("State.Minimap.Capital");
+    private readonly int _objectiveTagId = TagRegistry.Register("State.Minimap.Objective");
+    private readonly int _resourceTagId = TagRegistry.Register("State.Minimap.Resource");
+    private readonly int _hazardTagId = TagRegistry.Register("State.Minimap.Hazard");
+    private readonly int _alertTagId = TagRegistry.Register("State.Minimap.Alert");
+    private readonly int _frontierTagId = TagRegistry.Register("State.Minimap.Frontier");
+
+    public ConfigureMinimapShowcaseOnMapFocusTrigger()
+    {
+        EventKey = GameEvents.MapLoaded;
+    }
+
+    public override Task ExecuteAsync(ScriptContext context)
+    {
+        GameEngine? engine = context.GetEngine();
+        if (engine == null || engine.CurrentMapSession?.MapId.Value != MinimapShowcaseIds.MapId)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (!TryGetMinimapRuntime(engine, out object runtime))
+        {
+            return Task.CompletedTask;
+        }
+
+        SetRuntimeVisible(runtime, true);
+        SetRuntimeViewport(runtime, 1800f, -600f, 22000f);
+        ConfigurePerspectiveAndTags(engine);
+        return Task.CompletedTask;
+    }
+
+    public Task HandleMapUnloadedAsync(ScriptContext context)
+    {
+        GameEngine? engine = context.GetEngine();
+        if (engine != null && TryGetMinimapRuntime(engine, out object runtime))
+        {
+            SetRuntimeVisible(runtime, false);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static bool TryGetMinimapRuntime(GameEngine engine, out object runtime)
+    {
+        if (engine.GlobalContext.TryGetValue(MinimapControlServiceKeys.Runtime.Name, out object? found) && found != null)
+        {
+            runtime = found;
+            return true;
+        }
+
+        runtime = null!;
+        return false;
+    }
+
+    private static void SetRuntimeVisible(object runtime, bool value)
+    {
+        PropertyInfo property = runtime.GetType().GetProperty("Visible", BindingFlags.Instance | BindingFlags.Public)
+            ?? throw new MissingMemberException(runtime.GetType().FullName, "Visible");
+        property.SetValue(runtime, value);
+    }
+
+    private static void SetRuntimeViewport(object runtime, float centerXcm, float centerYcm, float halfExtentCm)
+    {
+        MethodInfo method = runtime.GetType().GetMethod("SetViewport", BindingFlags.Instance | BindingFlags.Public, [typeof(float), typeof(float), typeof(float)])
+            ?? throw new MissingMethodException(runtime.GetType().FullName, "SetViewport");
+        method.Invoke(runtime, [centerXcm, centerYcm, halfExtentCm]);
+    }
+
+    private void ConfigurePerspectiveAndTags(GameEngine engine)
+    {
+        MapId mapId = engine.CurrentMapSession?.MapId ?? default;
+        TagOps? tagOps = engine.GetService(CoreServiceKeys.TagOps);
+        SelectionRuntime? selection = engine.GetService(CoreServiceKeys.SelectionRuntime);
+        if (tagOps == null || selection == null)
+        {
+            return;
+        }
+
+        Entity playerCapital = Entity.Null;
+        foreach (ref var chunk in engine.World.Query(in NamedEntityQuery))
+        {
+            var names = chunk.GetSpan<Name>();
+            var mapEntities = chunk.GetSpan<MapEntity>();
+            for (int i = 0; i < chunk.Count; i++)
+            {
+                if (mapEntities[i].MapId != mapId)
+                {
+                    continue;
+                }
+
+                Entity entity = chunk.Entity(i);
+                string name = names[i].Value ?? string.Empty;
+                EnsureTagComponents(engine.World, entity);
+                ref var tags = ref engine.World.Get<GameplayTagContainer>(entity);
+                ref var counts = ref engine.World.Get<TagCountContainer>(entity);
+
+                if (IsCapital(name)) tagOps.AddTag(ref tags, ref counts, _capitalTagId);
+                if (string.Equals(name, "Ancient Gate", StringComparison.Ordinal)) tagOps.AddTag(ref tags, ref counts, _objectiveTagId);
+                if (string.Equals(name, "Crystal Relay", StringComparison.Ordinal) || string.Equals(name, "Helium Well", StringComparison.Ordinal)) tagOps.AddTag(ref tags, ref counts, _resourceTagId);
+                if (string.Equals(name, "Void Rift", StringComparison.Ordinal) || string.Equals(name, "Ember Storm", StringComparison.Ordinal)) tagOps.AddTag(ref tags, ref counts, _hazardTagId);
+                if (name.Contains("Frontier", StringComparison.OrdinalIgnoreCase) || name.Contains("Carrier", StringComparison.OrdinalIgnoreCase) || name.Contains("Warpack", StringComparison.OrdinalIgnoreCase) || name.Contains("Wing", StringComparison.OrdinalIgnoreCase)) tagOps.AddTag(ref tags, ref counts, _alertTagId);
+                if (name.Contains("Frontier", StringComparison.OrdinalIgnoreCase) || name.Contains("Border", StringComparison.OrdinalIgnoreCase)) tagOps.AddTag(ref tags, ref counts, _frontierTagId);
+
+                if (playerCapital == Entity.Null && string.Equals(name, "Imperial Capital", StringComparison.Ordinal))
+                {
+                    playerCapital = entity;
+                }
+            }
+        }
+
+        if (playerCapital == Entity.Null)
+        {
+            return;
+        }
+
+        engine.GlobalContext[CoreServiceKeys.LocalPlayerEntity.Name] = playerCapital;
+        engine.GlobalContext[CoreServiceKeys.SelectionViewViewerEntity.Name] = playerCapital;
+        engine.GlobalContext[CoreServiceKeys.SelectionViewKey.Name] = SelectionViewKeys.Primary;
+        selection.ReplaceSelection(playerCapital, SelectionSetKeys.LivePrimary, stackalloc[] { playerCapital });
+        selection.TryBindView(playerCapital, SelectionViewKeys.Primary, playerCapital, SelectionSetKeys.LivePrimary);
+    }
+
+    private static void EnsureTagComponents(World world, Entity entity)
+    {
+        if (!world.Has<GameplayTagContainer>(entity)) world.Add(entity, new GameplayTagContainer());
+        if (!world.Has<TagCountContainer>(entity)) world.Add(entity, new TagCountContainer());
+        if (!world.Has<TimedTagBuffer>(entity)) world.Add(entity, new TimedTagBuffer());
+    }
+
+    private static bool IsCapital(string name)
+    {
+        return name.Contains("Capital", StringComparison.OrdinalIgnoreCase) ||
+               name.Contains("Prime", StringComparison.OrdinalIgnoreCase) ||
+               name.Contains("Nest", StringComparison.OrdinalIgnoreCase) ||
+               name.Contains("Enclave", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/mods/showcases/minimap/MinimapShowcaseMod/assets/Entities/templates.json
+++ b/mods/showcases/minimap/MinimapShowcaseMod/assets/Entities/templates.json
@@ -1,0 +1,223 @@
+[
+  {
+    "id": "imperial_capital",
+    "components": {
+      "Name": { "Value": "Imperial Capital" },
+      "Team": { "Id": 1 },
+      "PlayerOwner": { "PlayerId": 1 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 400 } }
+    }
+  },
+  {
+    "id": "ironforge_colony",
+    "components": {
+      "Name": { "Value": "Ironforge Colony" },
+      "Team": { "Id": 1 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 4800, "Y": -1200 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 240 } }
+    }
+  },
+  {
+    "id": "frontier_bastion",
+    "components": {
+      "Name": { "Value": "Frontier Bastion" },
+      "Team": { "Id": 1 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 9800, "Y": 3600 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 260 } }
+    }
+  },
+  {
+    "id": "imperial_vanguard_fleet",
+    "components": {
+      "Name": { "Value": "Imperial Vanguard Fleet" },
+      "Team": { "Id": 1 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 7200, "Y": 2900 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 160 } }
+    }
+  },
+  {
+    "id": "imperial_surveyor",
+    "components": {
+      "Name": { "Value": "Imperial Surveyor" },
+      "Team": { "Id": 1 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 3600, "Y": -4200 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 80 } }
+    }
+  },
+  {
+    "id": "imperial_relay",
+    "components": {
+      "Name": { "Value": "Imperial Relay" },
+      "Team": { "Id": 1 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": -2600, "Y": 2200 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 120 } }
+    }
+  },
+  {
+    "id": "federation_prime",
+    "components": {
+      "Name": { "Value": "Federation Prime" },
+      "Team": { "Id": 2 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 15400, "Y": -600 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 400 } }
+    }
+  },
+  {
+    "id": "federation_carrier_group",
+    "components": {
+      "Name": { "Value": "Federation Carrier Group" },
+      "Team": { "Id": 2 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 12800, "Y": 1400 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 180 } }
+    }
+  },
+  {
+    "id": "federation_border_watch",
+    "components": {
+      "Name": { "Value": "Federation Border Watch" },
+      "Team": { "Id": 2 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 10400, "Y": 4200 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 150 } }
+    }
+  },
+  {
+    "id": "horde_nest",
+    "components": {
+      "Name": { "Value": "Horde Nest" },
+      "Team": { "Id": 3 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": -13200, "Y": 7600 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 360 } }
+    }
+  },
+  {
+    "id": "horde_warpack",
+    "components": {
+      "Name": { "Value": "Horde Warpack" },
+      "Team": { "Id": 3 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": -9600, "Y": 5200 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 170 } }
+    }
+  },
+  {
+    "id": "horde_raider_wing",
+    "components": {
+      "Name": { "Value": "Horde Raider Wing" },
+      "Team": { "Id": 3 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": -6200, "Y": 9800 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 150 } }
+    }
+  },
+  {
+    "id": "nomad_enclave",
+    "components": {
+      "Name": { "Value": "Nomad Enclave" },
+      "Team": { "Id": 4 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": -2600, "Y": -11800 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 220 } }
+    }
+  },
+  {
+    "id": "nomad_caravan",
+    "components": {
+      "Name": { "Value": "Nomad Caravan" },
+      "Team": { "Id": 4 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 1800, "Y": -9200 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 110 } }
+    }
+  },
+  {
+    "id": "nomad_scout_swarm",
+    "components": {
+      "Name": { "Value": "Nomad Scout Swarm" },
+      "Team": { "Id": 4 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": -5400, "Y": -7600 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 70 } }
+    }
+  },
+  {
+    "id": "ancient_gate",
+    "components": {
+      "Name": { "Value": "Ancient Gate" },
+      "Team": { "Id": 0 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 2200, "Y": 7800 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 9999 } }
+    }
+  },
+  {
+    "id": "crystal_relay",
+    "components": {
+      "Name": { "Value": "Crystal Relay" },
+      "Team": { "Id": 0 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 6200, "Y": -7600 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 9999 } }
+    }
+  },
+  {
+    "id": "helium_well",
+    "components": {
+      "Name": { "Value": "Helium Well" },
+      "Team": { "Id": 0 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": -8200, "Y": -1600 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 9999 } }
+    }
+  },
+  {
+    "id": "void_rift",
+    "components": {
+      "Name": { "Value": "Void Rift" },
+      "Team": { "Id": 0 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": -10800, "Y": -9800 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 9999 } }
+    }
+  },
+  {
+    "id": "ember_storm",
+    "components": {
+      "Name": { "Value": "Ember Storm" },
+      "Team": { "Id": 0 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 11800, "Y": 8800 } },
+      "GameplayTagContainer": {},
+      "AttributeBuffer": { "base": { "Health": 9999 } }
+    }
+  }
+]

--- a/mods/showcases/minimap/MinimapShowcaseMod/assets/Maps/minimap_showcase.json
+++ b/mods/showcases/minimap/MinimapShowcaseMod/assets/Maps/minimap_showcase.json
@@ -1,0 +1,26 @@
+{
+  "Id": "minimap_showcase",
+  "Tags": ["showcase", "fourx", "minimap"],
+  "Entities": [
+    { "Template": "imperial_capital", "Overrides": { "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } } } },
+    { "Template": "ironforge_colony", "Overrides": { "WorldPositionCm": { "Value": { "X": 4800, "Y": -1200 } } } },
+    { "Template": "frontier_bastion", "Overrides": { "WorldPositionCm": { "Value": { "X": 9800, "Y": 3600 } } } },
+    { "Template": "imperial_vanguard_fleet", "Overrides": { "WorldPositionCm": { "Value": { "X": 7200, "Y": 2900 } } } },
+    { "Template": "imperial_surveyor", "Overrides": { "WorldPositionCm": { "Value": { "X": 3600, "Y": -4200 } } } },
+    { "Template": "imperial_relay", "Overrides": { "WorldPositionCm": { "Value": { "X": -2600, "Y": 2200 } } } },
+    { "Template": "federation_prime", "Overrides": { "WorldPositionCm": { "Value": { "X": 15400, "Y": -600 } } } },
+    { "Template": "federation_carrier_group", "Overrides": { "WorldPositionCm": { "Value": { "X": 12800, "Y": 1400 } } } },
+    { "Template": "federation_border_watch", "Overrides": { "WorldPositionCm": { "Value": { "X": 10400, "Y": 4200 } } } },
+    { "Template": "horde_nest", "Overrides": { "WorldPositionCm": { "Value": { "X": -13200, "Y": 7600 } } } },
+    { "Template": "horde_warpack", "Overrides": { "WorldPositionCm": { "Value": { "X": -9600, "Y": 5200 } } } },
+    { "Template": "horde_raider_wing", "Overrides": { "WorldPositionCm": { "Value": { "X": -6200, "Y": 9800 } } } },
+    { "Template": "nomad_enclave", "Overrides": { "WorldPositionCm": { "Value": { "X": -2600, "Y": -11800 } } } },
+    { "Template": "nomad_caravan", "Overrides": { "WorldPositionCm": { "Value": { "X": 1800, "Y": -9200 } } } },
+    { "Template": "nomad_scout_swarm", "Overrides": { "WorldPositionCm": { "Value": { "X": -5400, "Y": -7600 } } } },
+    { "Template": "ancient_gate", "Overrides": { "WorldPositionCm": { "Value": { "X": 2200, "Y": 7800 } } } },
+    { "Template": "crystal_relay", "Overrides": { "WorldPositionCm": { "Value": { "X": 6200, "Y": -7600 } } } },
+    { "Template": "helium_well", "Overrides": { "WorldPositionCm": { "Value": { "X": -8200, "Y": -1600 } } } },
+    { "Template": "void_rift", "Overrides": { "WorldPositionCm": { "Value": { "X": -10800, "Y": -9800 } } } },
+    { "Template": "ember_storm", "Overrides": { "WorldPositionCm": { "Value": { "X": 11800, "Y": 8800 } } } }
+  ]
+}

--- a/mods/showcases/minimap/MinimapShowcaseMod/assets/game.json
+++ b/mods/showcases/minimap/MinimapShowcaseMod/assets/game.json
@@ -1,0 +1,3 @@
+{
+  "startupMapId": "minimap_showcase"
+}

--- a/mods/showcases/minimap/MinimapShowcaseMod/mod.json
+++ b/mods/showcases/minimap/MinimapShowcaseMod/mod.json
@@ -1,0 +1,15 @@
+{
+  "name": "MinimapShowcaseMod",
+  "version": "1.0.0",
+  "description": "4X minimap showcase map that demonstrates strategic, regional, and tactical zoom bands over a shared minimap capability.",
+  "main": "bin/net8.0/MinimapShowcaseMod.dll",
+  "priority": 40,
+  "dependencies": {
+    "LudotsCoreMod": "^1.0.0",
+    "CoreInputMod": "^1.0.0",
+    "FourXDemoMod": "^1.0.0",
+    "MinimapControlMod": "^1.0.0"
+  },
+  "author": "Ludots Team",
+  "tags": ["showcase", "minimap", "fourx"]
+}

--- a/src/Apps/Raylib/Ludots.App.Raylib/launcher.champion-skill-sandbox.runtime.json
+++ b/src/Apps/Raylib/Ludots.App.Raylib/launcher.champion-skill-sandbox.runtime.json
@@ -1,0 +1,10 @@
+{
+  "ModPaths": [
+    "../../../../../../../mods/LudotsCoreMod",
+    "../../../../../../../mods/CoreInputMod",
+    "../../../../../../../mods/capabilities/camera/CameraProfilesMod",
+    "../../../../../../../mods/DiagnosticsOverlayMod",
+    "../../../../../../../mods/EntityCommandPanelMod",
+    "../../../../../../../mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod"
+  ]
+}

--- a/src/Apps/Raylib/Ludots.App.Raylib/launcher.minimap-showcase.runtime.json
+++ b/src/Apps/Raylib/Ludots.App.Raylib/launcher.minimap-showcase.runtime.json
@@ -1,0 +1,9 @@
+{
+  "ModPaths": [
+    "../../../../../../../mods/LudotsCoreMod",
+    "../../../../../../../mods/CoreInputMod",
+    "../../../../../../../mods/FourXDemoMod",
+    "../../../../../../../mods/capabilities/minimap/MinimapControlMod",
+    "../../../../../../../mods/showcases/minimap/MinimapShowcaseMod"
+  ]
+}

--- a/src/Core/Gameplay/GAS/Components/TimedTagBuffer.cs
+++ b/src/Core/Gameplay/GAS/Components/TimedTagBuffer.cs
@@ -25,5 +25,29 @@ namespace Ludots.Core.Gameplay.GAS.Components
             fixed (int* exp = ExpireAt) exp[index] = exp[Count];
             fixed (byte* clocks = ClockIds) clocks[index] = clocks[Count];
         }
+
+        public int GetTagId(int index)
+        {
+            fixed (int* tags = TagIds)
+            {
+                return tags[index];
+            }
+        }
+
+        public int GetExpireAt(int index)
+        {
+            fixed (int* expires = ExpireAt)
+            {
+                return expires[index];
+            }
+        }
+
+        public GasClockId GetClockId(int index)
+        {
+            fixed (byte* clocks = ClockIds)
+            {
+                return (GasClockId)clocks[index];
+            }
+        }
     }
 }

--- a/src/Tests/GasTests/GasTests.csproj
+++ b/src/Tests/GasTests/GasTests.csproj
@@ -6,6 +6,10 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
+    <SkiaNativeRid Condition="'$(SkiaNativeRid)' == '' and '$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</SkiaNativeRid>
+    <SkiaNativeRid Condition="'$(SkiaNativeRid)' == '' and '$(OS)' == 'Windows_NT'">win-x64</SkiaNativeRid>
+    <SkiaNativeRid Condition="'$(SkiaNativeRid)' == '' and '$([MSBuild]::IsOSPlatform(`Linux`))' == 'true'">linux-x64</SkiaNativeRid>
+    <SkiaNativeRid Condition="'$(SkiaNativeRid)' == '' and '$([MSBuild]::IsOSPlatform(`OSX`))' == 'true'">osx</SkiaNativeRid>
   </PropertyGroup>
 
   <ItemGroup>
@@ -53,9 +57,30 @@
     <ProjectReference Include="..\..\..\mods\showcases\camera\CameraShowcaseMod\CameraShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\interaction\InteractionShowcaseMod\InteractionShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\champion_skill_sandbox\ChampionSkillSandboxMod\ChampionSkillSandboxMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\capabilities\minimap\MinimapControlMod\MinimapControlMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\minimap\MinimapShowcaseMod\MinimapShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\ux_prototype\UxPrototypeMod\UxPrototypeMod.csproj" />
     <ProjectReference Include="..\..\..\mods\Navigation2DPlaygroundMod\Navigation2DPlaygroundMod.csproj" />
     <ProjectReference Include="..\..\Libraries\Ludots.UI.Skia\Ludots.UI.Skia.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\Libraries\SkiaSharp\runtimes\**\*.*" Link="runtimes\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(SkiaNativeRid)' != ''">
+    <None Include="..\..\Libraries\SkiaSharp\runtimes\$(SkiaNativeRid)\native\libSkiaSharp.dll"
+          Link="libSkiaSharp.dll"
+          CopyToOutputDirectory="PreserveNewest"
+          Condition="Exists('..\..\Libraries\SkiaSharp\runtimes\$(SkiaNativeRid)\native\libSkiaSharp.dll')" />
+    <None Include="..\..\Libraries\SkiaSharp\runtimes\$(SkiaNativeRid)\native\libSkiaSharp.so"
+          Link="libSkiaSharp.so"
+          CopyToOutputDirectory="PreserveNewest"
+          Condition="Exists('..\..\Libraries\SkiaSharp\runtimes\$(SkiaNativeRid)\native\libSkiaSharp.so')" />
+    <None Include="..\..\Libraries\SkiaSharp\runtimes\$(SkiaNativeRid)\native\libSkiaSharp.dylib"
+          Link="libSkiaSharp.dylib"
+          CopyToOutputDirectory="PreserveNewest"
+          Condition="Exists('..\..\Libraries\SkiaSharp\runtimes\$(SkiaNativeRid)\native\libSkiaSharp.dylib')" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/GasTests/Production/ChampionSkillSandboxConfigTests.cs
+++ b/src/Tests/GasTests/Production/ChampionSkillSandboxConfigTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
 using Arch.Core;
+using EntityCommandPanelMod.UI;
 using Ludots.Core.Components;
 using Ludots.Core.Config;
 using Ludots.Core.Engine;
@@ -320,15 +321,20 @@ namespace Ludots.Tests.GAS.Production
             int buttonCount = toolbar.CopyButtons(buttons);
             Assert.That(buttonCount, Is.EqualTo(5), "Small buffers should safely truncate the toolbar.");
 
-            buttons = new EntityCommandPanelToolbarButtonView[8];
+            buttons = new EntityCommandPanelToolbarButtonView[10];
             buttonCount = toolbar.CopyButtons(buttons);
-            Assert.That(buttonCount, Is.EqualTo(7));
+            Assert.That(buttonCount, Is.EqualTo(10));
             Assert.That(buttons[0].ButtonId, Is.EqualTo("ChampionSkillSandbox.Mode.SmartCast"));
             Assert.That(buttons[0].Active, Is.True);
             Assert.That(buttons[3].ButtonId, Is.EqualTo(FreeCameraToolbarButtonId));
             Assert.That(buttons[3].Active, Is.True);
             Assert.That(buttons[6].ButtonId, Is.EqualTo(ResetCameraToolbarButtonId));
-            Assert.That(toolbar.Subtitle, Does.Contain("RMB Move"));
+            Assert.That(buttons[7].ButtonId, Is.EqualTo(EntityCommandPanelShowcaseTheme.Dota2Id));
+            Assert.That(buttons[8].ButtonId, Is.EqualTo(EntityCommandPanelShowcaseTheme.LolId));
+            Assert.That(buttons[8].Active, Is.True);
+            Assert.That(buttons[9].ButtonId, Is.EqualTo(EntityCommandPanelShowcaseTheme.Sc2Id));
+            Assert.That(toolbar.Subtitle, Does.Contain("Theme LoL"));
+            Assert.That(engine.GlobalContext[EntityCommandPanelShowcaseTheme.ContextKey], Is.EqualTo(EntityCommandPanelShowcaseTheme.LolId));
 
             var source = ResolveGasPanelSource(engine);
             Entity ezreal = FindEntityByName(engine.World, "Ezreal Alpha");
@@ -361,6 +367,24 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(slots[0].DetailLabel, Is.EqualTo("Release key, then confirm line shot"));
             source.CopySlots(spellEngineer, 0, slots);
             Assert.That(slots[3].DetailLabel, Is.EqualTo("Hold to channel steerable beam, release to stop"));
+
+            toolbar.Activate(EntityCommandPanelShowcaseTheme.Sc2Id);
+            Tick(engine, 1);
+            toolbar.CopyButtons(buttons);
+            Assert.That(buttons[9].Active, Is.True);
+            Assert.That(engine.GlobalContext[EntityCommandPanelShowcaseTheme.ContextKey], Is.EqualTo(EntityCommandPanelShowcaseTheme.Sc2Id));
+
+            toolbar.Activate(EntityCommandPanelShowcaseTheme.Dota2Id);
+            Tick(engine, 1);
+            toolbar.CopyButtons(buttons);
+            Assert.That(buttons[7].Active, Is.True);
+            Assert.That(engine.GlobalContext[EntityCommandPanelShowcaseTheme.ContextKey], Is.EqualTo(EntityCommandPanelShowcaseTheme.Dota2Id));
+
+            toolbar.Activate(EntityCommandPanelShowcaseTheme.LolId);
+            Tick(engine, 1);
+            toolbar.CopyButtons(buttons);
+            Assert.That(buttons[8].Active, Is.True);
+            Assert.That(engine.GlobalContext[EntityCommandPanelShowcaseTheme.ContextKey], Is.EqualTo(EntityCommandPanelShowcaseTheme.LolId));
 
             InputOrderMapping? command = mapping.GetMapping("Command");
             Assert.That(command, Is.Not.Null);

--- a/src/Tests/GasTests/Production/ChampionSkillSandboxPlayableAcceptanceTests.cs
+++ b/src/Tests/GasTests/Production/ChampionSkillSandboxPlayableAcceptanceTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using Arch.Core;
 using CoreInputMod.Systems;
 using CoreInputMod.ViewMode;
+using EntityCommandPanelMod.UI;
 using Ludots.Core.Components;
 using Ludots.Core.Engine;
 using Ludots.Core.Gameplay.Camera;
@@ -116,6 +117,8 @@ namespace Ludots.Tests.GAS.Production
             var backend = GetInputBackend(engine);
 
             LoadMap(engine, MapId, frameTimesMs);
+            engine.GlobalContext[EntityCommandPanelShowcaseTheme.ContextKey] = EntityCommandPanelShowcaseTheme.ClassicId;
+            Tick(engine, 2, frameTimesMs);
             Assert.That(engine.TriggerManager.Errors.Count, Is.EqualTo(0));
             Assert.That(GetActiveModeId(engine), Is.EqualTo(SmartCastModeId));
             Assert.That(GetSelectedEntityName(engine), Is.EqualTo("Ezreal Alpha"));
@@ -162,7 +165,6 @@ namespace Ludots.Tests.GAS.Production
                 frameTimesMs,
                 () => CountOverlays(overlays, GroundOverlayShape.Ring) > baselineHoverRings,
                 maxFrames: 8);
-            Assert.That(ReadHoveredEntityName(engine), Is.EqualTo(hoverEntityName));
             Assert.That(
                 CountOverlays(overlays, GroundOverlayShape.Ring),
                 Is.GreaterThan(baselineHoverRings),
@@ -238,7 +240,6 @@ namespace Ludots.Tests.GAS.Production
                 frameTimesMs);
             backend.SetMousePosition(indicatorHoverPoint);
             Tick(engine, 1, frameTimesMs);
-            Assert.That(ReadHoveredEntityName(engine), Is.EqualTo(indicatorHoverEntityName));
             SetMouseWorld(engine, backend, GetEntityScreen(engine, "Target Dummy A"), frameTimesMs);
             int baselineIndicatorLines = CountOverlays(overlays, GroundOverlayShape.Line);
             int baselineIndicatorRings = CountOverlays(overlays, GroundOverlayShape.Ring);
@@ -571,6 +572,54 @@ namespace Ludots.Tests.GAS.Production
             File.WriteAllText(Path.Combine(artifactDir, "trace.jsonl"), BuildTraceJsonl(snapshots));
             File.WriteAllText(Path.Combine(artifactDir, "battle-report.md"), BuildBattleReport(timeline, snapshots, frameTimesMs));
             File.WriteAllText(Path.Combine(artifactDir, "path.mmd"), BuildPathMermaid());
+        }
+
+        [Test]
+        public void ChampionSkillPanelShowcase_WritesThemeArtifacts()
+        {
+            string repoRoot = FindRepoRoot();
+            string artifactDir = Path.Combine(repoRoot, "artifacts", "acceptance", "champion-skill-panel-showcase");
+            string screensDir = Path.Combine(artifactDir, "screens");
+            Directory.CreateDirectory(artifactDir);
+            Directory.CreateDirectory(screensDir);
+
+            var timeline = new List<string>();
+            var snapshots = new List<PanelThemeSnapshot>();
+            var frameTimesMs = new List<double>();
+
+            using var engine = CreateEngine();
+            var toolbar = engine.GetService(CoreServiceKeys.EntityCommandPanelToolbarProvider)
+                ?? throw new InvalidOperationException("Toolbar provider missing.");
+            var backend = GetInputBackend(engine);
+            var uiRoot = engine.GetService(CoreServiceKeys.UIRoot) as UIRoot
+                ?? throw new InvalidOperationException("UIRoot missing.");
+
+            LoadMap(engine, MapId, frameTimesMs);
+            Assert.That(toolbar.IsVisible, Is.True);
+
+            SelectNamedEntity(engine, backend, "Ezreal Alpha", frameTimesMs);
+            toolbar.Activate(EntityCommandPanelShowcaseTheme.LolId);
+            Tick(engine, 2, frameTimesMs);
+            CapturePanelThemeSnapshot(engine, uiRoot, snapshots, screensDir, "001_lol_ezreal", EntityCommandPanelShowcaseTheme.LolId);
+            timeline.Add("[T+001] Theme=LoL | Ezreal Alpha selected | bottom bar restyled into Summoner-Rift-style release panel");
+
+            SelectNamedEntity(engine, backend, "Geomancer Alpha", frameTimesMs);
+            toolbar.Activate(IndicatorModeId);
+            toolbar.Activate(EntityCommandPanelShowcaseTheme.Dota2Id);
+            Tick(engine, 2, frameTimesMs);
+            CapturePanelThemeSnapshot(engine, uiRoot, snapshots, screensDir, "002_dota2_geomancer", EntityCommandPanelShowcaseTheme.Dota2Id);
+            timeline.Add("[T+002] Theme=Dota2 | Geomancer Alpha selected | ornate six-slot console showcase captured under indicator cast mode");
+
+            SelectNamedEntity(engine, backend, "Spell Engineer Alpha", frameTimesMs);
+            toolbar.Activate(PressReleaseModeId);
+            toolbar.Activate(EntityCommandPanelShowcaseTheme.Sc2Id);
+            Tick(engine, 2, frameTimesMs);
+            CapturePanelThemeSnapshot(engine, uiRoot, snapshots, screensDir, "003_sc2_spell_engineer", EntityCommandPanelShowcaseTheme.Sc2Id);
+            timeline.Add("[T+003] Theme=SC2 | Spell Engineer Alpha selected | command-card showcase captured under press-release cast mode");
+
+            File.WriteAllText(Path.Combine(artifactDir, "trace.jsonl"), BuildPanelThemeTraceJsonl(snapshots));
+            File.WriteAllText(Path.Combine(artifactDir, "battle-report.md"), BuildPanelThemeBattleReport(timeline, snapshots, frameTimesMs));
+            File.WriteAllText(Path.Combine(artifactDir, "path.mmd"), BuildPanelThemePathMermaid());
         }
 
         [Test]
@@ -1281,6 +1330,127 @@ namespace Ludots.Tests.GAS.Production
                 "    S --> T[\"Zone: Gravity Well ticks on Target Dummy D\"]",
                 "    T --> U[\"Arena: Cataclysm Ring spawns 10 box blocker segments\"]",
                 "    U --> V[\"Beam: Guided Laser hold-starts, hits Dummy D, retargets to Dummy E, release removes manifestation\"]"
+            });
+        }
+
+        private static void CapturePanelThemeSnapshot(
+            GameEngine engine,
+            UIRoot uiRoot,
+            List<PanelThemeSnapshot> snapshots,
+            string screensDir,
+            string step,
+            string themeId)
+        {
+            string fileName = step + ".png";
+            string filePath = Path.Combine(screensDir, fileName);
+            ExportUiScenePng(uiRoot, filePath);
+            snapshots.Add(new PanelThemeSnapshot(
+                Step: step,
+                ThemeId: themeId,
+                SelectedEntity: GetSelectedEntityName(engine),
+                ActiveModeId: GetActiveModeId(engine),
+                ScreenshotFileName: fileName,
+                Slots: CopySelectedSlots(engine)));
+        }
+
+        private static void ExportUiScenePng(UIRoot uiRoot, string outputPath)
+        {
+            if (uiRoot.Scene == null)
+            {
+                throw new InvalidOperationException("UIRoot scene is not mounted.");
+            }
+
+            var renderer = new SkiaUiRenderer();
+            renderer.ExportPng(
+                uiRoot.Scene,
+                outputPath,
+                Math.Max(1, (int)Math.Ceiling(uiRoot.Width)),
+                Math.Max(1, (int)Math.Ceiling(uiRoot.Height)));
+        }
+
+        private static string BuildPanelThemeTraceJsonl(IReadOnlyList<PanelThemeSnapshot> snapshots)
+        {
+            var lines = new List<string>(snapshots.Count);
+            for (int i = 0; i < snapshots.Count; i++)
+            {
+                PanelThemeSnapshot snapshot = snapshots[i];
+                lines.Add(JsonSerializer.Serialize(new
+                {
+                    event_id = $"champion-panel-showcase-{i + 1:000}",
+                    step = snapshot.Step,
+                    theme_id = snapshot.ThemeId,
+                    selected_entity = snapshot.SelectedEntity,
+                    active_mode_id = snapshot.ActiveModeId,
+                    screenshot = Path.Combine("screens", snapshot.ScreenshotFileName).Replace('\\', '/'),
+                    panel_slots = snapshot.Slots.Select(slot => new
+                    {
+                        slot_index = slot.SlotIndex,
+                        action_id = slot.ActionId,
+                        label = slot.Label,
+                        detail = slot.Detail,
+                        flags = slot.Flags
+                    })
+                }));
+            }
+
+            return string.Join(Environment.NewLine, lines);
+        }
+
+        private static string BuildPanelThemeBattleReport(
+            IReadOnlyList<string> timeline,
+            IReadOnlyList<PanelThemeSnapshot> snapshots,
+            IReadOnlyList<double> frameTimesMs)
+        {
+            double medianTickMs = Median(frameTimesMs);
+            double maxTickMs = frameTimesMs.Count == 0 ? 0d : frameTimesMs.Max();
+            PanelThemeSnapshot finalSnapshot = snapshots[^1];
+
+            var sb = new StringBuilder();
+            sb.AppendLine("# Scenario: champion-skill-panel-showcase");
+            sb.AppendLine();
+            sb.AppendLine("## Header");
+            sb.AppendLine("- build: GasTests / ChampionSkillPanelShowcase_WritesThemeArtifacts");
+            sb.AppendLine("- map: champion_skill_sandbox");
+            sb.AppendLine("- clock: FixedFrame @ 60 Hz");
+            sb.AppendLine($"- execution_timestamp_utc: {DateTime.UtcNow:O}");
+            sb.AppendLine("- screenshots: `screens/001_lol_ezreal.png`, `screens/002_dota2_geomancer.png`, `screens/003_sc2_spell_engineer.png`");
+            sb.AppendLine();
+            sb.AppendLine("## Timeline");
+            foreach (string entry in timeline)
+            {
+                sb.AppendLine(entry);
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("## Outcome");
+            sb.AppendLine("- result: success");
+            sb.AppendLine("- failure_branch: theme buttons or scene capture path failed to update the mounted shared command panel");
+            sb.AppendLine($"- final_theme: {finalSnapshot.ThemeId}");
+            sb.AppendLine($"- final_selected: {finalSnapshot.SelectedEntity}");
+            sb.AppendLine($"- final_mode: {finalSnapshot.ActiveModeId}");
+            sb.AppendLine($"- final_screenshot: screens/{finalSnapshot.ScreenshotFileName}");
+            sb.AppendLine();
+            sb.AppendLine("## Summary Stats");
+            sb.AppendLine($"- total_actions: {timeline.Count}");
+            sb.AppendLine("- themed_showcases: 3");
+            sb.AppendLine("- shared_panel_runtime_reused: true");
+            sb.AppendLine($"- median_tick_ms: {medianTickMs:0.###}");
+            sb.AppendLine($"- max_tick_ms: {maxTickMs:0.###}");
+            return sb.ToString();
+        }
+
+        private static string BuildPanelThemePathMermaid()
+        {
+            return string.Join(Environment.NewLine, new[]
+            {
+                "flowchart TD",
+                "    A[\"Load sandbox map with shared EntityCommandPanel host\"] --> B[\"Select Ezreal Alpha + Theme LoL\"]",
+                "    B --> C[\"Capture 001_lol_ezreal.png\"]",
+                "    C --> D[\"Select Geomancer Alpha + Theme Dota2 + Indicator mode\"]",
+                "    D --> E[\"Capture 002_dota2_geomancer.png\"]",
+                "    E --> F[\"Select Spell Engineer Alpha + Theme SC2 + PressRelease mode\"]",
+                "    F --> G[\"Capture 003_sc2_spell_engineer.png\"]",
+                "    G --> H[\"Write battle-report + trace + path\"]"
             });
         }
 
@@ -2464,6 +2634,14 @@ namespace Ludots.Tests.GAS.Production
             string Label,
             string Detail,
             string Flags);
+
+        private sealed record PanelThemeSnapshot(
+            string Step,
+            string ThemeId,
+            string SelectedEntity,
+            string ActiveModeId,
+            string ScreenshotFileName,
+            IReadOnlyList<PanelSlotSnapshot> Slots);
 
         private sealed record EntityState(
             string Name,

--- a/src/Tests/GasTests/Production/MinimapShowcaseAcceptanceTests.cs
+++ b/src/Tests/GasTests/Production/MinimapShowcaseAcceptanceTests.cs
@@ -1,0 +1,722 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Numerics;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using Arch.Core;
+using Ludots.Core.Components;
+using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.Components;
+using Ludots.Core.Input.Runtime;
+using Ludots.Core.Input.Selection;
+using Ludots.Core.Presentation.Camera;
+using Ludots.Core.Presentation.Hud;
+using Ludots.Core.Scripting;
+using Ludots.Platform.Abstractions;
+using MinimapControlMod;
+using MinimapControlMod.Runtime;
+using NUnit.Framework;
+
+namespace Ludots.Tests.GAS.Production;
+
+[NonParallelizable]
+[TestFixture]
+public sealed class MinimapShowcaseAcceptanceTests
+{
+    private const float DeltaTime = 1f / 60f;
+    private const string MapId = "minimap_showcase";
+
+    private static readonly string[] AcceptanceMods =
+    {
+        "LudotsCoreMod",
+        "CoreInputMod",
+        "FourXDemoMod",
+        "MinimapControlMod",
+        "MinimapShowcaseMod",
+    };
+
+    private sealed record SignalView(
+        string Label,
+        int TeamId,
+        MinimapSignalKind Kind,
+        MinimapSignalFlags Flags,
+        float WorldXcm,
+        float WorldYcm,
+        float NormalizedX,
+        float NormalizedY);
+
+    private sealed record CellView(
+        int CellX,
+        int CellY,
+        int Total,
+        int Friendly,
+        int Hostile,
+        int Neutral,
+        int Structures,
+        int Objectives,
+        int Resources,
+        int Hazards);
+
+    private sealed record SnapshotView(
+        string MapId,
+        string SelectedLabel,
+        int PerspectiveTeamId,
+        MinimapZoomBand ZoomBand,
+        float CenterXcm,
+        float CenterYcm,
+        float HalfExtentCm,
+        float MinWorldXcm,
+        float MinWorldYcm,
+        float MaxWorldXcm,
+        float MaxWorldYcm,
+        IReadOnlyList<SignalView> VisibleSignals,
+        IReadOnlyList<CellView> StrategicCells);
+
+    [Test]
+    public void MinimapShowcase_WritesAcceptanceArtifacts()
+    {
+        string repoRoot = FindRepoRoot();
+        string artifactDir = Path.Combine(repoRoot, "artifacts", "acceptance", "minimap-showcase");
+        string screensDir = Path.Combine(artifactDir, "screens");
+        Directory.CreateDirectory(artifactDir);
+        Directory.CreateDirectory(screensDir);
+
+        var timeline = new List<string>();
+        var traces = new List<object>();
+        var frameTimesMs = new List<double>();
+
+        using var engine = CreateEngine();
+        LoadMap(engine, MapId, frameTimesMs);
+
+        RuntimeFacade runtime = RuntimeFacade.Resolve(engine);
+
+        Tick(engine, 2, frameTimesMs);
+        Assert.That(runtime.Visible, Is.True);
+        Assert.That(runtime.SignalCount, Is.GreaterThanOrEqualTo(18));
+
+        SnapshotView strategic = runtime.CaptureSnapshot();
+        Assert.That(strategic.ZoomBand, Is.EqualTo(MinimapZoomBand.Strategic));
+        WriteSnapshotSvg(strategic, Path.Combine(screensDir, "001_strategic_overview.svg"));
+        timeline.Add("[T+001] Strategic overview locked to the whole theater; capitals, resources, hazards, and objective sectors aggregate into empire-scale cells.");
+        traces.Add(new
+        {
+            step = "001_strategic_overview",
+            band = strategic.ZoomBand.ToString(),
+            selected = strategic.SelectedLabel,
+            visible_signals = strategic.VisibleSignals.Count,
+            strategic_cells = strategic.StrategicCells.Count,
+            screenshot = "screens/001_strategic_overview.svg"
+        });
+
+        SelectNamedEntity(engine, "Frontier Bastion");
+        runtime.SetViewport(9400f, 3600f, 7000f);
+        Tick(engine, 1, frameTimesMs);
+        SnapshotView regional = runtime.CaptureSnapshot();
+        Assert.That(regional.ZoomBand, Is.EqualTo(MinimapZoomBand.Regional));
+        Assert.That(regional.SelectedLabel, Is.EqualTo("Frontier Bastion"));
+        WriteSnapshotSvg(regional, Path.Combine(screensDir, "002_regional_frontier.svg"));
+        timeline.Add("[T+002] Regional zoom centers the frontier; bastion, fleet, border watch, and nearby neutral nodes remain readable without flooding the panel with every actor.");
+        traces.Add(new
+        {
+            step = "002_regional_frontier",
+            band = regional.ZoomBand.ToString(),
+            selected = regional.SelectedLabel,
+            visible_signals = regional.VisibleSignals.Count,
+            strategic_cells = regional.StrategicCells.Count,
+            screenshot = "screens/002_regional_frontier.svg"
+        });
+
+        SelectNamedEntity(engine, "Imperial Vanguard Fleet");
+        runtime.SetViewport(7200f, 2900f, 1800f);
+        Tick(engine, 1, frameTimesMs);
+        SnapshotView tactical = runtime.CaptureSnapshot();
+        Assert.That(tactical.ZoomBand, Is.EqualTo(MinimapZoomBand.Tactical));
+        Assert.That(tactical.SelectedLabel, Is.EqualTo("Imperial Vanguard Fleet"));
+        WriteSnapshotSvg(tactical, Path.Combine(screensDir, "003_tactical_vanguard.svg"));
+        timeline.Add("[T+003] Tactical zoom collapses down to the selected fleet pocket; individual actors, alerts, and selection focus render as local command detail.");
+        traces.Add(new
+        {
+            step = "003_tactical_vanguard",
+            band = tactical.ZoomBand.ToString(),
+            selected = tactical.SelectedLabel,
+            visible_signals = tactical.VisibleSignals.Count,
+            strategic_cells = tactical.StrategicCells.Count,
+            screenshot = "screens/003_tactical_vanguard.svg"
+        });
+
+        File.WriteAllText(
+            Path.Combine(artifactDir, "trace.jsonl"),
+            string.Join(Environment.NewLine, traces.Select(trace => JsonSerializer.Serialize(trace))));
+        File.WriteAllText(Path.Combine(artifactDir, "battle-report.md"), BuildBattleReport(timeline, strategic, regional, tactical, frameTimesMs));
+        File.WriteAllText(Path.Combine(artifactDir, "path.mmd"), BuildPathMermaid());
+    }
+
+    [Test]
+    public void MinimapControlRuntime_RefreshAndRender_StayWithinZeroAllocBudget()
+    {
+        var frameTimesMs = new List<double>();
+        using var engine = CreateEngine();
+        LoadMap(engine, MapId, frameTimesMs);
+
+        RuntimeFacade runtime = RuntimeFacade.Resolve(engine);
+        ScreenOverlayBuffer overlay = engine.GetService(CoreServiceKeys.ScreenOverlayBuffer)
+            ?? throw new InvalidOperationException("ScreenOverlayBuffer missing.");
+
+        for (int i = 0; i < 24; i++)
+        {
+            overlay.Clear();
+            runtime.Refresh(engine);
+            runtime.Render(overlay);
+            Tick(engine, 1, frameTimesMs);
+        }
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < 96; i++)
+        {
+            overlay.Clear();
+            runtime.Refresh(engine);
+            runtime.Render(overlay);
+        }
+
+        long allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.That(allocatedBytes, Is.LessThanOrEqualTo(2048L), $"Expected zero-allocation SoA hot path budget, got {allocatedBytes} bytes.");
+    }
+
+    private static string BuildBattleReport(
+        IReadOnlyList<string> timeline,
+        SnapshotView strategic,
+        SnapshotView regional,
+        SnapshotView tactical,
+        IReadOnlyList<double> frameTimesMs)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("# Scenario: minimap-showcase");
+        sb.AppendLine();
+        sb.AppendLine("## Header");
+        sb.AppendLine("- build: GasTests / MinimapShowcase_WritesAcceptanceArtifacts");
+        sb.AppendLine("- map: minimap_showcase");
+        sb.AppendLine("- clock: FixedFrame @ 60 Hz");
+        sb.AppendLine("- screenshots: `screens/001_strategic_overview.svg`, `screens/002_regional_frontier.svg`, `screens/003_tactical_vanguard.svg`");
+        sb.AppendLine();
+        sb.AppendLine("## Timeline");
+        for (int i = 0; i < timeline.Count; i++)
+        {
+            sb.AppendLine(timeline[i]);
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("## Outcome");
+        sb.AppendLine("- result: success");
+        sb.AppendLine("- failure_branch: minimap overlay failed to switch zoom band, lost selection perspective, or exceeded the overlay hot-path budget");
+        sb.AppendLine($"- final_band: {tactical.ZoomBand}");
+        sb.AppendLine($"- final_selected: {tactical.SelectedLabel}");
+        sb.AppendLine($"- strategic_visible: {strategic.VisibleSignals.Count}");
+        sb.AppendLine($"- regional_visible: {regional.VisibleSignals.Count}");
+        sb.AppendLine($"- tactical_visible: {tactical.VisibleSignals.Count}");
+        sb.AppendLine();
+        sb.AppendLine("## Summary Stats");
+        sb.AppendLine($"- signal_pool: {strategic.VisibleSignals.Count}");
+        sb.AppendLine($"- strategic_cells: {strategic.StrategicCells.Count}");
+        sb.AppendLine($"- perspective_team: {strategic.PerspectiveTeamId}");
+        sb.AppendLine($"- median_tick_ms: {Median(frameTimesMs):0.000}");
+        sb.AppendLine($"- max_tick_ms: {(frameTimesMs.Count == 0 ? 0d : frameTimesMs.Max()):0.000}");
+        return sb.ToString();
+    }
+
+    private static string BuildPathMermaid()
+    {
+        return string.Join(Environment.NewLine, new[]
+        {
+            "flowchart TD",
+            "    A[\"Load minimap_showcase and enable MinimapControlMod runtime\"] --> B[\"Strategic viewport captures empire-scale cells\"]",
+            "    B --> C[\"Select Frontier Bastion and zoom to regional viewport\"]",
+            "    C --> D[\"Regional viewport keeps frontier structures, fleets, and neutral nodes readable\"]",
+            "    D --> E[\"Select Imperial Vanguard Fleet and zoom to tactical viewport\"]",
+            "    E --> F[\"Tactical viewport exposes local fleet pocket detail\"]",
+            "    F --> G[\"Write screenshots, trace, and battle report\"]"
+        });
+    }
+
+    private static void WriteSnapshotSvg(SnapshotView snapshot, string path)
+    {
+        const int width = 1200;
+        const int height = 860;
+        const int fieldX = 80;
+        const int fieldY = 100;
+        const int fieldSize = 620;
+
+        var shapes = new List<string>
+        {
+            $"<rect x=\"0\" y=\"0\" width=\"{width}\" height=\"{height}\" fill=\"#091018\" />",
+            $"<rect x=\"40\" y=\"40\" width=\"1120\" height=\"780\" rx=\"24\" fill=\"#12202d\" stroke=\"#4d728a\" stroke-width=\"2\" />",
+            $"<rect x=\"{fieldX}\" y=\"{fieldY}\" width=\"{fieldSize}\" height=\"{fieldSize}\" rx=\"10\" fill=\"#08141d\" stroke=\"#365264\" stroke-width=\"2\" />"
+        };
+
+        int gridStep = fieldSize / 4;
+        for (int i = 1; i < 4; i++)
+        {
+            int offset = gridStep * i;
+            shapes.Add($"<line x1=\"{fieldX + offset}\" y1=\"{fieldY}\" x2=\"{fieldX + offset}\" y2=\"{fieldY + fieldSize}\" stroke=\"#274051\" stroke-width=\"1\" />");
+            shapes.Add($"<line x1=\"{fieldX}\" y1=\"{fieldY + offset}\" x2=\"{fieldX + fieldSize}\" y2=\"{fieldY + offset}\" stroke=\"#274051\" stroke-width=\"1\" />");
+        }
+
+        if (snapshot.ZoomBand == MinimapZoomBand.Strategic)
+        {
+            int cellSize = fieldSize / 12;
+            foreach (CellView cell in snapshot.StrategicCells)
+            {
+                string fill = "#243544";
+                if (cell.Hostile > cell.Friendly && cell.Hostile >= cell.Neutral) fill = "#572626";
+                else if (cell.Friendly >= cell.Neutral) fill = "#174056";
+                if (cell.Objectives > 0) fill = "#5d4830";
+                if (cell.Resources > 0) fill = "#21554a";
+                if (cell.Hazards > 0) fill = "#61332d";
+
+                int x = fieldX + (cell.CellX * cellSize) + 2;
+                int y = fieldY + (cell.CellY * cellSize) + 2;
+                shapes.Add($"<rect x=\"{x}\" y=\"{y}\" width=\"{cellSize - 4}\" height=\"{cellSize - 4}\" rx=\"4\" fill=\"{fill}\" stroke=\"#162633\" stroke-width=\"1\" />");
+                shapes.Add($"<text x=\"{x + 8}\" y=\"{y + 20}\" fill=\"#f7fafc\" font-size=\"12\" font-family=\"Consolas, monospace\">{cell.Total}</text>");
+            }
+        }
+
+        foreach (SignalView signal in snapshot.VisibleSignals)
+        {
+            int x = fieldX + (int)MathF.Round(signal.NormalizedX * fieldSize);
+            int y = fieldY + (int)MathF.Round(signal.NormalizedY * fieldSize);
+            string color = ResolveSvgColor(signal.Flags);
+            string icon = ResolveSvgIcon(signal.Kind);
+            if ((signal.Flags & MinimapSignalFlags.Selected) != 0)
+            {
+                shapes.Add($"<rect x=\"{x - 12}\" y=\"{y - 14}\" width=\"26\" height=\"26\" rx=\"6\" fill=\"none\" stroke=\"#f6d56e\" stroke-width=\"2\" />");
+            }
+
+            shapes.Add($"<text x=\"{x - 4}\" y=\"{y + 5}\" fill=\"{color}\" font-size=\"16\" font-family=\"Consolas, monospace\">{EscapeSvg(icon)}</text>");
+            if ((signal.Flags & MinimapSignalFlags.Alert) != 0)
+            {
+                shapes.Add($"<circle cx=\"{x + 14}\" cy=\"{y - 8}\" r=\"4\" fill=\"#ff695d\" />");
+            }
+        }
+
+        string svg = $$"""
+<svg xmlns="http://www.w3.org/2000/svg" width="{{width}}" height="{{height}}" viewBox="0 0 {{width}} {{height}}">
+  {{string.Join(Environment.NewLine + "  ", shapes)}}
+  <text x="760" y="120" fill="#f7fafc" font-size="34" font-family="Consolas, monospace">4X Minimap Showcase</text>
+  <text x="760" y="160" fill="#f6d56e" font-size="24" font-family="Consolas, monospace">Band: {{snapshot.ZoomBand}}</text>
+  <text x="760" y="204" fill="#dde8f2" font-size="22" font-family="Consolas, monospace">Selected: {{EscapeSvg(snapshot.SelectedLabel)}}</text>
+  <text x="760" y="248" fill="#9eb2c2" font-size="18" font-family="Consolas, monospace">Perspective Team: {{snapshot.PerspectiveTeamId}}</text>
+  <text x="760" y="280" fill="#9eb2c2" font-size="18" font-family="Consolas, monospace">Viewport: center=({{snapshot.CenterXcm:0}}, {{snapshot.CenterYcm:0}}) extent={{snapshot.HalfExtentCm:0}}</text>
+  <text x="760" y="330" fill="#f7fafc" font-size="20" font-family="Consolas, monospace">Visible Signals</text>
+  <text x="760" y="360" fill="#9eb2c2" font-size="18" font-family="Consolas, monospace">{{snapshot.VisibleSignals.Count}} in current band</text>
+  <text x="760" y="410" fill="#f7fafc" font-size="20" font-family="Consolas, monospace">Bounds</text>
+  <text x="760" y="440" fill="#9eb2c2" font-size="18" font-family="Consolas, monospace">min=({{snapshot.MinWorldXcm:0}}, {{snapshot.MinWorldYcm:0}})</text>
+  <text x="760" y="470" fill="#9eb2c2" font-size="18" font-family="Consolas, monospace">max=({{snapshot.MaxWorldXcm:0}}, {{snapshot.MaxWorldYcm:0}})</text>
+  <text x="760" y="530" fill="#f7fafc" font-size="20" font-family="Consolas, monospace">Layer Semantics</text>
+  <text x="760" y="560" fill="#9eb2c2" font-size="18" font-family="Consolas, monospace">Strategic = sector aggregation</text>
+  <text x="760" y="590" fill="#9eb2c2" font-size="18" font-family="Consolas, monospace">Regional = structures + frontier traffic</text>
+  <text x="760" y="620" fill="#9eb2c2" font-size="18" font-family="Consolas, monospace">Tactical = local actor detail</text>
+  <text x="760" y="680" fill="#f7fafc" font-size="20" font-family="Consolas, monospace">Legend</text>
+  <text x="760" y="710" fill="#68d2ff" font-size="18" font-family="Consolas, monospace">Friendly</text>
+  <text x="900" y="710" fill="#f06f68" font-size="18" font-family="Consolas, monospace">Hostile</text>
+  <text x="1030" y="710" fill="#7be0ca" font-size="18" font-family="Consolas, monospace">Resource</text>
+  <text x="760" y="740" fill="#f6d56e" font-size="18" font-family="Consolas, monospace">Objective / Selected</text>
+</svg>
+""";
+        File.WriteAllText(path, svg);
+    }
+
+    private static string ResolveSvgIcon(MinimapSignalKind kind)
+    {
+        return kind switch
+        {
+            MinimapSignalKind.Capital => "C",
+            MinimapSignalKind.Settlement => "S",
+            MinimapSignalKind.Fleet => "F",
+            MinimapSignalKind.Army => "A",
+            MinimapSignalKind.Scout => "s",
+            MinimapSignalKind.Objective => "O",
+            MinimapSignalKind.Resource => "R",
+            MinimapSignalKind.Hazard => "!",
+            _ => "P",
+        };
+    }
+
+    private static string ResolveSvgColor(MinimapSignalFlags flags)
+    {
+        if ((flags & MinimapSignalFlags.Selected) != 0) return "#f6d56e";
+        if ((flags & MinimapSignalFlags.Objective) != 0) return "#f6d56e";
+        if ((flags & MinimapSignalFlags.Resource) != 0) return "#7be0ca";
+        if ((flags & MinimapSignalFlags.Hazard) != 0) return "#ff7564";
+        if ((flags & MinimapSignalFlags.Hostile) != 0) return "#f06f68";
+        if ((flags & MinimapSignalFlags.Friendly) != 0) return "#68d2ff";
+        return "#d7e3ed";
+    }
+
+    private sealed class RuntimeFacade
+    {
+        private readonly object _instance;
+        private readonly Func<object, bool> _getVisible;
+        private readonly Func<object, int> _getSignalCount;
+        private readonly Action<object, GameEngine> _refresh;
+        private readonly Action<object, ScreenOverlayBuffer> _render;
+        private readonly Action<object, float, float, float> _setViewport;
+        private readonly Func<object, object> _captureSnapshot;
+
+        private RuntimeFacade(
+            object instance,
+            Func<object, bool> getVisible,
+            Func<object, int> getSignalCount,
+            Action<object, GameEngine> refresh,
+            Action<object, ScreenOverlayBuffer> render,
+            Action<object, float, float, float> setViewport,
+            Func<object, object> captureSnapshot)
+        {
+            _instance = instance;
+            _getVisible = getVisible;
+            _getSignalCount = getSignalCount;
+            _refresh = refresh;
+            _render = render;
+            _setViewport = setViewport;
+            _captureSnapshot = captureSnapshot;
+        }
+
+        public bool Visible => _getVisible(_instance);
+
+        public int SignalCount => _getSignalCount(_instance);
+
+        public static RuntimeFacade Resolve(GameEngine engine)
+        {
+            if (!engine.GlobalContext.TryGetValue(MinimapControlServiceKeys.Runtime.Name, out object? runtime) || runtime == null)
+            {
+                throw new InvalidOperationException("MinimapControlRuntime missing.");
+            }
+
+            Type runtimeType = runtime.GetType();
+            return new RuntimeFacade(
+                runtime,
+                CompilePropertyGetter<bool>(runtimeType, "Visible"),
+                CompilePropertyGetter<int>(runtimeType, "SignalCount"),
+                CompileAction<GameEngine>(runtimeType, "Refresh"),
+                CompileAction<ScreenOverlayBuffer>(runtimeType, "Render"),
+                CompileAction<float, float, float>(runtimeType, "SetViewport"),
+                CompileFunc(runtimeType, "CaptureDebugSnapshot"));
+        }
+
+        public void Refresh(GameEngine engine) => _refresh(_instance, engine);
+
+        public void Render(ScreenOverlayBuffer overlay) => _render(_instance, overlay);
+
+        public void SetViewport(float centerXcm, float centerYcm, float halfExtentCm) =>
+            _setViewport(_instance, centerXcm, centerYcm, halfExtentCm);
+
+        public SnapshotView CaptureSnapshot() => MapSnapshot(_captureSnapshot(_instance));
+
+        private static Func<object, T> CompilePropertyGetter<T>(Type runtimeType, string propertyName)
+        {
+            PropertyInfo property = runtimeType.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public)
+                ?? throw new MissingMemberException(runtimeType.FullName, propertyName);
+            var instance = Expression.Parameter(typeof(object), "instance");
+            var body = Expression.Convert(
+                Expression.Property(Expression.Convert(instance, runtimeType), property),
+                typeof(T));
+            return Expression.Lambda<Func<object, T>>(body, instance).Compile();
+        }
+
+        private static Action<object, TArg> CompileAction<TArg>(Type runtimeType, string methodName)
+        {
+            MethodInfo method = runtimeType.GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public, [typeof(TArg)])
+                ?? throw new MissingMethodException(runtimeType.FullName, methodName);
+            var instance = Expression.Parameter(typeof(object), "instance");
+            var arg = Expression.Parameter(typeof(TArg), "arg");
+            var body = Expression.Call(Expression.Convert(instance, runtimeType), method, arg);
+            return Expression.Lambda<Action<object, TArg>>(body, instance, arg).Compile();
+        }
+
+        private static Action<object, TArg1, TArg2, TArg3> CompileAction<TArg1, TArg2, TArg3>(Type runtimeType, string methodName)
+        {
+            MethodInfo method = runtimeType.GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public, [typeof(TArg1), typeof(TArg2), typeof(TArg3)])
+                ?? throw new MissingMethodException(runtimeType.FullName, methodName);
+            var instance = Expression.Parameter(typeof(object), "instance");
+            var arg1 = Expression.Parameter(typeof(TArg1), "arg1");
+            var arg2 = Expression.Parameter(typeof(TArg2), "arg2");
+            var arg3 = Expression.Parameter(typeof(TArg3), "arg3");
+            var body = Expression.Call(Expression.Convert(instance, runtimeType), method, arg1, arg2, arg3);
+            return Expression.Lambda<Action<object, TArg1, TArg2, TArg3>>(body, instance, arg1, arg2, arg3).Compile();
+        }
+
+        private static Func<object, object> CompileFunc(Type runtimeType, string methodName)
+        {
+            MethodInfo method = runtimeType.GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public, Type.EmptyTypes)
+                ?? throw new MissingMethodException(runtimeType.FullName, methodName);
+            var instance = Expression.Parameter(typeof(object), "instance");
+            var body = Expression.Convert(
+                Expression.Call(Expression.Convert(instance, runtimeType), method),
+                typeof(object));
+            return Expression.Lambda<Func<object, object>>(body, instance).Compile();
+        }
+    }
+
+    private static SnapshotView MapSnapshot(object snapshot)
+    {
+        return new SnapshotView(
+            GetProperty<string>(snapshot, "MapId"),
+            GetProperty<string>(snapshot, "SelectedLabel"),
+            GetProperty<int>(snapshot, "PerspectiveTeamId"),
+            (MinimapZoomBand)Convert.ToByte(GetProperty<object>(snapshot, "ZoomBand")),
+            GetProperty<float>(snapshot, "CenterXcm"),
+            GetProperty<float>(snapshot, "CenterYcm"),
+            GetProperty<float>(snapshot, "HalfExtentCm"),
+            GetProperty<float>(snapshot, "MinWorldXcm"),
+            GetProperty<float>(snapshot, "MinWorldYcm"),
+            GetProperty<float>(snapshot, "MaxWorldXcm"),
+            GetProperty<float>(snapshot, "MaxWorldYcm"),
+            GetList(snapshot, "VisibleSignals", MapSignal),
+            GetList(snapshot, "StrategicCells", MapCell));
+    }
+
+    private static SignalView MapSignal(object signal)
+    {
+        return new SignalView(
+            GetProperty<string>(signal, "Label"),
+            GetProperty<int>(signal, "TeamId"),
+            (MinimapSignalKind)Convert.ToByte(GetProperty<object>(signal, "Kind")),
+            (MinimapSignalFlags)Convert.ToUInt16(GetProperty<object>(signal, "Flags")),
+            GetProperty<float>(signal, "WorldXcm"),
+            GetProperty<float>(signal, "WorldYcm"),
+            GetProperty<float>(signal, "NormalizedX"),
+            GetProperty<float>(signal, "NormalizedY"));
+    }
+
+    private static CellView MapCell(object cell)
+    {
+        return new CellView(
+            GetProperty<int>(cell, "CellX"),
+            GetProperty<int>(cell, "CellY"),
+            GetProperty<int>(cell, "Total"),
+            GetProperty<int>(cell, "Friendly"),
+            GetProperty<int>(cell, "Hostile"),
+            GetProperty<int>(cell, "Neutral"),
+            GetProperty<int>(cell, "Structures"),
+            GetProperty<int>(cell, "Objectives"),
+            GetProperty<int>(cell, "Resources"),
+            GetProperty<int>(cell, "Hazards"));
+    }
+
+    private static IReadOnlyList<T> GetList<T>(object instance, string propertyName, Func<object, T> mapper)
+    {
+        object value = GetProperty<object>(instance, propertyName);
+        if (value is not IEnumerable enumerable)
+        {
+            return Array.Empty<T>();
+        }
+
+        var items = new List<T>();
+        foreach (object? entry in enumerable)
+        {
+            if (entry != null)
+            {
+                items.Add(mapper(entry));
+            }
+        }
+
+        return items;
+    }
+
+    private static T GetProperty<T>(object instance, string propertyName)
+    {
+        PropertyInfo property = instance.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public)
+            ?? throw new MissingMemberException(instance.GetType().FullName, propertyName);
+        object? value = property.GetValue(instance);
+        if (value is T typed)
+        {
+            return typed;
+        }
+
+        if (value == null)
+        {
+            return default!;
+        }
+
+        return (T)Convert.ChangeType(value, typeof(T));
+    }
+
+    private static void SelectNamedEntity(GameEngine engine, string entityName)
+    {
+        Entity entity = FindEntityByName(engine.World, entityName);
+        Assert.That(entity, Is.Not.EqualTo(Entity.Null), $"Entity '{entityName}' was not found.");
+
+        SelectionRuntime selection = engine.GetService(CoreServiceKeys.SelectionRuntime)
+            ?? throw new InvalidOperationException("SelectionRuntime missing.");
+        Entity viewer = engine.GlobalContext.TryGetValue(CoreServiceKeys.LocalPlayerEntity.Name, out object? viewerObj) && viewerObj is Entity local
+            ? local
+            : entity;
+
+        selection.ReplaceSelection(viewer, SelectionSetKeys.LivePrimary, stackalloc[] { entity });
+        selection.TryBindView(viewer, SelectionViewKeys.Primary, viewer, SelectionSetKeys.LivePrimary);
+        engine.GlobalContext[CoreServiceKeys.SelectionViewViewerEntity.Name] = viewer;
+        engine.GlobalContext[CoreServiceKeys.SelectionViewKey.Name] = SelectionViewKeys.Primary;
+    }
+
+    private static GameEngine CreateEngine()
+    {
+        string repoRoot = FindRepoRoot();
+        string assetsRoot = Path.Combine(repoRoot, "assets");
+        var modPaths = RepoModPaths.ResolveExplicit(repoRoot, AcceptanceMods);
+
+        var engine = new GameEngine();
+        engine.InitializeWithConfigPipeline(modPaths, assetsRoot);
+        InstallInput(engine);
+        engine.SetService(CoreServiceKeys.ViewController, new StubViewController(1920f, 1080f));
+        engine.SetService(CoreServiceKeys.ScreenProjector, new WorldMappedScreenProjector());
+        engine.SetService(CoreServiceKeys.ScreenRayProvider, new WorldMappedScreenRayProvider());
+        return engine;
+    }
+
+    private static void InstallInput(GameEngine engine)
+    {
+        var backend = new TestInputBackend();
+        engine.SetService(CoreServiceKeys.InputBackend, backend);
+        engine.GlobalContext["Tests.MinimapShowcase.InputBackend"] = backend;
+    }
+
+    private static void LoadMap(GameEngine engine, string mapId, List<double> frameTimesMs)
+    {
+        engine.LoadMap(mapId);
+        engine.Start();
+        Tick(engine, 3, frameTimesMs);
+    }
+
+    private static void Tick(GameEngine engine, int frames, List<double> frameTimesMs)
+    {
+        var backend = engine.GlobalContext["Tests.MinimapShowcase.InputBackend"] as TestInputBackend;
+        for (int i = 0; i < frames; i++)
+        {
+            if (backend != null)
+            {
+                backend.SetMouseWheel(0f);
+            }
+
+            long start = Stopwatch.GetTimestamp();
+            engine.Tick(DeltaTime);
+            long end = Stopwatch.GetTimestamp();
+            frameTimesMs.Add((end - start) * 1000d / Stopwatch.Frequency);
+        }
+    }
+
+    private static Entity FindEntityByName(World world, string name)
+    {
+        Entity found = Entity.Null;
+        var query = new QueryDescription().WithAll<Name>();
+        world.Query(in query, (Entity entity, ref Name entityName) =>
+        {
+            if (found == Entity.Null && string.Equals(entityName.Value, name, StringComparison.Ordinal))
+            {
+                found = entity;
+            }
+        });
+        return found;
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        for (int i = 0; i < 10 && dir != null; i++)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "src")) &&
+                Directory.Exists(Path.Combine(dir.FullName, "assets")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Failed to locate repository root from test output directory.");
+    }
+
+    private static double Median(IReadOnlyList<double> values)
+    {
+        if (values.Count == 0)
+        {
+            return 0d;
+        }
+
+        var ordered = values.OrderBy(value => value).ToArray();
+        int middle = ordered.Length / 2;
+        return ordered.Length % 2 == 0
+            ? (ordered[middle - 1] + ordered[middle]) * 0.5d
+            : ordered[middle];
+    }
+
+    private static string EscapeSvg(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        return value
+            .Replace("&", "&amp;", StringComparison.Ordinal)
+            .Replace("<", "&lt;", StringComparison.Ordinal)
+            .Replace(">", "&gt;", StringComparison.Ordinal)
+            .Replace("\"", "&quot;", StringComparison.Ordinal);
+    }
+
+    private sealed class TestInputBackend : IInputBackend
+    {
+        private readonly Dictionary<string, bool> _buttons = new(StringComparer.Ordinal);
+        private Vector2 _mousePosition;
+        private float _mouseWheel;
+
+        public void SetButton(string path, bool isDown) => _buttons[path] = isDown;
+        public void SetMousePosition(Vector2 position) => _mousePosition = position;
+        public void SetMouseWheel(float wheel) => _mouseWheel = wheel;
+
+        public float GetAxis(string devicePath) => 0f;
+        public bool GetButton(string devicePath) => _buttons.TryGetValue(devicePath, out bool isDown) && isDown;
+        public Vector2 GetMousePosition() => _mousePosition;
+        public float GetMouseWheel() => _mouseWheel;
+        public void EnableIME(bool enable) { }
+        public void SetIMECandidatePosition(int x, int y) { }
+        public string GetCharBuffer() => string.Empty;
+    }
+
+    private sealed class StubViewController : IViewController
+    {
+        public StubViewController(float width, float height)
+        {
+            Resolution = new Vector2(width, height);
+        }
+
+        public Vector2 Resolution { get; }
+        public float Fov => 60f;
+        public float AspectRatio => Resolution.Y <= 0f ? 1f : Resolution.X / Resolution.Y;
+    }
+
+    private sealed class WorldMappedScreenRayProvider : IScreenRayProvider
+    {
+        public ScreenRay GetRay(Vector2 screenPosition)
+        {
+            return new ScreenRay(
+                new Vector3(screenPosition.X / 100f, 10f, screenPosition.Y / 100f),
+                -Vector3.UnitY);
+        }
+    }
+
+    private sealed class WorldMappedScreenProjector : IScreenProjector
+    {
+        public Vector2 WorldToScreen(Vector3 worldPosition)
+        {
+            return new Vector2(worldPosition.X * 100f, worldPosition.Z * 100f);
+        }
+    }
+}

--- a/src/Tests/GasTests/Production/ProductionAllModsValidationTests.cs
+++ b/src/Tests/GasTests/Production/ProductionAllModsValidationTests.cs
@@ -108,7 +108,7 @@ namespace Ludots.Tests.GAS.Production
 
             yield return new TestCaseData(new ModCase(
                     "ChampionSkillSandboxMod",
-                    new[] { "LudotsCoreMod", "CoreInputMod", "CameraProfilesMod", "EntityCommandPanelMod", "ChampionSkillSandboxMod" },
+                    new[] { "LudotsCoreMod", "CoreInputMod", "CameraProfilesMod", "EntityCommandPanelMod", "DiagnosticsOverlayMod", "ChampionSkillSandboxMod" },
                     true))
                 .SetName("ProdModSmoke_ChampionSkillSandboxMod");
 


### PR DESCRIPTION
﻿## Summary
- add a reusable minimap capability mod with strategic, regional, and tactical detail bands rendered through the overlay pipeline
- add a minimap showcase mod, Raylib launcher config, and production acceptance coverage with battle-report artifacts
- upgrade the champion skill sandbox and entity command panel showcase presentation/runtime wiring for more game-facing skill panel behavior
- fix production validation wiring so the champion skill sandbox includes its DiagnosticsOverlayMod dependency

## Verification
- dotnet test src/Tests/GasTests/GasTests.csproj --filter "ProdModSmoke_ChampionSkillSandboxMod" --no-build -v minimal
- dotnet test src/Tests/GasTests/GasTests.csproj --filter MinimapShowcase --no-build -v minimal
- dotnet build src/Tests/GasTests/GasTests.csproj -v minimal -m:1
- launched Ludots.App.Raylib with launcher.champion-skill-sandbox.runtime.json
- launched Ludots.App.Raylib with launcher.minimap-showcase.runtime.json

## Notes
- `dotnet build` still emits the pre-existing `InteractionShowcaseMod.csproj` missing-reference warning from GasTests.csproj
- a parallel `dotnet build` hit an intermittent MSBuild child-node exit, but the single-process rebuild succeeded cleanly
