### PR TITLE
Add UE5 host camera diagnostics contracts

### DIFF
--- a/src/Adapters/UE5/Ludots.Adapter.UE5/UE5AdapterServiceKeys.cs
+++ b/src/Adapters/UE5/Ludots.Adapter.UE5/UE5AdapterServiceKeys.cs
@@ -12,5 +12,8 @@ namespace Ludots.Adapter.UE5
         public static readonly ServiceKey<IExternalSessionTransitionHandler> ExternalSessionTransitionHandler = new("UE5.ExternalSessionTransitionHandler");
         public static readonly ServiceKey<IHostBoundMapSessionService> HostBoundMapSessionService = new("UE5.HostBoundMapSessionService");
         public static readonly ServiceKey<HostBoundMapSessionSnapshot> HostBoundMapSessionState = new("UE5.HostBoundMapSessionState");
+        public static readonly ServiceKey<UE5SharedCameraState> SharedCameraState = new("UE5.SharedCameraState");
+        public static readonly ServiceKey<UE5HostCameraDiagnosticsSnapshot> HostCameraDiagnosticsSnapshot = new("UE5.HostCameraDiagnosticsSnapshot");
+        public static readonly ServiceKey<UE5HostCameraDiagnosticsCommandState> HostCameraDiagnosticsCommands = new("UE5.HostCameraDiagnosticsCommands");
     }
 }

--- a/src/Adapters/UE5/Ludots.Adapter.UE5/UE5HostCameraDiagnostics.cs
+++ b/src/Adapters/UE5/Ludots.Adapter.UE5/UE5HostCameraDiagnostics.cs
@@ -1,0 +1,51 @@
+namespace Ludots.Adapter.UE5
+{
+    public readonly record struct UE5HostCameraDiagnosticsSnapshot(
+        string CurrentWorldName,
+        string CurrentLevelPath,
+        string[] SummaryLines,
+        string[] OwnershipLines,
+        string[] PcmLines,
+        string[] FinalViewLines,
+        string[] PawnLines,
+        string[] VerdictLines,
+        string[] ProbeLines)
+    {
+        public static UE5HostCameraDiagnosticsSnapshot Empty { get; } = new(
+            string.Empty,
+            string.Empty,
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            []);
+
+        public bool IsActive =>
+            !string.IsNullOrWhiteSpace(CurrentWorldName) ||
+            SummaryLines.Length > 0 ||
+            OwnershipLines.Length > 0 ||
+            PcmLines.Length > 0 ||
+            FinalViewLines.Length > 0 ||
+            PawnLines.Length > 0 ||
+            VerdictLines.Length > 0 ||
+            ProbeLines.Length > 0;
+    }
+
+    public sealed class UE5HostCameraDiagnosticsCommandState
+    {
+        public bool EnablePcmPulseProbe { get; set; }
+
+        public bool KeepPanelVisible { get; set; }
+
+        public string LastTriggerSource { get; set; } = string.Empty;
+
+        public void Reset()
+        {
+            EnablePcmPulseProbe = false;
+            KeepPanelVisible = false;
+            LastTriggerSource = string.Empty;
+        }
+    }
+}

--- a/src/Adapters/UE5/Ludots.Adapter.UE5/UE5HostComposer.cs
+++ b/src/Adapters/UE5/Ludots.Adapter.UE5/UE5HostComposer.cs
@@ -201,8 +201,13 @@ namespace Ludots.Adapter.UE5
                 ViewportWidth  = initialViewportWidth,
                 ViewportHeight = initialViewportHeight,
             };
+            var hostCameraDiagnosticsSnapshot = UE5HostCameraDiagnosticsSnapshot.Empty;
+            var hostCameraDiagnosticsCommands = new UE5HostCameraDiagnosticsCommandState();
 
             UE5HostBoundMapSessionInstaller.Install(engine);
+            engine.SetService(UE5AdapterServiceKeys.SharedCameraState, sharedState);
+            engine.SetService(UE5AdapterServiceKeys.HostCameraDiagnosticsSnapshot, hostCameraDiagnosticsSnapshot);
+            engine.SetService(UE5AdapterServiceKeys.HostCameraDiagnosticsCommands, hostCameraDiagnosticsCommands);
 
             // ── 4. 注入 UE5 适配器 ───────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- add shared UE5 host camera diagnostics snapshot and command-state contracts
- expose service keys for shared camera state and host camera diagnostics access
- keep this change limited to UE5 adapter contracts

## Testing
- validated in the Shipping camera investigation flow
- formal local chain rerun after the host-side fix: publish-ludots-shared, project generate, project build Runtime_Release, build-mod, write-runtime-bootstrap