### PR TITLE
Add champion musou melee showcase combos

### DIFF
--- a/mods/showcases/champion_musou_branch_entry/ChampionMusouBranchShowcaseMod/ChampionMusouBranchShowcaseMod.csproj
+++ b/mods/showcases/champion_musou_branch_entry/ChampionMusouBranchShowcaseMod/ChampionMusouBranchShowcaseMod.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputPath>bin\net8.0\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\..\assets\ModSdk\ModSdk.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/mods/showcases/champion_musou_branch_entry/ChampionMusouBranchShowcaseMod/ChampionMusouBranchShowcaseModEntry.cs
+++ b/mods/showcases/champion_musou_branch_entry/ChampionMusouBranchShowcaseMod/ChampionMusouBranchShowcaseModEntry.cs
@@ -1,0 +1,14 @@
+using Ludots.Core.Modding;
+
+namespace ChampionMusouBranchShowcaseMod;
+
+public sealed class ChampionMusouBranchShowcaseModEntry : IMod
+{
+    public void OnLoad(IModContext context)
+    {
+    }
+
+    public void OnUnload()
+    {
+    }
+}

--- a/mods/showcases/champion_musou_branch_entry/ChampionMusouBranchShowcaseMod/assets/game.json
+++ b/mods/showcases/champion_musou_branch_entry/ChampionMusouBranchShowcaseMod/assets/game.json
@@ -1,0 +1,3 @@
+{
+  "startupMapId": "champion_musou_branch_showcase"
+}

--- a/mods/showcases/champion_musou_branch_entry/ChampionMusouBranchShowcaseMod/mod.json
+++ b/mods/showcases/champion_musou_branch_entry/ChampionMusouBranchShowcaseMod/mod.json
@@ -1,0 +1,10 @@
+{
+  "name": "ChampionMusouBranchShowcaseMod",
+  "version": "1.0.0",
+  "description": "Direct launcher entry for the Dynasty Warriors style square-triangle branching melee showcase.",
+  "main": "bin/net8.0/ChampionMusouBranchShowcaseMod.dll",
+  "priority": 0,
+  "dependencies": {
+    "ChampionSkillSandboxMod": "^1.0.0"
+  }
+}

--- a/mods/showcases/champion_musou_hit_confirm_entry/ChampionMusouHitConfirmShowcaseMod/ChampionMusouHitConfirmShowcaseMod.csproj
+++ b/mods/showcases/champion_musou_hit_confirm_entry/ChampionMusouHitConfirmShowcaseMod/ChampionMusouHitConfirmShowcaseMod.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputPath>bin\net8.0\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\..\assets\ModSdk\ModSdk.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/mods/showcases/champion_musou_hit_confirm_entry/ChampionMusouHitConfirmShowcaseMod/ChampionMusouHitConfirmShowcaseModEntry.cs
+++ b/mods/showcases/champion_musou_hit_confirm_entry/ChampionMusouHitConfirmShowcaseMod/ChampionMusouHitConfirmShowcaseModEntry.cs
@@ -1,0 +1,14 @@
+using Ludots.Core.Modding;
+
+namespace ChampionMusouHitConfirmShowcaseMod;
+
+public sealed class ChampionMusouHitConfirmShowcaseModEntry : IMod
+{
+    public void OnLoad(IModContext context)
+    {
+    }
+
+    public void OnUnload()
+    {
+    }
+}

--- a/mods/showcases/champion_musou_hit_confirm_entry/ChampionMusouHitConfirmShowcaseMod/assets/game.json
+++ b/mods/showcases/champion_musou_hit_confirm_entry/ChampionMusouHitConfirmShowcaseMod/assets/game.json
@@ -1,0 +1,3 @@
+{
+  "startupMapId": "champion_musou_hit_confirm_showcase"
+}

--- a/mods/showcases/champion_musou_hit_confirm_entry/ChampionMusouHitConfirmShowcaseMod/mod.json
+++ b/mods/showcases/champion_musou_hit_confirm_entry/ChampionMusouHitConfirmShowcaseMod/mod.json
@@ -1,0 +1,10 @@
+{
+  "name": "ChampionMusouHitConfirmShowcaseMod",
+  "version": "1.0.0",
+  "description": "Direct launcher entry for the hit-confirm gated melee combo showcase.",
+  "main": "bin/net8.0/ChampionMusouHitConfirmShowcaseMod.dll",
+  "priority": 0,
+  "dependencies": {
+    "ChampionSkillSandboxMod": "^1.0.0"
+  }
+}

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/ChampionSkillSandboxIds.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/ChampionSkillSandboxIds.cs
@@ -6,6 +6,8 @@ namespace ChampionSkillSandboxMod
     {
         public const string MapId = "champion_skill_sandbox";
         public const string StressMapId = "champion_skill_stress";
+        public const string MusouBranchMapId = "champion_musou_branch_showcase";
+        public const string MusouHitConfirmMapId = "champion_musou_hit_confirm_showcase";
         public const string InputContextId = "ChampionSkillSandbox.Controls";
 
         public const string SmartCastModeId = "ChampionSkillSandbox.Mode.SmartCast";
@@ -60,6 +62,9 @@ namespace ChampionSkillSandboxMod
         public const string TargetDummyDName = "Target Dummy D";
         public const string TargetDummyEName = "Target Dummy E";
         public const string TargetDummyFName = "Target Dummy F";
+        public const string MusouBranchHeroName = "Musou Branch Alpha";
+        public const string MusouHitHeroName = "Musou Confirm Alpha";
+        public const string MusouMissHeroName = "Musou Confirm Miss";
 
         public const string GarenCourageTag = "State.Champion.Garen.Courage";
         public const string JayceHammerTag = "State.Champion.Jayce.Hammer";
@@ -68,12 +73,24 @@ namespace ChampionSkillSandboxMod
         public static bool IsSandboxMap(string? mapId)
         {
             return string.Equals(mapId, MapId, StringComparison.OrdinalIgnoreCase) ||
-                   string.Equals(mapId, StressMapId, StringComparison.OrdinalIgnoreCase);
+                   string.Equals(mapId, StressMapId, StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(mapId, MusouBranchMapId, StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(mapId, MusouHitConfirmMapId, StringComparison.OrdinalIgnoreCase);
         }
 
         public static bool IsStressMap(string? mapId)
         {
             return string.Equals(mapId, StressMapId, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool IsMusouBranchMap(string? mapId)
+        {
+            return string.Equals(mapId, MusouBranchMapId, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool IsMusouHitConfirmMap(string? mapId)
+        {
+            return string.Equals(mapId, MusouHitConfirmMapId, StringComparison.OrdinalIgnoreCase);
         }
 
         public static bool IsSandboxMode(string? modeId)

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillCastModeToolbarProvider.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillCastModeToolbarProvider.cs
@@ -56,16 +56,47 @@ namespace ChampionSkillSandboxMod.Runtime
             }
         }
 
-        public string Title => ChampionSkillSandboxIds.IsStressMap(_engine?.CurrentMapSession?.MapId.Value)
-            ? "Stress Harness"
-            : "Cast Mode";
+        public string Title
+        {
+            get
+            {
+                string? mapId = _engine?.CurrentMapSession?.MapId.Value;
+                if (ChampionSkillSandboxIds.IsStressMap(mapId))
+                {
+                    return "Stress Harness";
+                }
+
+                if (ChampionSkillSandboxIds.IsMusouBranchMap(mapId))
+                {
+                    return "Musou Branch";
+                }
+
+                if (ChampionSkillSandboxIds.IsMusouHitConfirmMap(mapId))
+                {
+                    return "Hit Confirm";
+                }
+
+                return "Cast Mode";
+            }
+        }
 
         public string Subtitle
         {
             get
             {
-                if (!ChampionSkillSandboxIds.IsStressMap(_engine?.CurrentMapSession?.MapId.Value))
+                string? mapId = _engine?.CurrentMapSession?.MapId.Value;
+                if (!ChampionSkillSandboxIds.IsStressMap(mapId))
                 {
+                    if (ChampionSkillSandboxIds.IsMusouBranchMap(mapId))
+                    {
+                        return "Q=Square chain | E=Triangle branch | W/R extra melee";
+                    }
+
+                    if (ChampionSkillSandboxIds.IsMusouHitConfirmMap(mapId))
+                    {
+                        return "Q must hit before Q/E follow-ups unlock";
+                    }
+
                     return "Cast + Camera | F1/F2/F3 Cast | RMB Move";
                 }
 

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxVisualFeedback.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxVisualFeedback.cs
@@ -526,6 +526,21 @@ namespace ChampionSkillSandboxMod.Runtime
             RegisterAbilityCue(performers, "Ability.Champion.SpellEngineer.GravityWell", "champion_skill_sandbox.cue.spell_engineer_gravity_well_cast");
             RegisterAbilityCue(performers, "Ability.Champion.SpellEngineer.CataclysmRing", "champion_skill_sandbox.cue.spell_engineer_cataclysm_ring_cast");
             RegisterAbilityCue(performers, "Ability.Champion.SpellEngineer.GuidedLaser", "champion_skill_sandbox.cue.spell_engineer_guided_laser_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.MusouBranch.Square1", "champion_skill_sandbox.cue.musou_branch_square1_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.MusouBranch.Square2", "champion_skill_sandbox.cue.musou_branch_square2_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.MusouBranch.Square3", "champion_skill_sandbox.cue.musou_branch_square3_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.MusouBranch.TriangleNeutral", "champion_skill_sandbox.cue.musou_branch_triangle_neutral_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.MusouBranch.TriangleStage1", "champion_skill_sandbox.cue.musou_branch_triangle_stage1_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.MusouBranch.TriangleStage2", "champion_skill_sandbox.cue.musou_branch_triangle_stage2_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.MusouBranch.TriangleStage3", "champion_skill_sandbox.cue.musou_branch_triangle_stage3_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.MusouBranch.StepSlash", "champion_skill_sandbox.cue.musou_branch_step_slash_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.MusouBranch.WhirlwindSweep", "champion_skill_sandbox.cue.musou_branch_whirlwind_sweep_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.MusouConfirm.Square1", "champion_skill_sandbox.cue.musou_confirm_square1_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.MusouConfirm.Square2", "champion_skill_sandbox.cue.musou_confirm_square2_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.MusouConfirm.TriangleStage1", "champion_skill_sandbox.cue.musou_confirm_triangle_stage1_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.MusouConfirm.TriangleStage2", "champion_skill_sandbox.cue.musou_confirm_triangle_stage2_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.MusouConfirm.GuardStep", "champion_skill_sandbox.cue.musou_confirm_guard_step_cast");
+            RegisterAbilityCue(performers, "Ability.Champion.MusouConfirm.ExecutionSweep", "champion_skill_sandbox.cue.musou_confirm_execution_sweep_cast");
 
             RegisterEffectCue(performers, "Effect.Champion.Garen.JudgmentHit", "champion_skill_sandbox.cue.garen_judgment_hit");
             RegisterEffectCue(performers, "Effect.Champion.Garen.DemacianJusticeHit", "champion_skill_sandbox.cue.garen_demacian_justice_hit");
@@ -541,6 +556,21 @@ namespace ChampionSkillSandboxMod.Runtime
             RegisterEffectCue(performers, "Effect.ChampionStress.Priest.Heal", "champion_skill_sandbox.cue.stress_priest_heal_hit");
             RegisterEffectCue(performers, "Effect.Champion.SpellEngineer.GravityWellHit", "champion_skill_sandbox.cue.spell_engineer_gravity_well_hit");
             RegisterEffectCue(performers, "Effect.Champion.SpellEngineer.GuidedLaserHit", "champion_skill_sandbox.cue.spell_engineer_guided_laser_hit");
+            RegisterEffectCue(performers, "Effect.Champion.MusouBranch.Square1Hit", "champion_skill_sandbox.cue.musou_branch_square1_hit");
+            RegisterEffectCue(performers, "Effect.Champion.MusouBranch.Square2Hit", "champion_skill_sandbox.cue.musou_branch_square2_hit");
+            RegisterEffectCue(performers, "Effect.Champion.MusouBranch.Square3Hit", "champion_skill_sandbox.cue.musou_branch_square3_hit");
+            RegisterEffectCue(performers, "Effect.Champion.MusouBranch.TriangleNeutralHit", "champion_skill_sandbox.cue.musou_branch_triangle_neutral_hit");
+            RegisterEffectCue(performers, "Effect.Champion.MusouBranch.TriangleStage1Hit", "champion_skill_sandbox.cue.musou_branch_triangle_stage1_hit");
+            RegisterEffectCue(performers, "Effect.Champion.MusouBranch.TriangleStage2Hit", "champion_skill_sandbox.cue.musou_branch_triangle_stage2_hit");
+            RegisterEffectCue(performers, "Effect.Champion.MusouBranch.TriangleStage3Hit", "champion_skill_sandbox.cue.musou_branch_triangle_stage3_hit");
+            RegisterEffectCue(performers, "Effect.Champion.MusouBranch.StepSlashHit", "champion_skill_sandbox.cue.musou_branch_step_slash_hit");
+            RegisterEffectCue(performers, "Effect.Champion.MusouBranch.WhirlwindSweepHit", "champion_skill_sandbox.cue.musou_branch_whirlwind_sweep_hit");
+            RegisterEffectCue(performers, "Effect.Champion.MusouConfirm.Square1Hit", "champion_skill_sandbox.cue.musou_confirm_square1_hit");
+            RegisterEffectCue(performers, "Effect.Champion.MusouConfirm.Square2Hit", "champion_skill_sandbox.cue.musou_confirm_square2_hit");
+            RegisterEffectCue(performers, "Effect.Champion.MusouConfirm.TriangleStage1Hit", "champion_skill_sandbox.cue.musou_confirm_triangle_stage1_hit");
+            RegisterEffectCue(performers, "Effect.Champion.MusouConfirm.TriangleStage2Hit", "champion_skill_sandbox.cue.musou_confirm_triangle_stage2_hit");
+            RegisterEffectCue(performers, "Effect.Champion.MusouConfirm.GuardStepHit", "champion_skill_sandbox.cue.musou_confirm_guard_step_hit");
+            RegisterEffectCue(performers, "Effect.Champion.MusouConfirm.ExecutionSweepHit", "champion_skill_sandbox.cue.musou_confirm_execution_sweep_hit");
 
             _cueIdsInitialized = true;
         }

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Entities/templates.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Entities/templates.json
@@ -331,6 +331,98 @@
     }
   },
   {
+    "id": "champion_skill_sandbox_musou_branch_hero",
+    "components": {
+      "Name": { "Value": "Musou Branch Hero" },
+      "Team": { "Id": 1 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } },
+      "FacingDirection": { "AngleRad": 0.0 },
+      "Presentation": { "visualTemplateId": "core.character.hero_skinned" },
+      "AttributeBuffer": { "base": { "Health": 280, "Shield": 0, "MoveSpeed": 332, "Armor": 14 } },
+      "Collider2D": {
+        "shape": {
+          "type": "circle",
+          "radiusCm": 44
+        }
+      },
+      "PhysicsMaterial2D": {
+        "friction": 0.92,
+        "restitution": 0.0,
+        "baseDamping": 0.94
+      },
+      "NavKinematics2D": {
+        "maxAccelCmPerSec2": 1820,
+        "radiusCm": 44,
+        "neighborDistCm": 312,
+        "timeHorizonSec": 2.4,
+        "maxNeighbors": 20
+      },
+      "AbilityStateBuffer": {
+        "abilityIds": [
+          "Ability.Champion.MusouBranch.Square1",
+          "Ability.Champion.MusouBranch.StepSlash",
+          "Ability.Champion.MusouBranch.TriangleNeutral",
+          "Ability.Champion.MusouBranch.WhirlwindSweep"
+        ]
+      },
+      "AbilityFormSetRef": {
+        "formSetId": "champion_skill_sandbox_musou_branch_forms"
+      },
+      "GameplayTagContainer": {},
+      "OrderBuffer": {},
+      "BlackboardSpatialBuffer": {},
+      "BlackboardEntityBuffer": {},
+      "BlackboardIntBuffer": {}
+    }
+  },
+  {
+    "id": "champion_skill_sandbox_musou_confirm_hero",
+    "components": {
+      "Name": { "Value": "Musou Confirm Hero" },
+      "Team": { "Id": 1 },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } },
+      "FacingDirection": { "AngleRad": 0.0 },
+      "Presentation": { "visualTemplateId": "core.character.hero_skinned" },
+      "AttributeBuffer": { "base": { "Health": 265, "Shield": 0, "MoveSpeed": 336, "Armor": 12 } },
+      "Collider2D": {
+        "shape": {
+          "type": "circle",
+          "radiusCm": 42
+        }
+      },
+      "PhysicsMaterial2D": {
+        "friction": 0.92,
+        "restitution": 0.0,
+        "baseDamping": 0.94
+      },
+      "NavKinematics2D": {
+        "maxAccelCmPerSec2": 1840,
+        "radiusCm": 42,
+        "neighborDistCm": 304,
+        "timeHorizonSec": 2.4,
+        "maxNeighbors": 20
+      },
+      "AbilityStateBuffer": {
+        "abilityIds": [
+          "Ability.Champion.MusouConfirm.Square1",
+          "Ability.Champion.MusouConfirm.GuardStep",
+          "Ability.Champion.MusouConfirm.TriangleLocked",
+          "Ability.Champion.MusouConfirm.ExecutionSweep"
+        ]
+      },
+      "AbilityFormSetRef": {
+        "formSetId": "champion_skill_sandbox_musou_confirm_forms"
+      },
+      "GameplayTagContainer": {},
+      "OrderBuffer": {},
+      "BlackboardSpatialBuffer": {},
+      "BlackboardEntityBuffer": {},
+      "BlackboardIntBuffer": {}
+    }
+  },
+  {
     "id": "champion_skill_sandbox_enemy_dummy",
     "components": {
       "Name": { "Value": "EnemyDummy" },

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/abilities.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/abilities.json
@@ -678,5 +678,315 @@
         "SmartCast": "Hold to channel steerable beam, release to stop"
       }
     }
+  },
+  {
+    "id": "Ability.Champion.MusouBranch.Square1",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouBranch.Source.Stage1Window", "dispatchTarget": "Source" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouBranch.Square1" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "blockTags": { "blockedAny": ["State.Champion.MusouBranch.ComboStage1", "State.Champion.MusouBranch.ComboStage2", "State.Champion.MusouBranch.ComboStage3"] },
+    "indicator": { "shape": "Circle", "range": 220, "radius": 120, "showRangeCircle": true, "validColor": "#F7D76877", "invalidColor": "#E2575788" },
+    "presentation": {
+      "displayName": "Square 1",
+      "iconGlyph": "Q",
+      "accentColor": "#F7D768",
+      "hintText": "Classic opener that starts the Square chain",
+      "modeHints": {
+        "SmartCastWithIndicator": "Press Q to open the Square combo",
+        "PressReleaseAimCast": "Release Q to commit the opener"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.MusouBranch.Square2",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouBranch.Source.Stage2Window", "dispatchTarget": "Source" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouBranch.Square2" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "blockTags": { "requiredAll": ["State.Champion.MusouBranch.ComboStage1"] },
+    "indicator": { "shape": "Circle", "range": 240, "radius": 135, "showRangeCircle": true, "validColor": "#F4BD5D77", "invalidColor": "#E2575788" },
+    "presentation": {
+      "displayName": "Square 2",
+      "iconGlyph": "Q",
+      "accentColor": "#F4BD5D",
+      "hintText": "Continue into the second Square hit",
+      "modeHints": {
+        "SmartCastWithIndicator": "Press Q again before the combo tag expires"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.MusouBranch.Square3",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouBranch.Source.Stage3Window", "dispatchTarget": "Source" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouBranch.Square3" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "blockTags": { "requiredAll": ["State.Champion.MusouBranch.ComboStage2"] },
+    "indicator": { "shape": "Circle", "range": 270, "radius": 150, "showRangeCircle": true, "validColor": "#F29D4F77", "invalidColor": "#E2575788" },
+    "presentation": {
+      "displayName": "Square 3",
+      "iconGlyph": "Q",
+      "accentColor": "#F29D4F",
+      "hintText": "Third Square hit that opens the longest Triangle finisher",
+      "modeHints": {
+        "SmartCastWithIndicator": "Press Q a third time to hold the Stage 3 window"
+      }
+    }
+  },
+  {
+    "id": "Ability.Champion.MusouBranch.TriangleNeutral",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 36, "tag": "Cooldown.Champion.MusouBranch.E" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouBranch.TriangleNeutral" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "blockTags": { "blockedAny": ["State.Champion.MusouBranch.ComboStage1", "State.Champion.MusouBranch.ComboStage2", "State.Champion.MusouBranch.ComboStage3", "Cooldown.Champion.MusouBranch.E"] },
+    "indicator": { "shape": "Cone", "range": 260, "radius": 160, "showRangeCircle": true, "validColor": "#87D6FF77", "invalidColor": "#E2575788" },
+    "presentation": {
+      "displayName": "Triangle Neutral",
+      "iconGlyph": "E",
+      "accentColor": "#87D6FF",
+      "hintText": "Standalone heavy slash when no Square stage is active"
+    }
+  },
+  {
+    "id": "Ability.Champion.MusouBranch.TriangleStage1",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouBranch.Source.ResetWindows", "dispatchTarget": "Source" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouBranch.TriangleStage1" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "blockTags": { "requiredAll": ["State.Champion.MusouBranch.ComboStage1"] },
+    "indicator": { "shape": "Cone", "range": 280, "radius": 190, "showRangeCircle": true, "validColor": "#79E7BC77", "invalidColor": "#E2575788" },
+    "presentation": {
+      "displayName": "Square-Triangle",
+      "iconGlyph": "E",
+      "accentColor": "#79E7BC",
+      "hintText": "First Dynasty-style branch ender"
+    }
+  },
+  {
+    "id": "Ability.Champion.MusouBranch.TriangleStage2",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouBranch.Source.ResetWindows", "dispatchTarget": "Source" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouBranch.TriangleStage2" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "blockTags": { "requiredAll": ["State.Champion.MusouBranch.ComboStage2"] },
+    "indicator": { "shape": "Circle", "range": 300, "radius": 210, "showRangeCircle": true, "validColor": "#67E2A777", "invalidColor": "#E2575788" },
+    "presentation": {
+      "displayName": "Square-Square-Triangle",
+      "iconGlyph": "E",
+      "accentColor": "#67E2A7",
+      "hintText": "Wide crowd sweep branch from the second Square"
+    }
+  },
+  {
+    "id": "Ability.Champion.MusouBranch.TriangleStage3",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouBranch.Source.ResetWindows", "dispatchTarget": "Source" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouBranch.TriangleStage3" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "blockTags": { "requiredAll": ["State.Champion.MusouBranch.ComboStage3"] },
+    "indicator": { "shape": "Line", "range": 360, "radius": 110, "showRangeCircle": true, "validColor": "#4FE8F077", "invalidColor": "#E2575788" },
+    "presentation": {
+      "displayName": "Square-Square-Square-Triangle",
+      "iconGlyph": "E",
+      "accentColor": "#4FE8F0",
+      "hintText": "Long-range crowd finisher from the full Square chain"
+    }
+  },
+  {
+    "id": "Ability.Champion.MusouBranch.StepSlash",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 42, "tag": "Cooldown.Champion.MusouBranch.W" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouBranch.StepSlash" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.MusouBranch.W"] },
+    "indicator": { "shape": "Line", "range": 260, "radius": 90, "showRangeCircle": true, "validColor": "#FFB06A77", "invalidColor": "#E2575788" },
+    "presentation": {
+      "displayName": "Step Slash",
+      "iconGlyph": "W",
+      "accentColor": "#FFB06A",
+      "hintText": "Short melee puncture for spacing without touching the combo route"
+    }
+  },
+  {
+    "id": "Ability.Champion.MusouBranch.WhirlwindSweep",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 84, "tag": "Cooldown.Champion.MusouBranch.R" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouBranch.WhirlwindSweep" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.MusouBranch.R"] },
+    "indicator": { "shape": "Circle", "range": 0, "radius": 260, "showRangeCircle": false, "validColor": "#FF8E6B77", "invalidColor": "#E2575788" },
+    "presentation": {
+      "displayName": "Whirlwind Sweep",
+      "iconGlyph": "R",
+      "accentColor": "#FF8E6B",
+      "hintText": "Big circular melee showcase finisher"
+    }
+  },
+  {
+    "id": "Ability.Champion.MusouConfirm.Square1",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouConfirm.Square1" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "blockTags": { "blockedAny": ["State.Champion.MusouConfirm.HitStage1", "State.Champion.MusouConfirm.HitStage2"] },
+    "indicator": { "shape": "Circle", "range": 200, "radius": 105, "showRangeCircle": true, "validColor": "#F4D96A77", "invalidColor": "#E2575788" },
+    "presentation": {
+      "displayName": "Hit Confirm Q1",
+      "iconGlyph": "Q",
+      "accentColor": "#F4D96A",
+      "hintText": "Must land before any follow-up slot unlocks"
+    }
+  },
+  {
+    "id": "Ability.Champion.MusouConfirm.Square2",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouConfirm.Square2" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "blockTags": { "requiredAll": ["State.Champion.MusouConfirm.HitStage1"] },
+    "indicator": { "shape": "Cone", "range": 240, "radius": 135, "showRangeCircle": true, "validColor": "#F0BC5777", "invalidColor": "#E2575788" },
+    "presentation": {
+      "displayName": "Hit Confirm Q2",
+      "iconGlyph": "Q",
+      "accentColor": "#F0BC57",
+      "hintText": "Only appears after Q1 actually hits"
+    }
+  },
+  {
+    "id": "Ability.Champion.MusouConfirm.TriangleLocked",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "blockTags": { "requiredAll": ["State.Champion.MusouConfirm.HitStage1"] },
+    "indicator": { "shape": "Circle", "range": 0, "radius": 0, "showRangeCircle": false, "validColor": "#5BD2FF77", "invalidColor": "#E2575788" },
+    "presentation": {
+      "displayName": "Triangle Locked",
+      "iconGlyph": "E",
+      "accentColor": "#5BD2FF",
+      "hintText": "Land Q first to unlock the Triangle route"
+    }
+  },
+  {
+    "id": "Ability.Champion.MusouConfirm.TriangleStage1",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouConfirm.Source.ResetWindows", "dispatchTarget": "Source" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouConfirm.TriangleStage1" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "blockTags": { "requiredAll": ["State.Champion.MusouConfirm.HitStage1"] },
+    "indicator": { "shape": "Cone", "range": 260, "radius": 170, "showRangeCircle": true, "validColor": "#68DDFB77", "invalidColor": "#E2575788" },
+    "presentation": {
+      "displayName": "Confirm Triangle 1",
+      "iconGlyph": "E",
+      "accentColor": "#68DDFB",
+      "hintText": "Triangle branch that only exists after a confirmed Q hit"
+    }
+  },
+  {
+    "id": "Ability.Champion.MusouConfirm.TriangleStage2",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouConfirm.Source.ResetWindows", "dispatchTarget": "Source" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouConfirm.TriangleStage2" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "blockTags": { "requiredAll": ["State.Champion.MusouConfirm.HitStage2"] },
+    "indicator": { "shape": "Line", "range": 320, "radius": 95, "showRangeCircle": true, "validColor": "#4FE9E277", "invalidColor": "#E2575788" },
+    "presentation": {
+      "displayName": "Confirm Triangle 2",
+      "iconGlyph": "E",
+      "accentColor": "#4FE9E2",
+      "hintText": "Final confirm-only ender unlocked by landing Q2"
+    }
+  },
+  {
+    "id": "Ability.Champion.MusouConfirm.GuardStep",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 45, "tag": "Cooldown.Champion.MusouConfirm.W" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouConfirm.GuardStep" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.MusouConfirm.W"] },
+    "indicator": { "shape": "Circle", "range": 170, "radius": 110, "showRangeCircle": true, "validColor": "#FFA45C77", "invalidColor": "#E2575788" },
+    "presentation": {
+      "displayName": "Guard Step",
+      "iconGlyph": "W",
+      "accentColor": "#FFA45C",
+      "hintText": "Independent melee interrupt that does not unlock combo follow-ups"
+    }
+  },
+  {
+    "id": "Ability.Champion.MusouConfirm.ExecutionSweep",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        { "kind": "TagClip", "tick": 0, "duration": 90, "tag": "Cooldown.Champion.MusouConfirm.R" },
+        { "kind": "EffectSignal", "tick": 0, "template": "Effect.Champion.MusouConfirm.ExecutionSweep" },
+        { "kind": "End", "tick": 0 }
+      ]
+    },
+    "blockTags": { "blockedAny": ["Cooldown.Champion.MusouConfirm.R"] },
+    "indicator": { "shape": "Circle", "range": 0, "radius": 250, "showRangeCircle": false, "validColor": "#FF7E7277", "invalidColor": "#E2575788" },
+    "presentation": {
+      "displayName": "Execution Sweep",
+      "iconGlyph": "R",
+      "accentColor": "#FF7E72",
+      "hintText": "Standalone crowd sweep for comparison against the confirm-only chain"
+    }
   }
 ]

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/ability_form_sets.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/ability_form_sets.json
@@ -13,5 +13,53 @@
         ]
       }
     ]
+  },
+  {
+    "id": "champion_skill_sandbox_musou_branch_forms",
+    "routes": [
+      {
+        "requiredAll": ["State.Champion.MusouBranch.ComboStage3"],
+        "priority": 300,
+        "slotOverrides": [
+          { "slotIndex": 2, "abilityId": "Ability.Champion.MusouBranch.TriangleStage3" }
+        ]
+      },
+      {
+        "requiredAll": ["State.Champion.MusouBranch.ComboStage2"],
+        "priority": 200,
+        "slotOverrides": [
+          { "slotIndex": 0, "abilityId": "Ability.Champion.MusouBranch.Square3" },
+          { "slotIndex": 2, "abilityId": "Ability.Champion.MusouBranch.TriangleStage2" }
+        ]
+      },
+      {
+        "requiredAll": ["State.Champion.MusouBranch.ComboStage1"],
+        "priority": 100,
+        "slotOverrides": [
+          { "slotIndex": 0, "abilityId": "Ability.Champion.MusouBranch.Square2" },
+          { "slotIndex": 2, "abilityId": "Ability.Champion.MusouBranch.TriangleStage1" }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox_musou_confirm_forms",
+    "routes": [
+      {
+        "requiredAll": ["State.Champion.MusouConfirm.HitStage2"],
+        "priority": 200,
+        "slotOverrides": [
+          { "slotIndex": 2, "abilityId": "Ability.Champion.MusouConfirm.TriangleStage2" }
+        ]
+      },
+      {
+        "requiredAll": ["State.Champion.MusouConfirm.HitStage1"],
+        "priority": 100,
+        "slotOverrides": [
+          { "slotIndex": 0, "abilityId": "Ability.Champion.MusouConfirm.Square2" },
+          { "slotIndex": 2, "abilityId": "Ability.Champion.MusouConfirm.TriangleStage1" }
+        ]
+      }
+    ]
   }
 ]

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/effects.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/effects.json
@@ -643,5 +643,395 @@
     "modifiers": [
       { "attribute": "Health", "op": "Add", "value": -5.0 }
     ]
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.Source.Stage1Window",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.ComboWindow"],
+    "presetType": "Buff",
+    "lifetime": "After",
+    "participatesInResponse": false,
+    "duration": { "durationTicks": 32 },
+    "grantedTags": [
+      { "tag": "State.Champion.MusouBranch.ComboStage1", "formula": "Fixed", "amount": 1 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.Source.Stage2Window",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.ComboWindow"],
+    "presetType": "Buff",
+    "lifetime": "After",
+    "participatesInResponse": false,
+    "duration": { "durationTicks": 34 },
+    "grantedTags": [
+      { "tag": "State.Champion.MusouBranch.ComboStage2", "formula": "Fixed", "amount": 1 }
+    ],
+    "phaseGraphs": {
+      "OnApply": { "post": "Graph.Champion.MusouBranch.RemoveStage1Window" }
+    }
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.Source.Stage3Window",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.ComboWindow"],
+    "presetType": "Buff",
+    "lifetime": "After",
+    "participatesInResponse": false,
+    "duration": { "durationTicks": 36 },
+    "grantedTags": [
+      { "tag": "State.Champion.MusouBranch.ComboStage3", "formula": "Fixed", "amount": 1 }
+    ],
+    "phaseGraphs": {
+      "OnApply": { "post": "Graph.Champion.MusouBranch.RemoveStage2Window" }
+    }
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.Source.ResetWindows",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.ComboReset"],
+    "presetType": "None",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "phaseGraphs": {
+      "OnApply": { "post": "Graph.Champion.MusouBranch.ResetWindows" }
+    }
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.Square1",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.MusouBranch"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Circle", "radius": 150 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 4 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.MusouBranch.Square1Hit" }
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.Square1Hit",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.MusouBranch"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -11.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.Square2",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.MusouBranch"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Cone", "radius": 230, "halfAngle": 42 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 6 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.MusouBranch.Square2Hit" }
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.Square2Hit",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.MusouBranch"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -13.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.Square3",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.MusouBranch"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Line", "length": 320, "halfWidth": 95 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 8 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.MusouBranch.Square3Hit" }
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.Square3Hit",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.MusouBranch"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -16.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.TriangleNeutral",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.MusouBranch"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Cone", "radius": 240, "halfAngle": 38 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 5 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.MusouBranch.TriangleNeutralHit" }
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.TriangleNeutralHit",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.MusouBranch"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -18.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.TriangleStage1",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.MusouBranch"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Cone", "radius": 270, "halfAngle": 50 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 6 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.MusouBranch.TriangleStage1Hit" }
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.TriangleStage1Hit",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.MusouBranch"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -21.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.TriangleStage2",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.MusouBranch"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Circle", "radius": 210 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 8 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.MusouBranch.TriangleStage2Hit" }
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.TriangleStage2Hit",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.MusouBranch"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -24.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.TriangleStage3",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.MusouBranch"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Line", "length": 360, "halfWidth": 120 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 10 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.MusouBranch.TriangleStage3Hit" }
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.TriangleStage3Hit",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.MusouBranch"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -29.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.StepSlash",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.MusouBranch"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Line", "length": 250, "halfWidth": 80 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 3 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.MusouBranch.StepSlashHit" }
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.StepSlashHit",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.MusouBranch"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -17.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.WhirlwindSweep",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.MusouBranch"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Ring", "radius": 270, "innerRadius": 80 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 10 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.MusouBranch.WhirlwindSweepHit" }
+  },
+  {
+    "id": "Effect.Champion.MusouBranch.WhirlwindSweepHit",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.MusouBranch"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -23.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.MusouConfirm.Source.HitStage1Window",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.HitConfirm"],
+    "presetType": "Buff",
+    "lifetime": "After",
+    "participatesInResponse": false,
+    "duration": { "durationTicks": 24 },
+    "grantedTags": [
+      { "tag": "State.Champion.MusouConfirm.HitStage1", "formula": "Fixed", "amount": 1 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.MusouConfirm.Source.HitStage2Window",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.HitConfirm"],
+    "presetType": "Buff",
+    "lifetime": "After",
+    "participatesInResponse": false,
+    "duration": { "durationTicks": 28 },
+    "grantedTags": [
+      { "tag": "State.Champion.MusouConfirm.HitStage2", "formula": "Fixed", "amount": 1 }
+    ],
+    "phaseGraphs": {
+      "OnApply": { "post": "Graph.Champion.MusouConfirm.RemoveHitStage1Window" }
+    }
+  },
+  {
+    "id": "Effect.Champion.MusouConfirm.Source.ResetWindows",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.HitConfirm"],
+    "presetType": "None",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "phaseGraphs": {
+      "OnApply": { "post": "Graph.Champion.MusouConfirm.ResetWindows" }
+    }
+  },
+  {
+    "id": "Effect.Champion.MusouConfirm.Square1",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.HitConfirm"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Circle", "radius": 120 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 1 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.MusouConfirm.Square1Hit" }
+  },
+  {
+    "id": "Effect.Champion.MusouConfirm.Square1Hit",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.HitConfirm"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "phaseGraphs": {
+      "OnApply": { "post": "Graph.Champion.MusouConfirm.GrantHitStage1" }
+    },
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -12.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.MusouConfirm.Square2",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.HitConfirm"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Cone", "radius": 220, "halfAngle": 34 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 1 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.MusouConfirm.Square2Hit" }
+  },
+  {
+    "id": "Effect.Champion.MusouConfirm.Square2Hit",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.HitConfirm"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "phaseGraphs": {
+      "OnApply": { "post": "Graph.Champion.MusouConfirm.GrantHitStage2" }
+    },
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -16.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.MusouConfirm.TriangleStage1",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.HitConfirm"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Cone", "radius": 260, "halfAngle": 46 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 2 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.MusouConfirm.TriangleStage1Hit" }
+  },
+  {
+    "id": "Effect.Champion.MusouConfirm.TriangleStage1Hit",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.HitConfirm"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -20.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.MusouConfirm.TriangleStage2",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.HitConfirm"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Line", "length": 320, "halfWidth": 100 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 3 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.MusouConfirm.TriangleStage2Hit" }
+  },
+  {
+    "id": "Effect.Champion.MusouConfirm.TriangleStage2Hit",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.HitConfirm"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -27.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.MusouConfirm.GuardStep",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.HitConfirm"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Circle", "radius": 140 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 2 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.MusouConfirm.GuardStepHit" }
+  },
+  {
+    "id": "Effect.Champion.MusouConfirm.GuardStepHit",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.HitConfirm"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -15.0 }
+    ]
+  },
+  {
+    "id": "Effect.Champion.MusouConfirm.ExecutionSweep",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.HitConfirm"],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "targetQuery": { "kind": "BuiltinSpatial", "shape": "Ring", "radius": 255, "innerRadius": 60 },
+    "targetFilter": { "relationFilter": "Hostile", "excludeSource": true, "maxTargets": 6 },
+    "targetDispatch": { "payloadEffect": "Effect.Champion.MusouConfirm.ExecutionSweepHit" }
+  },
+  {
+    "id": "Effect.Champion.MusouConfirm.ExecutionSweepHit",
+    "tags": ["Effect.Champion.Melee", "Effect.Champion.HitConfirm"],
+    "presetType": "InstantDamage",
+    "lifetime": "Instant",
+    "participatesInResponse": true,
+    "modifiers": [
+      { "attribute": "Health", "op": "Add", "value": -22.0 }
+    ]
   }
 ]

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/graphs.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/graphs.json
@@ -8,5 +8,71 @@
       { "id": "pop", "op": "ApplyEffectTemplate", "effectTemplate": "Effect.Champion.Ezreal.EssenceFluxPop", "inputs": [ "target" ], "next": "consume" },
       { "id": "consume", "op": "RemoveEffectTemplate", "effectTemplate": "Effect.Champion.Ezreal.EssenceFluxHit", "inputs": [ "target" ] }
     ]
+  },
+  {
+    "id": "Graph.Champion.MusouBranch.RemoveStage1Window",
+    "kind": "Effect",
+    "entry": "target",
+    "nodes": [
+      { "id": "target", "op": "LoadContextTarget", "next": "remove" },
+      { "id": "remove", "op": "RemoveEffectTemplate", "effectTemplate": "Effect.Champion.MusouBranch.Source.Stage1Window", "inputs": [ "target" ] }
+    ]
+  },
+  {
+    "id": "Graph.Champion.MusouBranch.RemoveStage2Window",
+    "kind": "Effect",
+    "entry": "target",
+    "nodes": [
+      { "id": "target", "op": "LoadContextTarget", "next": "remove" },
+      { "id": "remove", "op": "RemoveEffectTemplate", "effectTemplate": "Effect.Champion.MusouBranch.Source.Stage2Window", "inputs": [ "target" ] }
+    ]
+  },
+  {
+    "id": "Graph.Champion.MusouBranch.ResetWindows",
+    "kind": "Effect",
+    "entry": "target",
+    "nodes": [
+      { "id": "target", "op": "LoadContextTarget", "next": "remove_stage1" },
+      { "id": "remove_stage1", "op": "RemoveEffectTemplate", "effectTemplate": "Effect.Champion.MusouBranch.Source.Stage1Window", "inputs": [ "target" ], "next": "remove_stage2" },
+      { "id": "remove_stage2", "op": "RemoveEffectTemplate", "effectTemplate": "Effect.Champion.MusouBranch.Source.Stage2Window", "inputs": [ "target" ], "next": "remove_stage3" },
+      { "id": "remove_stage3", "op": "RemoveEffectTemplate", "effectTemplate": "Effect.Champion.MusouBranch.Source.Stage3Window", "inputs": [ "target" ] }
+    ]
+  },
+  {
+    "id": "Graph.Champion.MusouConfirm.GrantHitStage1",
+    "kind": "Effect",
+    "entry": "source",
+    "nodes": [
+      { "id": "source", "op": "LoadContextSource", "next": "grant" },
+      { "id": "grant", "op": "ApplyEffectTemplate", "effectTemplate": "Effect.Champion.MusouConfirm.Source.HitStage1Window", "inputs": [ "source" ] }
+    ]
+  },
+  {
+    "id": "Graph.Champion.MusouConfirm.GrantHitStage2",
+    "kind": "Effect",
+    "entry": "source",
+    "nodes": [
+      { "id": "source", "op": "LoadContextSource", "next": "grant" },
+      { "id": "grant", "op": "ApplyEffectTemplate", "effectTemplate": "Effect.Champion.MusouConfirm.Source.HitStage2Window", "inputs": [ "source" ] }
+    ]
+  },
+  {
+    "id": "Graph.Champion.MusouConfirm.RemoveHitStage1Window",
+    "kind": "Effect",
+    "entry": "target",
+    "nodes": [
+      { "id": "target", "op": "LoadContextTarget", "next": "remove" },
+      { "id": "remove", "op": "RemoveEffectTemplate", "effectTemplate": "Effect.Champion.MusouConfirm.Source.HitStage1Window", "inputs": [ "target" ] }
+    ]
+  },
+  {
+    "id": "Graph.Champion.MusouConfirm.ResetWindows",
+    "kind": "Effect",
+    "entry": "target",
+    "nodes": [
+      { "id": "target", "op": "LoadContextTarget", "next": "remove_stage1" },
+      { "id": "remove_stage1", "op": "RemoveEffectTemplate", "effectTemplate": "Effect.Champion.MusouConfirm.Source.HitStage1Window", "inputs": [ "target" ], "next": "remove_stage2" },
+      { "id": "remove_stage2", "op": "RemoveEffectTemplate", "effectTemplate": "Effect.Champion.MusouConfirm.Source.HitStage2Window", "inputs": [ "target" ] }
+    ]
   }
 ]

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Maps/champion_musou_branch_showcase.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Maps/champion_musou_branch_showcase.json
@@ -1,0 +1,50 @@
+{
+  "Id": "champion_musou_branch_showcase",
+  "Tags": ["champion.skill.sandbox", "showcase.melee", "showcase.combo", "showcase.musou"],
+  "DefaultCamera": {
+    "VirtualCameraId": "ChampionSkillSandbox.Camera.Tactical",
+    "TargetXCm": 1640,
+    "TargetYCm": 920,
+    "DistanceCm": 3200,
+    "Pitch": 54,
+    "FovYDeg": 42
+  },
+  "Entities": [
+    {
+      "Template": "champion_skill_sandbox_musou_branch_hero",
+      "Overrides": {
+        "Name": { "Value": "Musou Branch Alpha" },
+        "PlayerOwner": { "PlayerId": 1 },
+        "WorldPositionCm": { "Value": { "X": 1260, "Y": 920 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_enemy_dummy",
+      "Overrides": {
+        "Name": { "Value": "Branch Dummy Front" },
+        "WorldPositionCm": { "Value": { "X": 1440, "Y": 920 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_enemy_dummy",
+      "Overrides": {
+        "Name": { "Value": "Branch Dummy Left" },
+        "WorldPositionCm": { "Value": { "X": 1500, "Y": 840 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_enemy_dummy",
+      "Overrides": {
+        "Name": { "Value": "Branch Dummy Right" },
+        "WorldPositionCm": { "Value": { "X": 1500, "Y": 1000 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_enemy_brute",
+      "Overrides": {
+        "Name": { "Value": "Branch Brute Ender" },
+        "WorldPositionCm": { "Value": { "X": 1560, "Y": 920 } }
+      }
+    }
+  ]
+}

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Maps/champion_musou_hit_confirm_showcase.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Maps/champion_musou_hit_confirm_showcase.json
@@ -1,0 +1,44 @@
+{
+  "Id": "champion_musou_hit_confirm_showcase",
+  "Tags": ["champion.skill.sandbox", "showcase.melee", "showcase.combo", "showcase.hit-confirm"],
+  "DefaultCamera": {
+    "VirtualCameraId": "ChampionSkillSandbox.Camera.Tactical",
+    "TargetXCm": 1880,
+    "TargetYCm": 960,
+    "DistanceCm": 4200,
+    "Pitch": 54,
+    "FovYDeg": 42
+  },
+  "Entities": [
+    {
+      "Template": "champion_skill_sandbox_musou_confirm_hero",
+      "Overrides": {
+        "Name": { "Value": "Musou Confirm Miss" },
+        "PlayerOwner": { "PlayerId": 1 },
+        "WorldPositionCm": { "Value": { "X": 980, "Y": 1460 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_musou_confirm_hero",
+      "Overrides": {
+        "Name": { "Value": "Musou Confirm Alpha" },
+        "PlayerOwner": { "PlayerId": 1 },
+        "WorldPositionCm": { "Value": { "X": 1380, "Y": 920 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_enemy_dummy",
+      "Overrides": {
+        "Name": { "Value": "Confirm Dummy Front" },
+        "WorldPositionCm": { "Value": { "X": 1550, "Y": 920 } }
+      }
+    },
+    {
+      "Template": "champion_skill_sandbox_enemy_brute",
+      "Overrides": {
+        "Name": { "Value": "Confirm Brute Finisher" },
+        "WorldPositionCm": { "Value": { "X": 1710, "Y": 920 } }
+      }
+    }
+  ]
+}

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Presentation/performers.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/Presentation/performers.json
@@ -770,5 +770,437 @@
     "defaultLifetime": 0.18,
     "alphaFadeOverLifetime": true,
     "positionOffset": [0, 0.82, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_branch_square1_cast",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Circle",
+    "defaultColor": [0.97, 0.84, 0.41, 0.16],
+    "defaultScale": 1.18,
+    "defaultLifetime": 0.22,
+    "positionOffset": [0, 0.05, 0],
+    "bindings": [
+      { "paramKey": 8, "source": "constant", "constantValue": 0.99 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.86 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.45 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.96 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.035 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_branch_square2_cast",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Ring",
+    "defaultColor": [0.96, 0.72, 0.37, 0.14],
+    "defaultScale": 1.36,
+    "defaultLifetime": 0.22,
+    "positionOffset": [0, 0.05, 0],
+    "bindings": [
+      { "paramKey": 1, "source": "constant", "constantValue": 0.88 },
+      { "paramKey": 8, "source": "constant", "constantValue": 0.97 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.75 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.4 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.04 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_branch_square3_cast",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Ring",
+    "defaultColor": [0.93, 0.58, 0.3, 0.14],
+    "defaultScale": 1.56,
+    "defaultLifetime": 0.24,
+    "positionOffset": [0, 0.05, 0],
+    "bindings": [
+      { "paramKey": 1, "source": "constant", "constantValue": 0.96 },
+      { "paramKey": 8, "source": "constant", "constantValue": 0.95 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.64 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.34 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.045 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_branch_triangle_neutral_cast",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Circle",
+    "defaultColor": [0.54, 0.83, 1.0, 0.14],
+    "defaultScale": 1.4,
+    "defaultLifetime": 0.24,
+    "positionOffset": [0, 0.05, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_branch_triangle_stage1_cast",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Circle",
+    "defaultColor": [0.46, 0.89, 0.72, 0.14],
+    "defaultScale": 1.56,
+    "defaultLifetime": 0.24,
+    "positionOffset": [0, 0.05, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_branch_triangle_stage2_cast",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Circle",
+    "defaultColor": [0.42, 0.88, 0.66, 0.14],
+    "defaultScale": 1.76,
+    "defaultLifetime": 0.24,
+    "positionOffset": [0, 0.05, 0],
+    "bindings": [
+      { "paramKey": 8, "source": "constant", "constantValue": 0.44 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.9 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.7 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.96 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.04 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_branch_triangle_stage3_cast",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Line",
+    "defaultColor": [0.38, 0.88, 0.93, 0.16],
+    "defaultScale": 1.0,
+    "defaultLifetime": 0.24,
+    "positionOffset": [0, 0.06, 0],
+    "bindings": [
+      { "paramKey": 3, "source": "facingradians" },
+      { "paramKey": 8, "source": "constant", "constantValue": 0.42 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.9 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.95 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.08 },
+      { "paramKey": 13, "source": "constant", "constantValue": 3.6 },
+      { "paramKey": 14, "source": "constant", "constantValue": 1.1 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_branch_step_slash_cast",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Line",
+    "defaultColor": [1.0, 0.69, 0.42, 0.16],
+    "defaultScale": 1.0,
+    "defaultLifetime": 0.2,
+    "positionOffset": [0, 0.05, 0],
+    "bindings": [
+      { "paramKey": 3, "source": "facingradians" },
+      { "paramKey": 8, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.72 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.46 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.07 },
+      { "paramKey": 13, "source": "constant", "constantValue": 2.5 },
+      { "paramKey": 14, "source": "constant", "constantValue": 0.8 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_branch_whirlwind_sweep_cast",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Ring",
+    "defaultColor": [1.0, 0.55, 0.42, 0.14],
+    "defaultScale": 2.8,
+    "defaultLifetime": 0.28,
+    "positionOffset": [0, 0.05, 0],
+    "bindings": [
+      { "paramKey": 1, "source": "constant", "constantValue": 1.82 },
+      { "paramKey": 8, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.6 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.47 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.05 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_branch_square1_hit",
+    "visualKind": "Marker3D",
+    "meshOrShapeId": "Sphere",
+    "defaultColor": [1.0, 0.84, 0.48, 0.9],
+    "defaultScale": 0.22,
+    "defaultLifetime": 0.16,
+    "alphaFadeOverLifetime": true,
+    "positionOffset": [0, 0.8, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_branch_square2_hit",
+    "visualKind": "Marker3D",
+    "meshOrShapeId": "Sphere",
+    "defaultColor": [1.0, 0.73, 0.44, 0.9],
+    "defaultScale": 0.24,
+    "defaultLifetime": 0.16,
+    "alphaFadeOverLifetime": true,
+    "positionOffset": [0, 0.82, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_branch_square3_hit",
+    "visualKind": "Marker3D",
+    "meshOrShapeId": "Sphere",
+    "defaultColor": [1.0, 0.62, 0.4, 0.92],
+    "defaultScale": 0.26,
+    "defaultLifetime": 0.18,
+    "alphaFadeOverLifetime": true,
+    "positionOffset": [0, 0.84, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_branch_triangle_neutral_hit",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Circle",
+    "defaultColor": [0.58, 0.84, 1.0, 0.16],
+    "defaultScale": 1.26,
+    "defaultLifetime": 0.2,
+    "positionOffset": [0, 0.06, 0],
+    "bindings": [
+      { "paramKey": 8, "source": "constant", "constantValue": 0.62 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.86 },
+      { "paramKey": 10, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.04 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_branch_triangle_stage1_hit",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Circle",
+    "defaultColor": [0.48, 0.9, 0.75, 0.16],
+    "defaultScale": 1.34,
+    "defaultLifetime": 0.22,
+    "positionOffset": [0, 0.06, 0],
+    "bindings": [
+      { "paramKey": 8, "source": "constant", "constantValue": 0.52 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.92 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.78 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.04 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_branch_triangle_stage2_hit",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Circle",
+    "defaultColor": [0.43, 0.88, 0.67, 0.18],
+    "defaultScale": 1.52,
+    "defaultLifetime": 0.24,
+    "positionOffset": [0, 0.06, 0],
+    "bindings": [
+      { "paramKey": 8, "source": "constant", "constantValue": 0.48 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.9 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.72 },
+      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.045 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_branch_triangle_stage3_hit",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Line",
+    "defaultColor": [0.44, 0.91, 0.97, 0.16],
+    "defaultScale": 1.0,
+    "defaultLifetime": 0.22,
+    "positionOffset": [0, 0.06, 0],
+    "bindings": [
+      { "paramKey": 3, "source": "facingradians" },
+      { "paramKey": 8, "source": "constant", "constantValue": 0.48 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.92 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.09 },
+      { "paramKey": 13, "source": "constant", "constantValue": 3.2 },
+      { "paramKey": 14, "source": "constant", "constantValue": 1.0 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_branch_step_slash_hit",
+    "visualKind": "Marker3D",
+    "meshOrShapeId": "Sphere",
+    "defaultColor": [1.0, 0.73, 0.48, 0.9],
+    "defaultScale": 0.24,
+    "defaultLifetime": 0.18,
+    "alphaFadeOverLifetime": true,
+    "positionOffset": [0, 0.82, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_branch_whirlwind_sweep_hit",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Ring",
+    "defaultColor": [1.0, 0.6, 0.48, 0.16],
+    "defaultScale": 1.8,
+    "defaultLifetime": 0.24,
+    "positionOffset": [0, 0.06, 0],
+    "bindings": [
+      { "paramKey": 1, "source": "constant", "constantValue": 1.04 },
+      { "paramKey": 8, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.66 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.54 },
+      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.05 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_confirm_square1_cast",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Circle",
+    "defaultColor": [0.96, 0.86, 0.43, 0.16],
+    "defaultScale": 1.12,
+    "defaultLifetime": 0.2,
+    "positionOffset": [0, 0.05, 0],
+    "bindings": [
+      { "paramKey": 8, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.88 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.48 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.96 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.035 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_confirm_square2_cast",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Ring",
+    "defaultColor": [0.95, 0.71, 0.35, 0.14],
+    "defaultScale": 1.34,
+    "defaultLifetime": 0.22,
+    "positionOffset": [0, 0.05, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_confirm_triangle_stage1_cast",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Circle",
+    "defaultColor": [0.43, 0.85, 0.99, 0.16],
+    "defaultScale": 1.46,
+    "defaultLifetime": 0.22,
+    "positionOffset": [0, 0.05, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_confirm_triangle_stage2_cast",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Line",
+    "defaultColor": [0.36, 0.91, 0.89, 0.16],
+    "defaultScale": 1.0,
+    "defaultLifetime": 0.24,
+    "positionOffset": [0, 0.06, 0],
+    "bindings": [
+      { "paramKey": 3, "source": "facingradians" },
+      { "paramKey": 8, "source": "constant", "constantValue": 0.42 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.94 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.92 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.08 },
+      { "paramKey": 13, "source": "constant", "constantValue": 3.2 },
+      { "paramKey": 14, "source": "constant", "constantValue": 0.95 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_confirm_guard_step_cast",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Ring",
+    "defaultColor": [1.0, 0.67, 0.38, 0.14],
+    "defaultScale": 1.18,
+    "defaultLifetime": 0.2,
+    "positionOffset": [0, 0.05, 0],
+    "bindings": [
+      { "paramKey": 1, "source": "constant", "constantValue": 0.76 },
+      { "paramKey": 8, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.72 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.44 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.04 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_confirm_execution_sweep_cast",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Ring",
+    "defaultColor": [1.0, 0.5, 0.46, 0.14],
+    "defaultScale": 2.6,
+    "defaultLifetime": 0.24,
+    "positionOffset": [0, 0.05, 0],
+    "bindings": [
+      { "paramKey": 1, "source": "constant", "constantValue": 1.72 },
+      { "paramKey": 8, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.56 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.5 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.05 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_confirm_square1_hit",
+    "visualKind": "Marker3D",
+    "meshOrShapeId": "Sphere",
+    "defaultColor": [1.0, 0.88, 0.52, 0.9],
+    "defaultScale": 0.22,
+    "defaultLifetime": 0.16,
+    "alphaFadeOverLifetime": true,
+    "positionOffset": [0, 0.8, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_confirm_square2_hit",
+    "visualKind": "Marker3D",
+    "meshOrShapeId": "Sphere",
+    "defaultColor": [1.0, 0.74, 0.44, 0.9],
+    "defaultScale": 0.24,
+    "defaultLifetime": 0.18,
+    "alphaFadeOverLifetime": true,
+    "positionOffset": [0, 0.82, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_confirm_triangle_stage1_hit",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Circle",
+    "defaultColor": [0.48, 0.85, 1.0, 0.16],
+    "defaultScale": 1.34,
+    "defaultLifetime": 0.22,
+    "positionOffset": [0, 0.06, 0],
+    "bindings": [
+      { "paramKey": 8, "source": "constant", "constantValue": 0.52 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.88 },
+      { "paramKey": 10, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 11, "source": "constant", "constantValue": 0.98 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.04 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_confirm_triangle_stage2_hit",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Line",
+    "defaultColor": [0.4, 0.93, 0.9, 0.16],
+    "defaultScale": 1.0,
+    "defaultLifetime": 0.22,
+    "positionOffset": [0, 0.06, 0],
+    "bindings": [
+      { "paramKey": 3, "source": "facingradians" },
+      { "paramKey": 8, "source": "constant", "constantValue": 0.44 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.96 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.94 },
+      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.09 },
+      { "paramKey": 13, "source": "constant", "constantValue": 3.0 },
+      { "paramKey": 14, "source": "constant", "constantValue": 0.9 }
+    ]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_confirm_guard_step_hit",
+    "visualKind": "Marker3D",
+    "meshOrShapeId": "Sphere",
+    "defaultColor": [1.0, 0.73, 0.46, 0.9],
+    "defaultScale": 0.24,
+    "defaultLifetime": 0.18,
+    "alphaFadeOverLifetime": true,
+    "positionOffset": [0, 0.82, 0]
+  },
+  {
+    "id": "champion_skill_sandbox.cue.musou_confirm_execution_sweep_hit",
+    "visualKind": "GroundOverlay",
+    "meshOrShapeId": "Ring",
+    "defaultColor": [1.0, 0.58, 0.5, 0.16],
+    "defaultScale": 1.72,
+    "defaultLifetime": 0.24,
+    "positionOffset": [0, 0.06, 0],
+    "bindings": [
+      { "paramKey": 1, "source": "constant", "constantValue": 1.02 },
+      { "paramKey": 8, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 9, "source": "constant", "constantValue": 0.64 },
+      { "paramKey": 10, "source": "constant", "constantValue": 0.56 },
+      { "paramKey": 11, "source": "constant", "constantValue": 1.0 },
+      { "paramKey": 12, "source": "constant", "constantValue": 0.05 }
+    ]
   }
 ]

--- a/src/Tests/GasTests/Production/ChampionSkillSandboxConfigTests.cs
+++ b/src/Tests/GasTests/Production/ChampionSkillSandboxConfigTests.cs
@@ -42,6 +42,10 @@ namespace Ludots.Tests.GAS.Production
     {
         private const float DeltaTime = 1f / 60f;
         private const string StressMapId = "champion_skill_stress";
+        private const string MusouBranchMapId = "champion_musou_branch_showcase";
+        private const string MusouHitConfirmMapId = "champion_musou_hit_confirm_showcase";
+        private const string MusouBranchHeroName = "Musou Branch Alpha";
+        private const string MusouHitHeroName = "Musou Confirm Alpha";
         private const string SandboxTacticalCameraId = "ChampionSkillSandbox.Camera.Tactical";
         private const string FreeCameraToolbarButtonId = "ChampionSkillSandbox.Camera.Free";
         private const string FollowSelectionToolbarButtonId = "ChampionSkillSandbox.Camera.Selection";
@@ -117,6 +121,154 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(
                 AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm: true, in grantedSlots, hasGranted: false, slotIndex: 3).AbilityId,
                 Is.EqualTo(cannonR));
+        }
+
+        [Test]
+        public void ChampionSkillSandbox_TemplateConfig_LoadsMusouBranchFormRouting()
+        {
+            using var engine = CreateEngine();
+
+            var templates = new Dictionary<string, EntityTemplate>(StringComparer.OrdinalIgnoreCase);
+            foreach (var template in engine.MapLoader.TemplateRegistry.GetAll())
+            {
+                templates[template.Id] = template;
+            }
+
+            var entity = new EntityBuilder(engine.World, templates, engine.MapLoader.PresentationAuthoringContext)
+                .UseTemplate("champion_skill_sandbox_musou_branch_hero")
+                .Build();
+
+            Assert.That(engine.World.Has<AbilityStateBuffer>(entity), Is.True);
+            Assert.That(engine.World.Has<AbilityFormSetRef>(entity), Is.True);
+            Assert.That(engine.World.Has<AbilityFormSlotBuffer>(entity), Is.True);
+
+            ref var abilities = ref engine.World.Get<AbilityStateBuffer>(entity);
+            Assert.That(abilities.Count, Is.EqualTo(4));
+
+            int stage1TagId = TagRegistry.GetId("State.Champion.MusouBranch.ComboStage1");
+            int stage2TagId = TagRegistry.GetId("State.Champion.MusouBranch.ComboStage2");
+            int stage3TagId = TagRegistry.GetId("State.Champion.MusouBranch.ComboStage3");
+            Assert.That(stage1TagId, Is.GreaterThan(0));
+            Assert.That(stage2TagId, Is.GreaterThan(0));
+            Assert.That(stage3TagId, Is.GreaterThan(0));
+
+            int square1 = AbilityIdRegistry.GetId("Ability.Champion.MusouBranch.Square1");
+            int square2 = AbilityIdRegistry.GetId("Ability.Champion.MusouBranch.Square2");
+            int square3 = AbilityIdRegistry.GetId("Ability.Champion.MusouBranch.Square3");
+            int triangleNeutral = AbilityIdRegistry.GetId("Ability.Champion.MusouBranch.TriangleNeutral");
+            int triangleStage1 = AbilityIdRegistry.GetId("Ability.Champion.MusouBranch.TriangleStage1");
+            int triangleStage2 = AbilityIdRegistry.GetId("Ability.Champion.MusouBranch.TriangleStage2");
+            int triangleStage3 = AbilityIdRegistry.GetId("Ability.Champion.MusouBranch.TriangleStage3");
+
+            var routing = new AbilityFormRoutingSystem(
+                engine.World,
+                engine.GetService(CoreServiceKeys.AbilityFormSetRegistry),
+                engine.GetService(CoreServiceKeys.TagOps));
+            ref var tags = ref engine.World.Get<GameplayTagContainer>(entity);
+            ref var formSlots = ref engine.World.Get<AbilityFormSlotBuffer>(entity);
+            var grantedSlots = default(GrantedSlotBuffer);
+
+            routing.Update(0f);
+            Assert.That(
+                AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm: true, in grantedSlots, hasGranted: false, slotIndex: 0).AbilityId,
+                Is.EqualTo(square1));
+            Assert.That(
+                AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm: true, in grantedSlots, hasGranted: false, slotIndex: 2).AbilityId,
+                Is.EqualTo(triangleNeutral));
+
+            tags.AddTag(stage1TagId);
+            routing.Update(0f);
+            Assert.That(
+                AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm: true, in grantedSlots, hasGranted: false, slotIndex: 0).AbilityId,
+                Is.EqualTo(square2));
+            Assert.That(
+                AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm: true, in grantedSlots, hasGranted: false, slotIndex: 2).AbilityId,
+                Is.EqualTo(triangleStage1));
+
+            tags.RemoveTag(stage1TagId);
+            tags.AddTag(stage2TagId);
+            routing.Update(0f);
+            Assert.That(
+                AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm: true, in grantedSlots, hasGranted: false, slotIndex: 0).AbilityId,
+                Is.EqualTo(square3));
+            Assert.That(
+                AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm: true, in grantedSlots, hasGranted: false, slotIndex: 2).AbilityId,
+                Is.EqualTo(triangleStage2));
+
+            tags.RemoveTag(stage2TagId);
+            tags.AddTag(stage3TagId);
+            routing.Update(0f);
+            Assert.That(
+                AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm: true, in grantedSlots, hasGranted: false, slotIndex: 0).AbilityId,
+                Is.EqualTo(square1));
+            Assert.That(
+                AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm: true, in grantedSlots, hasGranted: false, slotIndex: 2).AbilityId,
+                Is.EqualTo(triangleStage3));
+        }
+
+        [Test]
+        public void ChampionSkillSandbox_TemplateConfig_LoadsMusouHitConfirmFormRouting()
+        {
+            using var engine = CreateEngine();
+
+            var templates = new Dictionary<string, EntityTemplate>(StringComparer.OrdinalIgnoreCase);
+            foreach (var template in engine.MapLoader.TemplateRegistry.GetAll())
+            {
+                templates[template.Id] = template;
+            }
+
+            var entity = new EntityBuilder(engine.World, templates, engine.MapLoader.PresentationAuthoringContext)
+                .UseTemplate("champion_skill_sandbox_musou_confirm_hero")
+                .Build();
+
+            Assert.That(engine.World.Has<AbilityStateBuffer>(entity), Is.True);
+            Assert.That(engine.World.Has<AbilityFormSetRef>(entity), Is.True);
+            Assert.That(engine.World.Has<AbilityFormSlotBuffer>(entity), Is.True);
+
+            ref var abilities = ref engine.World.Get<AbilityStateBuffer>(entity);
+            Assert.That(abilities.Count, Is.EqualTo(4));
+
+            int stage1TagId = TagRegistry.GetId("State.Champion.MusouConfirm.HitStage1");
+            int stage2TagId = TagRegistry.GetId("State.Champion.MusouConfirm.HitStage2");
+            Assert.That(stage1TagId, Is.GreaterThan(0));
+            Assert.That(stage2TagId, Is.GreaterThan(0));
+
+            int square1 = AbilityIdRegistry.GetId("Ability.Champion.MusouConfirm.Square1");
+            int square2 = AbilityIdRegistry.GetId("Ability.Champion.MusouConfirm.Square2");
+            int triangleLocked = AbilityIdRegistry.GetId("Ability.Champion.MusouConfirm.TriangleLocked");
+            int triangleStage1 = AbilityIdRegistry.GetId("Ability.Champion.MusouConfirm.TriangleStage1");
+            int triangleStage2 = AbilityIdRegistry.GetId("Ability.Champion.MusouConfirm.TriangleStage2");
+
+            var routing = new AbilityFormRoutingSystem(
+                engine.World,
+                engine.GetService(CoreServiceKeys.AbilityFormSetRegistry),
+                engine.GetService(CoreServiceKeys.TagOps));
+            ref var tags = ref engine.World.Get<GameplayTagContainer>(entity);
+            ref var formSlots = ref engine.World.Get<AbilityFormSlotBuffer>(entity);
+            var grantedSlots = default(GrantedSlotBuffer);
+
+            routing.Update(0f);
+            Assert.That(
+                AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm: true, in grantedSlots, hasGranted: false, slotIndex: 0).AbilityId,
+                Is.EqualTo(square1));
+            Assert.That(
+                AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm: true, in grantedSlots, hasGranted: false, slotIndex: 2).AbilityId,
+                Is.EqualTo(triangleLocked));
+
+            tags.AddTag(stage1TagId);
+            routing.Update(0f);
+            Assert.That(
+                AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm: true, in grantedSlots, hasGranted: false, slotIndex: 0).AbilityId,
+                Is.EqualTo(square2));
+            Assert.That(
+                AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm: true, in grantedSlots, hasGranted: false, slotIndex: 2).AbilityId,
+                Is.EqualTo(triangleStage1));
+
+            tags.AddTag(stage2TagId);
+            routing.Update(0f);
+            Assert.That(
+                AbilitySlotResolver.Resolve(in abilities, in formSlots, hasForm: true, in grantedSlots, hasGranted: false, slotIndex: 2).AbilityId,
+                Is.EqualTo(triangleStage2));
         }
 
         [Test]
@@ -302,6 +454,70 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(geomancerSlots[1].DisplayLabel, Is.EqualTo("Rune Field"));
             Assert.That(geomancerSlots[2].DisplayLabel, Is.EqualTo("Stone Pillar"));
             Assert.That(geomancerSlots[3].DisplayLabel, Is.EqualTo("Prismatic Beam"));
+        }
+
+        [Test]
+        public void ChampionSkillSandbox_MusouMaps_LoadSelectionAndPanelRouting()
+        {
+            using (var engine = CreateEngine())
+            {
+                var toolbar = engine.GetService(CoreServiceKeys.EntityCommandPanelToolbarProvider)
+                    ?? throw new InvalidOperationException("Toolbar provider missing.");
+
+                LoadMap(engine, MusouBranchMapId);
+
+                Entity selected = SelectionContextRuntime.TryGetCurrentPrimary(engine.World, engine.GlobalContext, out Entity currentPrimary)
+                    ? currentPrimary
+                    : Entity.Null;
+                Assert.That(ReadEntityName(engine.World, selected), Is.EqualTo(MusouBranchHeroName));
+                Assert.That(toolbar.Title, Is.EqualTo("Musou Branch"));
+                Assert.That(toolbar.Subtitle, Does.Contain("Square chain"));
+
+                var source = ResolveGasPanelSource(engine);
+                var slots = new EntityCommandPanelSlotView[8];
+                int branchCount = source.CopySlots(FindEntityByName(engine.World, MusouBranchHeroName), 0, slots);
+                Assert.That(branchCount, Is.EqualTo(4));
+                Assert.That(slots[0].DisplayLabel, Is.EqualTo("Square 1"));
+                Assert.That(slots[1].DisplayLabel, Is.EqualTo("Step Slash"));
+                Assert.That(slots[2].DisplayLabel, Is.EqualTo("Triangle Neutral"));
+                Assert.That(slots[3].DisplayLabel, Is.EqualTo("Whirlwind Sweep"));
+            }
+
+            using (var engine = CreateEngine())
+            {
+                var toolbar = engine.GetService(CoreServiceKeys.EntityCommandPanelToolbarProvider)
+                    ?? throw new InvalidOperationException("Toolbar provider missing.");
+
+                LoadMap(engine, MusouHitConfirmMapId);
+
+                Assert.That(toolbar.Title, Is.EqualTo("Hit Confirm"));
+                Assert.That(toolbar.Subtitle, Does.Contain("must hit"));
+
+                SelectionRuntime selection = engine.GetService(CoreServiceKeys.SelectionRuntime)
+                    ?? throw new InvalidOperationException("SelectionRuntime missing.");
+                Entity owner = engine.GetService(CoreServiceKeys.LocalPlayerEntity);
+                Entity musouHitHero = FindEntityByName(engine.World, MusouHitHeroName);
+                if (!engine.World.IsAlive(owner))
+                {
+                    owner = musouHitHero;
+                    engine.GlobalContext[CoreServiceKeys.LocalPlayerEntity.Name] = owner;
+                }
+
+                Span<Entity> nextSelection = stackalloc Entity[1];
+                nextSelection[0] = musouHitHero;
+                selection.ReplaceSelection(owner, SelectionSetKeys.Ambient, nextSelection);
+                Tick(engine, 2);
+
+                var source = ResolveGasPanelSource(engine);
+                var slots = new EntityCommandPanelSlotView[8];
+                int confirmCount = source.CopySlots(musouHitHero, 0, slots);
+                Assert.That(confirmCount, Is.EqualTo(4));
+                Assert.That(slots[0].DisplayLabel, Is.EqualTo("Hit Confirm Q1"));
+                Assert.That(slots[1].DisplayLabel, Is.EqualTo("Guard Step"));
+                Assert.That(slots[2].DisplayLabel, Is.EqualTo("Triangle Locked"));
+                Assert.That(slots[2].StateFlags.HasFlag(EntityCommandSlotStateFlags.Blocked), Is.True);
+                Assert.That(slots[3].DisplayLabel, Is.EqualTo("Execution Sweep"));
+            }
         }
 
         [Test]
@@ -761,6 +977,36 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(performers.GetId("champion_skill_sandbox.cue.spell_engineer_cataclysm_ring_cast"), Is.GreaterThan(0));
             Assert.That(performers.GetId("champion_skill_sandbox.cue.spell_engineer_guided_laser_cast"), Is.GreaterThan(0));
             Assert.That(performers.GetId("champion_skill_sandbox.cue.spell_engineer_guided_laser_hit"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_branch_square1_cast"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_branch_square2_cast"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_branch_square3_cast"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_branch_triangle_neutral_cast"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_branch_triangle_stage1_cast"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_branch_triangle_stage2_cast"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_branch_triangle_stage3_cast"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_branch_step_slash_cast"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_branch_whirlwind_sweep_cast"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_branch_square1_hit"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_branch_square2_hit"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_branch_square3_hit"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_branch_triangle_neutral_hit"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_branch_triangle_stage1_hit"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_branch_triangle_stage2_hit"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_branch_triangle_stage3_hit"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_branch_step_slash_hit"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_branch_whirlwind_sweep_hit"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_confirm_square1_cast"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_confirm_square2_cast"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_confirm_triangle_stage1_cast"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_confirm_triangle_stage2_cast"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_confirm_guard_step_cast"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_confirm_execution_sweep_cast"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_confirm_square1_hit"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_confirm_square2_hit"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_confirm_triangle_stage1_hit"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_confirm_triangle_stage2_hit"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_confirm_guard_step_hit"), Is.GreaterThan(0));
+            Assert.That(performers.GetId("champion_skill_sandbox.cue.musou_confirm_execution_sweep_hit"), Is.GreaterThan(0));
         }
 
         [Test]

--- a/src/Tests/GasTests/Production/ChampionSkillSandboxPlayableAcceptanceTests.cs
+++ b/src/Tests/GasTests/Production/ChampionSkillSandboxPlayableAcceptanceTests.cs
@@ -49,6 +49,11 @@ namespace Ludots.Tests.GAS.Production
         private const float DeltaTime = 1f / 60f;
         private const string MapId = "champion_skill_sandbox";
         private const string StressMapId = "champion_skill_stress";
+        private const string MusouBranchMapId = "champion_musou_branch_showcase";
+        private const string MusouHitConfirmMapId = "champion_musou_hit_confirm_showcase";
+        private const string MusouBranchHeroName = "Musou Branch Alpha";
+        private const string MusouHitHeroName = "Musou Confirm Alpha";
+        private const string MusouMissHeroName = "Musou Confirm Miss";
         private const string SmartCastModeId = "ChampionSkillSandbox.Mode.SmartCast";
         private const string IndicatorModeId = "ChampionSkillSandbox.Mode.Indicator";
         private const string PressReleaseModeId = "ChampionSkillSandbox.Mode.PressReleaseAim";
@@ -571,6 +576,320 @@ namespace Ludots.Tests.GAS.Production
             File.WriteAllText(Path.Combine(artifactDir, "trace.jsonl"), BuildTraceJsonl(snapshots));
             File.WriteAllText(Path.Combine(artifactDir, "battle-report.md"), BuildBattleReport(timeline, snapshots, frameTimesMs));
             File.WriteAllText(Path.Combine(artifactDir, "path.mmd"), BuildPathMermaid());
+        }
+
+        [Test]
+        public void ChampionMusouBranch_PlayableFlow_WritesAcceptanceArtifacts()
+        {
+            string repoRoot = FindRepoRoot();
+            string artifactDir = Path.Combine(repoRoot, "artifacts", "acceptance", "champion-musou-branch-showcase");
+            string screensDir = Path.Combine(artifactDir, "screens");
+            Directory.CreateDirectory(artifactDir);
+            Directory.CreateDirectory(screensDir);
+
+            var timeline = new List<string>();
+            var snapshots = new List<AcceptanceSnapshot>();
+            var frameTimesMs = new List<double>();
+            string[] trackedEntities =
+            {
+                MusouBranchHeroName,
+                "Branch Dummy Front",
+                "Branch Dummy Left",
+                "Branch Dummy Right",
+                "Branch Brute Ender"
+            };
+
+            using var engine = CreateEngine();
+            var overlays = engine.GetService(CoreServiceKeys.GroundOverlayBuffer)
+                ?? throw new InvalidOperationException("GroundOverlayBuffer missing.");
+            var primitives = engine.GetService(CoreServiceKeys.PresentationPrimitiveDrawBuffer)
+                ?? throw new InvalidOperationException("PrimitiveDrawBuffer missing.");
+            var worldHud = engine.GetService(CoreServiceKeys.PresentationWorldHudBuffer)
+                ?? throw new InvalidOperationException("WorldHudBatchBuffer missing.");
+            var toolbar = engine.GetService(CoreServiceKeys.EntityCommandPanelToolbarProvider)
+                ?? throw new InvalidOperationException("Toolbar provider missing.");
+            var backend = GetInputBackend(engine);
+
+            LoadMap(engine, MusouBranchMapId, frameTimesMs);
+            Assert.That(engine.TriggerManager.Errors.Count, Is.EqualTo(0));
+            Assert.That(toolbar.Title, Is.EqualTo("Musou Branch"));
+            Assert.That(GetSelectedEntityName(engine), Is.EqualTo(MusouBranchHeroName));
+
+            IReadOnlyList<PanelSlotSnapshot> slots = CopySelectedSlots(engine);
+            Assert.That(slots[0].Label, Is.EqualTo("Square 1"));
+            Assert.That(slots[1].Label, Is.EqualTo("Step Slash"));
+            Assert.That(slots[2].Label, Is.EqualTo("Triangle Neutral"));
+            Assert.That(slots[3].Label, Is.EqualTo("Whirlwind Sweep"));
+            CaptureScenarioSnapshot(engine, overlays, primitives, worldHud, snapshots, trackedEntities, "map_loaded");
+            timeline.Add("[T+001] champion_musou_branch_showcase loaded | Square/Triangle branch routing ready");
+
+            SetMouseWorld(engine, backend, GetEntityScreen(engine, "Branch Dummy Front"), frameTimesMs);
+            float frontBeforeSquare1 = ReadHealth(engine.World, "Branch Dummy Front");
+            PressButton(engine, backend, "<Keyboard>/q", frameTimesMs);
+            TickUntilHealthChanges(engine, frameTimesMs, "Branch Dummy Front", frontBeforeSquare1, maxFrames: 24);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () =>
+                {
+                    IReadOnlyList<PanelSlotSnapshot> routed = CopySelectedSlots(engine);
+                    return routed[0].Label == "Square 2" && routed[2].Label == "Square-Triangle";
+                },
+                maxFrames: 12);
+            CaptureScenarioSnapshot(engine, overlays, primitives, worldHud, snapshots, trackedEntities, "square1_routed");
+            timeline.Add($"[T+002] Q opener hits Branch Dummy Front | HP {frontBeforeSquare1:0}->{ReadHealth(engine.World, "Branch Dummy Front"):0} | Q routes to Square 2 and E routes to Square-Triangle");
+
+            float frontBeforeTriangle1 = ReadHealth(engine.World, "Branch Dummy Front");
+            PressButton(engine, backend, "<Keyboard>/e", frameTimesMs);
+            TickUntilHealthChanges(engine, frameTimesMs, "Branch Dummy Front", frontBeforeTriangle1, maxFrames: 24);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () =>
+                {
+                    IReadOnlyList<PanelSlotSnapshot> neutral = CopySelectedSlots(engine);
+                    return neutral[0].Label == "Square 1" && neutral[2].Label == "Triangle Neutral";
+                },
+                maxFrames: 12);
+            CaptureScenarioSnapshot(engine, overlays, primitives, worldHud, snapshots, trackedEntities, "square_triangle_finisher");
+            timeline.Add($"[T+003] E branch from Stage1 lands classic Square-Triangle finisher | Front HP {frontBeforeTriangle1:0}->{ReadHealth(engine.World, "Branch Dummy Front"):0}");
+
+            float leftBeforeSquare2 = ReadHealth(engine.World, "Branch Dummy Left");
+            SetMouseWorld(engine, backend, GetEntityScreen(engine, "Branch Dummy Left"), frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/q", frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => CopySelectedSlots(engine)[0].Label == "Square 2",
+                maxFrames: 12);
+            PressButton(engine, backend, "<Keyboard>/q", frameTimesMs);
+            TickUntilHealthChanges(engine, frameTimesMs, "Branch Dummy Left", leftBeforeSquare2, maxFrames: 24);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () =>
+                {
+                    IReadOnlyList<PanelSlotSnapshot> routed = CopySelectedSlots(engine);
+                    return routed[0].Label == "Square 3" && routed[2].Label == "Square-Square-Triangle";
+                },
+                maxFrames: 12);
+            CaptureScenarioSnapshot(engine, overlays, primitives, worldHud, snapshots, trackedEntities, "square2_routed");
+            timeline.Add($"[T+004] Q follow-up hits the left lane dummy | HP {leftBeforeSquare2:0}->{ReadHealth(engine.World, "Branch Dummy Left"):0} | E upgrades to Square-Square-Triangle");
+
+            float rightBeforeTriangle2 = ReadHealth(engine.World, "Branch Dummy Right");
+            SetMouseWorld(engine, backend, GetEntityScreen(engine, "Branch Dummy Right"), frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/e", frameTimesMs);
+            TickUntilHealthChanges(engine, frameTimesMs, "Branch Dummy Right", rightBeforeTriangle2, maxFrames: 24);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () =>
+                {
+                    IReadOnlyList<PanelSlotSnapshot> neutral = CopySelectedSlots(engine);
+                    return neutral[0].Label == "Square 1" && neutral[2].Label == "Triangle Neutral";
+                },
+                maxFrames: 24);
+            CaptureScenarioSnapshot(engine, overlays, primitives, worldHud, snapshots, trackedEntities, "square_square_triangle_finisher");
+            timeline.Add($"[T+005] Stage2 branch finisher sweeps the right lane, then the panel returns to neutral Square 1 / Triangle Neutral | HP {rightBeforeTriangle2:0}->{ReadHealth(engine.World, "Branch Dummy Right"):0}");
+
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () =>
+                {
+                    IReadOnlyList<PanelSlotSnapshot> neutral = CopySelectedSlots(engine);
+                    return neutral[0].Label == "Square 1" && neutral[2].Label == "Triangle Neutral";
+                },
+                maxFrames: 12);
+
+            float frontBeforeSquare3 = ReadHealth(engine.World, "Branch Dummy Front");
+            float bruteBeforeSquare3 = ReadHealth(engine.World, "Branch Brute Ender");
+            SetMouseWorld(engine, backend, GetEntityScreen(engine, "Branch Dummy Front"), frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/q", frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => CopySelectedSlots(engine)[0].Label == "Square 2",
+                maxFrames: 12);
+            PressButton(engine, backend, "<Keyboard>/q", frameTimesMs);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => CopySelectedSlots(engine)[0].Label == "Square 3",
+                maxFrames: 12);
+            PressButton(engine, backend, "<Keyboard>/q", frameTimesMs);
+            TickUntilHealthChanges(engine, frameTimesMs, "Branch Brute Ender", bruteBeforeSquare3, maxFrames: 24);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => CopySelectedSlots(engine)[2].Label == "Square-Square-Square-Triangle",
+                maxFrames: 12);
+            CaptureScenarioSnapshot(engine, overlays, primitives, worldHud, snapshots, trackedEntities, "square3_routed");
+            timeline.Add($"[T+006] Third Q completes the full Square chain on the front lane | HP {frontBeforeSquare3:0}->{ReadHealth(engine.World, "Branch Dummy Front"):0} | E upgrades to the full Square-Square-Square-Triangle ender");
+
+            float frontBeforeTriangle3 = ReadHealth(engine.World, "Branch Dummy Front");
+            SetMouseWorld(engine, backend, GetEntityScreen(engine, "Branch Dummy Front"), frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/e", frameTimesMs);
+            TickUntilHealthChanges(engine, frameTimesMs, "Branch Dummy Front", frontBeforeTriangle3, maxFrames: 24);
+            CaptureScenarioSnapshot(engine, overlays, primitives, worldHud, snapshots, trackedEntities, "square_square_square_triangle_finisher");
+            timeline.Add($"[T+007] Full-chain Triangle finisher lands after the complete Square route | Front HP {frontBeforeTriangle3:0}->{ReadHealth(engine.World, "Branch Dummy Front"):0}");
+
+            float frontBeforeW = ReadHealth(engine.World, "Branch Dummy Front");
+            SetMouseWorld(engine, backend, GetEntityScreen(engine, "Branch Dummy Front"), frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/w", frameTimesMs);
+            TickUntilHealthChanges(engine, frameTimesMs, "Branch Dummy Front", frontBeforeW, maxFrames: 24);
+            CaptureScenarioSnapshot(engine, overlays, primitives, worldHud, snapshots, trackedEntities, "step_slash_hit");
+            timeline.Add($"[T+008] W Step Slash lands without affecting combo routing | Front HP {frontBeforeW:0}->{ReadHealth(engine.World, "Branch Dummy Front"):0}");
+
+            float leftBeforeR = ReadHealth(engine.World, "Branch Dummy Left");
+            PressButton(engine, backend, "<Keyboard>/r", frameTimesMs);
+            TickUntilHealthChanges(engine, frameTimesMs, "Branch Dummy Left", leftBeforeR, maxFrames: 24);
+            CaptureScenarioSnapshot(engine, overlays, primitives, worldHud, snapshots, trackedEntities, "whirlwind_sweep_hit");
+            timeline.Add($"[T+009] R Whirlwind Sweep clips the nearby crowd pack | Left HP {leftBeforeR:0}->{ReadHealth(engine.World, "Branch Dummy Left"):0}");
+
+            File.WriteAllText(Path.Combine(artifactDir, "trace.jsonl"), BuildScenarioTraceJsonl(snapshots, "champion-musou-branch"));
+            File.WriteAllText(Path.Combine(artifactDir, "battle-report.md"), BuildMusouBranchBattleReport(timeline, snapshots, frameTimesMs));
+            File.WriteAllText(Path.Combine(artifactDir, "path.mmd"), BuildMusouBranchPathMermaid());
+            WriteAcceptanceScreenshots(snapshots, "Champion Musou Branch", screensDir);
+        }
+
+        [Test]
+        public void ChampionMusouHitConfirm_PlayableFlow_WritesAcceptanceArtifacts()
+        {
+            string repoRoot = FindRepoRoot();
+            string artifactDir = Path.Combine(repoRoot, "artifacts", "acceptance", "champion-musou-hit-confirm-showcase");
+            string screensDir = Path.Combine(artifactDir, "screens");
+            Directory.CreateDirectory(artifactDir);
+            Directory.CreateDirectory(screensDir);
+
+            var timeline = new List<string>();
+            var snapshots = new List<AcceptanceSnapshot>();
+            var frameTimesMs = new List<double>();
+            string[] trackedEntities =
+            {
+                MusouHitHeroName,
+                MusouMissHeroName,
+                "Confirm Dummy Front",
+                "Confirm Brute Finisher"
+            };
+
+            using var engine = CreateEngine();
+            var overlays = engine.GetService(CoreServiceKeys.GroundOverlayBuffer)
+                ?? throw new InvalidOperationException("GroundOverlayBuffer missing.");
+            var primitives = engine.GetService(CoreServiceKeys.PresentationPrimitiveDrawBuffer)
+                ?? throw new InvalidOperationException("PrimitiveDrawBuffer missing.");
+            var worldHud = engine.GetService(CoreServiceKeys.PresentationWorldHudBuffer)
+                ?? throw new InvalidOperationException("WorldHudBatchBuffer missing.");
+            var toolbar = engine.GetService(CoreServiceKeys.EntityCommandPanelToolbarProvider)
+                ?? throw new InvalidOperationException("Toolbar provider missing.");
+            var backend = GetInputBackend(engine);
+
+            LoadMap(engine, MusouHitConfirmMapId, frameTimesMs);
+            Assert.That(engine.TriggerManager.Errors.Count, Is.EqualTo(0));
+            Assert.That(toolbar.Title, Is.EqualTo("Hit Confirm"));
+            Assert.That(GetSelectedEntityName(engine), Is.EqualTo(MusouHitHeroName));
+
+            IReadOnlyList<PanelSlotSnapshot> slots = CopySelectedSlots(engine);
+            Assert.That(slots[0].Label, Is.EqualTo("Hit Confirm Q1"));
+            Assert.That(slots[1].Label, Is.EqualTo("Guard Step"));
+            Assert.That(slots[2].Label, Is.EqualTo("Triangle Locked"));
+            Assert.That(slots[2].Flags, Does.Contain("Blocked"));
+            Assert.That(slots[3].Label, Is.EqualTo("Execution Sweep"));
+            CaptureScenarioSnapshot(engine, overlays, primitives, worldHud, snapshots, trackedEntities, "map_loaded");
+            timeline.Add("[T+001] champion_musou_hit_confirm_showcase loaded | E starts locked until a real hit grants the follow-up window");
+
+            SelectNamedEntity(engine, backend, MusouMissHeroName, frameTimesMs);
+            SetMouseWorld(engine, backend, GetGroundScreenFromWorld(engine, new Vector2(980f, 1700f)), frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/q", frameTimesMs);
+            Tick(engine, 20, frameTimesMs);
+            Assert.That(EntityHasTag(engine.World, MusouMissHeroName, "State.Champion.MusouConfirm.HitStage1"), Is.False);
+            slots = CopySelectedSlots(engine);
+            Assert.That(slots[0].Label, Is.EqualTo("Hit Confirm Q1"));
+            Assert.That(slots[2].Label, Is.EqualTo("Triangle Locked"));
+            Assert.That(slots[2].Flags, Does.Contain("Blocked"));
+            CaptureScenarioSnapshot(engine, overlays, primitives, worldHud, snapshots, trackedEntities, "miss_keeps_followups_locked");
+            timeline.Add("[T+002] Musou Confirm Miss whiffs Q1 in empty space | no hit-confirm tag granted | Q2/E stay locked");
+
+            SelectNamedEntity(engine, backend, MusouHitHeroName, frameTimesMs);
+            SetMouseWorld(engine, backend, GetEntityScreen(engine, "Confirm Dummy Front"), frameTimesMs);
+            float frontBeforeQ1 = ReadHealth(engine.World, "Confirm Dummy Front");
+            PressButton(engine, backend, "<Keyboard>/q", frameTimesMs);
+            TickUntilHealthChanges(engine, frameTimesMs, "Confirm Dummy Front", frontBeforeQ1, maxFrames: 24);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () =>
+                {
+                    IReadOnlyList<PanelSlotSnapshot> routed = CopySelectedSlots(engine);
+                    return routed[0].Label == "Hit Confirm Q2" && routed[2].Label == "Confirm Triangle 1";
+                },
+                maxFrames: 12);
+            Assert.That(EntityHasTag(engine.World, MusouHitHeroName, "State.Champion.MusouConfirm.HitStage1"), Is.True);
+            CaptureScenarioSnapshot(engine, overlays, primitives, worldHud, snapshots, trackedEntities, "hit_unlocks_q2_and_e1");
+            timeline.Add($"[T+003] Alpha lands Q1 on Confirm Dummy Front | HP {frontBeforeQ1:0}->{ReadHealth(engine.World, "Confirm Dummy Front"):0} | hit-confirm opens Q2 and Triangle 1");
+
+            float frontBeforeQ2 = ReadHealth(engine.World, "Confirm Dummy Front");
+            PressButton(engine, backend, "<Keyboard>/q", frameTimesMs);
+            TickUntilHealthChanges(engine, frameTimesMs, "Confirm Dummy Front", frontBeforeQ2, maxFrames: 24);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () => CopySelectedSlots(engine)[2].Label == "Confirm Triangle 2",
+                maxFrames: 12);
+            Assert.That(EntityHasTag(engine.World, MusouHitHeroName, "State.Champion.MusouConfirm.HitStage2"), Is.True);
+            CaptureScenarioSnapshot(engine, overlays, primitives, worldHud, snapshots, trackedEntities, "q2_hit_unlocks_e2");
+            timeline.Add($"[T+004] Q2 also lands on the front dummy | HP {frontBeforeQ2:0}->{ReadHealth(engine.World, "Confirm Dummy Front"):0} | final Triangle 2 unlocks only after the second confirmed hit");
+
+            float bruteBeforeE2 = ReadHealth(engine.World, "Confirm Brute Finisher");
+            SetMouseWorld(engine, backend, GetEntityScreen(engine, "Confirm Brute Finisher"), frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/e", frameTimesMs);
+            TickUntilHealthChanges(engine, frameTimesMs, "Confirm Brute Finisher", bruteBeforeE2, maxFrames: 24);
+            TickUntil(
+                engine,
+                frameTimesMs,
+                () =>
+                {
+                    IReadOnlyList<PanelSlotSnapshot> neutral = CopySelectedSlots(engine);
+                    return neutral[0].Label == "Hit Confirm Q1" && neutral[2].Label == "Triangle Locked";
+                },
+                maxFrames: 12);
+            CaptureScenarioSnapshot(engine, overlays, primitives, worldHud, snapshots, trackedEntities, "triangle2_finisher_resets_windows");
+            timeline.Add($"[T+005] Confirm Triangle 2 lands on the brute lane and consumes the hit-confirm windows | Brute HP {bruteBeforeE2:0}->{ReadHealth(engine.World, "Confirm Brute Finisher"):0}");
+
+            float frontBeforeW = ReadHealth(engine.World, "Confirm Dummy Front");
+            SetMouseWorld(engine, backend, GetEntityScreen(engine, "Confirm Dummy Front"), frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/w", frameTimesMs);
+            TickUntilHealthChanges(engine, frameTimesMs, "Confirm Dummy Front", frontBeforeW, maxFrames: 24);
+            Assert.That(EntityHasTag(engine.World, MusouHitHeroName, "State.Champion.MusouConfirm.HitStage1"), Is.False);
+            CaptureScenarioSnapshot(engine, overlays, primitives, worldHud, snapshots, trackedEntities, "guard_step_no_unlock");
+            timeline.Add($"[T+006] Guard Step deals damage but does not fake a confirm window | Front HP {frontBeforeW:0}->{ReadHealth(engine.World, "Confirm Dummy Front"):0}");
+
+            float frontBeforeR = ReadHealth(engine.World, "Confirm Dummy Front");
+            int primitiveBeforeR = CountPrimitiveMarkers(primitives);
+            int worldTextBeforeR = CountWorldHudItems(worldHud, WorldHudItemKind.Text);
+            SetMouseWorld(engine, backend, GetEntityScreen(engine, "Confirm Dummy Front"), frameTimesMs);
+            PressButton(engine, backend, "<Keyboard>/r", frameTimesMs);
+            bool executionSweepHit = WaitUntil(
+                engine,
+                frameTimesMs,
+                () => ReadHealth(engine.World, "Confirm Dummy Front") < frontBeforeR,
+                maxFrames: 24);
+            bool executionSweepCast = EntityHasTag(engine.World, MusouHitHeroName, "Cooldown.Champion.MusouConfirm.R") ||
+                                      CountPrimitiveMarkers(primitives) > primitiveBeforeR ||
+                                      CountWorldHudItems(worldHud, WorldHudItemKind.Text) > worldTextBeforeR;
+            Assert.That(
+                executionSweepHit || executionSweepCast,
+                Is.True,
+                $"Execution Sweep should at least commit and emit visible feedback. {BuildAbilityDiagnostics(engine, MusouHitHeroName)} || {BuildSelectionStateDiagnostics(engine)} || {BuildFeedbackDiagnostics(primitives, worldHud)}");
+            CaptureScenarioSnapshot(engine, overlays, primitives, worldHud, snapshots, trackedEntities, "execution_sweep_hit");
+            timeline.Add(executionSweepHit
+                ? $"[T+007] Execution Sweep gives a neutral comparison skill outside the hit-confirm route | Front HP {frontBeforeR:0}->{ReadHealth(engine.World, "Confirm Dummy Front"):0}"
+                : $"[T+007] Execution Sweep commits as a neutral comparison skill outside the hit-confirm route | feedback {primitiveBeforeR}->{CountPrimitiveMarkers(primitives)} primitives, text {worldTextBeforeR}->{CountWorldHudItems(worldHud, WorldHudItemKind.Text)}");
+
+            File.WriteAllText(Path.Combine(artifactDir, "trace.jsonl"), BuildScenarioTraceJsonl(snapshots, "champion-musou-hit-confirm"));
+            File.WriteAllText(Path.Combine(artifactDir, "battle-report.md"), BuildMusouHitConfirmBattleReport(timeline, snapshots, frameTimesMs));
+            File.WriteAllText(Path.Combine(artifactDir, "path.mmd"), BuildMusouHitConfirmPathMermaid());
+            WriteAcceptanceScreenshots(snapshots, "Champion Musou Hit Confirm", screensDir);
         }
 
         [Test]
@@ -1112,26 +1431,43 @@ namespace Ludots.Tests.GAS.Production
             List<AcceptanceSnapshot> snapshots,
             string step)
         {
-            string selectedName = GetSelectedEntityName(engine);
-            var trackedEntities = new[]
-            {
-                "Ezreal Alpha",
-                "Ezreal Cooldown",
-                "Garen Courage",
-                "Jayce Hammer",
-                "Geomancer Alpha",
-                "Spell Engineer Alpha",
-                "Target Dummy A",
-                "Target Dummy C",
-                "Target Dummy D",
-                "Target Dummy E",
-                "Target Dummy F"
-            };
+            CaptureScenarioSnapshot(
+                engine,
+                overlays,
+                primitives,
+                worldHud,
+                snapshots,
+                new[]
+                {
+                    "Ezreal Alpha",
+                    "Ezreal Cooldown",
+                    "Garen Courage",
+                    "Jayce Hammer",
+                    "Geomancer Alpha",
+                    "Spell Engineer Alpha",
+                    "Target Dummy A",
+                    "Target Dummy C",
+                    "Target Dummy D",
+                    "Target Dummy E",
+                    "Target Dummy F"
+                },
+                step);
+        }
 
-            var states = new List<EntityState>(trackedEntities.Length + 3);
+        private static void CaptureScenarioSnapshot(
+            GameEngine engine,
+            GroundOverlayBuffer overlays,
+            PrimitiveDrawBuffer primitives,
+            WorldHudBatchBuffer worldHud,
+            List<AcceptanceSnapshot> snapshots,
+            IReadOnlyList<string> trackedEntities,
+            string step)
+        {
+            string selectedName = GetSelectedEntityName(engine);
+            var states = new List<EntityState>(trackedEntities.Count + 8);
             foreach (string name in trackedEntities)
             {
-                states.Add(new EntityState(name, ReadHealth(engine.World, name)));
+                AddEntityStateIfPresent(engine.World, states, name);
             }
 
             AddEntityStateIfPresent(engine.World, states, "Runic Beacon");
@@ -1167,13 +1503,18 @@ namespace Ludots.Tests.GAS.Production
 
         private static string BuildTraceJsonl(IReadOnlyList<AcceptanceSnapshot> snapshots)
         {
+            return BuildScenarioTraceJsonl(snapshots, "champion-sandbox");
+        }
+
+        private static string BuildScenarioTraceJsonl(IReadOnlyList<AcceptanceSnapshot> snapshots, string eventPrefix)
+        {
             var lines = new List<string>(snapshots.Count);
             for (int i = 0; i < snapshots.Count; i++)
             {
                 AcceptanceSnapshot snapshot = snapshots[i];
                 lines.Add(JsonSerializer.Serialize(new
                 {
-                    event_id = $"champion-sandbox-{i + 1:000}",
+                    event_id = $"{eventPrefix}-{i + 1:000}",
                     step = snapshot.Step,
                     active_mode_id = snapshot.ActiveModeId,
                     selected_entity = snapshot.SelectedEntity,
@@ -1281,6 +1622,127 @@ namespace Ludots.Tests.GAS.Production
                 "    S --> T[\"Zone: Gravity Well ticks on Target Dummy D\"]",
                 "    T --> U[\"Arena: Cataclysm Ring spawns 10 box blocker segments\"]",
                 "    U --> V[\"Beam: Guided Laser hold-starts, hits Dummy D, retargets to Dummy E, release removes manifestation\"]"
+            });
+        }
+
+        private static string BuildMusouBranchBattleReport(
+            IReadOnlyList<string> timeline,
+            IReadOnlyList<AcceptanceSnapshot> snapshots,
+            IReadOnlyList<double> frameTimesMs)
+        {
+            double medianTickMs = Median(frameTimesMs);
+            double maxTickMs = frameTimesMs.Count == 0 ? 0d : frameTimesMs.Max();
+            AcceptanceSnapshot finalSnapshot = snapshots[^1];
+
+            var sb = new StringBuilder();
+            sb.AppendLine("# Scenario: champion-musou-branch-showcase");
+            sb.AppendLine();
+            sb.AppendLine("## Header");
+            sb.AppendLine("- build: GasTests / ChampionMusouBranch_PlayableFlow_WritesAcceptanceArtifacts");
+            sb.AppendLine($"- map: {MusouBranchMapId}");
+            sb.AppendLine("- clock: FixedFrame @ 60 Hz");
+            sb.AppendLine($"- execution_timestamp_utc: {DateTime.UtcNow:O}");
+            sb.AppendLine("- screenshots: `screens/*.svg`, `screens/timeline.svg`");
+            sb.AppendLine();
+            sb.AppendLine("## Timeline");
+            foreach (string entry in timeline)
+            {
+                sb.AppendLine(entry);
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("## Outcome");
+            sb.AppendLine("- result: success");
+            sb.AppendLine("- failure_branch: combo slot routing or stage reset fails to reflect the expected Square/Triangle branch state");
+            sb.AppendLine($"- final_selected: {finalSnapshot.SelectedEntity}");
+            sb.AppendLine($"- final_mode: {finalSnapshot.ActiveModeId}");
+            sb.AppendLine($"- final_feedback_primitives: {finalSnapshot.PrimitiveCount}");
+            sb.AppendLine($"- final_feedback_world_text: {finalSnapshot.WorldTextCount}");
+            sb.AppendLine();
+            sb.AppendLine("## Summary Stats");
+            sb.AppendLine($"- total_actions: {timeline.Count}");
+            sb.AppendLine("- square_openers: 3");
+            sb.AppendLine("- triangle_finishers: 3");
+            sb.AppendLine("- utility_melee_skills: 2");
+            sb.AppendLine("- classic_branch_cases: 3");
+            sb.AppendLine($"- median_tick_ms: {medianTickMs:0.###}");
+            sb.AppendLine($"- max_tick_ms: {maxTickMs:0.###}");
+            return sb.ToString();
+        }
+
+        private static string BuildMusouHitConfirmBattleReport(
+            IReadOnlyList<string> timeline,
+            IReadOnlyList<AcceptanceSnapshot> snapshots,
+            IReadOnlyList<double> frameTimesMs)
+        {
+            double medianTickMs = Median(frameTimesMs);
+            double maxTickMs = frameTimesMs.Count == 0 ? 0d : frameTimesMs.Max();
+            AcceptanceSnapshot finalSnapshot = snapshots[^1];
+
+            var sb = new StringBuilder();
+            sb.AppendLine("# Scenario: champion-musou-hit-confirm-showcase");
+            sb.AppendLine();
+            sb.AppendLine("## Header");
+            sb.AppendLine("- build: GasTests / ChampionMusouHitConfirm_PlayableFlow_WritesAcceptanceArtifacts");
+            sb.AppendLine($"- map: {MusouHitConfirmMapId}");
+            sb.AppendLine("- clock: FixedFrame @ 60 Hz");
+            sb.AppendLine($"- execution_timestamp_utc: {DateTime.UtcNow:O}");
+            sb.AppendLine("- screenshots: `screens/*.svg`, `screens/timeline.svg`");
+            sb.AppendLine();
+            sb.AppendLine("## Timeline");
+            foreach (string entry in timeline)
+            {
+                sb.AppendLine(entry);
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("## Outcome");
+            sb.AppendLine("- result: success");
+            sb.AppendLine("- failure_branch: follow-up slots unlock without a landed hit or fail to reset after the finisher");
+            sb.AppendLine($"- final_selected: {finalSnapshot.SelectedEntity}");
+            sb.AppendLine($"- final_mode: {finalSnapshot.ActiveModeId}");
+            sb.AppendLine($"- final_feedback_primitives: {finalSnapshot.PrimitiveCount}");
+            sb.AppendLine($"- final_feedback_world_text: {finalSnapshot.WorldTextCount}");
+            sb.AppendLine();
+            sb.AppendLine("## Summary Stats");
+            sb.AppendLine($"- total_actions: {timeline.Count}");
+            sb.AppendLine("- intentional_whiffs: 1");
+            sb.AppendLine("- confirms_required: 2");
+            sb.AppendLine("- confirm_only_finishers: 1");
+            sb.AppendLine("- neutral_comparison_skills: 2");
+            sb.AppendLine($"- median_tick_ms: {medianTickMs:0.###}");
+            sb.AppendLine($"- max_tick_ms: {maxTickMs:0.###}");
+            return sb.ToString();
+        }
+
+        private static string BuildMusouBranchPathMermaid()
+        {
+            return string.Join(Environment.NewLine, new[]
+            {
+                "flowchart TD",
+                "    A[\"MapLoaded: Musou Branch Alpha selected\"] --> B[\"Q1 hits front dummy -> Q routes to Square 2\"]",
+                "    B --> C[\"E from Stage1 -> Square-Triangle finisher\"]",
+                "    C --> D[\"Q1 into Q2 -> Stage2 route opens Square-Square-Triangle\"]",
+                "    D --> E[\"E from Stage2 -> wide sweep branch lands\"]",
+                "    E --> F[\"Q1 into Q2 into Q3 -> Stage3 route opens full Triangle finisher\"]",
+                "    F --> G[\"E from Stage3 -> long-line musou finisher lands on brute\"]",
+                "    G --> H[\"W Step Slash -> independent utility strike\"]",
+                "    H --> I[\"R Whirlwind Sweep -> neutral crowd finisher\"]"
+            });
+        }
+
+        private static string BuildMusouHitConfirmPathMermaid()
+        {
+            return string.Join(Environment.NewLine, new[]
+            {
+                "flowchart TD",
+                "    A[\"MapLoaded: Hit Confirm Alpha selected\"] --> B[\"Miss hero whiffs Q1 -> follow-ups remain locked\"]",
+                "    B --> C[\"Alpha Q1 hits front dummy -> Q2 and Triangle1 unlock\"]",
+                "    C --> D[\"Alpha Q2 hits again -> Triangle2 unlocks\"]",
+                "    D --> E[\"Triangle2 finisher lands -> confirm windows reset\"]",
+                "    E --> F[\"Guard Step deals damage but does not unlock combo\"]",
+                "    F --> G[\"Execution Sweep provides neutral comparison skill\"]",
+                "    B --> X[\"if miss still unlocks follow-ups -> fail hit-confirm contract\"]"
             });
         }
 
@@ -1417,6 +1879,77 @@ namespace Ludots.Tests.GAS.Production
                 "    F --> G[\"Toolbar: A+ and B+ -> both teams scale to 56 units\"]",
                 "    B --> X[\"if counts do not converge -> fail stress spawn / queue regression\"]"
             });
+        }
+
+        private static void WriteAcceptanceScreenshots(IReadOnlyList<AcceptanceSnapshot> snapshots, string title, string screensDir)
+        {
+            for (int i = 0; i < snapshots.Count; i++)
+            {
+                AcceptanceSnapshot snapshot = snapshots[i];
+                WriteAcceptanceSnapshotSvg(snapshot, title, Path.Combine(screensDir, $"{i + 1:000}_{snapshot.Step}.svg"));
+            }
+
+            WriteAcceptanceTimelineSvg(snapshots, title, Path.Combine(screensDir, "timeline.svg"));
+        }
+
+        private static void WriteAcceptanceSnapshotSvg(AcceptanceSnapshot snapshot, string title, string path)
+        {
+            var slotLines = snapshot.PanelSlots
+                .Select((slot, index) => $"[{index}] {slot.Label} | {slot.ActionId} | {slot.Flags}")
+                .Take(6)
+                .ToArray();
+            var entityLines = snapshot.Entities
+                .Select(entity => $"{entity.Name}: {entity.Health:0}")
+                .Take(8)
+                .ToArray();
+
+            string slotsText = EscapeSvg(string.Join(" || ", slotLines));
+            string entitiesText = EscapeSvg(string.Join(" || ", entityLines));
+            string svg = $$"""
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <rect width="1600" height="900" fill="#0b1218" />
+  <rect x="40" y="40" width="1520" height="820" rx="18" fill="#152330" stroke="#5ea2cf" stroke-width="2" />
+  <text x="72" y="104" fill="#f7d36d" font-size="34" font-family="Consolas, monospace">{{EscapeSvg(title)}} | {{EscapeSvg(snapshot.Step)}}</text>
+  <text x="72" y="152" fill="#ffffff" font-size="24" font-family="Consolas, monospace">Selected: {{EscapeSvg(snapshot.SelectedEntity)}} | Mode: {{EscapeSvg(snapshot.ActiveModeId)}}</text>
+  <text x="72" y="198" fill="#bccdde" font-size="20" font-family="Consolas, monospace">Camera target=({{snapshot.Camera.TargetXCm:0}}, {{snapshot.Camera.TargetYCm:0}}) distance={{snapshot.Camera.DistanceCm:0}} pitch={{snapshot.Camera.Pitch:0}} fov={{snapshot.Camera.FovYDeg:0}}</text>
+  <text x="72" y="256" fill="#ffffff" font-size="22" font-family="Consolas, monospace">Panel</text>
+  <text x="72" y="292" fill="#bccdde" font-size="18" font-family="Consolas, monospace">{{slotsText}}</text>
+  <text x="72" y="360" fill="#ffffff" font-size="22" font-family="Consolas, monospace">Tracked Health</text>
+  <text x="72" y="396" fill="#bccdde" font-size="18" font-family="Consolas, monospace">{{entitiesText}}</text>
+  <text x="72" y="468" fill="#ffffff" font-size="22" font-family="Consolas, monospace">Overlay counts circle/cone/line/ring = {{snapshot.OverlayCounts["circle"]}} / {{snapshot.OverlayCounts["cone"]}} / {{snapshot.OverlayCounts["line"]}} / {{snapshot.OverlayCounts["ring"]}}</text>
+  <text x="72" y="508" fill="#ffffff" font-size="22" font-family="Consolas, monospace">Primitive feedback = {{snapshot.PrimitiveCount}} | World text = {{snapshot.WorldTextCount}}</text>
+</svg>
+""";
+            File.WriteAllText(path, svg);
+        }
+
+        private static void WriteAcceptanceTimelineSvg(IReadOnlyList<AcceptanceSnapshot> snapshots, string title, string path)
+        {
+            if (snapshots.Count == 0)
+            {
+                return;
+            }
+
+            var lines = new List<string>(snapshots.Count * 4);
+            int y = 100;
+            for (int i = 0; i < snapshots.Count; i++)
+            {
+                AcceptanceSnapshot snapshot = snapshots[i];
+                lines.Add($"""  <rect x="40" y="{y - 36}" width="1520" height="72" rx="12" fill="#14212e" stroke="#35536b" stroke-width="1.5" />""");
+                lines.Add($"""  <text x="72" y="{y}" fill="#f7d36d" font-size="24" font-family="Consolas, monospace">{EscapeSvg($"{i + 1:000} {snapshot.Step}")}</text>""");
+                lines.Add($"""  <text x="430" y="{y}" fill="#ffffff" font-size="20" font-family="Consolas, monospace">{EscapeSvg(snapshot.SelectedEntity)}</text>""");
+                lines.Add($"""  <text x="72" y="{y + 28}" fill="#bccdde" font-size="18" font-family="Consolas, monospace">{EscapeSvg($"mode={snapshot.ActiveModeId} | overlays={snapshot.OverlayCounts["circle"]}/{snapshot.OverlayCounts["cone"]}/{snapshot.OverlayCounts["line"]}/{snapshot.OverlayCounts["ring"]} | feedback={snapshot.PrimitiveCount}/{snapshot.WorldTextCount}")}</text>""");
+                y += 96;
+            }
+
+            string svg = $$"""
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="{{Math.Max(240, y + 40)}}" viewBox="0 0 1600 {{Math.Max(240, y + 40)}}">
+  <rect width="1600" height="{{Math.Max(240, y + 40)}}" fill="#080a10" />
+  <text x="20" y="36" fill="#ffffff" font-size="28" font-family="Consolas, monospace">{{EscapeSvg(title)}} timeline</text>
+{{string.Join(Environment.NewLine, lines)}}
+</svg>
+""";
+            File.WriteAllText(path, svg);
         }
 
         private static void WriteStressScreenshots(IReadOnlyList<StressAcceptanceSnapshot> snapshots, string screensDir)

--- a/src/Tests/GasTests/Production/ProductionAllModsValidationTests.cs
+++ b/src/Tests/GasTests/Production/ProductionAllModsValidationTests.cs
@@ -108,9 +108,21 @@ namespace Ludots.Tests.GAS.Production
 
             yield return new TestCaseData(new ModCase(
                     "ChampionSkillSandboxMod",
-                    new[] { "LudotsCoreMod", "CoreInputMod", "CameraProfilesMod", "EntityCommandPanelMod", "ChampionSkillSandboxMod" },
+                    new[] { "LudotsCoreMod", "CoreInputMod", "CameraProfilesMod", "DiagnosticsOverlayMod", "EntityCommandPanelMod", "ChampionSkillSandboxMod" },
                     true))
                 .SetName("ProdModSmoke_ChampionSkillSandboxMod");
+
+            yield return new TestCaseData(new ModCase(
+                    "ChampionMusouBranchShowcaseMod",
+                    new[] { "LudotsCoreMod", "CoreInputMod", "CameraProfilesMod", "DiagnosticsOverlayMod", "EntityCommandPanelMod", "ChampionSkillSandboxMod", "ChampionMusouBranchShowcaseMod" },
+                    true))
+                .SetName("ProdModSmoke_ChampionMusouBranchShowcaseMod");
+
+            yield return new TestCaseData(new ModCase(
+                    "ChampionMusouHitConfirmShowcaseMod",
+                    new[] { "LudotsCoreMod", "CoreInputMod", "CameraProfilesMod", "DiagnosticsOverlayMod", "EntityCommandPanelMod", "ChampionSkillSandboxMod", "ChampionMusouHitConfirmShowcaseMod" },
+                    true))
+                .SetName("ProdModSmoke_ChampionMusouHitConfirmShowcaseMod");
 
             yield return new TestCaseData(new ModCase(
                     "UiTestMod",


### PR DESCRIPTION
## Summary
- extend `ChampionSkillSandboxMod` with two melee combo showcases: Musou Branch and Musou Hit Confirm
- add two standalone entry mods so each showcase can be launched directly from a clean workspace
- add production/config/playable validation for routing, cue wiring, startup maps, and acceptance artifact generation

## Validation
- `dotnet test src/Tests/GasTests/GasTests.csproj --filter "ProdModSmoke_ChampionSkillSandboxMod|ProdModSmoke_ChampionMusouBranchShowcaseMod|ProdModSmoke_ChampionMusouHitConfirmShowcaseMod|ChampionSkillSandbox_MusouMaps_LoadSelectionAndPanelRouting|ChampionSkillSandbox_ProjectileBindingsAndSkillCueConfigs_AreRegistered|ChampionMusouBranch_PlayableFlow_WritesAcceptanceArtifacts|ChampionMusouHitConfirm_PlayableFlow_WritesAcceptanceArtifacts"`

## Evidence
- manual startup screenshots and rendered combo videos are under `artifacts/manual/champion-musou-branch-showcase/` and `artifacts/manual/champion-musou-hit-confirm-showcase/`
- headless acceptance artifacts are under `artifacts/acceptance/champion-musou-branch-showcase/` and `artifacts/acceptance/champion-musou-hit-confirm-showcase/`
