### PR TITLE
Add gameplay replication foundation snapshot

### DIFF
--- a/artifacts/doc-governance-report.md
+++ b/artifacts/doc-governance-report.md
@@ -1,47 +1,25 @@
 # Documentation Governance Report
 
-Date: 2026-03-20
-Scope:
-
-- `docs/architecture/entity_selection_architecture.md`
-- `docs/architecture/interaction/features/companion/r3_multi_unit_micro.md`
-- `docs/rfcs/RFC-0059-entity-selection-container-ssot.md`
-- `docs/rfcs/README.md`
-
-Ruleset:
-
-- `docs/conventions/04_documentation_governance.md`
-- `C:/Users/ROG/.codex/skills/ludots-doc-governance/references/doc-governance-checklist.md`
-- `C:/Users/ROG/.codex/skills/ludots-doc-governance/references/link-validation.md`
+Date: 2026-03-31
+Scope: `docs/architecture/gameplay_replication_contract.md`, `docs/architecture/README.md`
+Ruleset: `docs/conventions/04_documentation_governance.md`, `ludots-doc-governance/references/doc-governance-checklist.md`, `ludots-doc-governance/references/link-validation.md`
 
 ## Summary
-
-- Total findings in scoped docs after fixes: 0
+- Total findings: 0
 - P0: 0
 - P1: 0
 - P2: 0
 - P3: 0
 
-## Validation Notes
-
-Validated in scope:
-
-- architecture SSOT now points to container/member selection truth
-- RFC-0059 now explicitly defers to architecture SSOT and links implementation evidence
-- multi-unit micro reference no longer cites `SelectionGroupBuffer`
-- referenced code/doc/artifact paths exist
-
 ## Findings
 
-No governance violations remain in the scoped selection packet.
-
-## Residual Risks Outside Scope
-
-- historical docs such as `docs/rfcs/RFC-0053-entity-info-panels-for-ui-and-overlay.md` still contain legacy `SelectedEntity` wording
-- debt is tracked in `artifacts/techdebt/2026-03-20-selection-container-ssot-redesign.md`
+No findings in scoped review. The new architecture entry uses repository-relative links only, links resolve to existing targets, and strong claims are backed by code/test/artifact paths.
 
 ## Fix Order
+1. No documentation fixes required for the scoped review.
+2. Keep `docs/architecture/README.md` synchronized if the contract file is renamed or split.
+3. If future transport or lockstep docs land, keep this file as the SSOT for authoritative gameplay snapshot semantics only.
 
-1. Keep the updated selection architecture document as the only authoritative design doc.
-2. Migrate remaining stale historical docs when their owning subsystems are touched.
-3. Delete remaining legacy key names from core once stale tests and docs are migrated.
+## Residual Risks
+- Future network transport documents could accidentally restate gameplay snapshot semantics instead of linking back to this SSOT.
+- The Web endpoint is intentionally debug-only; if it becomes production-facing later, its stability contract must be documented separately.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -24,6 +24,7 @@ This directory is the architecture SSOT entry for Ludots. It documents behavior 
 - [Animation Profile and Clip Kanban](animation_profile_clip_kanban.md)
 - [GAS Combat Infrastructure](gas_combat_infrastructure.md)
 - [GAS Layered Architecture](gas_layered_architecture.md)
+- [Gameplay Replication Contract](gameplay_replication_contract.md)
 - [Interaction Architecture](interaction/README.md)
 - [Persistent Static Adapter Sync](persistent_static_adapter_sync.md)
 - [Presentation Performer](presentation_performer.md)

--- a/docs/architecture/gameplay_replication_contract.md
+++ b/docs/architecture/gameplay_replication_contract.md
@@ -1,0 +1,108 @@
+# gameplay replication contract
+
+本文定义 Ludots 当前用于 authoritative gameplay replication 的最小联机合同。该合同服务于 DS + 状态同步基础层，明确把 gameplay truth 与 adapter-facing visual snapshot 分离，避免把 `PresentationVisualSnapshotBuffer` 误当成联机状态源。
+
+当前实现入口与证据路径：
+
+* `src/Core/Networking/GameplayReplicationSnapshotBuffer.cs`
+* `src/Core/Networking/Systems/GameplayReplicationBootstrapSystem.cs`
+* `src/Core/Networking/Systems/GameplayReplicationEmitSystem.cs`
+* `src/Core/Engine/GameEngine.cs`
+* `src/Adapters/Web/Ludots.Adapter.Web/Streaming/GameplayReplicationSnapshotExtractor.cs`
+* `src/Apps/Web/Ludots.App.Web/Program.cs`
+* `src/Tests/NetworkingTests/GameplayReplicationFoundationTests.cs`
+
+## 1 架构边界
+
+当前联机基础层只定义 authoritative gameplay snapshot，不实现 transport、回滚、lockstep 输入聚合或平台房间管理。
+
+边界约束如下：
+
+* gameplay truth 只来自 fixed-step 后的 ECS 逻辑态，不来自 render frame 的表现层缓冲。
+* `PresentationVisualSnapshotBuffer` 继续只服务 adapter 视觉同步，详见 [presentation_snapshot_contract.md](presentation_snapshot_contract.md)。
+* gameplay replication 当前服务于两类需求：
+  * DS 场景下对 authoritative world state 的调试导出与外部观测。
+  * 状态同步方案下的最小实体位姿 / 阵营 / owner / 朝向复制基础。
+* 帧同步方案当前未落地；未来如实现 lockstep，只能复用本合同作为 debug / observer 视图，不能反向把它当输入真相。
+
+## 2 Snapshot 生命周期
+
+authoritative gameplay snapshot 的生命周期与 fixed-step 对齐，而不是与 render frame 对齐：
+
+1. `src/Core/Engine/GameEngine.cs` 在初始化阶段创建 `GameplayReplicationEntityIdAllocator` 与 `GameplayReplicationSnapshotBuffer`，并通过 `CoreServiceKeys` 暴露服务。
+2. `src/Core/Engine/GameEngine.cs` 把 `GameplayReplicationBootstrapSystem` 和 `GameplayReplicationEmitSystem` 注册到 `SystemGroup.EventDispatch`，位于 `GameplayEventDispatchSystem` 之后、`GasBudgetReportSystem` 之前。
+3. `src/Core/Networking/Systems/GameplayReplicationBootstrapSystem.cs` 为所有带 `WorldPositionCm` 且缺少 replication id 的实体补齐稳定 `GameplayReplicationEntityId`。
+4. `src/Core/Networking/Systems/GameplayReplicationEmitSystem.cs` 在同一 fixed-step 内重建最新 authoritative snapshot，并确保当步新增实体不会被遗漏。
+5. `src/Core/Engine/GameEngine.cs` 的 render `Update(float dt)` 不会清理 `GameplayReplicationSnapshotBuffer`，因此最新快照会保留到下一次 fixed-step rebuild。
+
+这意味着：
+
+* 同一帧没有新的逻辑步时，外部 observer 仍可读取上一逻辑步的 authoritative snapshot。
+* 联机层如需 diff、压缩或按连接裁剪，必须在此合同之外的 adapter / transport 层完成，Core 不提供第二套“只发脏数据”的并行运行时。
+
+## 3 Contract 字段与硬约束
+
+当前 snapshot item 由 `src/Core/Networking/GameplayReplicationSnapshotItem.cs` 定义，字段语义如下：
+
+| 字段 | 来源 | 约束 |
+|------|------|------|
+| `ReplicationEntityId` | `GameplayReplicationEntityId.Value` | 必须为正整数；缺失时由 bootstrap / emit 在 authoritative fixed-step 内补齐 |
+| `PositionXRaw` / `PositionYRaw` | `WorldPositionCm.Value` | 使用 `Fix64.RawValue` 输出，保持状态同步可复用的精确性 |
+| `FacingAngleRad` | `FacingDirection.AngleRad` | 仅在 `Flags.HasFacing` 置位时有效 |
+| `TeamId` | `Team.Id` | 仅在 `Flags.HasTeam` 置位时有效 |
+| `PlayerId` | `PlayerOwner.PlayerId` | 仅在 `Flags.HasPlayerOwner` 置位时有效 |
+| `PresentationStableId` | `PresentationStableId.Value` | 仅作为 cross-reference；不能反向定义 gameplay identity |
+| `Flags` | `GameplayReplicationSnapshotFlags` | 显式声明可选字段是否存在，禁止 consumer 通过默认值猜测 |
+
+补充约束：
+
+* snapshot buffer 溢出只累计 `DroppedSinceClear` / `DroppedTotal`，不静默扩容。
+* contract 只复制 gameplay 所需字段，不包含 mesh、材质、缩放、动画控制器等 render-only 数据。
+* `RuntimeEntitySpawnQueue -> RuntimeEntitySpawnSystem` 仍是运行时结构变化唯一入口，详见 [runtime_entity_spawn_flow.md](runtime_entity_spawn_flow.md)。
+
+## 4 Web 调试读取面
+
+当前 Web 适配层提供只读调试出口：
+
+* `src/Adapters/Web/Ludots.Adapter.Web/Streaming/GameplayReplicationSnapshotExtractor.cs`
+* `src/Apps/Web/Ludots.App.Web/Program.cs`
+
+接口行为：
+
+* `GET /api/runtime/gameplay-snapshot`
+* 返回最新 authoritative gameplay snapshot 的 JSON 视图。
+* 该端点是 debug / observability 入口，不承诺客户端复制协议，也不承诺 backward compatibility。
+
+因此：
+
+* transport 层后续若引入二进制状态同步协议，应复用同一 Core snapshot 作为数据源。
+* Web 端点只承担“把当前 authoritative snapshot 可视化”的职责，不负责连接态、interest management 或补包策略。
+
+## 5 当前适配的联机方案位置
+
+本合同对应三类联机方案中的基础层位置如下：
+
+* 状态同步：直接复用本 snapshot 作为 authoritative state source，再在 adapter / gateway 侧做序列化、裁剪、压缩和纠错。
+* DS 方案：直接复用本 snapshot 作为服务器真相导出、回放抽样和观战调试入口。
+* 帧同步：当前不直接消费本 snapshot 做判定；它只适合作为 lockstep 运行时的旁路观测合同，用于验收、录制和 debug。
+
+## 6 验证证据
+
+自动化证据位于：
+
+* `src/Tests/NetworkingTests/GameplayReplicationFoundationTests.cs`
+* `artifacts/acceptance/gameplay-replication-foundation/trace.jsonl`
+* `artifacts/acceptance/gameplay-replication-foundation/battle-report.md`
+* `artifacts/acceptance/gameplay-replication-foundation/path.mmd`
+
+其中：
+
+* 系统顺序守卫验证 `EventDispatch` 中 authoritative snapshot 的注册顺序。
+* integration 验证覆盖 runtime spawn、team / owner 复制、稳定 replication id 与 Web extractor 输出。
+* acceptance artifact 记录 happy path 与 guard branch：owned spawn 复制 owner 信息，neutral spawn 则显式缺失可选 ownership flags。
+
+## 7 相关文档
+
+* 运行时实体生成链路：见 [runtime_entity_spawn_flow.md](runtime_entity_spawn_flow.md)
+* 表现层 visual snapshot 合同：见 [presentation_snapshot_contract.md](presentation_snapshot_contract.md)
+* 启动与宿主入口：见 [startup_entrypoints.md](startup_entrypoints.md)

--- a/src/Adapters/Web/Ludots.Adapter.Web/Streaming/GameplayReplicationSnapshotExtractor.cs
+++ b/src/Adapters/Web/Ludots.Adapter.Web/Streaming/GameplayReplicationSnapshotExtractor.cs
@@ -1,0 +1,73 @@
+using Ludots.Core.Engine;
+using Ludots.Core.Networking;
+using Ludots.Core.Scripting;
+
+namespace Ludots.Adapter.Web.Streaming
+{
+    public sealed class GameplayReplicationSnapshotExtractor
+    {
+        private readonly GameEngine _engine;
+
+        public GameplayReplicationSnapshotExtractor(GameEngine engine)
+        {
+            _engine = engine;
+        }
+
+        public GameplayReplicationSnapshotView Extract()
+        {
+            GameplayReplicationSnapshotBuffer? buffer = _engine.GetService(CoreServiceKeys.GameplayReplicationSnapshotBuffer);
+            if (buffer == null)
+            {
+                return new GameplayReplicationSnapshotView(
+                    SimTick: 0,
+                    Count: 0,
+                    Capacity: 0,
+                    DroppedSinceClear: 0,
+                    DroppedTotal: 0,
+                    Entities: System.Array.Empty<GameplayReplicationSnapshotEntityView>());
+            }
+
+            var span = buffer.GetSpan();
+            var entities = new GameplayReplicationSnapshotEntityView[span.Length];
+            for (int i = 0; i < span.Length; i++)
+            {
+                ref readonly var item = ref span[i];
+                entities[i] = new GameplayReplicationSnapshotEntityView(
+                    ReplicationEntityId: item.ReplicationEntityId,
+                    PresentationStableId: item.PresentationStableId,
+                    TeamId: item.TeamId,
+                    PlayerId: item.PlayerId,
+                    PositionXRaw: item.PositionXRaw,
+                    PositionYRaw: item.PositionYRaw,
+                    FacingAngleRad: item.FacingAngleRad,
+                    Flags: item.Flags);
+            }
+
+            return new GameplayReplicationSnapshotView(
+                SimTick: buffer.SimTick,
+                Count: buffer.Count,
+                Capacity: buffer.Capacity,
+                DroppedSinceClear: buffer.DroppedSinceClear,
+                DroppedTotal: buffer.DroppedTotal,
+                Entities: entities);
+        }
+    }
+
+    public sealed record GameplayReplicationSnapshotView(
+        int SimTick,
+        int Count,
+        int Capacity,
+        int DroppedSinceClear,
+        int DroppedTotal,
+        GameplayReplicationSnapshotEntityView[] Entities);
+
+    public sealed record GameplayReplicationSnapshotEntityView(
+        int ReplicationEntityId,
+        int PresentationStableId,
+        int TeamId,
+        int PlayerId,
+        long PositionXRaw,
+        long PositionYRaw,
+        float FacingAngleRad,
+        GameplayReplicationSnapshotFlags Flags);
+}

--- a/src/Apps/Web/Ludots.App.Web/Program.cs
+++ b/src/Apps/Web/Ludots.App.Web/Program.cs
@@ -10,6 +10,7 @@ var baseDir = AppDomain.CurrentDomain.BaseDirectory;
 var configFile = args.Length > 0 && !string.IsNullOrWhiteSpace(args[0]) ? args[0] : "launcher.runtime.json";
 var gameHost = new WebGameHost(baseDir, configFile);
 var setup = gameHost.Setup;
+var gameplaySnapshotExtractor = new GameplayReplicationSnapshotExtractor(setup.Engine);
 
 var cts = new CancellationTokenSource();
 var gameLoopTask = Task.Run(() => gameHost.Run(cts.Token));
@@ -34,6 +35,8 @@ app.MapGet("/health", () =>
         sessions = sessions.Select(s => new { s.Id, s.FramesSent, s.BytesSent, s.FramesDropped }),
     });
 });
+
+app.MapGet("/api/runtime/gameplay-snapshot", () => Results.Json(gameplaySnapshotExtractor.Extract()));
 
 app.Map("/ws", async (HttpContext context) =>
 {

--- a/src/Core/Engine/GameEngine.cs
+++ b/src/Core/Engine/GameEngine.cs
@@ -60,6 +60,8 @@ using Ludots.Core.Navigation.AOI;
 using Ludots.Core.Engine.Navigation2D;
 using Ludots.Core.Diagnostics;
 using Ludots.Core.Map.Board;
+using Ludots.Core.Networking;
+using Ludots.Core.Networking.Systems;
 using Ludots.Core.Gameplay.Camera.FollowTargets;
 using Ludots.Core.Navigation.GraphCore;
 using Ludots.Core.Navigation.Pathing;
@@ -107,6 +109,7 @@ namespace Ludots.Core.Engine
     {
         private const int PrimitiveDrawBufferCapacity = 8192;
         private const int VisualSnapshotBufferCapacity = 131072;
+        private const int GameplayReplicationSnapshotCapacity = 32768;
         private const int PerformerInstanceBufferCapacity = 4096;
         private const int PathStoreMaxPaths = 512;
         private const int PathStoreMaxPointsPerPath = 256;
@@ -493,8 +496,10 @@ namespace Ludots.Core.Engine
             var animationClips = new AnimationClipRegistry();
             var animationProfiles = new AnimationProfileRegistry();
             var presentationStableIds = new PresentationStableIdAllocator();
+            var gameplayReplicationIds = new GameplayReplicationEntityIdAllocator();
             var primitiveDrawBuffer = new PrimitiveDrawBuffer(PrimitiveDrawBufferCapacity);
             var visualSnapshotBuffer = new PrimitiveDrawBuffer(VisualSnapshotBufferCapacity);
+            var gameplayReplicationSnapshotBuffer = new GameplayReplicationSnapshotBuffer(GameplayReplicationSnapshotCapacity);
             var visualProxyBuffer = new PresentationVisualProxyBuffer(VisualSnapshotBufferCapacity);
             var skinnedVisualBatchBuffer = new SkinnedVisualBatchBuffer(VisualSnapshotBufferCapacity);
             var transientMarkerBuffer = new TransientMarkerBuffer();
@@ -680,6 +685,8 @@ namespace Ludots.Core.Engine
             SetService(CoreServiceKeys.AnimationClipRegistry, animationClips);
             SetService(CoreServiceKeys.AnimationProfileRegistry, animationProfiles);
             SetService(CoreServiceKeys.PresentationStableIdAllocator, presentationStableIds);
+            SetService(CoreServiceKeys.GameplayReplicationEntityIdAllocator, gameplayReplicationIds);
+            SetService(CoreServiceKeys.GameplayReplicationSnapshotBuffer, gameplayReplicationSnapshotBuffer);
             _primitiveDrawBuffer = primitiveDrawBuffer;
             _visualSnapshotBuffer = visualSnapshotBuffer;
             _visualProxyBuffer = visualProxyBuffer;
@@ -834,6 +841,8 @@ namespace Ludots.Core.Engine
             // Phase 6: Cleanup
             RegisterSystem(animatorRuntimeSystem, SystemGroup.EventDispatch);
             RegisterSystem(new GameplayEventDispatchSystem(EventBus, gasBudget), SystemGroup.EventDispatch);
+            RegisterSystem(new GameplayReplicationBootstrapSystem(World, gameplayReplicationIds), SystemGroup.EventDispatch);
+            RegisterSystem(new GameplayReplicationEmitSystem(World, gameplayReplicationIds, gameplayReplicationSnapshotBuffer, GameSession), SystemGroup.EventDispatch);
             RegisterSystem(new GasBudgetReportSystem(gasBudget), SystemGroup.EventDispatch);
             
             // Phase 7.1: ClearPresentationFlags

--- a/src/Core/Networking/Components/GameplayReplicationEntityId.cs
+++ b/src/Core/Networking/Components/GameplayReplicationEntityId.cs
@@ -1,0 +1,7 @@
+namespace Ludots.Core.Networking.Components
+{
+    public struct GameplayReplicationEntityId
+    {
+        public int Value;
+    }
+}

--- a/src/Core/Networking/GameplayReplicationEntityIdAllocator.cs
+++ b/src/Core/Networking/GameplayReplicationEntityIdAllocator.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Ludots.Core.Networking
+{
+    public sealed class GameplayReplicationEntityIdAllocator
+    {
+        private int _nextId = 1;
+
+        public int Allocate()
+        {
+            if (_nextId <= 0)
+            {
+                throw new InvalidOperationException("Gameplay replication entity id allocator overflowed.");
+            }
+
+            return _nextId++;
+        }
+    }
+}

--- a/src/Core/Networking/GameplayReplicationSnapshotBuffer.cs
+++ b/src/Core/Networking/GameplayReplicationSnapshotBuffer.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace Ludots.Core.Networking
+{
+    public sealed class GameplayReplicationSnapshotBuffer
+    {
+        private readonly GameplayReplicationSnapshotItem[] _items;
+        private int _count;
+
+        public GameplayReplicationSnapshotBuffer(int capacity = 8192)
+        {
+            if (capacity <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity));
+            }
+
+            _items = new GameplayReplicationSnapshotItem[capacity];
+        }
+
+        public int SimTick { get; private set; }
+        public int Count => _count;
+        public int Capacity => _items.Length;
+        public int DroppedSinceClear { get; private set; }
+        public int DroppedTotal { get; private set; }
+
+        public void BeginRebuild(int simTick)
+        {
+            SimTick = simTick;
+            _count = 0;
+            DroppedSinceClear = 0;
+        }
+
+        public bool TryAdd(in GameplayReplicationSnapshotItem item)
+        {
+            if (_count >= _items.Length)
+            {
+                DroppedSinceClear++;
+                DroppedTotal++;
+                return false;
+            }
+
+            _items[_count++] = item;
+            return true;
+        }
+
+        public ReadOnlySpan<GameplayReplicationSnapshotItem> GetSpan() => new(_items, 0, _count);
+    }
+}

--- a/src/Core/Networking/GameplayReplicationSnapshotFlags.cs
+++ b/src/Core/Networking/GameplayReplicationSnapshotFlags.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Ludots.Core.Networking
+{
+    [Flags]
+    public enum GameplayReplicationSnapshotFlags : ushort
+    {
+        None = 0,
+        HasFacing = 1 << 0,
+        HasTeam = 1 << 1,
+        HasPlayerOwner = 1 << 2,
+        HasPresentationStableId = 1 << 3,
+    }
+}

--- a/src/Core/Networking/GameplayReplicationSnapshotItem.cs
+++ b/src/Core/Networking/GameplayReplicationSnapshotItem.cs
@@ -1,0 +1,14 @@
+namespace Ludots.Core.Networking
+{
+    public struct GameplayReplicationSnapshotItem
+    {
+        public int ReplicationEntityId;
+        public int PresentationStableId;
+        public int TeamId;
+        public int PlayerId;
+        public long PositionXRaw;
+        public long PositionYRaw;
+        public float FacingAngleRad;
+        public GameplayReplicationSnapshotFlags Flags;
+    }
+}

--- a/src/Core/Networking/Systems/GameplayReplicationBootstrapSystem.cs
+++ b/src/Core/Networking/Systems/GameplayReplicationBootstrapSystem.cs
@@ -1,0 +1,39 @@
+using System;
+using Arch.Core;
+using Arch.System;
+using Ludots.Core.Components;
+using Ludots.Core.Networking.Components;
+
+namespace Ludots.Core.Networking.Systems
+{
+    public sealed class GameplayReplicationBootstrapSystem : BaseSystem<World, float>
+    {
+        private static readonly QueryDescription MissingReplicationIdQuery = new QueryDescription()
+            .WithAll<WorldPositionCm>()
+            .WithNone<GameplayReplicationEntityId>();
+
+        private readonly GameplayReplicationEntityIdAllocator _allocator;
+
+        public GameplayReplicationBootstrapSystem(World world, GameplayReplicationEntityIdAllocator allocator)
+            : base(world)
+        {
+            _allocator = allocator ?? throw new ArgumentNullException(nameof(allocator));
+        }
+
+        public override void Update(in float dt)
+        {
+            var query = World.Query(in MissingReplicationIdQuery);
+            foreach (var chunk in query)
+            {
+                for (int i = 0; i < chunk.Count; i++)
+                {
+                    Entity entity = chunk.Entity(i);
+                    World.Add(entity, new GameplayReplicationEntityId
+                    {
+                        Value = _allocator.Allocate(),
+                    });
+                }
+            }
+        }
+    }
+}

--- a/src/Core/Networking/Systems/GameplayReplicationEmitSystem.cs
+++ b/src/Core/Networking/Systems/GameplayReplicationEmitSystem.cs
@@ -1,0 +1,105 @@
+using System;
+using Arch.Core;
+using Arch.System;
+using Ludots.Core.Components;
+using Ludots.Core.Gameplay;
+using Ludots.Core.Gameplay.Components;
+using Ludots.Core.Networking.Components;
+using Ludots.Core.Presentation.Components;
+
+namespace Ludots.Core.Networking.Systems
+{
+    public sealed class GameplayReplicationEmitSystem : BaseSystem<World, float>
+    {
+        private static readonly QueryDescription ReplicationQuery = new QueryDescription()
+            .WithAll<WorldPositionCm>();
+
+        private readonly GameplayReplicationEntityIdAllocator _allocator;
+        private readonly GameplayReplicationSnapshotBuffer _buffer;
+        private readonly GameSession _gameSession;
+
+        public GameplayReplicationEmitSystem(
+            World world,
+            GameplayReplicationEntityIdAllocator allocator,
+            GameplayReplicationSnapshotBuffer buffer,
+            GameSession gameSession)
+            : base(world)
+        {
+            _allocator = allocator ?? throw new ArgumentNullException(nameof(allocator));
+            _buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
+            _gameSession = gameSession ?? throw new ArgumentNullException(nameof(gameSession));
+        }
+
+        public override void Update(in float dt)
+        {
+            _buffer.BeginRebuild(_gameSession.CurrentTick);
+
+            var query = World.Query(in ReplicationQuery);
+            foreach (var chunk in query)
+            {
+                var positions = chunk.GetArray<WorldPositionCm>();
+                for (int i = 0; i < chunk.Count; i++)
+                {
+                    Entity entity = chunk.Entity(i);
+                    int replicationEntityId = EnsureReplicationEntityId(entity);
+                    if (replicationEntityId <= 0)
+                    {
+                        throw new InvalidOperationException(
+                            $"Gameplay replication snapshot requires a positive GameplayReplicationEntityId for entity #{entity.Id}:{entity.WorldId}.");
+                    }
+
+                    var position = positions[i].Value;
+                    var item = new GameplayReplicationSnapshotItem
+                    {
+                        ReplicationEntityId = replicationEntityId,
+                        PositionXRaw = position.X.RawValue,
+                        PositionYRaw = position.Y.RawValue,
+                    };
+
+                    GameplayReplicationSnapshotFlags flags = GameplayReplicationSnapshotFlags.None;
+                    if (World.Has<FacingDirection>(entity))
+                    {
+                        item.FacingAngleRad = World.Get<FacingDirection>(entity).AngleRad;
+                        flags |= GameplayReplicationSnapshotFlags.HasFacing;
+                    }
+
+                    if (World.Has<Team>(entity))
+                    {
+                        item.TeamId = World.Get<Team>(entity).Id;
+                        flags |= GameplayReplicationSnapshotFlags.HasTeam;
+                    }
+
+                    if (World.Has<PlayerOwner>(entity))
+                    {
+                        item.PlayerId = World.Get<PlayerOwner>(entity).PlayerId;
+                        flags |= GameplayReplicationSnapshotFlags.HasPlayerOwner;
+                    }
+
+                    if (World.Has<PresentationStableId>(entity))
+                    {
+                        item.PresentationStableId = World.Get<PresentationStableId>(entity).Value;
+                        flags |= GameplayReplicationSnapshotFlags.HasPresentationStableId;
+                    }
+
+                    item.Flags = flags;
+                    _buffer.TryAdd(item);
+                }
+            }
+        }
+
+        private int EnsureReplicationEntityId(Entity entity)
+        {
+            if (World.Has<GameplayReplicationEntityId>(entity))
+            {
+                return World.Get<GameplayReplicationEntityId>(entity).Value;
+            }
+
+            int value = _allocator.Allocate();
+            World.Add(entity, new GameplayReplicationEntityId
+            {
+                Value = value,
+            });
+            return value;
+        }
+    }
+}

--- a/src/Core/Scripting/CoreServiceKeys.cs
+++ b/src/Core/Scripting/CoreServiceKeys.cs
@@ -31,6 +31,7 @@ using Ludots.Core.Navigation.NavMesh.Config;
 using Ludots.Core.Navigation.Pathing;
 using Ludots.Core.Navigation.Pathing.Config;
 using Ludots.Core.Navigation2D.Runtime;
+using Ludots.Core.Networking;
 using Ludots.Core.Presentation;
 using Ludots.Core.Presentation.Assets;
 using Ludots.Core.Presentation.Camera;
@@ -153,6 +154,8 @@ namespace Ludots.Core.Scripting
         public static readonly ServiceKey<Physics2DTickPolicy> Physics2DTickPolicy = new("Physics2DTickPolicy");
         public static readonly ServiceKey<Physics2DController> Physics2DController = new("Physics2DController");
         public static readonly ServiceKey<Navigation2DTickPolicy> Navigation2DTickPolicy = new("Navigation2DTickPolicy");
+        public static readonly ServiceKey<GameplayReplicationEntityIdAllocator> GameplayReplicationEntityIdAllocator = new("GameplayReplicationEntityIdAllocator");
+        public static readonly ServiceKey<GameplayReplicationSnapshotBuffer> GameplayReplicationSnapshotBuffer = new("GameplayReplicationSnapshotBuffer");
 
         // --- Presentation ---
         public static readonly ServiceKey<PresentationEventStream> PresentationEventStream = new("PresentationEventStream");

--- a/src/Tests/NetworkingTests/GameplayReplicationFoundationTests.cs
+++ b/src/Tests/NetworkingTests/GameplayReplicationFoundationTests.cs
@@ -1,0 +1,381 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Numerics;
+using Arch.Core;
+using Arch.System;
+using Ludots.Adapter.Web.Streaming;
+using Ludots.Core.Components;
+using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.Components;
+using Ludots.Core.Gameplay.Spawning;
+using Ludots.Core.Input.Config;
+using Ludots.Core.Input.Runtime;
+using Ludots.Core.Mathematics.FixedPoint;
+using Ludots.Core.Networking;
+using Ludots.Core.Scripting;
+using NUnit.Framework;
+
+namespace Ludots.Tests.Networking
+{
+    [TestFixture]
+    [NonParallelizable]
+    public sealed class GameplayReplicationFoundationTests
+    {
+        private static readonly string[] NetworkingMods =
+        {
+            "LudotsCoreMod",
+            "CoreInputMod"
+        };
+
+        [Test]
+        public void CoreBootstrap_EventDispatch_RegistersGameplayReplicationSystemsInAuthoritativeOrder()
+        {
+            using var engine = CreateEngine();
+
+            var eventDispatchNames = GetSystemNames(engine, SystemGroup.EventDispatch);
+
+            Assert.That(eventDispatchNames, Does.Contain("GameplayReplicationBootstrapSystem"));
+            Assert.That(eventDispatchNames, Does.Contain("GameplayReplicationEmitSystem"));
+            Assert.That(eventDispatchNames.IndexOf("GameplayEventDispatchSystem"), Is.LessThan(eventDispatchNames.IndexOf("GameplayReplicationBootstrapSystem")));
+            Assert.That(eventDispatchNames.IndexOf("GameplayReplicationBootstrapSystem"), Is.LessThan(eventDispatchNames.IndexOf("GameplayReplicationEmitSystem")));
+            Assert.That(eventDispatchNames.IndexOf("GameplayReplicationEmitSystem"), Is.LessThan(eventDispatchNames.IndexOf("GasBudgetReportSystem")));
+        }
+
+        [Test]
+        public void GameplayReplicationSnapshotExtractor_EmitsAuthoritativeSnapshotWithStableReplicationIds()
+        {
+            using var engine = CreateEngine();
+            ScenarioState scenario = SeedScenario(engine);
+
+            Tick(engine, 1);
+
+            var extractor = new GameplayReplicationSnapshotExtractor(engine);
+            GameplayReplicationSnapshotView first = extractor.Extract();
+
+            Assert.That(first.Count, Is.GreaterThanOrEqualTo(4));
+            Assert.That(first.SimTick, Is.GreaterThan(0));
+
+            var ownedSpawn = FindByPosition(first, scenario.OwnedSpawnPosition);
+            var neutralSpawn = FindByPosition(first, scenario.NeutralSpawnPosition);
+            var source = FindByPosition(first, scenario.SourcePosition);
+
+            Assert.That(source.ReplicationEntityId, Is.GreaterThan(0));
+            Assert.That(ownedSpawn.ReplicationEntityId, Is.GreaterThan(0));
+            Assert.That(neutralSpawn.ReplicationEntityId, Is.GreaterThan(0));
+            Assert.That(ownedSpawn.Flags.HasFlag(GameplayReplicationSnapshotFlags.HasFacing), Is.True);
+            Assert.That(ownedSpawn.Flags.HasFlag(GameplayReplicationSnapshotFlags.HasTeam), Is.True);
+            Assert.That(ownedSpawn.Flags.HasFlag(GameplayReplicationSnapshotFlags.HasPlayerOwner), Is.True);
+            Assert.That(ownedSpawn.TeamId, Is.EqualTo(2));
+            Assert.That(ownedSpawn.PlayerId, Is.EqualTo(17));
+            Assert.That(ownedSpawn.FacingAngleRad, Is.EqualTo(1.25f).Within(0.0001f));
+            Assert.That(neutralSpawn.Flags.HasFlag(GameplayReplicationSnapshotFlags.HasTeam), Is.False);
+            Assert.That(neutralSpawn.Flags.HasFlag(GameplayReplicationSnapshotFlags.HasPlayerOwner), Is.False);
+
+            GameplayReplicationSnapshotView secondWithoutTick = extractor.Extract();
+            Assert.That(secondWithoutTick.Count, Is.EqualTo(first.Count), "Latest authoritative snapshot should persist until the next fixed-step rebuild.");
+            Assert.That(FindByPosition(secondWithoutTick, scenario.OwnedSpawnPosition).ReplicationEntityId, Is.EqualTo(ownedSpawn.ReplicationEntityId));
+
+            Tick(engine, 2);
+            GameplayReplicationSnapshotView afterLaterTicks = extractor.Extract();
+            Assert.That(FindByPosition(afterLaterTicks, scenario.SourcePosition).ReplicationEntityId, Is.EqualTo(source.ReplicationEntityId));
+            Assert.That(FindByPosition(afterLaterTicks, scenario.OwnedSpawnPosition).ReplicationEntityId, Is.EqualTo(ownedSpawn.ReplicationEntityId));
+            Assert.That(FindByPosition(afterLaterTicks, scenario.NeutralSpawnPosition).ReplicationEntityId, Is.EqualTo(neutralSpawn.ReplicationEntityId));
+        }
+
+        [Test]
+        public void GameplayReplicationFoundation_WritesAcceptanceArtifacts()
+        {
+            string repoRoot = FindRepoRoot();
+            string artifactDir = Path.Combine(repoRoot, "artifacts", "acceptance", "gameplay-replication-foundation");
+            Directory.CreateDirectory(artifactDir);
+
+            using var engine = CreateEngine();
+            ScenarioState scenario = SeedScenario(engine);
+            var extractor = new GameplayReplicationSnapshotExtractor(engine);
+
+            var timeline = new List<string>();
+            var traceLines = new List<string>();
+
+            Tick(engine, 1);
+            var snapshotTick1 = extractor.Extract();
+            Tick(engine, 1);
+            var snapshotTick2 = extractor.Extract();
+
+            var source = FindByPosition(snapshotTick1, scenario.SourcePosition);
+            var ownedSpawnTick1 = FindByPosition(snapshotTick1, scenario.OwnedSpawnPosition);
+            var neutralSpawnTick1 = FindByPosition(snapshotTick1, scenario.NeutralSpawnPosition);
+            var ownedSpawnTick2 = FindByPosition(snapshotTick2, scenario.OwnedSpawnPosition);
+
+            timeline.Add($"[T+001] AuthoritySource#{source.ReplicationEntityId} enters gameplay replication bootstrap at ({scenario.SourcePosition.X.ToInt()},{scenario.SourcePosition.Y.ToInt()})cm");
+            timeline.Add($"[T+002] RuntimeEntitySpawnQueue.Assembly -> OwnedSpawn#{ownedSpawnTick1.ReplicationEntityId} | CopyTeam/PlayerOwner/Facing | Team {ownedSpawnTick1.TeamId} | Player {ownedSpawnTick1.PlayerId}");
+            timeline.Add($"[T+003] RuntimeEntitySpawnQueue.Assembly -> NeutralSpawn#{neutralSpawnTick1.ReplicationEntityId} | Guard branch strips optional ownership flags");
+            timeline.Add($"[T+004] Snapshot.Emit(simTick={snapshotTick2.SimTick}) -> OwnedSpawn#{ownedSpawnTick2.ReplicationEntityId} keeps a stable replication id across ticks");
+
+            AppendTrace(traceLines, "tick1", snapshotTick1);
+            AppendTrace(traceLines, "tick2", snapshotTick2);
+
+            string tracePath = Path.Combine(artifactDir, "trace.jsonl");
+            string battleReportPath = Path.Combine(artifactDir, "battle-report.md");
+            string pathPath = Path.Combine(artifactDir, "path.mmd");
+
+            File.WriteAllText(tracePath, string.Join(Environment.NewLine, traceLines));
+            File.WriteAllText(battleReportPath, BuildBattleReport(timeline, scenario, snapshotTick1, snapshotTick2));
+            File.WriteAllText(pathPath, BuildPathMermaid());
+
+            Assert.That(File.Exists(tracePath), Is.True);
+            Assert.That(File.Exists(battleReportPath), Is.True);
+            Assert.That(File.Exists(pathPath), Is.True);
+            Assert.That(File.ReadAllText(battleReportPath), Does.Contain("gameplay-replication-foundation"));
+            Assert.That(File.ReadAllText(pathPath), Does.Contain("guard branch"));
+        }
+
+        private static void AppendTrace(List<string> lines, string stage, GameplayReplicationSnapshotView snapshot)
+        {
+            for (int i = 0; i < snapshot.Entities.Length; i++)
+            {
+                var entity = snapshot.Entities[i];
+                lines.Add(JsonSerializer.Serialize(new
+                {
+                    event_id = $"{stage}_{i + 1}",
+                    stage,
+                    sim_tick = snapshot.SimTick,
+                    replication_entity_id = entity.ReplicationEntityId,
+                    presentation_stable_id = entity.PresentationStableId,
+                    team_id = entity.TeamId,
+                    player_id = entity.PlayerId,
+                    position_x_raw = entity.PositionXRaw,
+                    position_y_raw = entity.PositionYRaw,
+                    facing_angle_rad = entity.FacingAngleRad,
+                    flags = entity.Flags.ToString(),
+                }));
+            }
+        }
+
+        private static string BuildBattleReport(
+            List<string> timeline,
+            ScenarioState scenario,
+            GameplayReplicationSnapshotView tick1,
+            GameplayReplicationSnapshotView tick2)
+        {
+            var ownedSpawnTick1 = FindByPosition(tick1, scenario.OwnedSpawnPosition);
+            var ownedSpawnTick2 = FindByPosition(tick2, scenario.OwnedSpawnPosition);
+            var neutralSpawnTick1 = FindByPosition(tick1, scenario.NeutralSpawnPosition);
+
+            var sb = new StringBuilder();
+            sb.AppendLine("# gameplay-replication-foundation");
+            sb.AppendLine();
+            sb.AppendLine("## Header");
+            sb.AppendLine("- scenario name: gameplay-replication-foundation");
+            sb.AppendLine("- build/version: local test run");
+            sb.AppendLine("- seed/map/clock: seed=network-foundation-001 map=manual-world clock=60hz");
+            sb.AppendLine($"- execution timestamp: {DateTimeOffset.UtcNow:O}");
+            sb.AppendLine();
+            sb.AppendLine("## Timeline");
+            for (int i = 0; i < timeline.Count; i++)
+            {
+                sb.AppendLine(timeline[i]);
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("## Outcome");
+            sb.AppendLine($"- success/failure decision: success");
+            sb.AppendLine($"- failed assertions: none");
+            sb.AppendLine($"- reason codes: OWNED_FLAGS_PROPAGATED, NEUTRAL_FLAGS_GUARDED, REPLICATION_ID_STABLE={ownedSpawnTick1.ReplicationEntityId == ownedSpawnTick2.ReplicationEntityId}");
+            sb.AppendLine();
+            sb.AppendLine("## Summary Stats");
+            sb.AppendLine($"- total actions: {timeline.Count}");
+            sb.AppendLine($"- key damage/heal/control counters: not applicable for this infrastructure scenario");
+            sb.AppendLine($"- dropped/budget/fuse counters: dropped={tick2.DroppedTotal}, budget_fused=false");
+            sb.AppendLine($"- owned spawn: #{ownedSpawnTick1.ReplicationEntityId} team={ownedSpawnTick1.TeamId} player={ownedSpawnTick1.PlayerId} flags={ownedSpawnTick1.Flags}");
+            sb.AppendLine($"- neutral guard branch: #{neutralSpawnTick1.ReplicationEntityId} flags={neutralSpawnTick1.Flags}");
+            return sb.ToString();
+        }
+
+        private static string BuildPathMermaid()
+        {
+            return """
+flowchart TD
+    A["Scenario: seed authority source + neutral probe"] --> B["EventDispatch: GameplayReplicationBootstrapSystem assigns stable replication ids"]
+    B --> C["EventDispatch: GameplayReplicationEmitSystem rebuilds authoritative snapshot"]
+    C --> D["Web Debug: /api/runtime/gameplay-snapshot exposes latest snapshot"]
+    B --> E["guard branch: entity lacks Team / PlayerOwner"]
+    E --> F["Emit result: ownership flags omitted, position still replicated"]
+    B --> G["owned spawn branch: copy team/player/facing from source"]
+    G --> H["Emit result: HasTeam + HasPlayerOwner + HasFacing"]
+""";
+        }
+
+        private static GameplayReplicationSnapshotEntityView FindByPosition(GameplayReplicationSnapshotView snapshot, Fix64Vec2 position)
+        {
+            long xRaw = position.X.RawValue;
+            long yRaw = position.Y.RawValue;
+            for (int i = 0; i < snapshot.Entities.Length; i++)
+            {
+                var entity = snapshot.Entities[i];
+                if (entity.PositionXRaw == xRaw && entity.PositionYRaw == yRaw)
+                {
+                    return entity;
+                }
+            }
+
+            throw new AssertionException($"Missing gameplay replication snapshot entry for raw position ({xRaw}, {yRaw}).");
+        }
+
+        private static ScenarioState SeedScenario(GameEngine engine)
+        {
+            var queue = engine.GetService(CoreServiceKeys.RuntimeEntitySpawnQueue)
+                ?? throw new InvalidOperationException("RuntimeEntitySpawnQueue service missing.");
+
+            var sourcePosition = Fix64Vec2.FromInt(1200, 800);
+            var neutralProbePosition = Fix64Vec2.FromInt(300, 450);
+            var ownedSpawnPosition = Fix64Vec2.FromInt(1600, 950);
+            var neutralSpawnPosition = Fix64Vec2.FromInt(1800, 1200);
+
+            var source = engine.World.Create(
+                new Name { Value = "AuthoritySource" },
+                new WorldPositionCm { Value = sourcePosition },
+                new PreviousWorldPositionCm { Value = sourcePosition },
+                new Team { Id = 2 },
+                new PlayerOwner { PlayerId = 17 },
+                new FacingDirection { AngleRad = 0.5f });
+
+            var neutralProbe = engine.World.Create(
+                new Name { Value = "NeutralProbe" },
+                new WorldPositionCm { Value = neutralProbePosition },
+                new PreviousWorldPositionCm { Value = neutralProbePosition });
+
+            Assert.That(queue.TryEnqueue(new RuntimeEntitySpawnRequest
+            {
+                Kind = RuntimeEntitySpawnKind.Assembly,
+                Source = source,
+                WorldPositionCm = ownedSpawnPosition,
+                HasWorldPosition = 1,
+                CopySourceTeam = 1,
+                CopySourcePlayerOwner = 1,
+                HasFacing = 1,
+                FacingAngleRad = 1.25f,
+            }), Is.True);
+
+            Assert.That(queue.TryEnqueue(new RuntimeEntitySpawnRequest
+            {
+                Kind = RuntimeEntitySpawnKind.Assembly,
+                Source = neutralProbe,
+                WorldPositionCm = neutralSpawnPosition,
+                HasWorldPosition = 1,
+            }), Is.True);
+
+            return new ScenarioState(sourcePosition, ownedSpawnPosition, neutralSpawnPosition);
+        }
+
+        private static GameEngine CreateEngine()
+        {
+            string repoRoot = FindRepoRoot();
+            string assetsRoot = Path.Combine(repoRoot, "assets");
+
+            var engine = new GameEngine();
+            engine.InitializeWithConfigPipeline(RepoModPaths.ResolveExplicit(repoRoot, NetworkingMods), assetsRoot);
+            engine.SimulationBudgetMsPerFrame = 1000;
+            engine.SimulationMaxSlicesPerLogicFrame = 10000;
+            InstallInput(engine);
+            engine.Start();
+            if (!string.IsNullOrWhiteSpace(engine.MergedConfig.StartupMapId))
+            {
+                engine.LoadMap(engine.MergedConfig.StartupMapId);
+                Tick(engine, 2);
+            }
+
+            return engine;
+        }
+
+        private static void InstallInput(GameEngine engine)
+        {
+            var inputConfig = new InputConfigPipelineLoader(engine.ConfigPipeline).Load();
+            var inputHandler = new PlayerInputHandler(new NullInputBackend(), inputConfig);
+            for (int i = 0; i < engine.MergedConfig.StartupInputContexts.Count; i++)
+            {
+                inputHandler.PushContext(engine.MergedConfig.StartupInputContexts[i]);
+            }
+
+            engine.SetService(CoreServiceKeys.InputHandler, inputHandler);
+            engine.SetService(CoreServiceKeys.UiCaptured, false);
+        }
+
+        private static void Tick(GameEngine engine, int frames)
+        {
+            for (int i = 0; i < frames; i++)
+            {
+                engine.Tick(Time.FixedDeltaTime);
+            }
+        }
+
+        private static List<string> GetSystemNames(GameEngine engine, SystemGroup group)
+        {
+            var systems = GetSystems(engine, group);
+            var result = new List<string>(systems.Count);
+            for (int i = 0; i < systems.Count; i++)
+            {
+                result.Add(systems[i].GetType().Name);
+            }
+
+            return result;
+        }
+
+        private static List<ISystem<float>> GetSystems(GameEngine engine, SystemGroup group)
+        {
+            var field = typeof(GameEngine).GetField("_systemGroups", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(field, Is.Not.Null);
+
+            var systemGroups = field!.GetValue(engine) as Dictionary<SystemGroup, List<ISystem<float>>>;
+            Assert.That(systemGroups, Is.Not.Null);
+            Assert.That(systemGroups!.ContainsKey(group), Is.True);
+
+            return systemGroups[group];
+        }
+
+        private static string FindRepoRoot()
+        {
+            string dir = TestContext.CurrentContext.TestDirectory;
+            while (!string.IsNullOrWhiteSpace(dir))
+            {
+                if (File.Exists(Path.Combine(dir, "src", "Core", "Ludots.Core.csproj")))
+                {
+                    return dir;
+                }
+
+                dir = Path.GetDirectoryName(dir);
+            }
+
+            throw new DirectoryNotFoundException("Could not locate repository root.");
+        }
+
+        private readonly record struct ScenarioState(
+            Fix64Vec2 SourcePosition,
+            Fix64Vec2 OwnedSpawnPosition,
+            Fix64Vec2 NeutralSpawnPosition);
+
+        private sealed class NullInputBackend : IInputBackend
+        {
+            public float GetAxis(string devicePath) => 0f;
+
+            public bool GetButton(string devicePath) => false;
+
+            public Vector2 GetMousePosition() => Vector2.Zero;
+
+            public float GetMouseWheel() => 0f;
+
+            public void EnableIME(bool enable)
+            {
+            }
+
+            public void SetIMECandidatePosition(int x, int y)
+            {
+            }
+
+            public string GetCharBuffer() => string.Empty;
+        }
+    }
+}

--- a/src/Tests/ThreeCTests/ThreeCTests.csproj
+++ b/src/Tests/ThreeCTests/ThreeCTests.csproj
@@ -41,6 +41,7 @@
 
   <ItemGroup>
     <Compile Include="..\TestCommon\RepoModPaths.cs" Link="RepoModPaths.cs" />
+    <Compile Include="..\NetworkingTests\GameplayReplicationFoundationTests.cs" Link="GameplayReplicationFoundationTests.cs" />
     <None Include="..\..\Libraries\SkiaSharp\runtimes\**\*.*" Link="runtimes\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- add authoritative gameplay replication core contracts, allocator, buffer, and EventDispatch systems
- expose the latest gameplay snapshot through the Web debug endpoint /api/runtime/gameplay-snapshot
- add networking foundation tests, acceptance artifacts, and architecture SSOT documentation

## Validation
- dotnet test src/Tests/ThreeCTests/ThreeCTests.csproj --filter FullyQualifiedName~GameplayReplicationFoundationTests -v minimal
- dotnet build src/Apps/Web/Ludots.App.Web/Ludots.App.Web.csproj -v minimal

## Acceptance Artifacts
- rtifacts/acceptance/gameplay-replication-foundation/trace.jsonl
- rtifacts/acceptance/gameplay-replication-foundation/battle-report.md
- rtifacts/acceptance/gameplay-replication-foundation/path.mmd
