### PR TITLE
Add spatial bounds showcase and hit geometry

### DIFF
--- a/launcher.config.json
+++ b/launcher.config.json
@@ -42,6 +42,14 @@
       }
     },
     {
+      "name": "spatial_bounds_showcase",
+      "target": {
+        "type": "path",
+        "value": "mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod",
+        "projectPath": "SpatialBoundsShowcaseMod.csproj"
+      }
+    },
+    {
       "name": "road_network_showcase",
       "target": {
         "type": "path",

--- a/launcher.presets.json
+++ b/launcher.presets.json
@@ -54,6 +54,15 @@
       ],
       "adapterId": "raylib",
       "buildMode": "auto"
+    },
+    {
+      "id": "spatial_bounds_showcase_raylib",
+      "name": "Spatial Bounds Showcase Raylib",
+      "selectors": [
+        "$spatial_bounds_showcase"
+      ],
+      "adapterId": "raylib",
+      "buildMode": "auto"
     }
   ]
 }

--- a/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/Runtime/SpatialBoundsShowcaseRuntime.cs
+++ b/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/Runtime/SpatialBoundsShowcaseRuntime.cs
@@ -1,0 +1,461 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Threading.Tasks;
+using Arch.Core;
+using Ludots.Core.Components;
+using Ludots.Core.Config;
+using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.Camera;
+using Ludots.Core.Gameplay.Components;
+using Ludots.Core.Input.Selection;
+using Ludots.Core.Presentation.Hud;
+using Ludots.Core.Scripting;
+using Ludots.Core.Spatial;
+using Ludots.Platform.Abstractions;
+using Ludots.UI;
+using SpatialBoundsShowcaseMod.UI;
+
+namespace SpatialBoundsShowcaseMod.Runtime
+{
+    internal sealed class SpatialBoundsShowcaseRuntime
+    {
+        private static readonly Vector4 PanelFill = new(0.05f, 0.08f, 0.11f, 0.88f);
+        private static readonly Vector4 PanelBorder = new(0.31f, 0.76f, 0.89f, 0.95f);
+        private static readonly Vector4 TitleColor = new(0.95f, 0.87f, 0.53f, 1f);
+        private static readonly Vector4 TextColor = new(0.91f, 0.95f, 0.98f, 1f);
+        private static readonly Vector4 HintColor = new(0.71f, 0.80f, 0.88f, 1f);
+        private static readonly Vector4 AccentColor = new(0.52f, 0.85f, 0.76f, 1f);
+        private static readonly Vector4 HoverFill = new(0.16f, 0.74f, 0.96f, 0.12f);
+        private static readonly Vector4 HoverBorder = new(0.36f, 0.88f, 1f, 0.98f);
+        private static readonly Vector4 SelectedFill = new(0.18f, 0.85f, 0.42f, 0.12f);
+        private static readonly Vector4 SelectedBorder = new(0.45f, 1f, 0.62f, 0.98f);
+        private static readonly Vector4 PrimaryFill = new(0.98f, 0.75f, 0.22f, 0.16f);
+        private static readonly Vector4 PrimaryBorder = new(1f, 0.9f, 0.42f, 0.98f);
+        private static readonly Vector4 FootprintStroke = new(0.94f, 0.54f, 0.28f, 0.92f);
+        private static readonly Vector4 FootprintVertex = new(1f, 0.84f, 0.42f, 0.98f);
+        private Entity _selectionOwner = Entity.Null;
+        private bool _ownsSelectionOwner;
+        private readonly SpatialBoundsShowcasePanelController _panelController;
+
+        public SpatialBoundsShowcaseRuntime()
+        {
+            _panelController = new SpatialBoundsShowcasePanelController(this);
+        }
+
+        public Task HandleMapFocusedAsync(ScriptContext context)
+        {
+            if (context.GetEngine() is not GameEngine engine)
+            {
+                return Task.CompletedTask;
+            }
+
+            if (!SpatialBoundsShowcaseIds.IsShowcaseMap(engine.CurrentMapSession?.MapId.Value))
+            {
+                Disable(engine);
+                return Task.CompletedTask;
+            }
+
+            EnsureSelectionContext(engine);
+            return Task.CompletedTask;
+        }
+
+        public Task HandleMapUnloadedAsync(ScriptContext context)
+        {
+            if (context.GetEngine() is not GameEngine engine)
+            {
+                return Task.CompletedTask;
+            }
+
+            if (SpatialBoundsShowcaseIds.IsShowcaseMap(context.Get(CoreServiceKeys.MapId).Value))
+            {
+                Disable(engine);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public void Update(GameEngine engine)
+        {
+            if (!SpatialBoundsShowcaseIds.IsShowcaseMap(engine.CurrentMapSession?.MapId.Value))
+            {
+                Disable(engine);
+                return;
+            }
+
+            EnsureSelectionContext(engine);
+            RefreshPanel(engine);
+            DrawOverlay(engine);
+        }
+
+        private void EnsureSelectionContext(GameEngine engine)
+        {
+            SelectionRuntime selection = engine.GetService(CoreServiceKeys.SelectionRuntime)
+                ?? throw new InvalidOperationException("SpatialBoundsShowcaseMod requires SelectionRuntime.");
+
+            if (_selectionOwner == Entity.Null || !engine.World.IsAlive(_selectionOwner))
+            {
+                _selectionOwner = ResolveExistingLocalPlayer(engine);
+                _ownsSelectionOwner = false;
+            }
+
+            if (_selectionOwner == Entity.Null || !engine.World.IsAlive(_selectionOwner))
+            {
+                _selectionOwner = engine.World.Create(
+                    new Name { Value = "SpatialBoundsViewer" },
+                    new PlayerOwner { PlayerId = 1 },
+                    default(SelectionDragState));
+                _ownsSelectionOwner = true;
+            }
+
+            if (!engine.World.Has<SelectionDragState>(_selectionOwner))
+            {
+                engine.World.Add(_selectionOwner, default(SelectionDragState));
+            }
+
+            selection.TryGetOrCreateSelectionEntity(_selectionOwner, SelectionSetKeys.LivePrimary, out _);
+            selection.TryBindView(_selectionOwner, SelectionViewKeys.Primary, _selectionOwner, SelectionSetKeys.LivePrimary);
+
+            engine.GlobalContext[CoreServiceKeys.LocalPlayerEntity.Name] = _selectionOwner;
+            engine.GlobalContext[CoreServiceKeys.SelectionViewViewerEntity.Name] = _selectionOwner;
+            engine.GlobalContext[CoreServiceKeys.SelectionViewKey.Name] = SelectionViewKeys.Primary;
+        }
+
+        private void DrawOverlay(GameEngine engine)
+        {
+            ScreenOverlayBuffer? overlay = engine.GetService(CoreServiceKeys.ScreenOverlayBuffer);
+            if (overlay == null)
+            {
+                return;
+            }
+
+            int x = 18;
+            int y = 18;
+            DrawSelectionFeedback(engine, overlay);
+            overlay.AddRect(x, y, 760, 344, PanelFill, PanelBorder, stableId: 53100, dirtySerial: 1);
+            overlay.AddText(x + 16, y + 18, "Spatial Bounds Showcase", 22, TitleColor, stableId: 53101, dirtySerial: 1);
+            overlay.AddText(x + 16, y + 48, "Bounds are Core-owned reusable semantics. VisualTransform drives projection only.", 14, HintColor, stableId: 53102, dirtySerial: 1);
+            overlay.AddText(x + 16, y + 70, "LMB click | drag marquee | Shift additive (QueueModifier) | Ctrl toggle (PrecisionModifier)", 14, AccentColor, stableId: 53103, dirtySerial: 1);
+            overlay.AddText(x + 16, y + 92, "Orange outlines show footprint polygons directly, including disjoint multi-polygon shapes.", 14, HintColor, stableId: 53104, dirtySerial: 1);
+            overlay.AddText(x + 16, y + 110, "No physics truth is implied here; downstream physics can sink these profiles when needed.", 14, HintColor, stableId: 53108, dirtySerial: 1);
+
+            string hovered = ResolveEntityLabel(engine.World, ResolveHoveredEntity(engine)) ?? "(none)";
+            string primary = ResolveEntityLabel(engine.World, ResolvePrimary(engine)) ?? "(none)";
+            string selected = BuildSelectionPreview(engine);
+            overlay.AddText(x + 16, y + 142, $"Hovered {hovered}", 15, TextColor, stableId: 53105, dirtySerial: 1);
+            overlay.AddText(x + 16, y + 164, $"Primary {primary}", 15, TextColor, stableId: 53106, dirtySerial: 1);
+            overlay.AddText(x + 16, y + 186, $"Selected {selected}", 14, TextColor, stableId: 53107, dirtySerial: 1);
+
+            int lineY = y + 222;
+            for (int i = 0; i < SpatialBoundsShowcaseIds.Descriptors.Length; i++)
+            {
+                ShowcaseEntityDescriptor descriptor = SpatialBoundsShowcaseIds.Descriptors[i];
+                string entry = $"{descriptor.Name} [{descriptor.Kind}] {descriptor.Hint}";
+                overlay.AddText(x + 16, lineY + (i * 18), entry, 13, TextColor, stableId: 53120 + i, dirtySerial: 1);
+            }
+        }
+
+        private void DrawSelectionFeedback(GameEngine engine, ScreenOverlayBuffer overlay)
+        {
+            if (engine.GetService(CoreServiceKeys.ScreenProjector) is not IScreenProjector projector)
+            {
+                return;
+            }
+
+            DrawFootprintPolygons(engine, overlay, projector);
+
+            Entity hovered = ResolveHoveredEntity(engine);
+            Entity primary = ResolvePrimary(engine);
+            int selectedCount = SelectionContextRuntime.GetCurrentCount(engine.World, engine.GlobalContext);
+            Span<Entity> selected = selectedCount <= 16
+                ? stackalloc Entity[Math.Max(selectedCount, 1)]
+                : new Entity[selectedCount];
+            int written = selectedCount > 0
+                ? SelectionContextRuntime.CopyCurrentSelection(engine.World, engine.GlobalContext, selected)
+                : 0;
+
+            for (int i = 0; i < written; i++)
+            {
+                Entity entity = selected[i];
+                if (entity == primary)
+                {
+                    continue;
+                }
+
+                AddEntityHighlight(engine, overlay, projector, entity, SelectedFill, SelectedBorder, 54100 + i, includeLabel: false);
+            }
+
+            AddEntityHighlight(engine, overlay, projector, hovered, HoverFill, HoverBorder, 54001, includeLabel: true);
+            AddEntityHighlight(engine, overlay, projector, primary, PrimaryFill, PrimaryBorder, 54002, includeLabel: true);
+        }
+
+        private static void DrawFootprintPolygons(GameEngine engine, ScreenOverlayBuffer overlay, IScreenProjector projector)
+        {
+            var polygonScratch = new Vector2[SpatialFootprint2D.MaxVerticesPerPolygon];
+            int stableId = 55000;
+
+            var query = new QueryDescription().WithAll<SpatialBounds, SpatialFootprint2D>();
+            engine.World.Query(in query, (Entity entity, ref SpatialBounds bounds, ref SpatialFootprint2D footprint) =>
+            {
+                if (bounds.Kind != SpatialBoundsKind.Footprint2D)
+                {
+                    return;
+                }
+
+                for (int polygonIndex = 0; polygonIndex < footprint.PolygonCount; polygonIndex++)
+                {
+                    if (!SpatialBoundsUtility.TryProjectFootprintScreenPolygon(
+                            engine.World,
+                            entity,
+                            projector,
+                            polygonIndex,
+                            polygonScratch,
+                            out int count) ||
+                        count < 3)
+                    {
+                        continue;
+                    }
+
+                    for (int i = 0; i < count; i++)
+                    {
+                        Vector2 from = polygonScratch[i];
+                        Vector2 to = polygonScratch[(i + 1) % count];
+                        DrawSegment(overlay, from, to, FootprintStroke, stableId);
+                        stableId += 8;
+
+                        DrawPoint(overlay, from, FootprintVertex, stableId);
+                        stableId += 8;
+                    }
+                }
+            });
+        }
+
+        private static void AddEntityHighlight(
+            GameEngine engine,
+            ScreenOverlayBuffer overlay,
+            IScreenProjector projector,
+            Entity entity,
+            Vector4 fill,
+            Vector4 border,
+            int stableIdBase,
+            bool includeLabel)
+        {
+            if (entity == Entity.Null ||
+                !engine.World.IsAlive(entity) ||
+                !SpatialBoundsUtility.TryProjectScreenBounds(engine.World, entity, projector, out ScreenRect bounds))
+            {
+                return;
+            }
+
+            const int padding = 6;
+            float width = bounds.MaxX - bounds.MinX;
+            float height = bounds.MaxY - bounds.MinY;
+            float centerX = (bounds.MinX + bounds.MaxX) * 0.5f;
+            float centerY = (bounds.MinY + bounds.MaxY) * 0.5f;
+            float renderWidth = MathF.Max(width, 16f) + (padding * 2);
+            float renderHeight = MathF.Max(height, 16f) + (padding * 2);
+            int x = (int)MathF.Round(centerX - (renderWidth * 0.5f));
+            int y = (int)MathF.Round(centerY - (renderHeight * 0.5f));
+            int rectWidth = (int)MathF.Round(renderWidth);
+            int rectHeight = (int)MathF.Round(renderHeight);
+            overlay.AddRect(x, y, rectWidth, rectHeight, fill, border, stableIdBase, dirtySerial: 1);
+
+            if (!includeLabel)
+            {
+                return;
+            }
+
+            string label = ResolveEntityLabel(engine.World, entity) ?? $"Entity#{entity.Id}";
+            overlay.AddText(x, Math.Max(4, y - 20), label, 14, border, stableIdBase + 1000, dirtySerial: 1);
+        }
+
+        private static void DrawSegment(ScreenOverlayBuffer overlay, Vector2 from, Vector2 to, Vector4 color, int stableIdBase)
+        {
+            float dx = to.X - from.X;
+            float dy = to.Y - from.Y;
+            float length = MathF.Sqrt((dx * dx) + (dy * dy));
+            if (length <= 1f)
+            {
+                DrawPoint(overlay, from, color, stableIdBase);
+                return;
+            }
+
+            int steps = Math.Max(1, (int)MathF.Ceiling(length / 8f));
+            for (int i = 0; i <= steps; i++)
+            {
+                float t = i / (float)steps;
+                var point = new Vector2(
+                    from.X + (dx * t),
+                    from.Y + (dy * t));
+                DrawPoint(overlay, point, color, stableIdBase + i);
+            }
+        }
+
+        private static void DrawPoint(ScreenOverlayBuffer overlay, Vector2 point, Vector4 color, int stableId)
+        {
+            int x = (int)MathF.Round(point.X) - 2;
+            int y = (int)MathF.Round(point.Y) - 2;
+            overlay.AddRect(x, y, 4, 4, color, color, stableId, dirtySerial: 1);
+        }
+
+        public bool TryResetCamera(GameEngine engine)
+        {
+            CameraConfig? cameraConfig = engine.CurrentMapSession?.MapConfig?.DefaultCamera;
+            if (cameraConfig == null)
+            {
+                return false;
+            }
+
+            string virtualCameraId = string.IsNullOrWhiteSpace(cameraConfig.VirtualCameraId)
+                ? "Camera.Profile.Tactical"
+                : cameraConfig.VirtualCameraId;
+
+            if (engine.GetService(CoreServiceKeys.VirtualCameraRegistry) is not VirtualCameraRegistry registry ||
+                !registry.TryGet(virtualCameraId, out VirtualCameraDefinition? definition) ||
+                definition == null)
+            {
+                return false;
+            }
+
+            engine.GameSession.Camera.ResetVirtualCameras();
+            engine.GameSession.Camera.ActivateVirtualCamera(
+                virtualCameraId,
+                blendDurationSeconds: 0f,
+                followTarget: CameraFollowTargetFactory.Build(engine.World, engine.GlobalContext, definition.FollowTargetKind),
+                snapToFollowTargetWhenAvailable: definition.SnapToFollowTargetWhenAvailable);
+
+            engine.GameSession.Camera.ApplyPose(new CameraPoseRequest
+            {
+                VirtualCameraId = virtualCameraId,
+                TargetCm = (cameraConfig.TargetXCm.HasValue || cameraConfig.TargetYCm.HasValue)
+                    ? new Vector2(cameraConfig.TargetXCm ?? 0f, cameraConfig.TargetYCm ?? 0f)
+                    : null,
+                Yaw = cameraConfig.Yaw,
+                Pitch = cameraConfig.Pitch,
+                DistanceCm = cameraConfig.DistanceCm,
+                FovYDeg = cameraConfig.FovYDeg
+            });
+
+            RefreshPanel(engine);
+            return true;
+        }
+
+        private void RefreshPanel(GameEngine engine)
+        {
+            if (engine.GetService(CoreServiceKeys.UIRoot) is not UIRoot root)
+            {
+                return;
+            }
+
+            _panelController.MountOrSync(root, engine, BuildPanelState(engine));
+        }
+
+        private static SpatialBoundsShowcasePanelState BuildPanelState(GameEngine engine)
+        {
+            Vector2 target = engine.GameSession.Camera.State.TargetCm;
+            return new SpatialBoundsShowcasePanelState(
+                "Spatial Bounds",
+                $"Camera ({target.X:0},{target.Y:0})  Dist {engine.GameSession.Camera.State.DistanceCm:0}",
+                "Use the button to recenter the showcase camera if you pan away.");
+        }
+
+        private string BuildSelectionPreview(GameEngine engine)
+        {
+            int count = SelectionContextRuntime.GetCurrentCount(engine.World, engine.GlobalContext);
+            if (count <= 0)
+            {
+                return "(empty)";
+            }
+
+            Span<Entity> selected = count <= 16
+                ? stackalloc Entity[count]
+                : new Entity[count];
+            int written = SelectionContextRuntime.CopyCurrentSelection(engine.World, engine.GlobalContext, selected);
+            if (written <= 0)
+            {
+                return "(empty)";
+            }
+
+            var names = new List<string>(Math.Min(written, 5) + 1);
+            int previewCount = Math.Min(written, 5);
+            for (int i = 0; i < previewCount; i++)
+            {
+                names.Add(ResolveEntityLabel(engine.World, selected[i]) ?? $"Entity#{selected[i].Id}");
+            }
+
+            if (written > previewCount)
+            {
+                names.Add($"+{written - previewCount} more");
+            }
+
+            return string.Join(", ", names);
+        }
+
+        private static Entity ResolveExistingLocalPlayer(GameEngine engine)
+        {
+            return engine.GlobalContext.TryGetValue(CoreServiceKeys.LocalPlayerEntity.Name, out var localObj) &&
+                   localObj is Entity local &&
+                   engine.World.IsAlive(local)
+                ? local
+                : Entity.Null;
+        }
+
+        private static Entity ResolvePrimary(GameEngine engine)
+        {
+            return SelectionContextRuntime.TryGetCurrentPrimary(engine.World, engine.GlobalContext, out Entity primary)
+                ? primary
+                : Entity.Null;
+        }
+
+        private static Entity ResolveHoveredEntity(GameEngine engine)
+        {
+            return engine.GlobalContext.TryGetValue(CoreServiceKeys.HoveredEntity.Name, out var hoveredObj) &&
+                   hoveredObj is Entity hovered &&
+                   hovered != Entity.Null &&
+                   engine.World.IsAlive(hovered)
+                ? hovered
+                : Entity.Null;
+        }
+
+        private static string? ResolveEntityLabel(World world, Entity entity)
+        {
+            if (entity == Entity.Null || !world.IsAlive(entity))
+            {
+                return null;
+            }
+
+            return world.TryGet(entity, out Name name) ? name.Value : null;
+        }
+
+        private void Disable(GameEngine engine)
+        {
+            if (engine.GetService(CoreServiceKeys.UIRoot) is UIRoot root)
+            {
+                _panelController.ClearIfOwned(root);
+            }
+
+            if (_ownsSelectionOwner && engine.World.IsAlive(_selectionOwner))
+            {
+                engine.World.Destroy(_selectionOwner);
+            }
+
+            if (engine.GlobalContext.TryGetValue(CoreServiceKeys.LocalPlayerEntity.Name, out var localObj) &&
+                localObj is Entity local &&
+                local == _selectionOwner)
+            {
+                engine.GlobalContext.Remove(CoreServiceKeys.LocalPlayerEntity.Name);
+            }
+
+            if (engine.GlobalContext.TryGetValue(CoreServiceKeys.SelectionViewViewerEntity.Name, out var viewerObj) &&
+                viewerObj is Entity viewer &&
+                viewer == _selectionOwner)
+            {
+                engine.GlobalContext.Remove(CoreServiceKeys.SelectionViewViewerEntity.Name);
+                engine.GlobalContext.Remove(CoreServiceKeys.SelectionViewKey.Name);
+            }
+
+            _selectionOwner = Entity.Null;
+            _ownsSelectionOwner = false;
+        }
+    }
+}

--- a/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/SpatialBoundsShowcaseIds.cs
+++ b/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/SpatialBoundsShowcaseIds.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace SpatialBoundsShowcaseMod
+{
+    internal static class SpatialBoundsShowcaseIds
+    {
+        public const string ShowcaseMapId = "spatial_bounds_showcase";
+
+        public static bool IsShowcaseMap(string? mapId)
+        {
+            return string.Equals(mapId, ShowcaseMapId, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static readonly ShowcaseEntityDescriptor[] Descriptors =
+        {
+            new("PointPin", "Point", "Baseline point-only hit profile."),
+            new("RectFootprint", "Footprint2D", "Single-polygon XZ footprint."),
+            new("DiamondFootprint", "Footprint2D", "Rotated polygon footprint through VisualTransform."),
+            new("TwinPads", "Footprint2D", "Two disjoint polygons in one reusable footprint."),
+            new("BoxTower", "Box3D", "3D box with explicit height and local Y center."),
+            new("OverlapPad", "Footprint2D", "Larger overlap target for tie-break inspection."),
+            new("OverlapPoint", "Point", "Smaller overlap target that should win shared clicks."),
+        };
+    }
+
+    internal readonly record struct ShowcaseEntityDescriptor(string Name, string Kind, string Hint);
+}

--- a/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/SpatialBoundsShowcaseMod.csproj
+++ b/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/SpatialBoundsShowcaseMod.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Core.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Libraries\Ludots.UI\Ludots.UI.csproj">
+      <Private>false</Private>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/SpatialBoundsShowcaseModEntry.cs
+++ b/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/SpatialBoundsShowcaseModEntry.cs
@@ -1,0 +1,35 @@
+using System.Threading.Tasks;
+using Ludots.Core.Modding;
+using Ludots.Core.Scripting;
+using SpatialBoundsShowcaseMod.Runtime;
+using SpatialBoundsShowcaseMod.Systems;
+
+namespace SpatialBoundsShowcaseMod
+{
+    public sealed class SpatialBoundsShowcaseModEntry : IMod
+    {
+        public void OnLoad(IModContext context)
+        {
+            context.Log("[SpatialBoundsShowcaseMod] Loaded");
+            var runtime = new SpatialBoundsShowcaseRuntime();
+
+            context.OnEvent(GameEvents.GameStart, ctx =>
+            {
+                var engine = ctx.GetEngine();
+                if (engine != null)
+                {
+                    engine.RegisterPresentationSystem(new SpatialBoundsShowcasePresentationSystem(engine, runtime));
+                }
+
+                return Task.CompletedTask;
+            });
+            context.OnEvent(GameEvents.MapLoaded, runtime.HandleMapFocusedAsync);
+            context.OnEvent(GameEvents.MapResumed, runtime.HandleMapFocusedAsync);
+            context.OnEvent(GameEvents.MapUnloaded, runtime.HandleMapUnloadedAsync);
+        }
+
+        public void OnUnload()
+        {
+        }
+    }
+}

--- a/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/Systems/SpatialBoundsShowcasePresentationSystem.cs
+++ b/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/Systems/SpatialBoundsShowcasePresentationSystem.cs
@@ -1,0 +1,28 @@
+using Arch.System;
+using Ludots.Core.Engine;
+using SpatialBoundsShowcaseMod.Runtime;
+
+namespace SpatialBoundsShowcaseMod.Systems
+{
+    internal sealed class SpatialBoundsShowcasePresentationSystem : ISystem<float>
+    {
+        private readonly GameEngine _engine;
+        private readonly SpatialBoundsShowcaseRuntime _runtime;
+
+        public SpatialBoundsShowcasePresentationSystem(GameEngine engine, SpatialBoundsShowcaseRuntime runtime)
+        {
+            _engine = engine;
+            _runtime = runtime;
+        }
+
+        public void Initialize() { }
+        public void BeforeUpdate(in float t) { }
+        public void AfterUpdate(in float t) { }
+        public void Dispose() { }
+
+        public void Update(in float t)
+        {
+            _runtime.Update(_engine);
+        }
+    }
+}

--- a/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/UI/SpatialBoundsShowcasePanelController.cs
+++ b/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/UI/SpatialBoundsShowcasePanelController.cs
@@ -1,0 +1,140 @@
+using System;
+using Ludots.Core.Engine;
+using Ludots.Core.Scripting;
+using Ludots.UI;
+using Ludots.UI.Compose;
+using Ludots.UI.Reactive;
+using Ludots.UI.Runtime;
+using SpatialBoundsShowcaseMod.Runtime;
+
+namespace SpatialBoundsShowcaseMod.UI
+{
+    internal sealed class SpatialBoundsShowcasePanelController
+    {
+        private readonly SpatialBoundsShowcaseRuntime _runtime;
+        private ReactivePage<SpatialBoundsShowcasePanelState>? _page;
+        private GameEngine? _engine;
+
+        public SpatialBoundsShowcasePanelController(SpatialBoundsShowcaseRuntime runtime)
+        {
+            _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        }
+
+        public bool MountOrSync(UIRoot root, GameEngine engine, in SpatialBoundsShowcasePanelState state)
+        {
+            ArgumentNullException.ThrowIfNull(root);
+            ArgumentNullException.ThrowIfNull(engine);
+
+            _engine = engine;
+            ReactivePage<SpatialBoundsShowcasePanelState>? page = EnsurePage();
+            if (page == null)
+            {
+                return false;
+            }
+
+            SpatialBoundsShowcasePanelState snapshot = state;
+            page.SetState(_ => snapshot);
+            root.IsDirty = true;
+            if (ReferenceEquals(root.Scene, page.Scene))
+            {
+                return true;
+            }
+
+            root.MountScene(page.Scene);
+            return true;
+        }
+
+        public void ClearIfOwned(UIRoot root)
+        {
+            ArgumentNullException.ThrowIfNull(root);
+
+            if (_page != null && ReferenceEquals(root.Scene, _page.Scene))
+            {
+                root.ClearScene();
+            }
+
+            _engine = null;
+        }
+
+        private ReactivePage<SpatialBoundsShowcasePanelState>? EnsurePage()
+        {
+            if (_page != null)
+            {
+                return _page;
+            }
+
+            GameEngine engine = RequireEngine();
+            if (engine.GetService(CoreServiceKeys.UiTextMeasurer) is not IUiTextMeasurer textMeasurer ||
+                engine.GetService(CoreServiceKeys.UiImageSizeProvider) is not IUiImageSizeProvider imageSizeProvider)
+            {
+                return null;
+            }
+
+            _page = new ReactivePage<SpatialBoundsShowcasePanelState>(
+                textMeasurer,
+                imageSizeProvider,
+                SpatialBoundsShowcasePanelState.Empty,
+                BuildRoot);
+            return _page;
+        }
+
+        private UiElementBuilder BuildRoot(ReactiveContext<SpatialBoundsShowcasePanelState> context)
+        {
+            SpatialBoundsShowcasePanelState state = context.State;
+            return Ui.Card(
+                    Ui.Text(state.Title).FontSize(16f).Bold().Color("#F7FAFF"),
+                    Ui.Text(state.Camera).FontSize(12f).Color("#8FD0FF"),
+                    CommandButton("Reset Camera", ResetCamera, "#244E66"),
+                    Ui.Text(state.Hint).FontSize(11f).Color("#B9C8D8").WhiteSpace(UiWhiteSpace.Normal))
+                .Width(220f)
+                .Padding(14f)
+                .Gap(8f)
+                .Radius(14f)
+                .Background("#D40B0E13")
+                .Border(1f, Color("#33879AB3"))
+                .BackdropBlur(8f)
+                .Absolute(16f, 372f)
+                .ZIndex(30);
+        }
+
+        private void ResetCamera()
+        {
+            GameEngine? engine = _engine;
+            if (engine == null)
+            {
+                return;
+            }
+
+            if (_runtime.TryResetCamera(engine) &&
+                engine.GetService(CoreServiceKeys.UIRoot) is UIRoot root)
+            {
+                root.IsDirty = true;
+            }
+        }
+
+        private GameEngine RequireEngine()
+        {
+            return _engine ?? throw new InvalidOperationException("SpatialBoundsShowcase panel requires an active engine.");
+        }
+
+        private static UiElementBuilder CommandButton(string label, Action onClick, string background)
+        {
+            return Ui.Button(label, _ => onClick())
+                .Padding(10f, 8f)
+                .Radius(10f)
+                .Background(background)
+                .Color("#F7FAFF")
+                .FontSize(11f);
+        }
+
+        private static UiColor Color(string hex)
+        {
+            if (!UiColor.TryParse(hex, out UiColor color))
+            {
+                throw new InvalidOperationException($"Unsupported color literal '{hex}'.");
+            }
+
+            return color;
+        }
+    }
+}

--- a/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/UI/SpatialBoundsShowcasePanelState.cs
+++ b/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/UI/SpatialBoundsShowcasePanelState.cs
@@ -1,0 +1,13 @@
+namespace SpatialBoundsShowcaseMod.UI
+{
+    internal readonly record struct SpatialBoundsShowcasePanelState(
+        string Title,
+        string Camera,
+        string Hint)
+    {
+        public static readonly SpatialBoundsShowcasePanelState Empty = new(
+            "Spatial Bounds",
+            "Camera (0,0)  Dist 0",
+            "Use Reset Camera to recenter the showcase.");
+    }
+}

--- a/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/assets/Entities/templates.json
+++ b/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/assets/Entities/templates.json
@@ -1,0 +1,121 @@
+[
+  {
+    "id": "spatial_bounds_point_pin",
+    "components": {
+      "Name": { "Value": "PointPin" },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } },
+      "Presentation": { "visualTemplateId": "core.character.hero_skinned" },
+      "SpatialBounds": { "kind": "Point" }
+    }
+  },
+  {
+    "id": "spatial_bounds_rect_footprint",
+    "components": {
+      "Name": { "Value": "RectFootprint" },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } },
+      "Presentation": { "visualTemplateId": "core.prop.dummy_static" },
+      "SpatialBounds": { "kind": "Footprint2D" },
+      "SpatialFootprint2D": {
+        "vertices": [
+          { "x": -190, "y": -120 },
+          { "x": 190, "y": -120 },
+          { "x": 190, "y": 120 },
+          { "x": -190, "y": 120 }
+        ]
+      }
+    }
+  },
+  {
+    "id": "spatial_bounds_diamond_footprint",
+    "components": {
+      "Name": { "Value": "DiamondFootprint" },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } },
+      "FacingDirection": { "AngleRad": 0.0 },
+      "Presentation": { "visualTemplateId": "core.prop.dummy_static" },
+      "SpatialBounds": { "kind": "Footprint2D" },
+      "SpatialFootprint2D": {
+        "vertices": [
+          { "x": 0, "y": -220 },
+          { "x": 190, "y": 0 },
+          { "x": 0, "y": 220 },
+          { "x": -190, "y": 0 }
+        ]
+      }
+    }
+  },
+  {
+    "id": "spatial_bounds_multi_footprint",
+    "components": {
+      "Name": { "Value": "TwinPads" },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } },
+      "Presentation": { "visualTemplateId": "core.prop.dummy_static" },
+      "SpatialBounds": { "kind": "Footprint2D" },
+      "SpatialFootprint2D": {
+        "polygons": [
+          [
+            { "x": -250, "y": -120 },
+            { "x": -70, "y": -120 },
+            { "x": -70, "y": 120 },
+            { "x": -250, "y": 120 }
+          ],
+          [
+            { "x": 70, "y": -120 },
+            { "x": 250, "y": -120 },
+            { "x": 250, "y": 120 },
+            { "x": 70, "y": 120 }
+          ]
+        ]
+      }
+    }
+  },
+  {
+    "id": "spatial_bounds_box_tower",
+    "components": {
+      "Name": { "Value": "BoxTower" },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } },
+      "Presentation": { "visualTemplateId": "core.character.hero_skinned" },
+      "SpatialBounds": {
+        "kind": "Box3D",
+        "localCenterYCm": 150
+      },
+      "SpatialBox3D": {
+        "halfSizeXCm": 120,
+        "halfSizeYCm": 150,
+        "halfSizeZCm": 120
+      }
+    }
+  },
+  {
+    "id": "spatial_bounds_overlap_pad",
+    "components": {
+      "Name": { "Value": "OverlapPad" },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } },
+      "Presentation": { "visualTemplateId": "core.prop.dummy_static" },
+      "SpatialBounds": { "kind": "Footprint2D" },
+      "SpatialFootprint2D": {
+        "vertices": [
+          { "x": -210, "y": -150 },
+          { "x": 210, "y": -150 },
+          { "x": 210, "y": 150 },
+          { "x": -210, "y": 150 }
+        ]
+      }
+    }
+  },
+  {
+    "id": "spatial_bounds_overlap_point",
+    "components": {
+      "Name": { "Value": "OverlapPoint" },
+      "SelectionSelectableTag": {},
+      "WorldPositionCm": { "Value": { "X": 0, "Y": 0 } },
+      "Presentation": { "visualTemplateId": "core.character.hero_skinned" },
+      "SpatialBounds": { "kind": "Point" }
+    }
+  }
+]

--- a/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/assets/Maps/spatial_bounds_showcase.json
+++ b/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/assets/Maps/spatial_bounds_showcase.json
@@ -1,0 +1,57 @@
+{
+  "Id": "spatial_bounds_showcase",
+  "Tags": ["showcase", "spatial_bounds", "selection", "input"],
+  "DefaultCamera": {
+    "VirtualCameraId": "Camera.Profile.Tactical",
+    "TargetXCm": 1750,
+    "TargetYCm": 1050,
+    "DistanceCm": 4300,
+    "Pitch": 54,
+    "FovYDeg": 42
+  },
+  "Entities": [
+    {
+      "Template": "spatial_bounds_point_pin",
+      "Overrides": {
+        "WorldPositionCm": { "Value": { "X": 800, "Y": 620 } }
+      }
+    },
+    {
+      "Template": "spatial_bounds_rect_footprint",
+      "Overrides": {
+        "WorldPositionCm": { "Value": { "X": 1380, "Y": 620 } }
+      }
+    },
+    {
+      "Template": "spatial_bounds_diamond_footprint",
+      "Overrides": {
+        "WorldPositionCm": { "Value": { "X": 2080, "Y": 620 } },
+        "FacingDirection": { "AngleRad": 0.7853982 }
+      }
+    },
+    {
+      "Template": "spatial_bounds_multi_footprint",
+      "Overrides": {
+        "WorldPositionCm": { "Value": { "X": 1080, "Y": 1420 } }
+      }
+    },
+    {
+      "Template": "spatial_bounds_box_tower",
+      "Overrides": {
+        "WorldPositionCm": { "Value": { "X": 1760, "Y": 1420 } }
+      }
+    },
+    {
+      "Template": "spatial_bounds_overlap_pad",
+      "Overrides": {
+        "WorldPositionCm": { "Value": { "X": 2440, "Y": 1280 } }
+      }
+    },
+    {
+      "Template": "spatial_bounds_overlap_point",
+      "Overrides": {
+        "WorldPositionCm": { "Value": { "X": 2440, "Y": 1280 } }
+      }
+    }
+  ]
+}

--- a/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/assets/game.json
+++ b/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/assets/game.json
@@ -1,0 +1,3 @@
+{
+  "startupMapId": "spatial_bounds_showcase"
+}

--- a/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/mod.json
+++ b/mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/mod.json
@@ -1,0 +1,14 @@
+{
+  "name": "SpatialBoundsShowcaseMod",
+  "version": "1.0.0",
+  "description": "Dedicated showcase for reusable spatial bounds, polygon footprints, multi-polygon footprints, and 3D selection boxes.",
+  "main": "bin/net8.0/SpatialBoundsShowcaseMod.dll",
+  "priority": 0,
+  "dependencies": {
+    "LudotsCoreMod": "^1.0.0",
+    "CoreInputMod": "^1.0.0",
+    "CameraProfilesMod": "^1.0.0"
+  },
+  "author": "Ludots Team",
+  "tags": ["showcase", "selection", "spatial", "bounds", "input"]
+}

--- a/src/Core/Config/ComponentRegistry.cs
+++ b/src/Core/Config/ComponentRegistry.cs
@@ -17,6 +17,7 @@ using Ludots.Core.Modding;
 using Ludots.Core.Physics;
 using Ludots.Core.Input.Selection;
 using Ludots.Core.Presentation.Components;
+using Ludots.Core.Spatial;
 
 namespace Ludots.Core.Config
 {
@@ -51,6 +52,9 @@ namespace Ludots.Core.Config
             Register("OrderBuffer", SetOrderBuffer);
             Register<SelectionSelectableTag>("SelectionSelectableTag");
             Register("SelectionSelectableState", SetSelectionSelectableState);
+            Register("SpatialBounds", SetSpatialBounds);
+            Register("SpatialBox3D", SetSpatialBox3D);
+            Register("SpatialFootprint2D", SetSpatialFootprint2D);
             Register<BlackboardSpatialBuffer>("BlackboardSpatialBuffer");
             Register<BlackboardEntityBuffer>("BlackboardEntityBuffer");
             Register<BlackboardIntBuffer>("BlackboardIntBuffer");
@@ -135,6 +139,97 @@ namespace Ludots.Core.Config
             entity.Add(state);
         }
 
+        private static void SetSpatialBounds(Entity entity, JsonNode data)
+        {
+            if (data is not JsonObject obj)
+            {
+                throw new InvalidOperationException("SpatialBounds requires an object payload.");
+            }
+
+            string kindRaw =
+                obj["kind"]?.GetValue<string>() ??
+                obj["Kind"]?.GetValue<string>() ??
+                throw new InvalidOperationException("SpatialBounds requires 'kind'.");
+
+            var bounds = new SpatialBounds
+            {
+                Kind = ParseSpatialBoundsKind(kindRaw),
+            };
+
+            if (TryReadPointProperty(obj, out var localCenter, "localCenterCm", "LocalCenterCm"))
+            {
+                bounds.LocalCenterXCm = localCenter.X;
+                bounds.LocalCenterZCm = localCenter.Y;
+            }
+            else
+            {
+                bounds.LocalCenterXCm = ReadIntProperty(obj, "localCenterXCm", "LocalCenterXCm");
+                bounds.LocalCenterZCm = ReadIntProperty(obj, "localCenterZCm", "LocalCenterZCm");
+            }
+
+            bounds.LocalCenterYCm = ReadIntProperty(obj, "localCenterYCm", "LocalCenterYCm");
+            entity.Add(bounds);
+        }
+
+        private static void SetSpatialBox3D(Entity entity, JsonNode data)
+        {
+            if (data is not JsonObject obj)
+            {
+                throw new InvalidOperationException("SpatialBox3D requires an object payload.");
+            }
+
+            entity.Add(new SpatialBox3D
+            {
+                HalfSizeXCm = ReadIntProperty(obj, "halfSizeXCm", "HalfSizeXCm"),
+                HalfSizeYCm = ReadIntProperty(obj, "halfSizeYCm", "HalfSizeYCm"),
+                HalfSizeZCm = ReadIntProperty(obj, "halfSizeZCm", "HalfSizeZCm"),
+            });
+        }
+
+        private static void SetSpatialFootprint2D(Entity entity, JsonNode data)
+        {
+            if (data is not JsonObject obj)
+            {
+                throw new InvalidOperationException("SpatialFootprint2D requires an object payload.");
+            }
+
+            JsonArray? polygons =
+                obj["polygons"] as JsonArray ??
+                obj["Polygons"] as JsonArray;
+            JsonArray? vertices =
+                obj["vertices"] as JsonArray ??
+                obj["Vertices"] as JsonArray;
+
+            var footprint = new SpatialFootprint2D();
+            if (polygons != null)
+            {
+                if (polygons.Count == 0 || polygons.Count > SpatialFootprint2D.MaxPolygons)
+                {
+                    throw new InvalidOperationException($"SpatialFootprint2D polygons count must be between 1 and {SpatialFootprint2D.MaxPolygons}.");
+                }
+
+                for (int polygonIndex = 0; polygonIndex < polygons.Count; polygonIndex++)
+                {
+                    if (polygons[polygonIndex] is not JsonArray polygonVertices)
+                    {
+                        throw new InvalidOperationException("SpatialFootprint2D polygons entries must be vertex arrays.");
+                    }
+
+                    SetFootprintPolygon(ref footprint, polygonIndex, polygonVertices);
+                }
+            }
+            else if (vertices != null)
+            {
+                SetFootprintPolygon(ref footprint, 0, vertices);
+            }
+            else
+            {
+                throw new InvalidOperationException("SpatialFootprint2D requires either 'vertices' or 'polygons'.");
+            }
+
+            entity.Add(footprint);
+        }
+
         private static void SetAbilityStateBuffer(Entity entity, JsonNode data)
         {
             var buffer = default(AbilityStateBuffer);
@@ -182,6 +277,51 @@ namespace Ludots.Core.Config
                 JsonValueKind.Number => node.GetValue<int>() != 0 ? (byte)1 : (byte)0,
                 _ => 0,
             };
+        }
+
+        private static SpatialBoundsKind ParseSpatialBoundsKind(string value)
+        {
+            if (string.Equals(value, "Point", StringComparison.OrdinalIgnoreCase))
+            {
+                return SpatialBoundsKind.Point;
+            }
+
+            if (string.Equals(value, "Footprint2D", StringComparison.OrdinalIgnoreCase))
+            {
+                return SpatialBoundsKind.Footprint2D;
+            }
+
+            if (string.Equals(value, "Box3D", StringComparison.OrdinalIgnoreCase))
+            {
+                return SpatialBoundsKind.Box3D;
+            }
+
+            throw new InvalidOperationException($"Unsupported SpatialBounds kind '{value}'. Expected Point, Footprint2D, or Box3D.");
+        }
+
+        private static void SetFootprintPolygon(ref SpatialFootprint2D footprint, int polygonIndex, JsonArray vertices)
+        {
+            if (vertices.Count < 3 || vertices.Count > SpatialFootprint2D.MaxVerticesPerPolygon)
+            {
+                throw new InvalidOperationException(
+                    $"SpatialFootprint2D polygon vertex count must be between 3 and {SpatialFootprint2D.MaxVerticesPerPolygon}.");
+            }
+
+            footprint.SetPolygonVertexCount(polygonIndex, vertices.Count);
+            for (int i = 0; i < vertices.Count; i++)
+            {
+                if (vertices[i] is not JsonObject pointObj)
+                {
+                    throw new InvalidOperationException("SpatialFootprint2D vertices entries must be objects with X/Y.");
+                }
+
+                footprint.SetVertex(
+                    polygonIndex,
+                    i,
+                    new WorldCmInt2(
+                        ReadIntProperty(pointObj, "x", "X"),
+                        ReadIntProperty(pointObj, "y", "Y")));
+            }
         }
 
         private static void SetWorldPositionCm(Entity entity, JsonNode data)

--- a/src/Core/Input/Selection/CurrentSelectionApplySystem.cs
+++ b/src/Core/Input/Selection/CurrentSelectionApplySystem.cs
@@ -8,6 +8,7 @@ using Ludots.Core.Mathematics;
 using Ludots.Core.Presentation.Components;
 using Ludots.Core.Registry;
 using Ludots.Core.Scripting;
+using Ludots.Core.Spatial;
 using Ludots.Platform.Abstractions;
 
 namespace Ludots.Core.Input.Selection
@@ -24,6 +25,7 @@ namespace Ludots.Core.Input.Selection
         private readonly Dictionary<string, object> _globals;
         private readonly SelectionRuntime _selection;
         private Entity[] _boxSelectionScratch = new Entity[16];
+        private Entity[] _selectionScratch = new Entity[16];
         private bool _suppressConfirmRelease;
 
         public Action<WorldCmInt2, Entity>? OnEntitySelected { get; set; }
@@ -92,7 +94,7 @@ namespace Ludots.Core.Input.Selection
 
             if (pointer.Confirm.PressedThisFrame)
             {
-                drag.Begin(pointer.Confirm.ResolvePressPointerOrCurrent());
+                drag.Begin(pointer.Confirm.ResolvePressPointerOrCurrent(), ResolveAcquisitionMode());
             }
             else if (drag.Active && pointer.Confirm.IsDown)
             {
@@ -102,15 +104,19 @@ namespace Ludots.Core.Input.Selection
             if (pointer.Confirm.ReleasedThisFrame && drag.Active)
             {
                 drag.CurrentScreen = pointer.Confirm.ResolveReleasePointerOrCurrent();
+                SelectionAcquisitionMode acquisitionMode = drag.AcquisitionMode;
 
                 if (drag.ExceedsThreshold(_selection.Config.DragThresholdPixels))
                 {
-                    ApplyBoxSelection(owner, in drag);
+                    ApplyBoxSelection(owner, in drag, acquisitionMode);
                 }
-                else if (pointer.HasGroundPoint)
+                else
                 {
-                    ApplyClickSelection(owner, hovered);
-                    OnEntitySelected?.Invoke(pointer.GroundWorldCm, hovered);
+                    ApplyClickSelection(owner, hovered, acquisitionMode);
+                    if (pointer.HasGroundPoint)
+                    {
+                        OnEntitySelected?.Invoke(pointer.GroundWorldCm, hovered);
+                    }
                 }
 
                 drag.Clear();
@@ -159,28 +165,30 @@ namespace Ludots.Core.Input.Selection
             }
         }
 
-        private void ApplyClickSelection(Entity owner, Entity clicked)
+        private void ApplyClickSelection(Entity owner, Entity clicked, SelectionAcquisitionMode acquisitionMode)
         {
             if (_world.IsAlive(clicked))
             {
-                Span<Entity> next = stackalloc Entity[1];
-                next[0] = clicked;
-                _selection.ReplaceSelection(owner, SelectionSetKeys.Ambient, next);
+                Span<Entity> hit = stackalloc Entity[1];
+                hit[0] = clicked;
+                ApplyAcquisition(owner, hit, acquisitionMode);
                 return;
             }
 
-            _selection.ClearSelection(owner, SelectionSetKeys.Ambient);
+            if (acquisitionMode == SelectionAcquisitionMode.Replace)
+            {
+                _selection.ClearSelection(owner, SelectionSetKeys.Ambient);
+            }
         }
 
-        private void ApplyBoxSelection(Entity owner, in SelectionDragState drag)
+        private void ApplyBoxSelection(Entity owner, in SelectionDragState drag, SelectionAcquisitionMode acquisitionMode)
         {
             if (!_globals.TryGetValue(CoreServiceKeys.ScreenProjector.Name, out var projectorObj) || projectorObj is not IScreenProjector projector)
             {
                 return;
             }
 
-            var min = Vector2.Min(drag.StartScreen, drag.CurrentScreen);
-            var max = Vector2.Max(drag.StartScreen, drag.CurrentScreen);
+            ScreenRect marquee = ScreenRect.FromPoints(drag.StartScreen, drag.CurrentScreen);
 
             int nextCount = 0;
             _world.Query(in SelectableQuery, (Entity entity, ref VisualTransform transform, ref CullState cull, ref SelectionSelectableTag selectable) =>
@@ -191,13 +199,7 @@ namespace Ludots.Core.Input.Selection
                     return;
                 }
 
-                Vector2 screen = projector.WorldToScreen(transform.Position);
-                if (float.IsNaN(screen.X) || float.IsNaN(screen.Y) || float.IsInfinity(screen.X) || float.IsInfinity(screen.Y))
-                {
-                    return;
-                }
-
-                if (screen.X < min.X || screen.X > max.X || screen.Y < min.Y || screen.Y > max.Y)
+                if (!SpatialBoundsUtility.EntityIntersectsScreenRect(_world, entity, projector, in marquee))
                 {
                     return;
                 }
@@ -207,7 +209,7 @@ namespace Ludots.Core.Input.Selection
             });
 
             SortByEntityId(_boxSelectionScratch, nextCount);
-            _selection.ReplaceSelection(owner, SelectionSetKeys.Ambient, _boxSelectionScratch.AsSpan(0, nextCount));
+            ApplyAcquisition(owner, _boxSelectionScratch.AsSpan(0, nextCount), acquisitionMode);
         }
 
         private void EnsureScratchCapacity(int required)
@@ -234,8 +236,8 @@ namespace Ludots.Core.Input.Selection
             }
 
             Entity best = default;
-            float bestD2 = float.MaxValue;
-            float maxD2 = radiusPixels * radiusPixels;
+            ScreenRect bestBounds = default;
+            bool hasBestBounds = false;
 
             _world.Query(in SelectableQuery, (Entity entity, ref VisualTransform transform, ref CullState cull, ref SelectionSelectableTag selectable) =>
             {
@@ -244,28 +246,137 @@ namespace Ludots.Core.Input.Selection
                     return;
                 }
 
-                Vector2 screen = projector.WorldToScreen(transform.Position);
-                if (float.IsNaN(screen.X) || float.IsNaN(screen.Y) || float.IsInfinity(screen.X) || float.IsInfinity(screen.Y))
+                if (!SpatialBoundsUtility.PointerHitsEntity(_world, entity, projector, pointer, radiusPixels))
                 {
                     return;
                 }
 
-                float dx = screen.X - pointer.X;
-                float dy = screen.Y - pointer.Y;
-                float d2 = dx * dx + dy * dy;
-                if (d2 > maxD2)
+                if (!SpatialBoundsUtility.TryProjectScreenBounds(_world, entity, projector, out ScreenRect candidateBounds))
                 {
                     return;
                 }
 
-                if (d2 < bestD2 || (d2 == bestD2 && (best == Entity.Null || Compare(entity, best) < 0)))
+                if (!hasBestBounds ||
+                    CompareProjectedBounds(candidateBounds, bestBounds, pointer) < 0 ||
+                    (CompareProjectedBounds(candidateBounds, bestBounds, pointer) == 0 && (best == Entity.Null || Compare(entity, best) < 0)))
                 {
-                    bestD2 = d2;
                     best = entity;
+                    bestBounds = candidateBounds;
+                    hasBestBounds = true;
                 }
             });
 
             return best;
+        }
+
+        private void ApplyAcquisition(Entity owner, ReadOnlySpan<Entity> hits, SelectionAcquisitionMode mode)
+        {
+            switch (mode)
+            {
+                case SelectionAcquisitionMode.Replace:
+                    _selection.ReplaceSelection(owner, SelectionSetKeys.Ambient, hits);
+                    return;
+
+                case SelectionAcquisitionMode.Additive:
+                    for (int i = 0; i < hits.Length; i++)
+                    {
+                        _selection.AddToSelection(owner, SelectionSetKeys.Ambient, hits[i]);
+                    }
+                    return;
+
+                case SelectionAcquisitionMode.Toggle:
+                    for (int i = 0; i < hits.Length; i++)
+                    {
+                        Entity target = hits[i];
+                        if (SelectionContains(owner, target))
+                        {
+                            _selection.RemoveFromSelection(owner, SelectionSetKeys.Ambient, target);
+                        }
+                        else
+                        {
+                            _selection.AddToSelection(owner, SelectionSetKeys.Ambient, target);
+                        }
+                    }
+                    return;
+
+                default:
+                    throw new InvalidOperationException($"Unsupported selection acquisition mode '{mode}'.");
+            }
+        }
+
+        private bool SelectionContains(Entity owner, Entity target)
+        {
+            int count = _selection.GetSelectionCount(owner, SelectionSetKeys.Ambient);
+            if (count <= 0)
+            {
+                return false;
+            }
+
+            EnsureSelectionScratchCapacity(count);
+            int written = _selection.CopySelection(owner, SelectionSetKeys.Ambient, _selectionScratch);
+            for (int i = 0; i < written; i++)
+            {
+                if (_selectionScratch[i] == target)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private SelectionAcquisitionMode ResolveAcquisitionMode()
+        {
+            if (_globals.TryGetValue(CoreServiceKeys.AuthoritativeInput.Name, out var inputObj) &&
+                inputObj is Ludots.Core.Input.Runtime.IInputActionReader input)
+            {
+                bool additive = input.IsDown(SelectionModifierActionIds.Additive);
+                bool toggle = input.IsDown(SelectionModifierActionIds.Toggle);
+                if (toggle)
+                {
+                    return SelectionAcquisitionMode.Toggle;
+                }
+
+                if (additive)
+                {
+                    return SelectionAcquisitionMode.Additive;
+                }
+            }
+
+            return SelectionAcquisitionMode.Replace;
+        }
+
+        private void EnsureSelectionScratchCapacity(int required)
+        {
+            if (required <= _selectionScratch.Length)
+            {
+                return;
+            }
+
+            int nextSize = _selectionScratch.Length;
+            while (nextSize < required)
+            {
+                nextSize *= 2;
+            }
+
+            Array.Resize(ref _selectionScratch, nextSize);
+        }
+
+        private static int CompareProjectedBounds(in ScreenRect candidate, in ScreenRect best, Vector2 pointer)
+        {
+            float candidateArea = MathF.Max(0f, candidate.MaxX - candidate.MinX) * MathF.Max(0f, candidate.MaxY - candidate.MinY);
+            float bestArea = MathF.Max(0f, best.MaxX - best.MinX) * MathF.Max(0f, best.MaxY - best.MinY);
+            int areaComparison = candidateArea.CompareTo(bestArea);
+            if (areaComparison != 0)
+            {
+                return areaComparison;
+            }
+
+            Vector2 candidateCenter = new((candidate.MinX + candidate.MaxX) * 0.5f, (candidate.MinY + candidate.MaxY) * 0.5f);
+            Vector2 bestCenter = new((best.MinX + best.MaxX) * 0.5f, (best.MinY + best.MaxY) * 0.5f);
+            float candidateD2 = Vector2.DistanceSquared(candidateCenter, pointer);
+            float bestD2 = Vector2.DistanceSquared(bestCenter, pointer);
+            return candidateD2.CompareTo(bestD2);
         }
 
         private static void SortByEntityId(Span<Entity> entities, int count)
@@ -305,5 +416,18 @@ namespace Ludots.Core.Input.Selection
             throw new InvalidOperationException(
                 $"{nameof(CurrentSelectionApplySystem)} requires {CoreServiceKeys.SelectionRuntime.Name} to be registered before construction.");
         }
+    }
+
+    public enum SelectionAcquisitionMode : byte
+    {
+        Replace = 0,
+        Additive = 1,
+        Toggle = 2,
+    }
+
+    public static class SelectionModifierActionIds
+    {
+        public const string Additive = "QueueModifier";
+        public const string Toggle = "PrecisionModifier";
     }
 }

--- a/src/Core/Input/Selection/SelectionComponents.cs
+++ b/src/Core/Input/Selection/SelectionComponents.cs
@@ -156,13 +156,21 @@ namespace Ludots.Core.Input.Selection
         public Vector2 StartScreen;
         public Vector2 CurrentScreen;
         public byte IsActive;
+        public byte AcquisitionModeValue;
 
         public readonly bool Active => IsActive != 0;
 
-        public void Begin(Vector2 screenPosition)
+        public SelectionAcquisitionMode AcquisitionMode
+        {
+            readonly get => (SelectionAcquisitionMode)AcquisitionModeValue;
+            set => AcquisitionModeValue = (byte)value;
+        }
+
+        public void Begin(Vector2 screenPosition, SelectionAcquisitionMode acquisitionMode)
         {
             StartScreen = screenPosition;
             CurrentScreen = screenPosition;
+            AcquisitionMode = acquisitionMode;
             IsActive = 1;
         }
 
@@ -170,6 +178,7 @@ namespace Ludots.Core.Input.Selection
         {
             StartScreen = default;
             CurrentScreen = default;
+            AcquisitionModeValue = 0;
             IsActive = 0;
         }
 

--- a/src/Core/Spatial/SpatialBoundsComponents.cs
+++ b/src/Core/Spatial/SpatialBoundsComponents.cs
@@ -1,0 +1,151 @@
+using System;
+using Ludots.Core.Mathematics;
+
+namespace Ludots.Core.Spatial
+{
+    public enum SpatialBoundsKind : byte
+    {
+        Point = 0,
+        Footprint2D = 1,
+        Box3D = 2,
+    }
+
+    /// <summary>
+    /// Core-owned local-space spatial bounds contract.
+    /// The local center is resolved through VisualTransform at runtime.
+    /// </summary>
+    public struct SpatialBounds
+    {
+        public byte KindValue;
+        public int LocalCenterXCm;
+        public int LocalCenterYCm;
+        public int LocalCenterZCm;
+
+        public SpatialBoundsKind Kind
+        {
+            readonly get => (SpatialBoundsKind)KindValue;
+            set => KindValue = (byte)value;
+        }
+
+        public static SpatialBounds Point => new()
+        {
+            Kind = SpatialBoundsKind.Point,
+        };
+    }
+
+    public struct SpatialBox3D
+    {
+        public int HalfSizeXCm;
+        public int HalfSizeYCm;
+        public int HalfSizeZCm;
+    }
+
+    /// <summary>
+    /// Footprint polygons live on the local XZ plane and are transformed by VisualTransform.
+    /// Multiple disjoint polygons are supported for selection and other screen-space queries.
+    /// </summary>
+    public unsafe struct SpatialFootprint2D
+    {
+        public const int MaxPolygons = 4;
+        public const int MaxVerticesPerPolygon = 8;
+        public const int MaxVertices = MaxPolygons * MaxVerticesPerPolygon;
+
+        public byte PolygonCount;
+        public fixed byte PolygonVertexCounts[MaxPolygons];
+        public fixed int VertexXs[MaxVertices];
+        public fixed int VertexZs[MaxVertices];
+
+        public void SetPolygonVertexCount(int polygonIndex, int vertexCount)
+        {
+            if ((uint)polygonIndex >= MaxPolygons)
+            {
+                throw new ArgumentOutOfRangeException(nameof(polygonIndex));
+            }
+
+            if (vertexCount < 0 || vertexCount > MaxVerticesPerPolygon)
+            {
+                throw new ArgumentOutOfRangeException(nameof(vertexCount));
+            }
+
+            fixed (byte* counts = PolygonVertexCounts)
+            {
+                counts[polygonIndex] = (byte)vertexCount;
+            }
+
+            if (PolygonCount < polygonIndex + 1)
+            {
+                PolygonCount = (byte)(polygonIndex + 1);
+            }
+        }
+
+        public readonly int GetPolygonVertexCount(int polygonIndex)
+        {
+            if ((uint)polygonIndex >= PolygonCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(polygonIndex));
+            }
+
+            fixed (byte* counts = PolygonVertexCounts)
+            {
+                return counts[polygonIndex];
+            }
+        }
+
+        public void SetVertex(int polygonIndex, int vertexIndex, in WorldCmInt2 value)
+        {
+            int offset = GetVertexOffset(polygonIndex, vertexIndex, requireDeclaredVertex: true);
+            fixed (int* xs = VertexXs)
+            fixed (int* zs = VertexZs)
+            {
+                xs[offset] = value.X;
+                zs[offset] = value.Y;
+            }
+        }
+
+        public readonly WorldCmInt2 GetVertex(int polygonIndex, int vertexIndex)
+        {
+            int offset = GetVertexOffset(polygonIndex, vertexIndex, requireDeclaredVertex: true);
+            fixed (int* xs = VertexXs)
+            fixed (int* zs = VertexZs)
+            {
+                return new WorldCmInt2(xs[offset], zs[offset]);
+            }
+        }
+
+        private readonly int GetVertexOffset(int polygonIndex, int vertexIndex, bool requireDeclaredVertex)
+        {
+            if ((uint)polygonIndex >= MaxPolygons)
+            {
+                throw new ArgumentOutOfRangeException(nameof(polygonIndex));
+            }
+
+            fixed (byte* counts = PolygonVertexCounts)
+            {
+                int polygonCount = PolygonCount;
+                if ((uint)polygonIndex >= polygonCount)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(polygonIndex));
+                }
+
+                int offset = 0;
+                for (int i = 0; i < polygonIndex; i++)
+                {
+                    offset += counts[i];
+                }
+
+                int count = counts[polygonIndex];
+                if (requireDeclaredVertex && ((uint)vertexIndex >= (uint)count))
+                {
+                    throw new ArgumentOutOfRangeException(nameof(vertexIndex));
+                }
+
+                if ((uint)vertexIndex >= MaxVerticesPerPolygon)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(vertexIndex));
+                }
+
+                return offset + vertexIndex;
+            }
+        }
+    }
+}

--- a/src/Core/Spatial/SpatialBoundsUtility.cs
+++ b/src/Core/Spatial/SpatialBoundsUtility.cs
@@ -1,0 +1,531 @@
+using System;
+using System.Numerics;
+using Arch.Core;
+using Ludots.Core.Presentation.Components;
+using Ludots.Platform.Abstractions;
+
+namespace Ludots.Core.Spatial
+{
+    public readonly record struct ScreenRect(float MinX, float MinY, float MaxX, float MaxY)
+    {
+        public bool Contains(Vector2 point)
+        {
+            return point.X >= MinX && point.X <= MaxX &&
+                   point.Y >= MinY && point.Y <= MaxY;
+        }
+
+        public bool Intersects(in ScreenRect other)
+        {
+            return MinX <= other.MaxX && MaxX >= other.MinX &&
+                   MinY <= other.MaxY && MaxY >= other.MinY;
+        }
+
+        public static ScreenRect FromPoints(Vector2 a, Vector2 b)
+        {
+            return new ScreenRect(
+                MathF.Min(a.X, b.X),
+                MathF.Min(a.Y, b.Y),
+                MathF.Max(a.X, b.X),
+                MathF.Max(a.Y, b.Y));
+        }
+    }
+
+    public static class SpatialBoundsUtility
+    {
+        public static bool TryProjectScreenBounds(
+            World world,
+            Entity entity,
+            IScreenProjector projector,
+            out ScreenRect bounds)
+        {
+            bounds = default;
+            if (!world.IsAlive(entity) ||
+                !world.Has<VisualTransform>(entity))
+            {
+                return false;
+            }
+
+            ref readonly var transform = ref world.Get<VisualTransform>(entity);
+            SpatialBounds spatialBounds = world.Has<SpatialBounds>(entity)
+                ? world.Get<SpatialBounds>(entity)
+                : SpatialBounds.Point;
+
+            switch (spatialBounds.Kind)
+            {
+                case SpatialBoundsKind.Point:
+                    {
+                        if (!TryProjectPoint(projector, ResolveWorldPoint(transform, in spatialBounds), out Vector2 point))
+                        {
+                            return false;
+                        }
+
+                        bounds = new ScreenRect(point.X, point.Y, point.X, point.Y);
+                        return true;
+                    }
+
+                case SpatialBoundsKind.Box3D:
+                    if (!world.Has<SpatialBox3D>(entity))
+                    {
+                        throw new InvalidOperationException($"Entity {entity} declares SpatialBounds.Box3D but is missing SpatialBox3D.");
+                    }
+
+                    return TryProjectBox(projector, transform, in spatialBounds, world.Get<SpatialBox3D>(entity), out bounds);
+
+                case SpatialBoundsKind.Footprint2D:
+                    if (!world.Has<SpatialFootprint2D>(entity))
+                    {
+                        throw new InvalidOperationException($"Entity {entity} declares SpatialBounds.Footprint2D but is missing SpatialFootprint2D.");
+                    }
+
+                    return TryProjectFootprintBounds(projector, transform, in spatialBounds, world.Get<SpatialFootprint2D>(entity), out bounds);
+
+                default:
+                    throw new InvalidOperationException($"Unsupported SpatialBoundsKind '{spatialBounds.Kind}'.");
+            }
+        }
+
+        public static bool TryProjectFootprintScreenPolygon(
+            World world,
+            Entity entity,
+            IScreenProjector projector,
+            int polygonIndex,
+            Span<Vector2> destination,
+            out int count)
+        {
+            count = 0;
+            if (!world.IsAlive(entity) ||
+                !world.Has<VisualTransform>(entity) ||
+                !world.Has<SpatialBounds>(entity) ||
+                !world.Has<SpatialFootprint2D>(entity))
+            {
+                return false;
+            }
+
+            ref readonly var transform = ref world.Get<VisualTransform>(entity);
+            SpatialBounds spatialBounds = world.Get<SpatialBounds>(entity);
+            if (spatialBounds.Kind != SpatialBoundsKind.Footprint2D)
+            {
+                return false;
+            }
+
+            return TryProjectFootprintPolygon(
+                projector,
+                transform,
+                in spatialBounds,
+                world.Get<SpatialFootprint2D>(entity),
+                polygonIndex,
+                destination,
+                out count);
+        }
+
+        public static bool PointerHitsEntity(
+            World world,
+            Entity entity,
+            IScreenProjector projector,
+            Vector2 pointer,
+            float pointPickRadiusPixels)
+        {
+            if (!world.IsAlive(entity) || !world.Has<VisualTransform>(entity))
+            {
+                return false;
+            }
+
+            ref readonly var transform = ref world.Get<VisualTransform>(entity);
+            SpatialBounds spatialBounds = world.Has<SpatialBounds>(entity)
+                ? world.Get<SpatialBounds>(entity)
+                : SpatialBounds.Point;
+
+            return spatialBounds.Kind switch
+            {
+                SpatialBoundsKind.Point => PointerHitsPoint(projector, transform, in spatialBounds, pointer, pointPickRadiusPixels),
+                SpatialBoundsKind.Box3D => world.Has<SpatialBox3D>(entity) &&
+                                           PointerHitsBox(projector, transform, in spatialBounds, world.Get<SpatialBox3D>(entity), pointer),
+                SpatialBoundsKind.Footprint2D => world.Has<SpatialFootprint2D>(entity) &&
+                                                 PointerHitsFootprint(projector, transform, in spatialBounds, world.Get<SpatialFootprint2D>(entity), pointer),
+                _ => false,
+            };
+        }
+
+        public static bool EntityIntersectsScreenRect(
+            World world,
+            Entity entity,
+            IScreenProjector projector,
+            in ScreenRect marquee)
+        {
+            if (!world.IsAlive(entity) || !world.Has<VisualTransform>(entity))
+            {
+                return false;
+            }
+
+            ref readonly var transform = ref world.Get<VisualTransform>(entity);
+            SpatialBounds spatialBounds = world.Has<SpatialBounds>(entity)
+                ? world.Get<SpatialBounds>(entity)
+                : SpatialBounds.Point;
+
+            return spatialBounds.Kind switch
+            {
+                SpatialBoundsKind.Point => TryProjectPoint(projector, ResolveWorldPoint(transform, in spatialBounds), out Vector2 point) &&
+                                           marquee.Contains(point),
+                SpatialBoundsKind.Box3D => world.Has<SpatialBox3D>(entity) &&
+                                           TryProjectBox(projector, transform, in spatialBounds, world.Get<SpatialBox3D>(entity), out ScreenRect boxRect) &&
+                                           marquee.Intersects(in boxRect),
+                SpatialBoundsKind.Footprint2D => world.Has<SpatialFootprint2D>(entity) &&
+                                                 FootprintIntersectsRect(projector, transform, in spatialBounds, world.Get<SpatialFootprint2D>(entity), in marquee),
+                _ => false,
+            };
+        }
+
+        private static bool PointerHitsPoint(
+            IScreenProjector projector,
+            in VisualTransform transform,
+            in SpatialBounds spatialBounds,
+            Vector2 pointer,
+            float radiusPixels)
+        {
+            if (!TryProjectPoint(projector, ResolveWorldPoint(transform, in spatialBounds), out Vector2 point))
+            {
+                return false;
+            }
+
+            float dx = point.X - pointer.X;
+            float dy = point.Y - pointer.Y;
+            return (dx * dx) + (dy * dy) <= radiusPixels * radiusPixels;
+        }
+
+        private static bool PointerHitsBox(
+            IScreenProjector projector,
+            in VisualTransform transform,
+            in SpatialBounds spatialBounds,
+            in SpatialBox3D box,
+            Vector2 pointer)
+        {
+            return TryProjectBox(projector, transform, in spatialBounds, in box, out ScreenRect bounds) &&
+                   bounds.Contains(pointer);
+        }
+
+        private static bool PointerHitsFootprint(
+            IScreenProjector projector,
+            in VisualTransform transform,
+            in SpatialBounds spatialBounds,
+            in SpatialFootprint2D footprint,
+            Vector2 pointer)
+        {
+            Span<Vector2> projected = stackalloc Vector2[SpatialFootprint2D.MaxVerticesPerPolygon];
+            for (int polygonIndex = 0; polygonIndex < footprint.PolygonCount; polygonIndex++)
+            {
+                int count = footprint.GetPolygonVertexCount(polygonIndex);
+                if (count < 3)
+                {
+                    continue;
+                }
+
+                if (!TryProjectFootprintPolygon(projector, transform, in spatialBounds, in footprint, polygonIndex, projected, out int projectedCount))
+                {
+                    continue;
+                }
+
+                if (PointInPolygon(pointer, projected.Slice(0, projectedCount)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool FootprintIntersectsRect(
+            IScreenProjector projector,
+            in VisualTransform transform,
+            in SpatialBounds spatialBounds,
+            in SpatialFootprint2D footprint,
+            in ScreenRect marquee)
+        {
+            Span<Vector2> projected = stackalloc Vector2[SpatialFootprint2D.MaxVerticesPerPolygon];
+            for (int polygonIndex = 0; polygonIndex < footprint.PolygonCount; polygonIndex++)
+            {
+                int count = footprint.GetPolygonVertexCount(polygonIndex);
+                if (count < 3)
+                {
+                    continue;
+                }
+
+                if (!TryProjectFootprintPolygon(projector, transform, in spatialBounds, in footprint, polygonIndex, projected, out int projectedCount))
+                {
+                    continue;
+                }
+
+                if (PolygonIntersectsRect(projected.Slice(0, projectedCount), in marquee))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryProjectFootprintBounds(
+            IScreenProjector projector,
+            in VisualTransform transform,
+            in SpatialBounds spatialBounds,
+            in SpatialFootprint2D footprint,
+            out ScreenRect bounds)
+        {
+            bounds = default;
+            bool hasPoint = false;
+            float minX = 0f;
+            float minY = 0f;
+            float maxX = 0f;
+            float maxY = 0f;
+            Span<Vector2> projected = stackalloc Vector2[SpatialFootprint2D.MaxVerticesPerPolygon];
+
+            for (int polygonIndex = 0; polygonIndex < footprint.PolygonCount; polygonIndex++)
+            {
+                if (!TryProjectFootprintPolygon(projector, transform, in spatialBounds, in footprint, polygonIndex, projected, out int projectedCount))
+                {
+                    continue;
+                }
+
+                for (int i = 0; i < projectedCount; i++)
+                {
+                    Vector2 point = projected[i];
+                    if (!hasPoint)
+                    {
+                        minX = maxX = point.X;
+                        minY = maxY = point.Y;
+                        hasPoint = true;
+                    }
+                    else
+                    {
+                        minX = MathF.Min(minX, point.X);
+                        minY = MathF.Min(minY, point.Y);
+                        maxX = MathF.Max(maxX, point.X);
+                        maxY = MathF.Max(maxY, point.Y);
+                    }
+                }
+            }
+
+            if (!hasPoint)
+            {
+                return false;
+            }
+
+            bounds = new ScreenRect(minX, minY, maxX, maxY);
+            return true;
+        }
+
+        private static bool TryProjectBox(
+            IScreenProjector projector,
+            in VisualTransform transform,
+            in SpatialBounds spatialBounds,
+            in SpatialBox3D box,
+            out ScreenRect bounds)
+        {
+            bounds = default;
+
+            Vector3 center = ResolveWorldPoint(transform, in spatialBounds);
+            Vector3 half = new(
+                CmToMeters(box.HalfSizeXCm) * transform.Scale.X,
+                CmToMeters(box.HalfSizeYCm) * transform.Scale.Y,
+                CmToMeters(box.HalfSizeZCm) * transform.Scale.Z);
+
+            Span<Vector3> corners = stackalloc Vector3[8];
+            corners[0] = new Vector3(-half.X, -half.Y, -half.Z);
+            corners[1] = new Vector3(half.X, -half.Y, -half.Z);
+            corners[2] = new Vector3(-half.X, half.Y, -half.Z);
+            corners[3] = new Vector3(half.X, half.Y, -half.Z);
+            corners[4] = new Vector3(-half.X, -half.Y, half.Z);
+            corners[5] = new Vector3(half.X, -half.Y, half.Z);
+            corners[6] = new Vector3(-half.X, half.Y, half.Z);
+            corners[7] = new Vector3(half.X, half.Y, half.Z);
+
+            bool hasProjectedPoint = false;
+            float minX = 0f;
+            float minY = 0f;
+            float maxX = 0f;
+            float maxY = 0f;
+            for (int i = 0; i < corners.Length; i++)
+            {
+                Vector3 worldPoint = center + Vector3.Transform(corners[i], transform.Rotation);
+                if (!TryProjectPoint(projector, worldPoint, out Vector2 projected))
+                {
+                    continue;
+                }
+
+                if (!hasProjectedPoint)
+                {
+                    minX = maxX = projected.X;
+                    minY = maxY = projected.Y;
+                    hasProjectedPoint = true;
+                }
+                else
+                {
+                    minX = MathF.Min(minX, projected.X);
+                    minY = MathF.Min(minY, projected.Y);
+                    maxX = MathF.Max(maxX, projected.X);
+                    maxY = MathF.Max(maxY, projected.Y);
+                }
+            }
+
+            if (!hasProjectedPoint)
+            {
+                return false;
+            }
+
+            bounds = new ScreenRect(minX, minY, maxX, maxY);
+            return true;
+        }
+
+        private static bool TryProjectFootprintPolygon(
+            IScreenProjector projector,
+            in VisualTransform transform,
+            in SpatialBounds spatialBounds,
+            in SpatialFootprint2D footprint,
+            int polygonIndex,
+            Span<Vector2> destination,
+            out int count)
+        {
+            count = footprint.GetPolygonVertexCount(polygonIndex);
+            if (count < 3 || destination.Length < count)
+            {
+                count = 0;
+                return false;
+            }
+
+            Vector3 center = ResolveWorldPoint(transform, in spatialBounds);
+            for (int i = 0; i < count; i++)
+            {
+                var vertex = footprint.GetVertex(polygonIndex, i);
+                Vector3 local = new(
+                    CmToMeters(vertex.X) * transform.Scale.X,
+                    0f,
+                    CmToMeters(vertex.Y) * transform.Scale.Z);
+                Vector3 worldPoint = center + Vector3.Transform(local, transform.Rotation);
+                if (!TryProjectPoint(projector, worldPoint, out destination[i]))
+                {
+                    count = 0;
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static Vector3 ResolveWorldPoint(in VisualTransform transform, in SpatialBounds spatialBounds)
+        {
+            Vector3 local = new(
+                CmToMeters(spatialBounds.LocalCenterXCm) * transform.Scale.X,
+                CmToMeters(spatialBounds.LocalCenterYCm) * transform.Scale.Y,
+                CmToMeters(spatialBounds.LocalCenterZCm) * transform.Scale.Z);
+            return transform.Position + Vector3.Transform(local, transform.Rotation);
+        }
+
+        private static bool TryProjectPoint(IScreenProjector projector, Vector3 worldPoint, out Vector2 projected)
+        {
+            projected = projector.WorldToScreen(worldPoint);
+            return !(float.IsNaN(projected.X) ||
+                     float.IsNaN(projected.Y) ||
+                     float.IsInfinity(projected.X) ||
+                     float.IsInfinity(projected.Y));
+        }
+
+        private static float CmToMeters(int valueCm) => valueCm / 100f;
+
+        private static bool PolygonIntersectsRect(ReadOnlySpan<Vector2> polygon, in ScreenRect rect)
+        {
+            for (int i = 0; i < polygon.Length; i++)
+            {
+                if (rect.Contains(polygon[i]))
+                {
+                    return true;
+                }
+            }
+
+            var rectTopLeft = new Vector2(rect.MinX, rect.MinY);
+            var rectTopRight = new Vector2(rect.MaxX, rect.MinY);
+            var rectBottomRight = new Vector2(rect.MaxX, rect.MaxY);
+            var rectBottomLeft = new Vector2(rect.MinX, rect.MaxY);
+
+            if (PointInPolygon(rectTopLeft, polygon) ||
+                PointInPolygon(rectTopRight, polygon) ||
+                PointInPolygon(rectBottomRight, polygon) ||
+                PointInPolygon(rectBottomLeft, polygon))
+            {
+                return true;
+            }
+
+            for (int i = 0; i < polygon.Length; i++)
+            {
+                Vector2 a = polygon[i];
+                Vector2 b = polygon[(i + 1) % polygon.Length];
+                if (SegmentIntersectsRect(a, b, in rect))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool SegmentIntersectsRect(Vector2 a, Vector2 b, in ScreenRect rect)
+        {
+            var rectTopLeft = new Vector2(rect.MinX, rect.MinY);
+            var rectTopRight = new Vector2(rect.MaxX, rect.MinY);
+            var rectBottomRight = new Vector2(rect.MaxX, rect.MaxY);
+            var rectBottomLeft = new Vector2(rect.MinX, rect.MaxY);
+
+            return SegmentsIntersect(a, b, rectTopLeft, rectTopRight) ||
+                   SegmentsIntersect(a, b, rectTopRight, rectBottomRight) ||
+                   SegmentsIntersect(a, b, rectBottomRight, rectBottomLeft) ||
+                   SegmentsIntersect(a, b, rectBottomLeft, rectTopLeft);
+        }
+
+        private static bool PointInPolygon(Vector2 point, ReadOnlySpan<Vector2> polygon)
+        {
+            bool inside = false;
+            for (int i = 0, j = polygon.Length - 1; i < polygon.Length; j = i++)
+            {
+                Vector2 pi = polygon[i];
+                Vector2 pj = polygon[j];
+
+                bool intersects = ((pi.Y > point.Y) != (pj.Y > point.Y)) &&
+                                  (point.X < ((pj.X - pi.X) * (point.Y - pi.Y) / ((pj.Y - pi.Y) + float.Epsilon)) + pi.X);
+                if (intersects)
+                {
+                    inside = !inside;
+                }
+            }
+
+            return inside;
+        }
+
+        private static bool SegmentsIntersect(Vector2 a1, Vector2 a2, Vector2 b1, Vector2 b2)
+        {
+            float d1 = Cross(a1, a2, b1);
+            float d2 = Cross(a1, a2, b2);
+            float d3 = Cross(b1, b2, a1);
+            float d4 = Cross(b1, b2, a2);
+
+            if (((d1 > 0f && d2 < 0f) || (d1 < 0f && d2 > 0f)) &&
+                ((d3 > 0f && d4 < 0f) || (d3 < 0f && d4 > 0f)))
+            {
+                return true;
+            }
+
+            return (d1 == 0f && OnSegment(a1, a2, b1)) ||
+                   (d2 == 0f && OnSegment(a1, a2, b2)) ||
+                   (d3 == 0f && OnSegment(b1, b2, a1)) ||
+                   (d4 == 0f && OnSegment(b1, b2, a2));
+        }
+
+        private static float Cross(Vector2 a, Vector2 b, Vector2 c)
+        {
+            return ((b.X - a.X) * (c.Y - a.Y)) - ((b.Y - a.Y) * (c.X - a.X));
+        }
+
+        private static bool OnSegment(Vector2 a, Vector2 b, Vector2 p)
+        {
+            return p.X >= MathF.Min(a.X, b.X) && p.X <= MathF.Max(a.X, b.X) &&
+                   p.Y >= MathF.Min(a.Y, b.Y) && p.Y <= MathF.Max(a.Y, b.Y);
+        }
+    }
+}

--- a/src/Tests/GasTests/InteractionSelectionConvergenceTests.cs
+++ b/src/Tests/GasTests/InteractionSelectionConvergenceTests.cs
@@ -871,6 +871,209 @@ namespace Ludots.Tests.GAS
         }
 
         [Test]
+        public void CurrentSelectionApplySystem_ClickUsesFootprintPolygonInsteadOfProjectedOriginOnly()
+        {
+            using var world = World.Create();
+
+            var input = new PlayerInputHandler(new NullInputBackend(), CreateInputConfig());
+            var local = world.Create();
+            var entity = world.Create(
+                WorldPositionCm.FromCm(1600, 1200),
+                new VisualTransform { Position = new Vector3(16f, 0f, 12f) },
+                new CullState { IsVisible = true },
+                new SelectionSelectableTag(),
+                new SpatialBounds { Kind = SpatialBoundsKind.Footprint2D },
+                CreateRectFootprint(0, 0, 300, 200));
+
+            var globals = new Dictionary<string, object>
+            {
+                [CoreServiceKeys.AuthoritativeInput.Name] = input,
+                [CoreServiceKeys.AuthoritativePointerButtons.Name] = new AuthoritativePointerButtonSnapshot(),
+                [CoreServiceKeys.ScreenRayProvider.Name] = new WorldMappedScreenRayProvider(),
+                [CoreServiceKeys.VisualHeightmap.Name] = CreateFlatHeightmap(),
+                [CoreServiceKeys.ScreenProjector.Name] = new WorldMappedScreenProjector(),
+                [CoreServiceKeys.WorldSizeSpec.Name] = CreateWorldSizeSpec(),
+                [CoreServiceKeys.LocalPlayerEntity.Name] = local,
+                [CoreServiceKeys.InteractionActionBindings.Name] = new InteractionActionBindings(),
+            };
+            var selectionRuntime = CreateSelectionRuntime(world, globals);
+            var system = new CurrentSelectionApplySystem(world, globals);
+
+            Click(system, globals, input, new Vector2(1800f, 1200f));
+
+            AssertSelection(selectionRuntime, local, entity);
+        }
+
+        [Test]
+        public void CurrentSelectionApplySystem_DragSelectUsesFootprintIntersection()
+        {
+            using var world = World.Create();
+
+            var input = new PlayerInputHandler(new NullInputBackend(), CreateInputConfig());
+            var local = world.Create();
+            var entity = world.Create(
+                WorldPositionCm.FromCm(3000, 1500),
+                new VisualTransform { Position = new Vector3(30f, 0f, 15f) },
+                new CullState { IsVisible = true },
+                new SelectionSelectableTag(),
+                new SpatialBounds { Kind = SpatialBoundsKind.Footprint2D, LocalCenterXCm = -250 },
+                CreateRectFootprint(0, 0, 600, 300));
+
+            var globals = new Dictionary<string, object>
+            {
+                [CoreServiceKeys.AuthoritativeInput.Name] = input,
+                [CoreServiceKeys.AuthoritativePointerButtons.Name] = new AuthoritativePointerButtonSnapshot(),
+                [CoreServiceKeys.ScreenRayProvider.Name] = new WorldMappedScreenRayProvider(),
+                [CoreServiceKeys.VisualHeightmap.Name] = CreateFlatHeightmap(),
+                [CoreServiceKeys.ScreenProjector.Name] = new WorldMappedScreenProjector(),
+                [CoreServiceKeys.WorldSizeSpec.Name] = CreateWorldSizeSpec(),
+                [CoreServiceKeys.LocalPlayerEntity.Name] = local,
+                [CoreServiceKeys.InteractionActionBindings.Name] = new InteractionActionBindings(),
+            };
+            var selectionRuntime = CreateSelectionRuntime(world, globals);
+            var system = new CurrentSelectionApplySystem(world, globals);
+
+            DragSelect(system, globals, input, new Vector2(2500f, 1300f), new Vector2(2850f, 1700f));
+
+            AssertSelection(selectionRuntime, local, entity);
+        }
+
+        [Test]
+        public void CurrentSelectionApplySystem_Box3DProjectedBoundsAreSelectable()
+        {
+            using var world = World.Create();
+
+            var input = new PlayerInputHandler(new NullInputBackend(), CreateInputConfig());
+            var local = world.Create();
+            var entity = world.Create(
+                WorldPositionCm.FromCm(1600, 1200),
+                new VisualTransform { Position = new Vector3(16f, 0f, 12f) },
+                new CullState { IsVisible = true },
+                new SelectionSelectableTag(),
+                new SpatialBounds { Kind = SpatialBoundsKind.Box3D, LocalCenterYCm = 100 },
+                new SpatialBox3D { HalfSizeXCm = 150, HalfSizeYCm = 100, HalfSizeZCm = 150 });
+
+            var globals = new Dictionary<string, object>
+            {
+                [CoreServiceKeys.AuthoritativeInput.Name] = input,
+                [CoreServiceKeys.AuthoritativePointerButtons.Name] = new AuthoritativePointerButtonSnapshot(),
+                [CoreServiceKeys.ScreenRayProvider.Name] = new WorldMappedScreenRayProvider(),
+                [CoreServiceKeys.VisualHeightmap.Name] = CreateFlatHeightmap(),
+                [CoreServiceKeys.ScreenProjector.Name] = new WorldMappedScreenProjector(),
+                [CoreServiceKeys.WorldSizeSpec.Name] = CreateWorldSizeSpec(),
+                [CoreServiceKeys.LocalPlayerEntity.Name] = local,
+                [CoreServiceKeys.InteractionActionBindings.Name] = new InteractionActionBindings(),
+            };
+            var selectionRuntime = CreateSelectionRuntime(world, globals);
+            var system = new CurrentSelectionApplySystem(world, globals);
+
+            Click(system, globals, input, new Vector2(1700f, 1200f));
+
+            AssertSelection(selectionRuntime, local, entity);
+        }
+
+        [Test]
+        public void CurrentSelectionApplySystem_ClickWithoutGroundPoint_StillSelectsHoveredEntity()
+        {
+            using var world = World.Create();
+
+            var input = new PlayerInputHandler(new NullInputBackend(), CreateInputConfig());
+            var local = world.Create();
+            var entity = world.Create(
+                WorldPositionCm.FromCm(1600, 1200),
+                new VisualTransform { Position = new Vector3(16f, 0f, 12f) },
+                new CullState { IsVisible = true },
+                new SelectionSelectableTag(),
+                new SpatialBounds { Kind = SpatialBoundsKind.Footprint2D },
+                CreateRectFootprint(0, 0, 300, 200));
+
+            var globals = new Dictionary<string, object>
+            {
+                [CoreServiceKeys.AuthoritativeInput.Name] = input,
+                [CoreServiceKeys.AuthoritativePointerButtons.Name] = new AuthoritativePointerButtonSnapshot(),
+                [CoreServiceKeys.ScreenProjector.Name] = new WorldMappedScreenProjector(),
+                [CoreServiceKeys.LocalPlayerEntity.Name] = local,
+                [CoreServiceKeys.InteractionActionBindings.Name] = new InteractionActionBindings(),
+            };
+            var selectionRuntime = CreateSelectionRuntime(world, globals);
+            var system = new CurrentSelectionApplySystem(world, globals);
+
+            SetConfirmSnapshot(globals, new Vector2(1800f, 1200f), pressedThisFrame: true, isDown: true);
+            input.InjectAction("PointerPos", new Vector3(1800f, 1200f, 0f));
+            input.Update();
+            system.Update(0f);
+
+            SetConfirmSnapshot(globals, new Vector2(1800f, 1200f), pressedThisFrame: false, isDown: false, releasedThisFrame: true);
+            input.InjectAction("PointerPos", new Vector3(1800f, 1200f, 0f));
+            input.Update();
+            system.Update(0f);
+
+            AssertSelection(selectionRuntime, local, entity);
+        }
+
+        [Test]
+        public void CurrentSelectionApplySystem_AdditiveModifierAddsWithoutReplacing()
+        {
+            using var world = World.Create();
+
+            var input = new PlayerInputHandler(new NullInputBackend(), CreateInputConfig());
+            var local = world.Create();
+            var first = world.Create(WorldPositionCm.FromCm(1600, 1200), new VisualTransform { Position = new Vector3(16f, 0f, 12f) }, new CullState { IsVisible = true }, new SelectionSelectableTag());
+            var second = world.Create(WorldPositionCm.FromCm(2600, 1600), new VisualTransform { Position = new Vector3(26f, 0f, 16f) }, new CullState { IsVisible = true }, new SelectionSelectableTag());
+
+            var globals = new Dictionary<string, object>
+            {
+                [CoreServiceKeys.AuthoritativeInput.Name] = input,
+                [CoreServiceKeys.AuthoritativePointerButtons.Name] = new AuthoritativePointerButtonSnapshot(),
+                [CoreServiceKeys.ScreenRayProvider.Name] = new WorldMappedScreenRayProvider(),
+                [CoreServiceKeys.VisualHeightmap.Name] = CreateFlatHeightmap(),
+                [CoreServiceKeys.ScreenProjector.Name] = new WorldMappedScreenProjector(),
+                [CoreServiceKeys.WorldSizeSpec.Name] = CreateWorldSizeSpec(),
+                [CoreServiceKeys.LocalPlayerEntity.Name] = local,
+                [CoreServiceKeys.InteractionActionBindings.Name] = new InteractionActionBindings(),
+            };
+            var selectionRuntime = CreateSelectionRuntime(world, globals);
+            var system = new CurrentSelectionApplySystem(world, globals);
+
+            Click(system, globals, input, new Vector2(1600f, 1200f));
+            input.InjectAction(SelectionModifierActionIds.Additive, Vector3.One);
+            Click(system, globals, input, new Vector2(2600f, 1600f));
+
+            AssertSelection(selectionRuntime, local, first, second);
+        }
+
+        [Test]
+        public void CurrentSelectionApplySystem_ToggleModifierRemovesExistingSelectionMember()
+        {
+            using var world = World.Create();
+
+            var input = new PlayerInputHandler(new NullInputBackend(), CreateInputConfig());
+            var local = world.Create();
+            var first = world.Create(WorldPositionCm.FromCm(1600, 1200), new VisualTransform { Position = new Vector3(16f, 0f, 12f) }, new CullState { IsVisible = true }, new SelectionSelectableTag());
+            var second = world.Create(WorldPositionCm.FromCm(2600, 1600), new VisualTransform { Position = new Vector3(26f, 0f, 16f) }, new CullState { IsVisible = true }, new SelectionSelectableTag());
+
+            var globals = new Dictionary<string, object>
+            {
+                [CoreServiceKeys.AuthoritativeInput.Name] = input,
+                [CoreServiceKeys.AuthoritativePointerButtons.Name] = new AuthoritativePointerButtonSnapshot(),
+                [CoreServiceKeys.ScreenRayProvider.Name] = new WorldMappedScreenRayProvider(),
+                [CoreServiceKeys.VisualHeightmap.Name] = CreateFlatHeightmap(),
+                [CoreServiceKeys.ScreenProjector.Name] = new WorldMappedScreenProjector(),
+                [CoreServiceKeys.WorldSizeSpec.Name] = CreateWorldSizeSpec(),
+                [CoreServiceKeys.LocalPlayerEntity.Name] = local,
+                [CoreServiceKeys.InteractionActionBindings.Name] = new InteractionActionBindings(),
+            };
+            var selectionRuntime = CreateSelectionRuntime(world, globals);
+            SeedAmbientSelection(world, globals, local, first, second);
+            var system = new CurrentSelectionApplySystem(world, globals);
+
+            input.InjectAction(SelectionModifierActionIds.Toggle, Vector3.One);
+            Click(system, globals, input, new Vector2(1600f, 1200f));
+
+            AssertSelection(selectionRuntime, local, second);
+        }
+
+        [Test]
         public void CurrentSelectionApplySystem_AimConfirmRelease_DoesNotStealSelection()
         {
             using var world = World.Create();
@@ -1117,6 +1320,19 @@ namespace Ludots.Tests.GAS
         private static WorldSizeSpec CreateWorldSizeSpec()
         {
             return new WorldSizeSpec(new WorldAabbCm(-10_000, -10_000, 20_000, 20_000), 100);
+        }
+
+        private static SpatialFootprint2D CreateRectFootprint(int centerXCm, int centerZCm, int widthCm, int depthCm)
+        {
+            int halfWidth = widthCm / 2;
+            int halfDepth = depthCm / 2;
+            var footprint = new SpatialFootprint2D();
+            footprint.SetPolygonVertexCount(0, 4);
+            footprint.SetVertex(0, 0, new WorldCmInt2(centerXCm - halfWidth, centerZCm - halfDepth));
+            footprint.SetVertex(0, 1, new WorldCmInt2(centerXCm + halfWidth, centerZCm - halfDepth));
+            footprint.SetVertex(0, 2, new WorldCmInt2(centerXCm + halfWidth, centerZCm + halfDepth));
+            footprint.SetVertex(0, 3, new WorldCmInt2(centerXCm - halfWidth, centerZCm + halfDepth));
+            return footprint;
         }
 
         private static IVisualHeightmap CreateFlatHeightmap()


### PR DESCRIPTION
## Summary
- add core-owned spatial bounds contracts for point, 2D footprint, and 3D box hit geometry
- teach selection to use projected spatial bounds with additive/toggle acquisition and add coverage tests
- add a dedicated spatial bounds showcase with polygon overlays, visible selection feedback, and a Reset Camera button

## Validation
- dotnet build mods/showcases/spatial_bounds/SpatialBoundsShowcaseMod/SpatialBoundsShowcaseMod.csproj -c Release
- dotnet build src/Apps/Raylib/Ludots.App.Raylib/Ludots.App.Raylib.csproj -c Release
- manual Raylib launch of the spatial bounds showcase and verified selection feedback, footprint polygon display, and Reset Camera button

## Notes
- src/Tests/GasTests/InteractionSelectionConvergenceTests.cs contains new coverage, but the full GasTests project still has unrelated pre-existing compile/test blockers outside this change