### PR TITLE
feat(presentation): add core instanced batch pipeline

### DIFF
--- a/assets/Configs/config_catalog.json
+++ b/assets/Configs/config_catalog.json
@@ -31,6 +31,7 @@
   { "Path": "Presentation/material_assets.json", "Policy": "ArrayById", "IdField": "id" },
   { "Path": "Presentation/host_assets.json", "Policy": "ArrayById", "IdField": "id" },
   { "Path": "Presentation/prefabs.json", "Policy": "ArrayById", "IdField": "id" },
+  { "Path": "Presentation/instanced_batches.json", "Policy": "ArrayById", "IdField": "id" },
   { "Path": "Presentation/presentation_behaviors.json", "Policy": "ArrayById", "IdField": "id" },
   { "Path": "Presentation/animator_controllers.json", "Policy": "ArrayById", "IdField": "id" },
   { "Path": "Presentation/animation_clips.json", "Policy": "ArrayById", "IdField": "id" },

--- a/src/Core/Engine/GameEngine.cs
+++ b/src/Core/Engine/GameEngine.cs
@@ -47,6 +47,7 @@ using Ludots.Core.Presentation.Requests;
 using Ludots.Core.Presentation.Terrain;
 using Ludots.Core.Presentation.Rendering;
 using Ludots.Core.Presentation.Hud;
+using Ludots.Core.Presentation.Instancing;
 using Ludots.Core.Presentation.Minimap;
 using Ludots.Core.Gameplay.GAS.Presentation;
 using Ludots.Core.Presentation.Surfaces;
@@ -201,6 +202,8 @@ namespace Ludots.Core.Engine
         private Ludots.Core.Presentation.Rendering.SkinnedVisualBatchBuffer _skinnedVisualBatchBuffer;
         private Ludots.Core.Presentation.Requests.PresentationRequestBuffer _presentationRequestBuffer;
         private Ludots.Core.Presentation.Requests.SoundRequestBuffer _soundRequestBuffer;
+        private Ludots.Core.Presentation.Instancing.InstancedBatchRequestBuffer _instancedBatchRequestBuffer;
+        private Ludots.Core.Presentation.Instancing.InstancedBatchOperationBuffer _instancedBatchOperationBuffer;
         private GasPresentationEventBuffer _gasPresentationEvents;
         private Ludots.Core.Presentation.Rendering.GroundOverlayBuffer _groundOverlayBuffer;
         private Ludots.Core.Presentation.Rendering.RoadSplineBuffer _roadSplineBuffer;
@@ -677,6 +680,10 @@ namespace Ludots.Core.Engine
             var presentationPrefabs = new PrefabRegistry();
             var meshAssets = new MeshAssetRegistry();
             var materialAssets = new PresentationMaterialRegistry();
+            var instancedBatchAssets = new InstancedBatchAssetRegistry();
+            var instancedBatchRequests = new InstancedBatchRequestBuffer(presentationConfig.PresentationRequestCapacity);
+            var instancedBatchOperations = new InstancedBatchOperationBuffer(presentationConfig.PresentationRequestCapacity);
+            var instancedBatchSubmissionRuntime = new InstancedBatchSubmissionRuntime();
             var animatorControllers = new AnimatorControllerRegistry();
             var animationClips = new AnimationClipRegistry();
             var animationProfiles = new AnimationProfileRegistry();
@@ -702,8 +709,46 @@ namespace Ludots.Core.Engine
             var surfaceRuntime = new SurfaceSourceRuntimeRegistry();
             var presentationBehaviors = new PresentationBehaviorRegistry();
             var performerGraphApi = new GasGraphRuntimeApi(World, spatialQueries: null, coords: null, eventBus: null);
+            int ResolveInstancedBatchGasEventKey(PresentationEventKind eventKind, string key)
+            {
+                return eventKind == PresentationEventKind.EffectApplied
+                    ? EffectTemplateIdRegistry.GetId(key)
+                    : AbilityIdRegistry.GetId(key);
+            }
+
+            int ResolveInstancedBatchPresentationEventKey(PresentationEventKind eventKind, string key)
+            {
+                return eventKind switch
+                {
+                    PresentationEventKind.EntitySpawned => MapLoader.EntityTemplateKeys.GetId(key),
+                    PresentationEventKind.EntityDestroyed => MapLoader.EntityTemplateKeys.GetId(key),
+                    PresentationEventKind.ProjectileSpawned => EffectTemplateIdRegistry.GetId(key),
+                    PresentationEventKind.TagEffectiveChanged => TagRegistry.GetId(key),
+                    PresentationEventKind.GameplayEvent => TagRegistry.GetId(key),
+                    PresentationEventKind.EffectApplied => EffectTemplateIdRegistry.GetId(key),
+                    PresentationEventKind.CastCommitted => AbilityIdRegistry.GetId(key),
+                    PresentationEventKind.CastFailed => AbilityIdRegistry.GetId(key),
+                    PresentationEventKind.SelectionMemberAdded => selectionSetKeyRegistry.GetId(key),
+                    PresentationEventKind.SelectionMemberRemoved => selectionSetKeyRegistry.GetId(key),
+                    PresentationEventKind.GlobalDayNight => TagRegistry.GetId(key),
+                    PresentationEventKind.GlobalRegionChanged => TagRegistry.GetId(key),
+                    PresentationEventKind.GlobalWeather => TagRegistry.GetId(key),
+                    PresentationEventKind.PerformerCreated => key == "*" ? -1 : 0,
+                    PresentationEventKind.PerformerDestroyed => key == "*" ? -1 : 0,
+                    _ => 0,
+                };
+            }
+
             new MeshAssetConfigLoader(ConfigPipeline, meshAssets, presentationPrefabs).Load(ConfigCatalog, ConfigConflictReport);
             new PresentationMaterialConfigLoader(ConfigPipeline, materialAssets).Load(ConfigCatalog, ConfigConflictReport);
+            new InstancedBatchAssetConfigLoader(
+                ConfigPipeline,
+                instancedBatchAssets,
+                meshAssets,
+                materialAssets,
+                Ludots.Core.Gameplay.GAS.Registry.AttributeRegistry.GetId,
+                ResolveInstancedBatchGasEventKey,
+                ResolveInstancedBatchPresentationEventKey).Load(ConfigCatalog, ConfigConflictReport);
             new PresentationBehaviorConfigLoader(ConfigPipeline, presentationBehaviors, meshAssets).Load(ConfigCatalog, ConfigConflictReport);
             var presentationBehaviorResolver = new PresentationBehaviorResolver(presentationBehaviors, meshAssets);
             new AnimatorControllerConfigLoader(ConfigPipeline, animatorControllers).Load(ConfigCatalog, ConfigConflictReport);
@@ -797,7 +842,8 @@ namespace Ludots.Core.Engine
                     AssetKind.GroundOverlay => ResolveGroundOverlayShapeId(key),
                     _ => 0,
                 },
-                selectionSetKeyRegistry.Register).Load(ConfigCatalog, ConfigConflictReport);
+                selectionSetKeyRegistry.Register,
+                instancedBatchAssets.GetId).Load(ConfigCatalog, ConfigConflictReport);
             MapLoader.SetPresentationRuntime(
                 presentationStableIds,
                 performerRuntime,
@@ -955,6 +1001,9 @@ namespace Ludots.Core.Engine
             SetService(CoreServiceKeys.PresentationPrefabRegistry, presentationPrefabs);
             SetService(CoreServiceKeys.PresentationMeshAssetRegistry, meshAssets);
             SetService(CoreServiceKeys.PresentationMaterialRegistry, materialAssets);
+            SetService(CoreServiceKeys.InstancedBatchAssetRegistry, instancedBatchAssets);
+            SetService(CoreServiceKeys.InstancedBatchRequestBuffer, instancedBatchRequests);
+            SetService(CoreServiceKeys.InstancedBatchOperationBuffer, instancedBatchOperations);
             SetService(CoreServiceKeys.PresentationBehaviorRegistry, presentationBehaviors);
             SetService(CoreServiceKeys.PresentationBehaviorResolver, presentationBehaviorResolver);
             SetService(CoreServiceKeys.AnimatorControllerRegistry, animatorControllers);
@@ -969,6 +1018,8 @@ namespace Ludots.Core.Engine
             _skinnedVisualBatchBuffer = skinnedVisualBatchBuffer;
             _presentationRequestBuffer = presentationRequestBuffer;
             _soundRequestBuffer = soundRequestBuffer;
+            _instancedBatchRequestBuffer = instancedBatchRequests;
+            _instancedBatchOperationBuffer = instancedBatchOperations;
             _gasPresentationEvents = gasPresentationEvents;
             _groundOverlayBuffer = groundOverlayBuffer;
             _roadSplineBuffer = roadSplineBuffer;
@@ -1187,10 +1238,25 @@ namespace Ludots.Core.Engine
             RegisterPresentationSystem(new ResponseChainUiSyncSystem(GlobalContext, responseChainUiState, orderTypeRegistry));
             RegisterPresentationSystem(globalPresentationEventProjectionSystem);
             RegisterPresentationSystem(new SelectionPresentationEventSystem(World, selectionRuntime, presentationEventStream));
+            RegisterPresentationSystem(new InstancedBatchBehaviorSystem(
+                World,
+                performerDefinitions,
+                performerRuntime,
+                instancedBatchAssets,
+                instancedBatchOperations,
+                presentationEventStream,
+                presentationOwnerChanges));
             // PerformerRuleSystem reads events and produces commands.
             RegisterPresentationSystem(performerRuleSystem);
             // PerformerRuntimeSystem consumes commands, manages instance lifecycle.
             RegisterPresentationSystem(performerRuntimeSystem);
+            RegisterPresentationSystem(new InstancedBatchEmissionSystem(
+                World,
+                performerDefinitions,
+                instancedBatchAssets,
+                instancedBatchRequests,
+                instancedBatchSubmissionRuntime,
+                presentationEventStream));
             // Entity-anchored performers follow owner VisualTransform before behavior/animator/emit reads them.
             RegisterPresentationSystem(new PerformerEntityTransformSyncSystem(World, performerRuntime, performerDefinitions, presentationTimingDiagnostics));
             // PerformerBehaviorSystem drives blackboard-bound behavior before animator and emit read it.
@@ -2403,6 +2469,8 @@ namespace Ludots.Core.Engine
         {
             _presentationRequestBuffer?.Clear();
             _soundRequestBuffer?.Clear();
+            _instancedBatchRequestBuffer?.Clear();
+            _instancedBatchOperationBuffer?.Clear();
             _groundOverlayBuffer?.ClearTransient();
             _roadSplineBuffer?.ClearTransient();
             _worldHudBuffer?.ClearTransient();
@@ -2425,6 +2493,17 @@ namespace Ludots.Core.Engine
                     timingDiagnostics!.ObservePresentationSystem(_presentationSystems[i].GetType().Name, elapsedMs);
                 }
             }
+
+            if ((_instancedBatchRequestBuffer?.Count ?? 0) != 0 ||
+                (_instancedBatchOperationBuffer?.Count ?? 0) != 0)
+            {
+                TryGetService(CoreServiceKeys.PresentationAdapterCapabilities, out PresentationAdapterCapabilities capabilities);
+                InstancedBatchCapabilityValidator.Validate(
+                    _instancedBatchRequestBuffer,
+                    _instancedBatchOperationBuffer,
+                    capabilities);
+            }
+
             // Clear GAS presentation events AFTER all presentation systems have consumed them
             _gasPresentationEvents?.Clear();
         }

--- a/src/Core/Presentation/Config/InstancedBatchAssetConfigLoader.cs
+++ b/src/Core/Presentation/Config/InstancedBatchAssetConfigLoader.cs
@@ -1,0 +1,1001 @@
+using System;
+using System.Globalization;
+using System.Numerics;
+using System.Text.Json.Nodes;
+using Ludots.Core.Config;
+using Ludots.Core.Presentation.Assets;
+using Ludots.Core.Presentation.Components;
+using Ludots.Core.Presentation.Events;
+using Ludots.Core.Presentation.Instancing;
+using Ludots.Core.Presentation.Performers;
+
+namespace Ludots.Core.Presentation.Config
+{
+    public sealed class InstancedBatchAssetConfigLoader
+    {
+        public const string DefaultRelativePath = "Presentation/instanced_batches.json";
+
+        private readonly ConfigPipeline _configs;
+        private readonly InstancedBatchAssetRegistry _batches;
+        private readonly MeshAssetRegistry _meshes;
+        private readonly PresentationMaterialRegistry _materials;
+        private readonly Func<string, int> _resolveAttributeKey;
+        private readonly Func<PresentationEventKind, string, int> _resolveGasEventKey;
+        private readonly Func<PresentationEventKind, string, int> _resolvePresentationEventKey;
+
+        public InstancedBatchAssetConfigLoader(
+            ConfigPipeline configs,
+            InstancedBatchAssetRegistry batches,
+            MeshAssetRegistry meshes,
+            PresentationMaterialRegistry materials,
+            Func<string, int>? resolveAttributeKey = null,
+            Func<PresentationEventKind, string, int>? resolveGasEventKey = null,
+            Func<PresentationEventKind, string, int>? resolvePresentationEventKey = null)
+        {
+            _configs = configs ?? throw new ArgumentNullException(nameof(configs));
+            _batches = batches ?? throw new ArgumentNullException(nameof(batches));
+            _meshes = meshes ?? throw new ArgumentNullException(nameof(meshes));
+            _materials = materials ?? throw new ArgumentNullException(nameof(materials));
+            _resolveAttributeKey = resolveAttributeKey ?? (_ => 0);
+            _resolveGasEventKey = resolveGasEventKey ?? ((_, _) => 0);
+            _resolvePresentationEventKey = resolvePresentationEventKey ?? ((_, _) => 0);
+        }
+
+        public void Load(ConfigCatalog catalog = null, ConfigConflictReport report = null)
+        {
+            var entry = ConfigPipeline.RequireEntry(catalog, DefaultRelativePath, ConfigMergePolicy.ArrayById, "id");
+            var merged = _configs.MergeArrayByIdFromCatalog(in entry, report);
+
+            for (int i = 0; i < merged.Count; i++)
+            {
+                if (merged[i].Node is not JsonObject obj)
+                {
+                    throw new InvalidOperationException(
+                        $"{DefaultRelativePath} entry '{merged[i].Id}' must merge to a JSON object.");
+                }
+
+                ValidateObjectFields(
+                    obj,
+                    $"{DefaultRelativePath} entry '{merged[i].Id}'",
+                    "id",
+                    "renderPath",
+                    "ownerStableId",
+                    "groups",
+                    "customDataChannels",
+                    "behaviors",
+                    "progressiveSubmission");
+
+                string key = RequireString(obj["id"], $"{DefaultRelativePath} entry id");
+                var asset = new InstancedBatchAsset
+                {
+                    Key = key,
+                    RenderPath = ParseRenderPath(obj["renderPath"], key),
+                    OwnerStableId = RequireString(obj["ownerStableId"], $"Instanced batch '{key}' ownerStableId"),
+                    Groups = ParseGroups(obj["groups"], key),
+                    CustomDataChannels = ParseCustomDataChannels(obj["customDataChannels"], key),
+                    Behaviors = ParseBehaviors(obj["behaviors"], key),
+                    ProgressiveSubmission = ParseProgressiveSubmission(obj["progressiveSubmission"], key),
+                };
+
+                int batchId = _batches.Register(key, asset);
+                asset.AddressTable = BuildAddressTable(batchId, asset);
+                CompileGroupAddresses(asset);
+                CompileAndValidateBehaviors(asset);
+            }
+        }
+
+        private InstancedBatchGroup[] ParseGroups(JsonNode? node, string batchKey)
+        {
+            if (node is not JsonArray arr || arr.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' must declare a non-empty groups array.");
+            }
+
+            var groups = new InstancedBatchGroup[arr.Count];
+            for (int i = 0; i < arr.Count; i++)
+            {
+                if (arr[i] is not JsonObject obj)
+                {
+                    throw new InvalidOperationException(
+                        $"Instanced batch '{batchKey}' groups[{i}] must be an object.");
+                }
+
+                ValidateObjectFields(
+                    obj,
+                    $"Instanced batch '{batchKey}' groups[{i}]",
+                    "id",
+                    "meshAssetId",
+                    "materialId",
+                    "bucketId",
+                    "instanceSpanId",
+                    "transforms");
+
+                string groupId = RequireString(obj["id"], $"Instanced batch '{batchKey}' groups[{i}].id");
+                string meshKey = RequireString(obj["meshAssetId"], $"Instanced batch '{batchKey}' group '{groupId}' meshAssetId");
+                int meshAssetId = ResolveMeshId(meshKey, batchKey, groupId);
+                int materialId = ResolveOptionalMaterialId(obj["materialId"], batchKey, groupId);
+
+                groups[i] = new InstancedBatchGroup
+                {
+                    Id = groupId,
+                    MeshAssetId = meshAssetId,
+                    MaterialId = materialId,
+                    BucketId = ResolveBucketId(obj["bucketId"], batchKey, groupId),
+                    InstanceSpanId = RequireString(obj["instanceSpanId"], $"Instanced batch '{batchKey}' group '{groupId}' instanceSpanId"),
+                    Transforms = ParseTransforms(obj["transforms"], batchKey, groupId),
+                };
+            }
+
+            return groups;
+        }
+
+        private static string ResolveBucketId(JsonNode? node, string batchKey, string groupId)
+        {
+            return RequireString(node, $"Instanced batch '{batchKey}' group '{groupId}' bucketId");
+        }
+
+        private static InstancedBatchAddressTable BuildAddressTable(int batchId, InstancedBatchAsset asset)
+        {
+            InstancedBatchGroup[] groups = asset.Groups ?? Array.Empty<InstancedBatchGroup>();
+            var inputs = new InstancedBatchAddressGroupInput[groups.Length];
+            for (int i = 0; i < groups.Length; i++)
+            {
+                inputs[i] = new InstancedBatchAddressGroupInput(
+                    groups[i].Id,
+                    groups[i].BucketId,
+                    groups[i].InstanceSpanId);
+            }
+
+            return InstancedBatchAddressTable.Build(batchId, asset.OwnerStableId, inputs);
+        }
+
+        private static void CompileGroupAddresses(InstancedBatchAsset asset)
+        {
+            InstancedBatchGroup[] groups = asset.Groups ?? Array.Empty<InstancedBatchGroup>();
+            for (int i = 0; i < groups.Length; i++)
+            {
+                groups[i].Address = asset.AddressTable.Resolve(
+                    groups[i].Id,
+                    groups[i].BucketId,
+                    groups[i].InstanceSpanId);
+            }
+        }
+
+        private InstancedBatchTransform[] ParseTransforms(JsonNode? node, string batchKey, string groupId)
+        {
+            if (node is not JsonArray arr || arr.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' group '{groupId}' must declare a non-empty transforms array.");
+            }
+
+            var transforms = new InstancedBatchTransform[arr.Count];
+            for (int i = 0; i < arr.Count; i++)
+            {
+                if (arr[i] is not JsonObject obj)
+                {
+                    throw new InvalidOperationException(
+                        $"Instanced batch '{batchKey}' group '{groupId}' transforms[{i}] must be an object.");
+                }
+
+                ValidateObjectFields(
+                    obj,
+                    $"Instanced batch '{batchKey}' group '{groupId}' transforms[{i}]",
+                    "positionCm",
+                    "rotation",
+                    "scale");
+
+                transforms[i] = new InstancedBatchTransform
+                {
+                    PositionCm = ParseRequiredVector3(obj["positionCm"], $"Instanced batch '{batchKey}' group '{groupId}' transforms[{i}].positionCm"),
+                    Rotation = ParseQuaternionWithDefault(obj["rotation"], Quaternion.Identity, $"Instanced batch '{batchKey}' group '{groupId}' transforms[{i}].rotation"),
+                    Scale = ParseVector3WithDefault(obj["scale"], Vector3.One, $"Instanced batch '{batchKey}' group '{groupId}' transforms[{i}].scale"),
+                };
+            }
+
+            return transforms;
+        }
+
+        private InstancedBatchCustomDataChannel[] ParseCustomDataChannels(JsonNode? node, string batchKey)
+        {
+            if (node == null)
+            {
+                return Array.Empty<InstancedBatchCustomDataChannel>();
+            }
+
+            if (node is not JsonArray arr)
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' customDataChannels must be an array.");
+            }
+
+            if (arr.Count > MaterialCustomDataBinding.MaxSlots)
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' customDataChannels supports at most {MaterialCustomDataBinding.MaxSlots} slots.");
+            }
+
+            var channels = new InstancedBatchCustomDataChannel[arr.Count];
+            bool[] seen = new bool[MaterialCustomDataBinding.MaxSlots];
+            for (int i = 0; i < arr.Count; i++)
+            {
+                if (arr[i] is not JsonObject obj)
+                {
+                    throw new InvalidOperationException(
+                        $"Instanced batch '{batchKey}' customDataChannels[{i}] must be an object.");
+                }
+
+                ValidateObjectFields(
+                    obj,
+                    $"Instanced batch '{batchKey}' customDataChannels[{i}]",
+                    "key",
+                    "slot",
+                    "type");
+
+                int slot = ParseRequiredInt(obj["slot"], $"Instanced batch '{batchKey}' customDataChannels[{i}].slot");
+                if ((uint)slot >= MaterialCustomDataBinding.MaxSlots)
+                {
+                    throw new InvalidOperationException(
+                        $"Instanced batch '{batchKey}' customDataChannels[{i}].slot must be between 0 and {MaterialCustomDataBinding.MaxSlots - 1}.");
+                }
+
+                if (seen[slot])
+                {
+                    throw new InvalidOperationException(
+                        $"Instanced batch '{batchKey}' customDataChannels[{i}].slot duplicates slot {slot}.");
+                }
+
+                seen[slot] = true;
+                channels[i] = new InstancedBatchCustomDataChannel
+                {
+                    Key = RequireString(obj["key"], $"Instanced batch '{batchKey}' customDataChannels[{i}].key"),
+                    Slot = slot,
+                    Lane = ParseCustomDataLane(obj["type"], $"Instanced batch '{batchKey}' customDataChannels[{i}].type"),
+                };
+            }
+
+            SortCustomDataChannels(channels);
+            for (int i = 0; i < channels.Length; i++)
+            {
+                if (channels[i].Slot != i)
+                {
+                    throw new InvalidOperationException(
+                        $"Instanced batch '{batchKey}' customDataChannels slots must be contiguous starting at 0.");
+                }
+            }
+
+            return channels;
+        }
+
+        private static InstancedBatchProgressiveSubmissionPolicy ParseProgressiveSubmission(JsonNode? node, string batchKey)
+        {
+            if (node == null)
+            {
+                return InstancedBatchProgressiveSubmissionPolicy.None;
+            }
+
+            if (node is not JsonObject obj)
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' progressiveSubmission must be an object.");
+            }
+
+            ValidateObjectFields(
+                obj,
+                $"Instanced batch '{batchKey}' progressiveSubmission",
+                "maxInstancesPerFlush");
+
+            int maxInstancesPerFlush = ParseRequiredInt(
+                obj["maxInstancesPerFlush"],
+                $"Instanced batch '{batchKey}' progressiveSubmission.maxInstancesPerFlush");
+            if (maxInstancesPerFlush <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' progressiveSubmission.maxInstancesPerFlush must be positive.");
+            }
+
+            return new InstancedBatchProgressiveSubmissionPolicy(maxInstancesPerFlush);
+        }
+
+        private InstancedBatchBehaviorBinding[] ParseBehaviors(JsonNode? node, string batchKey)
+        {
+            if (node == null)
+            {
+                return Array.Empty<InstancedBatchBehaviorBinding>();
+            }
+
+            if (node is not JsonArray arr)
+            {
+                throw new InvalidOperationException($"Instanced batch '{batchKey}' behaviors must be an array.");
+            }
+
+            var bindings = new InstancedBatchBehaviorBinding[arr.Count];
+            for (int i = 0; i < arr.Count; i++)
+            {
+                if (arr[i] is not JsonObject obj)
+                {
+                    throw new InvalidOperationException($"Instanced batch '{batchKey}' behaviors[{i}] must be an object.");
+                }
+
+                ValidateObjectFields(
+                    obj,
+                    $"Instanced batch '{batchKey}' behaviors[{i}]",
+                    "id",
+                    "source",
+                    "target",
+                    "mapping",
+                    "order",
+                    "coalescing",
+                    "lifecycle");
+
+                string key = RequireString(obj["id"], $"Instanced batch '{batchKey}' behaviors[{i}].id");
+                (InstancedBatchSourceKind sourceKind, int sourceKeyId, PresentationEventKind sourceEventKind) = ParseBehaviorSource(obj["source"], batchKey, key);
+                (InstancedBatchOperationKind operationKind, string groupId, string bucketId, string spanId, int customDataSlot, int targetPayloadId) =
+                    ParseBehaviorTarget(obj["target"], batchKey, key);
+                (InstancedBatchValueMappingKind mappingKind, float inputMin, float inputMax, float outputMin, float outputMax, float constantValue) =
+                    ParseBehaviorMapping(obj["mapping"], batchKey, key);
+                int order = ParseOptionalInt(obj["order"], defaultValue: i, $"Instanced batch '{batchKey}' behavior '{key}' order");
+                InstancedBatchCoalescingMode coalescing = ParseOptionalEnum(
+                    obj["coalescing"],
+                    InstancedBatchCoalescingMode.LastWriteWins,
+                    $"Instanced batch '{batchKey}' behavior '{key}' coalescing");
+                InstancedBatchLifecycleMode lifecycle = ParseOptionalEnum(
+                    obj["lifecycle"],
+                    InstancedBatchLifecycleMode.UntilOwnerDestroyed,
+                    $"Instanced batch '{batchKey}' behavior '{key}' lifecycle");
+
+                bindings[i] = new InstancedBatchBehaviorBinding(
+                    key,
+                    sourceKind,
+                    sourceKeyId,
+                    sourceEventKind,
+                    operationKind,
+                    groupId,
+                    bucketId,
+                    spanId,
+                    customDataSlot,
+                    mappingKind,
+                    inputMin,
+                    inputMax,
+                    outputMin,
+                    outputMax,
+                    constantValue,
+                    order,
+                    coalescing,
+                    lifecycle,
+                    targetPayloadId);
+            }
+
+            SortBehaviorsByOrder(bindings);
+            return bindings;
+        }
+
+        private (InstancedBatchSourceKind Kind, int KeyId, PresentationEventKind EventKind) ParseBehaviorSource(JsonNode? node, string batchKey, string behaviorKey)
+        {
+            if (node is not JsonObject obj)
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' behavior '{behaviorKey}' source must be an object.");
+            }
+
+            ValidateObjectFields(
+                obj,
+                $"Instanced batch '{batchKey}' behavior '{behaviorKey}' source",
+                "kind",
+                "eventKind",
+                "key");
+
+            InstancedBatchSourceKind kind = ParseRequiredEnum<InstancedBatchSourceKind>(
+                obj["kind"],
+                $"Instanced batch '{batchKey}' behavior '{behaviorKey}' source.kind");
+            PresentationEventKind eventKind = ResolveSourceEventKind(obj["eventKind"], kind, batchKey, behaviorKey);
+            string key = RequireString(obj["key"], $"Instanced batch '{batchKey}' behavior '{behaviorKey}' source.key");
+            int keyId = kind switch
+            {
+                InstancedBatchSourceKind.Attribute => _resolveAttributeKey(key),
+                InstancedBatchSourceKind.GasEvent => _resolveGasEventKey(eventKind, key),
+                InstancedBatchSourceKind.PresentationEvent => _resolvePresentationEventKey(eventKind, key),
+                _ => 0,
+            };
+
+            if (IsInvalidSourceKey(kind, eventKind, keyId))
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' behavior '{behaviorKey}' references unknown {kind} source key '{key}'.");
+            }
+
+            return (kind, keyId, eventKind);
+        }
+
+        private static bool IsInvalidSourceKey(
+            InstancedBatchSourceKind kind,
+            PresentationEventKind eventKind,
+            int keyId)
+        {
+            if (kind == InstancedBatchSourceKind.Attribute)
+            {
+                return keyId < 0;
+            }
+
+            if (kind == InstancedBatchSourceKind.PresentationEvent &&
+                eventKind is PresentationEventKind.PerformerCreated or PresentationEventKind.PerformerDestroyed &&
+                keyId == -1)
+            {
+                return false;
+            }
+
+            return keyId <= 0;
+        }
+
+        private static PresentationEventKind ResolveSourceEventKind(
+            JsonNode? node,
+            InstancedBatchSourceKind sourceKind,
+            string batchKey,
+            string behaviorKey)
+        {
+            if (sourceKind == InstancedBatchSourceKind.Attribute)
+            {
+                if (node != null)
+                {
+                    throw new InvalidOperationException(
+                        $"Instanced batch '{batchKey}' behavior '{behaviorKey}' source.eventKind is not valid for Attribute sources.");
+                }
+
+                return PresentationEventKind.None;
+            }
+
+            PresentationEventKind eventKind = ParseRequiredEnum<PresentationEventKind>(
+                node,
+                $"Instanced batch '{batchKey}' behavior '{behaviorKey}' source.eventKind");
+            if (sourceKind == InstancedBatchSourceKind.GasEvent)
+            {
+                if (eventKind is not (PresentationEventKind.EffectApplied or PresentationEventKind.CastCommitted or PresentationEventKind.CastFailed))
+                {
+                    throw new InvalidOperationException(
+                        $"Instanced batch '{batchKey}' behavior '{behaviorKey}' GasEvent source.eventKind must be EffectApplied, CastCommitted, or CastFailed.");
+                }
+
+                return eventKind;
+            }
+
+            if (eventKind is PresentationEventKind.None or PresentationEventKind.AttributeValueChanged)
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' behavior '{behaviorKey}' PresentationEvent source.eventKind must be a concrete non-attribute event kind.");
+            }
+
+            return eventKind;
+        }
+
+        private (InstancedBatchOperationKind Kind, string GroupId, string BucketId, string SpanId, int CustomDataSlot, int TargetPayloadId)
+            ParseBehaviorTarget(JsonNode? node, string batchKey, string behaviorKey)
+        {
+            if (node is not JsonObject obj)
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' behavior '{behaviorKey}' target must be an object.");
+            }
+
+            ValidateObjectFields(
+                obj,
+                $"Instanced batch '{batchKey}' behavior '{behaviorKey}' target",
+                "operation",
+                "group",
+                "bucket",
+                "span",
+                "customDataSlot",
+                "presentationStateId",
+                "effectAssetId");
+
+            InstancedBatchOperationKind kind = ParseRequiredEnum<InstancedBatchOperationKind>(
+                obj["operation"],
+                $"Instanced batch '{batchKey}' behavior '{behaviorKey}' target.operation");
+            ValidateBehaviorTargetFields(obj, kind, batchKey, behaviorKey);
+            string groupId = RequireString(obj["group"], $"Instanced batch '{batchKey}' behavior '{behaviorKey}' target.group");
+            string bucketId = RequireString(obj["bucket"], $"Instanced batch '{batchKey}' behavior '{behaviorKey}' target.bucket");
+            string spanId = RequireString(obj["span"], $"Instanced batch '{batchKey}' behavior '{behaviorKey}' target.span");
+            int customDataSlot = kind == InstancedBatchOperationKind.WriteCustomData
+                ? ParseRequiredInt(obj["customDataSlot"], $"Instanced batch '{batchKey}' behavior '{behaviorKey}' target.customDataSlot")
+                : -1;
+            if (customDataSlot >= MaterialCustomDataBinding.MaxSlots)
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' behavior '{behaviorKey}' target.customDataSlot must be between 0 and {MaterialCustomDataBinding.MaxSlots - 1}.");
+            }
+
+            int targetPayloadId = kind switch
+            {
+                InstancedBatchOperationKind.SetPresentationState => ParseRequiredInt(
+                    obj["presentationStateId"],
+                    $"Instanced batch '{batchKey}' behavior '{behaviorKey}' target.presentationStateId"),
+                InstancedBatchOperationKind.AttachEffect => ResolveEffectAssetId(obj["effectAssetId"], batchKey, behaviorKey),
+                InstancedBatchOperationKind.UpdateEffect => ResolveEffectAssetId(obj["effectAssetId"], batchKey, behaviorKey),
+                InstancedBatchOperationKind.RemoveEffect => ResolveEffectAssetId(obj["effectAssetId"], batchKey, behaviorKey),
+                _ => 0,
+            };
+
+            if (targetPayloadId < 0)
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' behavior '{behaviorKey}' target payload id must not be negative.");
+            }
+
+            return (kind, groupId, bucketId, spanId, customDataSlot, targetPayloadId);
+        }
+
+        private int ResolveEffectAssetId(JsonNode? node, string batchKey, string behaviorKey)
+        {
+            string effectKey = RequireString(
+                node,
+                $"Instanced batch '{batchKey}' behavior '{behaviorKey}' target.effectAssetId");
+            int effectAssetId = _meshes.GetId(effectKey);
+            if (effectAssetId <= 0 || !_meshes.TryGetDescriptor(effectAssetId, out _))
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' behavior '{behaviorKey}' references unknown effect asset '{effectKey}'.");
+            }
+
+            return effectAssetId;
+        }
+
+        private static (InstancedBatchValueMappingKind Kind, float InputMin, float InputMax, float OutputMin, float OutputMax, float ConstantValue)
+            ParseBehaviorMapping(JsonNode? node, string batchKey, string behaviorKey)
+        {
+            if (node == null)
+            {
+                return (InstancedBatchValueMappingKind.Identity, 0f, 1f, 0f, 1f, 0f);
+            }
+
+            if (node is not JsonObject obj)
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' behavior '{behaviorKey}' mapping must be an object.");
+            }
+
+            ValidateObjectFields(
+                obj,
+                $"Instanced batch '{batchKey}' behavior '{behaviorKey}' mapping",
+                "kind",
+                "inputMin",
+                "inputMax",
+                "outputMin",
+                "outputMax",
+                "constantValue");
+
+            InstancedBatchValueMappingKind kind = ParseRequiredEnum<InstancedBatchValueMappingKind>(
+                obj["kind"],
+                $"Instanced batch '{batchKey}' behavior '{behaviorKey}' mapping.kind");
+            return (
+                kind,
+                obj["inputMin"]?.GetValue<float>() ?? 0f,
+                obj["inputMax"]?.GetValue<float>() ?? 1f,
+                obj["outputMin"]?.GetValue<float>() ?? 0f,
+                obj["outputMax"]?.GetValue<float>() ?? 1f,
+                obj["constantValue"]?.GetValue<float>() ?? 0f);
+        }
+
+        private int ResolveMeshId(string meshKey, string batchKey, string groupId)
+        {
+            int meshAssetId = _meshes.GetId(meshKey);
+            if (meshAssetId <= 0 || !_meshes.TryGetDescriptor(meshAssetId, out _))
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' group '{groupId}' references unknown mesh asset '{meshKey}'.");
+            }
+
+            return meshAssetId;
+        }
+
+        private static void CompileAndValidateBehaviors(InstancedBatchAsset asset)
+        {
+            InstancedBatchBehaviorBinding[] behaviors = asset.Behaviors ?? Array.Empty<InstancedBatchBehaviorBinding>();
+            if (behaviors.Length == 0)
+            {
+                return;
+            }
+
+            var compiled = new InstancedBatchBehaviorBinding[behaviors.Length];
+            for (int i = 0; i < behaviors.Length; i++)
+            {
+                InstancedBatchBehaviorBinding behavior = behaviors[i];
+                InstancedBatchAddress address = asset.AddressTable.Resolve(
+                    behavior.GroupId,
+                    behavior.BucketId,
+                    behavior.SpanId);
+                ValidateBehaviorTarget(asset, in behavior);
+                compiled[i] = behavior.WithCompiledAddress(address);
+            }
+
+            asset.Behaviors = compiled;
+        }
+
+        private static void ValidateBehaviorTarget(InstancedBatchAsset asset, in InstancedBatchBehaviorBinding behavior)
+        {
+            if (behavior.OperationKind == InstancedBatchOperationKind.WriteCustomData)
+            {
+                if (behavior.CustomDataSlot < 0 || behavior.CustomDataSlot >= MaterialCustomDataBinding.MaxSlots)
+                {
+                    throw new InvalidOperationException(
+                        $"Instanced batch '{asset.Key}' behavior '{behavior.Key}' target.customDataSlot must be between 0 and {MaterialCustomDataBinding.MaxSlots - 1}.");
+                }
+
+                InstancedBatchCustomDataChannel[] channels = asset.CustomDataChannels ?? Array.Empty<InstancedBatchCustomDataChannel>();
+                if (behavior.CustomDataSlot >= channels.Length || channels[behavior.CustomDataSlot].Slot != behavior.CustomDataSlot)
+                {
+                    throw new InvalidOperationException(
+                        $"Instanced batch '{asset.Key}' behavior '{behavior.Key}' writes undeclared customDataSlot {behavior.CustomDataSlot}.");
+                }
+            }
+            else if (behavior.CustomDataSlot >= 0)
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{asset.Key}' behavior '{behavior.Key}' target.customDataSlot is only valid for WriteCustomData.");
+            }
+
+            if (RequiresPayload(behavior.OperationKind) && behavior.TargetPayloadId <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{asset.Key}' behavior '{behavior.Key}' operation '{behavior.OperationKind}' requires a positive payload id.");
+            }
+        }
+
+        private static bool RequiresPayload(InstancedBatchOperationKind kind)
+        {
+            return kind is InstancedBatchOperationKind.SetPresentationState
+                or InstancedBatchOperationKind.AttachEffect
+                or InstancedBatchOperationKind.UpdateEffect
+                or InstancedBatchOperationKind.RemoveEffect;
+        }
+
+        private int ResolveOptionalMaterialId(JsonNode? node, string batchKey, string groupId)
+        {
+            string materialKey = ReadOptionalString(node, $"Instanced batch '{batchKey}' group '{groupId}' materialId");
+            if (materialKey.Length == 0)
+            {
+                return 0;
+            }
+
+            int materialId = _materials.GetId(materialKey);
+            if (materialId <= 0 || !_materials.TryGet(materialId, out _))
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' group '{groupId}' references unknown material asset '{materialKey}'.");
+            }
+
+            return materialId;
+        }
+
+        private static VisualRenderPath ParseRenderPath(JsonNode? node, string batchKey)
+        {
+            VisualRenderPath renderPath = ParseRequiredEnum<VisualRenderPath>(node, $"Instanced batch '{batchKey}' renderPath");
+            if (renderPath != VisualRenderPath.InstancedStaticMesh &&
+                renderPath != VisualRenderPath.HierarchicalInstancedStaticMesh)
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' renderPath must be 'InstancedStaticMesh' or 'HierarchicalInstancedStaticMesh', not '{renderPath}'.");
+            }
+
+            return renderPath;
+        }
+
+        private static MaterialCustomDataLane ParseCustomDataLane(JsonNode? node, string context)
+        {
+            return ParseRequiredEnum<MaterialCustomDataLane>(node, context);
+        }
+
+        private static Vector3 ParseRequiredVector3(JsonNode? node, string context)
+        {
+            if (node == null)
+            {
+                throw new InvalidOperationException($"{context} requires explicit x/y/z values.");
+            }
+
+            return ParseVector3WithDefault(node, Vector3.Zero, context);
+        }
+
+        private static Vector3 ParseVector3WithDefault(JsonNode? node, Vector3 defaultValue, string context)
+        {
+            if (node == null)
+            {
+                return defaultValue;
+            }
+
+            if (node is JsonObject obj)
+            {
+                ValidateVectorObjectFields(obj, context, requireW: false);
+                return new Vector3(
+                    ParseRequiredFiniteFloat(obj["x"], $"{context}.x"),
+                    ParseRequiredFiniteFloat(obj["y"], $"{context}.y"),
+                    ParseRequiredFiniteFloat(obj["z"], $"{context}.z"));
+            }
+
+            if (node is JsonArray arr)
+            {
+                if (arr.Count != 3)
+                {
+                    throw new InvalidOperationException($"{context} requires exactly 3 numeric array entries.");
+                }
+
+                return new Vector3(
+                    ParseRequiredFiniteFloat(arr[0], $"{context}[0]"),
+                    ParseRequiredFiniteFloat(arr[1], $"{context}[1]"),
+                    ParseRequiredFiniteFloat(arr[2], $"{context}[2]"));
+            }
+
+            throw new InvalidOperationException($"{context} must be an object with x/y/z or a 3-component array.");
+        }
+
+        private static Quaternion ParseQuaternionWithDefault(JsonNode? node, Quaternion defaultValue, string context)
+        {
+            if (node == null)
+            {
+                return defaultValue;
+            }
+
+            if (node is JsonObject obj)
+            {
+                ValidateVectorObjectFields(obj, context, requireW: true);
+                return new Quaternion(
+                    ParseRequiredFiniteFloat(obj["x"], $"{context}.x"),
+                    ParseRequiredFiniteFloat(obj["y"], $"{context}.y"),
+                    ParseRequiredFiniteFloat(obj["z"], $"{context}.z"),
+                    ParseRequiredFiniteFloat(obj["w"], $"{context}.w"));
+            }
+
+            if (node is JsonArray arr)
+            {
+                if (arr.Count != 4)
+                {
+                    throw new InvalidOperationException($"{context} requires exactly 4 numeric array entries.");
+                }
+
+                return new Quaternion(
+                    ParseRequiredFiniteFloat(arr[0], $"{context}[0]"),
+                    ParseRequiredFiniteFloat(arr[1], $"{context}[1]"),
+                    ParseRequiredFiniteFloat(arr[2], $"{context}[2]"),
+                    ParseRequiredFiniteFloat(arr[3], $"{context}[3]"));
+            }
+
+            throw new InvalidOperationException($"{context} must be an object with x/y/z/w or a 4-component array.");
+        }
+
+        private static void ValidateVectorObjectFields(JsonObject obj, string context, bool requireW)
+        {
+            foreach ((string propertyName, _) in obj)
+            {
+                if (propertyName != "x" &&
+                    propertyName != "y" &&
+                    propertyName != "z" &&
+                    (!requireW || propertyName != "w"))
+                {
+                    string expected = requireW ? "x, y, z, w" : "x, y, z";
+                    throw new InvalidOperationException(
+                        $"{context} object uses unsupported field '{propertyName}'. Expected exact fields {expected}.");
+                }
+            }
+        }
+
+        private static void ValidateObjectFields(JsonObject obj, string context, params string[] allowedNames)
+        {
+            foreach ((string propertyName, _) in obj)
+            {
+                bool allowed = false;
+                for (int i = 0; i < allowedNames.Length; i++)
+                {
+                    if (string.Equals(propertyName, allowedNames[i], StringComparison.Ordinal))
+                    {
+                        allowed = true;
+                        break;
+                    }
+                }
+
+                if (!allowed)
+                {
+                    throw new InvalidOperationException(
+                        $"{context} uses unsupported field '{propertyName}'.");
+                }
+            }
+        }
+
+        private static void ValidateBehaviorTargetFields(
+            JsonObject obj,
+            InstancedBatchOperationKind kind,
+            string batchKey,
+            string behaviorKey)
+        {
+            string context = $"Instanced batch '{batchKey}' behavior '{behaviorKey}' target";
+            if (kind != InstancedBatchOperationKind.WriteCustomData && obj.ContainsKey("customDataSlot"))
+            {
+                throw new InvalidOperationException(
+                    $"{context}.customDataSlot is only valid for WriteCustomData.");
+            }
+
+            if (kind != InstancedBatchOperationKind.SetPresentationState && obj.ContainsKey("presentationStateId"))
+            {
+                throw new InvalidOperationException(
+                    $"{context}.presentationStateId is only valid for SetPresentationState.");
+            }
+
+            bool effectOperation = kind is InstancedBatchOperationKind.AttachEffect
+                or InstancedBatchOperationKind.UpdateEffect
+                or InstancedBatchOperationKind.RemoveEffect;
+            if (!effectOperation && obj.ContainsKey("effectAssetId"))
+            {
+                throw new InvalidOperationException(
+                    $"{context}.effectAssetId is only valid for AttachEffect, UpdateEffect, or RemoveEffect.");
+            }
+        }
+
+        private static string RequireString(JsonNode? node, string context)
+        {
+            string value = ReadStringValue(node, context);
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new InvalidOperationException($"{context} must be a non-empty string.");
+            }
+
+            RequireNoBoundaryWhitespace(value, context);
+            return value;
+        }
+
+        private static string ReadOptionalString(JsonNode? node, string context)
+        {
+            if (node == null)
+            {
+                return string.Empty;
+            }
+
+            string value = ReadStringValue(node, context);
+            if (value.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new InvalidOperationException($"{context} must not be whitespace.");
+            }
+
+            RequireNoBoundaryWhitespace(value, context);
+            return value;
+        }
+
+        private static string ReadStringValue(JsonNode? node, string context)
+        {
+            if (node is JsonValue value && value.TryGetValue<string>(out string? parsed))
+            {
+                return parsed ?? string.Empty;
+            }
+
+            throw new InvalidOperationException($"{context} must be a string.");
+        }
+
+        private static int ParseRequiredInt(JsonNode? node, string context)
+        {
+            if (node is not JsonValue value || !value.TryGetValue<int>(out int parsed))
+            {
+                throw new InvalidOperationException($"{context} requires an explicit integer field.");
+            }
+
+            return parsed;
+        }
+
+        private static int ParseOptionalInt(JsonNode? node, int defaultValue, string context)
+        {
+            if (node == null)
+            {
+                return defaultValue;
+            }
+
+            return ParseRequiredInt(node, context);
+        }
+
+        private static float ParseRequiredFiniteFloat(JsonNode? node, string context)
+        {
+            if (node is not JsonValue value || !value.TryGetValue<float>(out float parsed))
+            {
+                throw new InvalidOperationException($"{context} requires an explicit numeric field.");
+            }
+
+            if (!float.IsFinite(parsed))
+            {
+                throw new InvalidOperationException($"{context} must be finite.");
+            }
+
+            return parsed;
+        }
+
+        private static T ParseRequiredEnum<T>(JsonNode? node, string context) where T : struct, Enum
+        {
+            if (node is not JsonValue value)
+            {
+                throw new InvalidOperationException($"{context} requires a non-empty enum string.");
+            }
+
+            if (value.TryGetValue<int>(out int numericValue))
+            {
+                throw new InvalidOperationException(
+                    $"{context} must be an enum string, not numeric value {numericValue}.");
+            }
+
+            if (!value.TryGetValue<string>(out string? text) || string.IsNullOrWhiteSpace(text))
+            {
+                throw new InvalidOperationException($"{context} requires a non-empty enum string.");
+            }
+
+            if (!TryParseDefinedEnum(text, out T parsed))
+            {
+                throw new InvalidOperationException($"{context} has invalid value '{text}'.");
+            }
+
+            return parsed;
+        }
+
+        private static T ParseOptionalEnum<T>(JsonNode? node, T defaultValue, string context) where T : struct, Enum
+        {
+            if (node == null)
+            {
+                return defaultValue;
+            }
+
+            return ParseRequiredEnum<T>(node, context);
+        }
+
+        private static bool TryParseDefinedEnum<T>(string text, out T parsed) where T : struct, Enum
+        {
+            parsed = default;
+            if (!string.Equals(text, text.Trim(), StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+            {
+                return false;
+            }
+
+            return Enum.TryParse(text, ignoreCase: false, out parsed) && Enum.IsDefined(typeof(T), parsed);
+        }
+
+        private static void SortCustomDataChannels(InstancedBatchCustomDataChannel[] channels)
+        {
+            for (int i = 1; i < channels.Length; i++)
+            {
+                InstancedBatchCustomDataChannel channel = channels[i];
+                int j = i - 1;
+                while (j >= 0 && channels[j].Slot > channel.Slot)
+                {
+                    channels[j + 1] = channels[j];
+                    j--;
+                }
+
+                channels[j + 1] = channel;
+            }
+        }
+
+        private static void SortBehaviorsByOrder(InstancedBatchBehaviorBinding[] behaviors)
+        {
+            for (int i = 1; i < behaviors.Length; i++)
+            {
+                InstancedBatchBehaviorBinding behavior = behaviors[i];
+                int j = i - 1;
+                while (j >= 0 && behaviors[j].Order > behavior.Order)
+                {
+                    behaviors[j + 1] = behaviors[j];
+                    j--;
+                }
+
+                behaviors[j + 1] = behavior;
+            }
+        }
+
+        private static void RequireNoBoundaryWhitespace(string value, string context)
+        {
+            if (!string.Equals(value, value.Trim(), StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"{context} must not include leading or trailing whitespace.");
+            }
+        }
+    }
+}

--- a/src/Core/Presentation/Config/PerformerDefinitionConfigLoader.cs
+++ b/src/Core/Presentation/Config/PerformerDefinitionConfigLoader.cs
@@ -9,6 +9,7 @@ using Ludots.Core.Gameplay.GAS.Registry;
 using Ludots.Core.Presentation.Components;
 using Ludots.Core.Presentation.Events;
 using Ludots.Core.Presentation.Hud;
+using Ludots.Core.Presentation.Instancing;
 using Ludots.Core.Presentation.Performers;
 using Ludots.Core.Presentation.Rendering;
 
@@ -32,6 +33,7 @@ namespace Ludots.Core.Presentation.Config
         private readonly Func<string, int> _resolveAnimationProfileId;
         private readonly Func<AssetKind, string, int> _resolveBehaviorAssetId;
         private readonly Func<string, int> _resolveSelectionSetKeyId;
+        private readonly Func<string, int> _resolveInstancedBatchAssetId;
 
         public PerformerDefinitionConfigLoader(
             ConfigPipeline configs,
@@ -45,7 +47,8 @@ namespace Ludots.Core.Presentation.Config
             Func<string, int> resolveAnimatorControllerId = null,
             Func<string, int> resolveAnimationProfileId = null,
             Func<AssetKind, string, int> resolveBehaviorAssetId = null,
-            Func<string, int> resolveSelectionSetKeyId = null)
+            Func<string, int> resolveSelectionSetKeyId = null,
+            Func<string, int> resolveInstancedBatchAssetId = null)
         {
             _configs = configs ?? throw new ArgumentNullException(nameof(configs));
             _registry = registry ?? throw new ArgumentNullException(nameof(registry));
@@ -59,6 +62,7 @@ namespace Ludots.Core.Presentation.Config
             _resolveAnimationProfileId = resolveAnimationProfileId ?? (_ => 0);
             _resolveBehaviorAssetId = resolveBehaviorAssetId ?? ((_, __) => 0);
             _resolveSelectionSetKeyId = resolveSelectionSetKeyId ?? (_ => 0);
+            _resolveInstancedBatchAssetId = resolveInstancedBatchAssetId ?? (_ => 0);
         }
 
         public void Load(ConfigCatalog catalog = null, ConfigConflictReport report = null)
@@ -388,6 +392,7 @@ namespace Ludots.Core.Presentation.Config
                 Bindings = ParseBindings(node["bindings"]),
                 Children = ParseChildren(node["children"]),
                 Behaviors = behaviors,
+                InstancedBatches = ParseInstancedBatchBindings(node["instancedBatches"], key),
                 ParamDefaults = ParseParamDefaults(node["paramDefaults"]),
             };
 
@@ -1184,6 +1189,55 @@ namespace Ludots.Core.Presentation.Config
             }
 
             return slots;
+        }
+
+        private InstancedBatchBinding[] ParseInstancedBatchBindings(JsonNode? node, string ownerKey)
+        {
+            if (node is not JsonArray arr || arr.Count == 0)
+            {
+                return Array.Empty<InstancedBatchBinding>();
+            }
+
+            var bindings = new InstancedBatchBinding[arr.Count];
+            for (int i = 0; i < arr.Count; i++)
+            {
+                if (arr[i] is not JsonObject obj)
+                {
+                    throw new InvalidOperationException($"Performer '{ownerKey}' instancedBatches[{i}] must be an object.");
+                }
+
+                string batchKey = ParseRequiredSemanticString(
+                    obj["batchAssetId"],
+                    $"Performer '{ownerKey}' instancedBatches[{i}].batchAssetId");
+                int batchAssetId = _resolveInstancedBatchAssetId(batchKey);
+                if (batchAssetId <= 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Performer '{ownerKey}' references unknown instanced batch asset '{batchKey}'.");
+                }
+
+                bindings[i] = new InstancedBatchBinding(batchAssetId);
+            }
+
+            return bindings;
+        }
+
+        private static string ParseRequiredSemanticString(JsonNode? node, string context)
+        {
+            if (node is JsonValue value)
+            {
+                if (value.TryGetValue<int>(out int numericId))
+                {
+                    throw new InvalidOperationException($"{context} must be a semantic string, not numeric id {numericId}.");
+                }
+
+                if (value.TryGetValue<string>(out string? text) && !string.IsNullOrWhiteSpace(text))
+                {
+                    return RequireCanonicalString(text, context);
+                }
+            }
+
+            throw new InvalidOperationException($"{context} must be a semantic string.");
         }
 
         private ParamDefault[] ParseParamDefaults(JsonNode? node)

--- a/src/Core/Presentation/Instancing/InstancedBatchAddressing.cs
+++ b/src/Core/Presentation/Instancing/InstancedBatchAddressing.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ludots.Core.Presentation.Instancing
+{
+    public readonly struct InstancedBatchOwnerId : IEquatable<InstancedBatchOwnerId>
+    {
+        public InstancedBatchOwnerId(int value) => Value = value;
+        public int Value { get; }
+        public bool IsValid => Value > 0;
+        public bool Equals(InstancedBatchOwnerId other) => Value == other.Value;
+        public override bool Equals(object? obj) => obj is InstancedBatchOwnerId other && Equals(other);
+        public override int GetHashCode() => Value;
+        public override string ToString() => Value.ToString();
+    }
+
+    public readonly struct InstancedBatchGroupId : IEquatable<InstancedBatchGroupId>
+    {
+        public InstancedBatchGroupId(int value) => Value = value;
+        public int Value { get; }
+        public bool IsValid => Value > 0;
+        public bool Equals(InstancedBatchGroupId other) => Value == other.Value;
+        public override bool Equals(object? obj) => obj is InstancedBatchGroupId other && Equals(other);
+        public override int GetHashCode() => Value;
+        public override string ToString() => Value.ToString();
+    }
+
+    public readonly struct InstancedBatchBucketId : IEquatable<InstancedBatchBucketId>
+    {
+        public InstancedBatchBucketId(int value) => Value = value;
+        public int Value { get; }
+        public bool IsValid => Value > 0;
+        public bool Equals(InstancedBatchBucketId other) => Value == other.Value;
+        public override bool Equals(object? obj) => obj is InstancedBatchBucketId other && Equals(other);
+        public override int GetHashCode() => Value;
+        public override string ToString() => Value.ToString();
+    }
+
+    public readonly struct InstancedBatchSpanId : IEquatable<InstancedBatchSpanId>
+    {
+        public InstancedBatchSpanId(int value) => Value = value;
+        public int Value { get; }
+        public bool IsValid => Value > 0;
+        public bool Equals(InstancedBatchSpanId other) => Value == other.Value;
+        public override bool Equals(object? obj) => obj is InstancedBatchSpanId other && Equals(other);
+        public override int GetHashCode() => Value;
+        public override string ToString() => Value.ToString();
+    }
+
+    public readonly struct InstancedBatchAddress : IEquatable<InstancedBatchAddress>
+    {
+        public InstancedBatchAddress(
+            int batchId,
+            InstancedBatchOwnerId owner,
+            InstancedBatchGroupId group,
+            InstancedBatchBucketId bucket,
+            InstancedBatchSpanId span)
+        {
+            BatchId = batchId;
+            Owner = owner;
+            Group = group;
+            Bucket = bucket;
+            Span = span;
+        }
+
+        public int BatchId { get; }
+        public InstancedBatchOwnerId Owner { get; }
+        public InstancedBatchGroupId Group { get; }
+        public InstancedBatchBucketId Bucket { get; }
+        public InstancedBatchSpanId Span { get; }
+        public bool IsValid => BatchId > 0 && Owner.IsValid && Group.IsValid && Bucket.IsValid && Span.IsValid;
+
+        public bool Equals(InstancedBatchAddress other)
+        {
+            return BatchId == other.BatchId &&
+                   Owner.Equals(other.Owner) &&
+                   Group.Equals(other.Group) &&
+                   Bucket.Equals(other.Bucket) &&
+                   Span.Equals(other.Span);
+        }
+
+        public override bool Equals(object? obj) => obj is InstancedBatchAddress other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(BatchId, Owner, Group, Bucket, Span);
+    }
+
+    public readonly struct InstancedBatchAddressGroupInput
+    {
+        public InstancedBatchAddressGroupInput(string groupId, string bucketId, string spanId)
+        {
+            GroupId = groupId ?? string.Empty;
+            BucketId = bucketId ?? string.Empty;
+            SpanId = spanId ?? string.Empty;
+        }
+
+        public string GroupId { get; }
+        public string BucketId { get; }
+        public string SpanId { get; }
+    }
+
+    public sealed class InstancedBatchAddressTable
+    {
+        private readonly Dictionary<string, InstancedBatchGroupId> _groups;
+        private readonly Dictionary<string, InstancedBatchBucketId> _buckets;
+        private readonly Dictionary<string, InstancedBatchSpanId> _spans;
+        private readonly Dictionary<AddressKey, InstancedBatchAddress> _addresses;
+        private readonly InstancedBatchAddressGroup[] _orderedGroups;
+
+        private InstancedBatchAddressTable(
+            int batchId,
+            string ownerStableId,
+            InstancedBatchOwnerId owner,
+            Dictionary<string, InstancedBatchGroupId> groups,
+            Dictionary<string, InstancedBatchBucketId> buckets,
+            Dictionary<string, InstancedBatchSpanId> spans,
+            Dictionary<AddressKey, InstancedBatchAddress> addresses,
+            InstancedBatchAddressGroup[] orderedGroups)
+        {
+            BatchId = batchId;
+            OwnerStableId = ownerStableId;
+            Owner = owner;
+            _groups = groups;
+            _buckets = buckets;
+            _spans = spans;
+            _addresses = addresses;
+            _orderedGroups = orderedGroups;
+        }
+
+        public int BatchId { get; }
+        public string OwnerStableId { get; }
+        public InstancedBatchOwnerId Owner { get; }
+        public int GroupCount => _orderedGroups.Length;
+        public ReadOnlySpan<InstancedBatchAddressGroup> Groups => _orderedGroups;
+
+        public static InstancedBatchAddressTable Build(
+            int batchId,
+            string ownerStableId,
+            ReadOnlySpan<InstancedBatchAddressGroupInput> groupInputs)
+        {
+            if (batchId <= 0)
+            {
+                throw new InvalidOperationException("Instanced batch address table requires a positive batch id.");
+            }
+
+            RequireCanonicalId(ownerStableId, "instanced batch ownerStableId");
+            if (groupInputs.Length == 0)
+            {
+                throw new InvalidOperationException("Instanced batch address table requires at least one group.");
+            }
+
+            var groups = new Dictionary<string, InstancedBatchGroupId>(groupInputs.Length, StringComparer.Ordinal);
+            var buckets = new Dictionary<string, InstancedBatchBucketId>(groupInputs.Length, StringComparer.Ordinal);
+            var spans = new Dictionary<string, InstancedBatchSpanId>(groupInputs.Length, StringComparer.Ordinal);
+            var addresses = new Dictionary<AddressKey, InstancedBatchAddress>(groupInputs.Length);
+            var ordered = new InstancedBatchAddressGroup[groupInputs.Length];
+            var owner = new InstancedBatchOwnerId(1);
+            for (int i = 0; i < groupInputs.Length; i++)
+            {
+                InstancedBatchAddressGroupInput input = groupInputs[i];
+                RequireCanonicalId(input.GroupId, $"instanced batch group[{i}].id");
+                RequireCanonicalId(input.BucketId, $"instanced batch group[{i}].bucketId");
+                RequireCanonicalId(input.SpanId, $"instanced batch group[{i}].instanceSpanId");
+
+                if (groups.ContainsKey(input.GroupId))
+                {
+                    throw new InvalidOperationException($"Instanced batch group id '{input.GroupId}' is duplicated.");
+                }
+
+                if (buckets.ContainsKey(input.BucketId))
+                {
+                    throw new InvalidOperationException($"Instanced batch bucket id '{input.BucketId}' is duplicated.");
+                }
+
+                if (spans.ContainsKey(input.SpanId))
+                {
+                    throw new InvalidOperationException($"Instanced batch instance span id '{input.SpanId}' is duplicated.");
+                }
+
+                var groupId = new InstancedBatchGroupId(i + 1);
+                var bucketId = new InstancedBatchBucketId(i + 1);
+                var spanId = new InstancedBatchSpanId(i + 1);
+                groups.Add(input.GroupId, groupId);
+                buckets.Add(input.BucketId, bucketId);
+                spans.Add(input.SpanId, spanId);
+                addresses.Add(
+                    new AddressKey(input.GroupId, input.BucketId, input.SpanId),
+                    new InstancedBatchAddress(batchId, owner, groupId, bucketId, spanId));
+                ordered[i] = new InstancedBatchAddressGroup(input.GroupId, input.BucketId, input.SpanId, groupId, bucketId, spanId);
+            }
+
+            return new InstancedBatchAddressTable(
+                batchId,
+                ownerStableId,
+                owner,
+                groups,
+                buckets,
+                spans,
+                addresses,
+                ordered);
+        }
+
+        public bool TryResolve(
+            string groupId,
+            string bucketId,
+            string spanId,
+            out InstancedBatchAddress address)
+        {
+            if (_addresses.TryGetValue(new AddressKey(groupId ?? string.Empty, bucketId ?? string.Empty, spanId ?? string.Empty), out address))
+            {
+                return true;
+            }
+
+            address = default;
+            return false;
+        }
+
+        public InstancedBatchAddress Resolve(string groupId, string bucketId, string spanId)
+        {
+            if (!TryResolve(groupId, bucketId, spanId, out InstancedBatchAddress address))
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch address target group='{groupId}' bucket='{bucketId}' span='{spanId}' is unknown.");
+            }
+
+            return address;
+        }
+
+        internal static void RequireCanonicalId(string? value, string context)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new InvalidOperationException($"{context} must be a non-empty id.");
+            }
+
+            if (!string.Equals(value, value.Trim(), StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"{context} must not include leading or trailing whitespace.");
+            }
+        }
+
+        private readonly struct AddressKey : IEquatable<AddressKey>
+        {
+            private readonly string _groupId;
+            private readonly string _bucketId;
+            private readonly string _spanId;
+
+            public AddressKey(string groupId, string bucketId, string spanId)
+            {
+                _groupId = groupId;
+                _bucketId = bucketId;
+                _spanId = spanId;
+            }
+
+            public bool Equals(AddressKey other)
+            {
+                return string.Equals(_groupId, other._groupId, StringComparison.Ordinal) &&
+                       string.Equals(_bucketId, other._bucketId, StringComparison.Ordinal) &&
+                       string.Equals(_spanId, other._spanId, StringComparison.Ordinal);
+            }
+
+            public override bool Equals(object? obj) => obj is AddressKey other && Equals(other);
+
+            public override int GetHashCode() => HashCode.Combine(
+                StringComparer.Ordinal.GetHashCode(_groupId),
+                StringComparer.Ordinal.GetHashCode(_bucketId),
+                StringComparer.Ordinal.GetHashCode(_spanId));
+        }
+    }
+
+    public readonly struct InstancedBatchAddressGroup
+    {
+        public InstancedBatchAddressGroup(
+            string groupKey,
+            string bucketKey,
+            string spanKey,
+            InstancedBatchGroupId group,
+            InstancedBatchBucketId bucket,
+            InstancedBatchSpanId span)
+        {
+            GroupKey = groupKey;
+            BucketKey = bucketKey;
+            SpanKey = spanKey;
+            Group = group;
+            Bucket = bucket;
+            Span = span;
+        }
+
+        public string GroupKey { get; }
+        public string BucketKey { get; }
+        public string SpanKey { get; }
+        public InstancedBatchGroupId Group { get; }
+        public InstancedBatchBucketId Bucket { get; }
+        public InstancedBatchSpanId Span { get; }
+    }
+}

--- a/src/Core/Presentation/Instancing/InstancedBatchAsset.cs
+++ b/src/Core/Presentation/Instancing/InstancedBatchAsset.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Numerics;
+using Ludots.Core.Presentation.Components;
+using Ludots.Core.Presentation.Performers;
+
+namespace Ludots.Core.Presentation.Instancing
+{
+    public sealed class InstancedBatchAsset
+    {
+        public InstancedBatchAsset()
+        {
+            Key = string.Empty;
+            OwnerStableId = string.Empty;
+            Groups = Array.Empty<InstancedBatchGroup>();
+            CustomDataChannels = Array.Empty<InstancedBatchCustomDataChannel>();
+            Behaviors = Array.Empty<InstancedBatchBehaviorBinding>();
+        }
+
+        public int Id { get; set; }
+        public string Key { get; set; }
+        public VisualRenderPath RenderPath { get; set; }
+        public string OwnerStableId { get; set; }
+        public InstancedBatchGroup[] Groups { get; set; }
+        public InstancedBatchCustomDataChannel[] CustomDataChannels { get; set; }
+        public InstancedBatchBehaviorBinding[] Behaviors { get; set; }
+        public InstancedBatchProgressiveSubmissionPolicy ProgressiveSubmission { get; set; }
+        public InstancedBatchAddressTable AddressTable { get; set; } = null!;
+    }
+
+    public struct InstancedBatchGroup
+    {
+        public string Id;
+        public int MeshAssetId;
+        public int MaterialId;
+        public string BucketId;
+        public string InstanceSpanId;
+        public InstancedBatchAddress Address;
+        public InstancedBatchTransform[] Transforms;
+    }
+
+    public struct InstancedBatchTransform
+    {
+        public Vector3 PositionCm;
+        public Quaternion Rotation;
+        public Vector3 Scale;
+    }
+
+    public struct InstancedBatchCustomDataChannel
+    {
+        public string Key;
+        public int Slot;
+        public MaterialCustomDataLane Lane;
+    }
+
+    public readonly struct InstancedBatchProgressiveSubmissionPolicy
+    {
+        public static readonly InstancedBatchProgressiveSubmissionPolicy None = new(0);
+
+        public InstancedBatchProgressiveSubmissionPolicy(int maxInstancesPerFlush)
+        {
+            MaxInstancesPerFlush = maxInstancesPerFlush;
+        }
+
+        public int MaxInstancesPerFlush { get; }
+        public bool IsEnabled => MaxInstancesPerFlush > 0;
+    }
+}

--- a/src/Core/Presentation/Instancing/InstancedBatchAssetRegistry.cs
+++ b/src/Core/Presentation/Instancing/InstancedBatchAssetRegistry.cs
@@ -1,0 +1,64 @@
+using System;
+using Ludots.Core.Registry;
+
+namespace Ludots.Core.Presentation.Instancing
+{
+    public sealed class InstancedBatchAssetRegistry
+    {
+        private readonly StringIntRegistry _ids;
+        private InstancedBatchAsset[] _assets;
+
+        public InstancedBatchAssetRegistry(int capacity = 256)
+        {
+            if (capacity <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity));
+            }
+
+            _ids = new StringIntRegistry(capacity, startId: 1, invalidId: 0, StringComparer.Ordinal);
+            _assets = new InstancedBatchAsset[capacity];
+        }
+
+        public int Register(string key, InstancedBatchAsset asset)
+        {
+            if (asset == null)
+            {
+                throw new ArgumentNullException(nameof(asset));
+            }
+
+            int id = _ids.Register(key);
+            EnsureCapacity(id);
+            asset.Id = id;
+            asset.Key = key;
+            _assets[id] = asset;
+            return id;
+        }
+
+        public int GetId(string key) => _ids.GetId(key);
+
+        public string GetName(int id) => _ids.GetName(id);
+
+        public bool TryGet(int id, out InstancedBatchAsset asset)
+        {
+            if ((uint)id < (uint)_assets.Length)
+            {
+                asset = _assets[id];
+                return asset != null;
+            }
+
+            asset = null!;
+            return false;
+        }
+
+        private void EnsureCapacity(int id)
+        {
+            if (id < _assets.Length)
+            {
+                return;
+            }
+
+            int next = Math.Max(_assets.Length * 2, id + 1);
+            Array.Resize(ref _assets, next);
+        }
+    }
+}

--- a/src/Core/Presentation/Instancing/InstancedBatchBinding.cs
+++ b/src/Core/Presentation/Instancing/InstancedBatchBinding.cs
@@ -1,0 +1,12 @@
+namespace Ludots.Core.Presentation.Instancing
+{
+    public readonly struct InstancedBatchBinding
+    {
+        public InstancedBatchBinding(int batchAssetId)
+        {
+            BatchAssetId = batchAssetId;
+        }
+
+        public int BatchAssetId { get; }
+    }
+}

--- a/src/Core/Presentation/Instancing/InstancedBatchCapabilityValidator.cs
+++ b/src/Core/Presentation/Instancing/InstancedBatchCapabilityValidator.cs
@@ -1,0 +1,78 @@
+using System;
+using Ludots.Core.Presentation.Components;
+using Ludots.Core.Presentation.Rendering;
+
+namespace Ludots.Core.Presentation.Instancing
+{
+    public static class InstancedBatchCapabilityValidator
+    {
+        public static void Validate(
+            InstancedBatchRequestBuffer requests,
+            InstancedBatchOperationBuffer operations,
+            PresentationAdapterCapabilities? capabilities)
+        {
+            if (requests == null) throw new ArgumentNullException(nameof(requests));
+            if (operations == null) throw new ArgumentNullException(nameof(operations));
+
+            ReadOnlySpan<InstancedBatchRequest> requestSpan = requests.GetSpan();
+            ReadOnlySpan<InstancedBatchOperation> operationSpan = operations.GetSpan();
+            if (requestSpan.Length == 0 && operationSpan.Length == 0)
+            {
+                return;
+            }
+
+            if (capabilities == null)
+            {
+                throw new InvalidOperationException(
+                    $"Presentation adapter has not declared capabilities for instanced batch work ({requestSpan.Length} request(s), {operationSpan.Length} operation(s)).");
+            }
+
+            for (int i = 0; i < requestSpan.Length; i++)
+            {
+                ValidateRequest(in requestSpan[i], capabilities);
+            }
+
+            for (int i = 0; i < operationSpan.Length; i++)
+            {
+                ValidateOperation(in operationSpan[i], capabilities);
+            }
+        }
+
+        private static void ValidateRequest(in InstancedBatchRequest request, PresentationAdapterCapabilities capabilities)
+        {
+            PresentationVisualCapabilities required = request.RenderPath switch
+            {
+                VisualRenderPath.InstancedStaticMesh => PresentationVisualCapabilities.InstancedStaticMeshBatch,
+                VisualRenderPath.HierarchicalInstancedStaticMesh => PresentationVisualCapabilities.HierarchicalInstancedStaticMeshBatch,
+                _ => PresentationVisualCapabilities.None,
+            };
+
+            if (required == PresentationVisualCapabilities.None || !capabilities.Visuals.HasFlag(required))
+            {
+                throw new InvalidOperationException(
+                    $"Presentation adapter does not support instanced batch renderPath '{request.RenderPath}' (batchAssetId={request.BatchAssetId}).");
+            }
+        }
+
+        private static void ValidateOperation(in InstancedBatchOperation operation, PresentationAdapterCapabilities capabilities)
+        {
+            PresentationVisualCapabilities required = operation.Kind switch
+            {
+                InstancedBatchOperationKind.SetVisibility => PresentationVisualCapabilities.InstancedBatchVisibility,
+                InstancedBatchOperationKind.WriteCustomData => PresentationVisualCapabilities.InstanceCustomData,
+                InstancedBatchOperationKind.SetPresentationState => PresentationVisualCapabilities.InstancedBatchPresentationState,
+                InstancedBatchOperationKind.Refresh => PresentationVisualCapabilities.InstancedBatchRefresh,
+                InstancedBatchOperationKind.AttachEffect => PresentationVisualCapabilities.InstancedBatchEffect,
+                InstancedBatchOperationKind.UpdateEffect => PresentationVisualCapabilities.InstancedBatchEffect,
+                InstancedBatchOperationKind.RemoveEffect => PresentationVisualCapabilities.InstancedBatchEffect,
+                _ => PresentationVisualCapabilities.None,
+            };
+
+            if (required == PresentationVisualCapabilities.None || !capabilities.Visuals.HasFlag(required))
+            {
+                throw new InvalidOperationException(
+                    $"Presentation adapter does not support instanced batch operation '{operation.Kind}' (batchAssetId={operation.BatchAssetId}).");
+            }
+        }
+    }
+}

--- a/src/Core/Presentation/Instancing/InstancedBatchOperationBuffer.cs
+++ b/src/Core/Presentation/Instancing/InstancedBatchOperationBuffer.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Numerics;
+using Arch.Core;
+using Ludots.Core.Presentation.Events;
+
+namespace Ludots.Core.Presentation.Instancing
+{
+    public enum InstancedBatchSourceKind : byte
+    {
+        Attribute = 1,
+        GasEvent = 2,
+        PresentationEvent = 3,
+    }
+
+    public enum InstancedBatchOperationKind : byte
+    {
+        SetVisibility = 1,
+        WriteCustomData = 2,
+        SetPresentationState = 3,
+        Refresh = 4,
+        AttachEffect = 5,
+        UpdateEffect = 6,
+        RemoveEffect = 7,
+    }
+
+    public enum InstancedBatchValueMappingKind : byte
+    {
+        Identity = 0,
+        Linear = 1,
+        Constant = 2,
+    }
+
+    public enum InstancedBatchCoalescingMode : byte
+    {
+        None = 0,
+        LastWriteWins = 1,
+    }
+
+    public enum InstancedBatchLifecycleMode : byte
+    {
+        Persistent = 0,
+        UntilOwnerDestroyed = 1,
+        Transient = 2,
+    }
+
+    public readonly struct InstancedBatchBehaviorBinding
+    {
+        public InstancedBatchBehaviorBinding(
+            string key,
+            InstancedBatchSourceKind sourceKind,
+            int sourceKeyId,
+            PresentationEventKind sourceEventKind,
+            InstancedBatchOperationKind operationKind,
+            string groupId,
+            string bucketId,
+            string spanId,
+            int customDataSlot,
+            InstancedBatchValueMappingKind mappingKind,
+            float inputMin,
+            float inputMax,
+            float outputMin,
+            float outputMax,
+            float constantValue,
+            int order = 0,
+            InstancedBatchCoalescingMode coalescing = InstancedBatchCoalescingMode.LastWriteWins,
+            InstancedBatchLifecycleMode lifecycle = InstancedBatchLifecycleMode.UntilOwnerDestroyed,
+            int targetPayloadId = 0,
+            InstancedBatchAddress address = default)
+        {
+            Key = key ?? string.Empty;
+            SourceKind = sourceKind;
+            SourceKeyId = sourceKeyId;
+            SourceEventKind = sourceEventKind;
+            OperationKind = operationKind;
+            GroupId = groupId ?? string.Empty;
+            BucketId = bucketId ?? string.Empty;
+            SpanId = spanId ?? string.Empty;
+            CustomDataSlot = customDataSlot;
+            MappingKind = mappingKind;
+            InputMin = inputMin;
+            InputMax = inputMax;
+            OutputMin = outputMin;
+            OutputMax = outputMax;
+            ConstantValue = constantValue;
+            Order = order;
+            Coalescing = coalescing;
+            Lifecycle = lifecycle;
+            TargetPayloadId = targetPayloadId;
+            Address = address;
+        }
+
+        public string Key { get; }
+        public InstancedBatchSourceKind SourceKind { get; }
+        public int SourceKeyId { get; }
+        public PresentationEventKind SourceEventKind { get; }
+        public InstancedBatchOperationKind OperationKind { get; }
+        public string GroupId { get; }
+        public string BucketId { get; }
+        public string SpanId { get; }
+        public int CustomDataSlot { get; }
+        public InstancedBatchValueMappingKind MappingKind { get; }
+        public float InputMin { get; }
+        public float InputMax { get; }
+        public float OutputMin { get; }
+        public float OutputMax { get; }
+        public float ConstantValue { get; }
+        public int Order { get; }
+        public InstancedBatchCoalescingMode Coalescing { get; }
+        public InstancedBatchLifecycleMode Lifecycle { get; }
+        public int TargetPayloadId { get; }
+        public InstancedBatchAddress Address { get; }
+        public bool HasCompiledAddress => Address.IsValid;
+
+        public InstancedBatchBehaviorBinding WithCompiledAddress(InstancedBatchAddress address)
+        {
+            return new InstancedBatchBehaviorBinding(
+                Key,
+                SourceKind,
+                SourceKeyId,
+                SourceEventKind,
+                OperationKind,
+                GroupId,
+                BucketId,
+                SpanId,
+                CustomDataSlot,
+                MappingKind,
+                InputMin,
+                InputMax,
+                OutputMin,
+                OutputMax,
+                ConstantValue,
+                Order,
+                Coalescing,
+                Lifecycle,
+                TargetPayloadId,
+                address);
+        }
+    }
+
+    public readonly struct InstancedBatchOperation
+    {
+        public InstancedBatchOperation(
+            InstancedBatchOperationKind kind,
+            int batchAssetId,
+            int performerStableId,
+            Entity owner,
+            Entity performer,
+            InstancedBatchAddress address,
+            int customDataSlot,
+            Vector4 value,
+            int payloadId = 0,
+            byte state = 0,
+            InstancedBatchCoalescingMode coalescing = InstancedBatchCoalescingMode.None,
+            InstancedBatchLifecycleMode lifecycle = InstancedBatchLifecycleMode.Persistent)
+        {
+            Kind = kind;
+            BatchAssetId = batchAssetId;
+            PerformerStableId = performerStableId;
+            Owner = owner;
+            Performer = performer;
+            Address = address;
+            CustomDataSlot = customDataSlot;
+            Value = value;
+            PayloadId = payloadId;
+            State = state;
+            Coalescing = coalescing;
+            Lifecycle = lifecycle;
+        }
+
+        public InstancedBatchOperationKind Kind { get; }
+        public int BatchAssetId { get; }
+        public int PerformerStableId { get; }
+        public Entity Owner { get; }
+        public Entity Performer { get; }
+        public InstancedBatchAddress Address { get; }
+        public int CustomDataSlot { get; }
+        public Vector4 Value { get; }
+        public int PayloadId { get; }
+        public byte State { get; }
+        public InstancedBatchCoalescingMode Coalescing { get; }
+        public InstancedBatchLifecycleMode Lifecycle { get; }
+    }
+
+    public sealed class InstancedBatchOperationBuffer
+    {
+        private InstancedBatchOperation[] _buffer;
+        private int _count;
+
+        public InstancedBatchOperationBuffer(int capacity = 4096)
+        {
+            if (capacity <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity));
+            }
+
+            _buffer = new InstancedBatchOperation[capacity];
+        }
+
+        public int Count => _count;
+        public int Capacity => _buffer.Length;
+
+        public void Add(in InstancedBatchOperation operation)
+        {
+            if (operation.Coalescing == InstancedBatchCoalescingMode.LastWriteWins)
+            {
+                for (int i = _count - 1; i >= 0; i--)
+                {
+                    if (CanCoalesce(in _buffer[i], in operation))
+                    {
+                        _buffer[i] = operation;
+                        return;
+                    }
+                }
+            }
+
+            if (_count >= _buffer.Length)
+            {
+                throw new InvalidOperationException(
+                    $"InstancedBatchOperationBuffer overflowed while adding kind={operation.Kind}, batchAssetId={operation.BatchAssetId}.");
+            }
+
+            _buffer[_count++] = operation;
+        }
+
+        public ReadOnlySpan<InstancedBatchOperation> GetSpan() => _buffer.AsSpan(0, _count);
+
+        public void Clear()
+        {
+            _count = 0;
+        }
+
+        private static bool CanCoalesce(in InstancedBatchOperation existing, in InstancedBatchOperation incoming)
+        {
+            return existing.Kind == incoming.Kind &&
+                   existing.BatchAssetId == incoming.BatchAssetId &&
+                   existing.PerformerStableId == incoming.PerformerStableId &&
+                   existing.Performer == incoming.Performer &&
+                   existing.Address.Equals(incoming.Address) &&
+                   existing.CustomDataSlot == incoming.CustomDataSlot &&
+                   PayloadIdentityMatches(in existing, in incoming);
+        }
+
+        private static bool PayloadIdentityMatches(in InstancedBatchOperation existing, in InstancedBatchOperation incoming)
+        {
+            return incoming.Kind switch
+            {
+                InstancedBatchOperationKind.AttachEffect or
+                InstancedBatchOperationKind.UpdateEffect or
+                InstancedBatchOperationKind.RemoveEffect => existing.PayloadId == incoming.PayloadId,
+                _ => true,
+            };
+        }
+    }
+}

--- a/src/Core/Presentation/Instancing/InstancedBatchRequestBuffer.cs
+++ b/src/Core/Presentation/Instancing/InstancedBatchRequestBuffer.cs
@@ -1,0 +1,101 @@
+using System;
+using Arch.Core;
+using Ludots.Core.Presentation.Components;
+
+namespace Ludots.Core.Presentation.Instancing
+{
+    public enum InstancedBatchRequestKind : byte
+    {
+        CreateOrUpdate = 1,
+        Remove = 2,
+    }
+
+    public readonly struct InstancedBatchRequest
+    {
+        public InstancedBatchRequest(
+            InstancedBatchRequestKind kind,
+            int batchAssetId,
+            int performerStableId,
+            Entity owner,
+            Entity performer,
+            InstancedBatchAddress address,
+            VisualRenderPath renderPath,
+            int meshAssetId,
+            int materialAssetId,
+            int instanceStart,
+            int instanceCount,
+            bool finalChunk)
+        {
+            Kind = kind;
+            BatchAssetId = batchAssetId;
+            PerformerStableId = performerStableId;
+            Owner = owner;
+            Performer = performer;
+            Address = address;
+            RenderPath = renderPath;
+            MeshAssetId = meshAssetId;
+            MaterialAssetId = materialAssetId;
+            InstanceStart = instanceStart;
+            InstanceCount = instanceCount;
+            FinalChunk = finalChunk;
+        }
+
+        public InstancedBatchRequestKind Kind { get; }
+        public int BatchAssetId { get; }
+        public int PerformerStableId { get; }
+        public Entity Owner { get; }
+        public Entity Performer { get; }
+        public InstancedBatchAddress Address { get; }
+        public VisualRenderPath RenderPath { get; }
+        public int MeshAssetId { get; }
+        public int MaterialAssetId { get; }
+        public int InstanceStart { get; }
+        public int InstanceCount { get; }
+        public bool FinalChunk { get; }
+    }
+
+    public sealed class InstancedBatchRequestBuffer
+    {
+        private InstancedBatchRequest[] _buffer;
+        private int _count;
+        private int _revision;
+
+        public InstancedBatchRequestBuffer(int capacity = 4096)
+        {
+            if (capacity <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity));
+            }
+
+            _buffer = new InstancedBatchRequest[capacity];
+        }
+
+        public int Count => _count;
+        public int Capacity => _buffer.Length;
+        public int Revision => _revision;
+        public int DroppedSinceClear { get; private set; }
+        public int DroppedTotal { get; private set; }
+
+        public void Add(in InstancedBatchRequest request)
+        {
+            if (_count >= _buffer.Length)
+            {
+                DroppedSinceClear++;
+                DroppedTotal++;
+                throw new InvalidOperationException(
+                    $"InstancedBatchRequestBuffer overflowed while adding kind={request.Kind}, batchAssetId={request.BatchAssetId}.");
+            }
+
+            _buffer[_count++] = request;
+            _revision++;
+        }
+
+        public ReadOnlySpan<InstancedBatchRequest> GetSpan() => _buffer.AsSpan(0, _count);
+
+        public void Clear()
+        {
+            _count = 0;
+            DroppedSinceClear = 0;
+        }
+    }
+}

--- a/src/Core/Presentation/Instancing/InstancedBatchSubmissionRuntime.cs
+++ b/src/Core/Presentation/Instancing/InstancedBatchSubmissionRuntime.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using Arch.Core;
+
+namespace Ludots.Core.Presentation.Instancing
+{
+    public sealed class InstancedBatchSubmissionRuntime
+    {
+        private readonly Dictionary<SubmissionKey, SubmissionState> _states = new();
+        private readonly List<SubmissionKey> _scratch = new(256);
+
+        public bool ShouldSubmit(Entity performer, int performerStableId, int batchAssetId, int groupIndex, int totalInstances, out int start, out int count, int budget)
+        {
+            if (totalInstances <= 0)
+            {
+                start = 0;
+                count = 0;
+                return false;
+            }
+
+            var key = new SubmissionKey(performer, performerStableId, batchAssetId, groupIndex);
+            if (!_states.TryGetValue(key, out SubmissionState state))
+            {
+                state = new SubmissionState();
+            }
+
+            if (state.Completed && state.TotalInstances == totalInstances)
+            {
+                start = 0;
+                count = 0;
+                return false;
+            }
+
+            if (state.TotalInstances != totalInstances)
+            {
+                state = new SubmissionState();
+            }
+
+            int resolvedBudget = budget <= 0 ? totalInstances : Math.Min(budget, totalInstances);
+            start = state.NextStart;
+            count = Math.Min(resolvedBudget, totalInstances - start);
+            state.NextStart += count;
+            state.TotalInstances = totalInstances;
+            state.Completed = state.NextStart >= totalInstances;
+            _states[key] = state;
+            return count > 0;
+        }
+
+        public void MarkDirty(Entity performer, int performerStableId, int batchAssetId)
+        {
+            _scratch.Clear();
+            foreach (SubmissionKey key in _states.Keys)
+            {
+                if (key.Performer == performer &&
+                    key.PerformerStableId == performerStableId &&
+                    key.BatchAssetId == batchAssetId)
+                {
+                    _scratch.Add(key);
+                }
+            }
+
+            for (int i = 0; i < _scratch.Count; i++)
+            {
+                _states.Remove(_scratch[i]);
+            }
+        }
+
+        public void Remove(Entity performer, int performerStableId)
+        {
+            _scratch.Clear();
+            foreach (SubmissionKey key in _states.Keys)
+            {
+                if (key.Performer == performer && key.PerformerStableId == performerStableId)
+                {
+                    _scratch.Add(key);
+                }
+            }
+
+            for (int i = 0; i < _scratch.Count; i++)
+            {
+                _states.Remove(_scratch[i]);
+            }
+        }
+
+        private readonly struct SubmissionKey : IEquatable<SubmissionKey>
+        {
+            public readonly Entity Performer;
+            public readonly int PerformerStableId;
+            public readonly int BatchAssetId;
+            public readonly int GroupIndex;
+
+            public SubmissionKey(Entity performer, int performerStableId, int batchAssetId, int groupIndex)
+            {
+                Performer = performer;
+                PerformerStableId = performerStableId;
+                BatchAssetId = batchAssetId;
+                GroupIndex = groupIndex;
+            }
+
+            public bool Equals(SubmissionKey other)
+            {
+                return Performer == other.Performer &&
+                       PerformerStableId == other.PerformerStableId &&
+                       BatchAssetId == other.BatchAssetId &&
+                       GroupIndex == other.GroupIndex;
+            }
+
+            public override bool Equals(object? obj) => obj is SubmissionKey other && Equals(other);
+
+            public override int GetHashCode() => HashCode.Combine(Performer, PerformerStableId, BatchAssetId, GroupIndex);
+        }
+
+        private struct SubmissionState
+        {
+            public int NextStart;
+            public int TotalInstances;
+            public bool Completed;
+        }
+    }
+}

--- a/src/Core/Presentation/Performers/PerformerDefinition.cs
+++ b/src/Core/Presentation/Performers/PerformerDefinition.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Ludots.Core.Presentation.Hud;
+using Ludots.Core.Presentation.Instancing;
 
 namespace Ludots.Core.Presentation.Performers
 {
@@ -68,6 +69,7 @@ namespace Ludots.Core.Presentation.Performers
         public string Extends = string.Empty;
         public ChildPerformerRef[] Children = System.Array.Empty<ChildPerformerRef>();
         public BehaviorSlot[] Behaviors = System.Array.Empty<BehaviorSlot>();
+        public InstancedBatchBinding[] InstancedBatches = System.Array.Empty<InstancedBatchBinding>();
         public PerformerRule[] Rules = System.Array.Empty<PerformerRule>();
         public ConditionRef VisibilityCondition;
         public PerformerParamBinding[] Bindings = System.Array.Empty<PerformerParamBinding>();
@@ -91,6 +93,7 @@ namespace Ludots.Core.Presentation.Performers
         internal uint AssetBindingSlotMask;
         internal uint AnimatorSlotMask;
         internal bool HasAssetBindingBehavior;
+        internal bool HasInstancedBatchBindings;
         internal bool HasAnimatorBehavior;
         internal bool HasSoundBehavior;
         internal bool HasMinimapMarkerBehavior;
@@ -278,11 +281,12 @@ namespace Ludots.Core.Presentation.Performers
             AssetBindingSlotMask = 0u;
             AnimatorSlotMask = 0u;
             HasAssetBindingBehavior = false;
+            HasInstancedBatchBindings = InstancedBatches != null && InstancedBatches.Length != 0;
             HasAnimatorBehavior = false;
             HasSoundBehavior = false;
             HasMinimapMarkerBehavior = false;
             HasSurfaceAuthoring = Surface != null;
-            RequiresBootstrapProcessing = (Bindings != null && Bindings.Length > 0) || HasSurfaceAuthoring;
+            RequiresBootstrapProcessing = (Bindings != null && Bindings.Length > 0) || HasSurfaceAuthoring || HasInstancedBatchBindings;
             UsesStableVisualCache = false;
             UsesEventDrivenStaticEmit = false;
             UsesRetainedPresentationRequest = false;

--- a/src/Core/Presentation/Rendering/PresentationAdapterCapabilities.cs
+++ b/src/Core/Presentation/Rendering/PresentationAdapterCapabilities.cs
@@ -12,6 +12,12 @@ namespace Ludots.Core.Presentation.Rendering
         MaterialOverride = 1 << 3,
         InstanceCustomData = 1 << 4,
         ExternalTargetLifecycle = 1 << 5,
+        InstancedStaticMeshBatch = 1 << 6,
+        HierarchicalInstancedStaticMeshBatch = 1 << 7,
+        InstancedBatchVisibility = 1 << 8,
+        InstancedBatchRefresh = 1 << 9,
+        InstancedBatchPresentationState = 1 << 10,
+        InstancedBatchEffect = 1 << 11,
     }
 
     public sealed class PresentationAdapterCapabilities

--- a/src/Core/Presentation/Systems/InstancedBatchBehaviorSystem.cs
+++ b/src/Core/Presentation/Systems/InstancedBatchBehaviorSystem.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Numerics;
+using Arch.Core;
+using Arch.System;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Presentation.Events;
+using Ludots.Core.Presentation.Instancing;
+using Ludots.Core.Presentation.Performers;
+
+namespace Ludots.Core.Presentation.Systems
+{
+    public sealed class InstancedBatchBehaviorSystem : BaseSystem<World, float>
+    {
+        private readonly PerformerDefinitionRegistry _definitions;
+        private readonly PerformerEntityRuntime _runtime;
+        private readonly InstancedBatchAssetRegistry _batchAssets;
+        private readonly InstancedBatchOperationBuffer _operations;
+        private readonly PresentationEventStream _events;
+        private readonly PresentationOwnerChangeBuffer _ownerChanges;
+
+        public InstancedBatchBehaviorSystem(
+            World world,
+            PerformerDefinitionRegistry definitions,
+            PerformerEntityRuntime runtime,
+            InstancedBatchAssetRegistry batchAssets,
+            InstancedBatchOperationBuffer operations,
+            PresentationEventStream events,
+            PresentationOwnerChangeBuffer ownerChanges)
+            : base(world)
+        {
+            _definitions = definitions ?? throw new ArgumentNullException(nameof(definitions));
+            _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+            _batchAssets = batchAssets ?? throw new ArgumentNullException(nameof(batchAssets));
+            _operations = operations ?? throw new ArgumentNullException(nameof(operations));
+            _events = events ?? throw new ArgumentNullException(nameof(events));
+            _ownerChanges = ownerChanges ?? throw new ArgumentNullException(nameof(ownerChanges));
+        }
+
+        public override void Update(in float dt)
+        {
+            EmitOwnerChangeOperations();
+            EmitEventOperations();
+        }
+
+        private void EmitOwnerChangeOperations()
+        {
+            ReadOnlySpan<PresentationOwnerChange> changes = _ownerChanges.GetSpan();
+            for (int i = 0; i < changes.Length; i++)
+            {
+                ref readonly PresentationOwnerChange change = ref changes[i];
+                if (change.Kind != PresentationOwnerChangeKind.Attribute)
+                {
+                    continue;
+                }
+
+                float value = ResolveOwnerAttributeValue(change.Owner, change.KeyId);
+                EmitForOwner(
+                    change.Owner,
+                    InstancedBatchSourceKind.Attribute,
+                    change.KeyId,
+                    value);
+            }
+        }
+
+        private void EmitEventOperations()
+        {
+            ReadOnlySpan<PresentationEvent> events = _events.GetSpan();
+            for (int i = 0; i < events.Length; i++)
+            {
+                ref readonly PresentationEvent evt = ref events[i];
+                if (evt.Kind == PresentationEventKind.AttributeValueChanged)
+                {
+                    continue;
+                }
+
+                InstancedBatchSourceKind sourceKind = IsGasPresentationEvent(evt.Kind)
+                    ? InstancedBatchSourceKind.GasEvent
+                    : InstancedBatchSourceKind.PresentationEvent;
+                EmitForOwner(
+                    evt.Source,
+                    sourceKind,
+                    evt.KeyId,
+                    evt.Magnitude,
+                    evt.Kind);
+            }
+        }
+
+        private void EmitForOwner(
+            Entity owner,
+            InstancedBatchSourceKind sourceKind,
+            int sourceKeyId,
+            float sourceValue,
+            PresentationEventKind sourceEventKind = PresentationEventKind.None)
+        {
+            if (!_runtime.TryGetActiveByOwner(owner, out PerformerEntityRuntime.OwnerPerformerBucket performers))
+            {
+                return;
+            }
+
+            for (int performerIndex = 0; performerIndex < performers.Count; performerIndex++)
+            {
+                Entity performer = performers.GetAt(performerIndex);
+                if (!World.IsAlive(performer) || !World.Has<PerformerState>(performer))
+                {
+                    continue;
+                }
+
+                ref readonly PerformerState state = ref World.Get<PerformerState>(performer);
+                if (!_definitions.TryGet(state.DefId, out PerformerDefinition definition) ||
+                    !definition.HasInstancedBatchBindings)
+                {
+                    continue;
+                }
+
+                InstancedBatchBinding[] bindings = definition.InstancedBatches;
+                for (int bindingIndex = 0; bindingIndex < bindings.Length; bindingIndex++)
+                {
+                    int batchAssetId = bindings[bindingIndex].BatchAssetId;
+                    if (!_batchAssets.TryGet(batchAssetId, out InstancedBatchAsset asset))
+                    {
+                        continue;
+                    }
+
+                    EmitMatchingBindings(
+                        performer,
+                        in state,
+                        asset,
+                        sourceKind,
+                        sourceKeyId,
+                        sourceValue,
+                        sourceEventKind);
+                }
+            }
+        }
+
+        private void EmitMatchingBindings(
+            Entity performer,
+            in PerformerState state,
+            InstancedBatchAsset asset,
+            InstancedBatchSourceKind sourceKind,
+            int sourceKeyId,
+            float sourceValue,
+            PresentationEventKind sourceEventKind)
+        {
+            InstancedBatchBehaviorBinding[] behaviors = asset.Behaviors;
+            for (int i = 0; i < behaviors.Length; i++)
+            {
+                ref readonly InstancedBatchBehaviorBinding binding = ref behaviors[i];
+                if (binding.SourceKind != sourceKind ||
+                    !SourceKeyMatches(in binding, sourceKeyId) ||
+                    binding.SourceEventKind != sourceEventKind)
+                {
+                    continue;
+                }
+
+                if (!binding.HasCompiledAddress)
+                {
+                    throw new InvalidOperationException(
+                        $"Instanced batch asset '{asset.Key}' behavior '{binding.Key}' has not been compiled to a stable address.");
+                }
+
+                float mapped = MapValue(sourceValue, in binding);
+                _operations.Add(new InstancedBatchOperation(
+                    binding.OperationKind,
+                    asset.Id,
+                    state.StableId,
+                    state.OwnerEntity,
+                    performer,
+                    binding.Address,
+                    binding.CustomDataSlot,
+                    new Vector4(mapped, 0f, 0f, 0f),
+                    binding.TargetPayloadId,
+                    ResolveOperationState(binding.OperationKind, mapped),
+                    binding.Coalescing,
+                    binding.Lifecycle));
+            }
+        }
+
+        private float ResolveOwnerAttributeValue(Entity owner, int attributeId)
+        {
+            if (!World.IsAlive(owner) || !World.Has<AttributeBuffer>(owner))
+            {
+                return 0f;
+            }
+
+            ref AttributeBuffer attributes = ref World.Get<AttributeBuffer>(owner);
+            return attributes.GetCurrent(attributeId);
+        }
+
+        private static bool IsGasPresentationEvent(PresentationEventKind kind)
+        {
+            return kind is PresentationEventKind.EffectApplied
+                or PresentationEventKind.CastCommitted
+                or PresentationEventKind.CastFailed;
+        }
+
+        private static bool SourceKeyMatches(in InstancedBatchBehaviorBinding binding, int eventKeyId)
+        {
+            if (binding.SourceKeyId == eventKeyId)
+            {
+                return true;
+            }
+
+            return binding.SourceKind == InstancedBatchSourceKind.PresentationEvent &&
+                   binding.SourceEventKind is PresentationEventKind.PerformerCreated or PresentationEventKind.PerformerDestroyed &&
+                   binding.SourceKeyId == -1;
+        }
+
+        private static float MapValue(float value, in InstancedBatchBehaviorBinding binding)
+        {
+            return binding.MappingKind switch
+            {
+                InstancedBatchValueMappingKind.Constant => binding.ConstantValue,
+                InstancedBatchValueMappingKind.Linear => MapLinear(value, binding.InputMin, binding.InputMax, binding.OutputMin, binding.OutputMax),
+                _ => value,
+            };
+        }
+
+        private static float MapLinear(float value, float inputMin, float inputMax, float outputMin, float outputMax)
+        {
+            if (MathF.Abs(inputMax - inputMin) <= 0.0001f)
+            {
+                return outputMin;
+            }
+
+            float t = (value - inputMin) / (inputMax - inputMin);
+            return outputMin + (outputMax - outputMin) * t;
+        }
+
+        private static byte ResolveOperationState(InstancedBatchOperationKind kind, float mappedValue)
+        {
+            return kind == InstancedBatchOperationKind.SetVisibility && mappedValue > 0f
+                ? (byte)1
+                : (byte)0;
+        }
+    }
+}

--- a/src/Core/Presentation/Systems/InstancedBatchEmissionSystem.cs
+++ b/src/Core/Presentation/Systems/InstancedBatchEmissionSystem.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using Arch.Core;
+using Arch.System;
+using Ludots.Core.Presentation.Events;
+using Ludots.Core.Presentation.Instancing;
+using Ludots.Core.Presentation.Performers;
+
+namespace Ludots.Core.Presentation.Systems
+{
+    public sealed class InstancedBatchEmissionSystem : BaseSystem<World, float>
+    {
+        private static readonly QueryDescription PerformerQuery = new QueryDescription()
+            .WithAll<PerformerState>();
+
+        private readonly PerformerDefinitionRegistry _definitions;
+        private readonly InstancedBatchAssetRegistry _batchAssets;
+        private readonly InstancedBatchRequestBuffer _requests;
+        private readonly InstancedBatchSubmissionRuntime _submissionRuntime;
+        private readonly PresentationEventStream _events;
+        private readonly List<RemovedPerformerKey> _removedThisFrame = new(32);
+
+        public InstancedBatchEmissionSystem(
+            World world,
+            PerformerDefinitionRegistry definitions,
+            InstancedBatchAssetRegistry batchAssets,
+            InstancedBatchRequestBuffer requests,
+            InstancedBatchSubmissionRuntime submissionRuntime,
+            PresentationEventStream events)
+            : base(world)
+        {
+            _definitions = definitions ?? throw new ArgumentNullException(nameof(definitions));
+            _batchAssets = batchAssets ?? throw new ArgumentNullException(nameof(batchAssets));
+            _requests = requests ?? throw new ArgumentNullException(nameof(requests));
+            _submissionRuntime = submissionRuntime ?? throw new ArgumentNullException(nameof(submissionRuntime));
+            _events = events ?? throw new ArgumentNullException(nameof(events));
+        }
+
+        public override void Update(in float dt)
+        {
+            _removedThisFrame.Clear();
+            EmitRemovals();
+
+            foreach (ref readonly Chunk chunk in World.Query(in PerformerQuery))
+            {
+                ref Entity firstEntity = ref chunk.Entity(0);
+                Span<PerformerState> states = chunk.GetSpan<PerformerState>();
+                for (int i = 0; i < chunk.Count; i++)
+                {
+                    Entity performer = System.Runtime.CompilerServices.Unsafe.Add(ref firstEntity, i);
+                    ref readonly PerformerState state = ref states[i];
+                    if (WasRemovedThisFrame(performer, state.StableId))
+                    {
+                        continue;
+                    }
+
+                    EmitForPerformer(performer, in state);
+                }
+            }
+        }
+
+        private void EmitForPerformer(Entity performer, in PerformerState state)
+        {
+            if (!_definitions.TryGet(state.DefId, out PerformerDefinition definition) ||
+                !definition.HasInstancedBatchBindings)
+            {
+                return;
+            }
+
+            InstancedBatchBinding[] bindings = definition.InstancedBatches;
+            for (int bindingIndex = 0; bindingIndex < bindings.Length; bindingIndex++)
+            {
+                int batchAssetId = bindings[bindingIndex].BatchAssetId;
+                if (!_batchAssets.TryGet(batchAssetId, out InstancedBatchAsset asset))
+                {
+                    throw new InvalidOperationException(
+                        $"Performer definition '{definition.Key}' references missing instanced batch asset id={batchAssetId}.");
+                }
+
+                InstancedBatchGroup[] groups = asset.Groups;
+                for (int groupIndex = 0; groupIndex < groups.Length; groupIndex++)
+                {
+                    ref readonly InstancedBatchGroup group = ref groups[groupIndex];
+                    int totalInstances = group.Transforms?.Length ?? 0;
+                    int budget = asset.ProgressiveSubmission.MaxInstancesPerFlush;
+                    if (!_submissionRuntime.ShouldSubmit(
+                            performer,
+                            state.StableId,
+                            batchAssetId,
+                            groupIndex,
+                            totalInstances,
+                            out int start,
+                            out int count,
+                            budget))
+                    {
+                        continue;
+                    }
+
+                    InstancedBatchAddress address = group.Address;
+                    if (!address.IsValid)
+                    {
+                        throw new InvalidOperationException(
+                            $"Instanced batch asset '{asset.Key}' group '{group.Id}' has not been compiled to a stable address.");
+                    }
+
+                    _requests.Add(new InstancedBatchRequest(
+                        InstancedBatchRequestKind.CreateOrUpdate,
+                        batchAssetId,
+                        state.StableId,
+                        state.OwnerEntity,
+                        performer,
+                        address,
+                        asset.RenderPath,
+                        group.MeshAssetId,
+                        group.MaterialId,
+                        start,
+                        count,
+                        finalChunk: start + count >= totalInstances));
+                }
+            }
+        }
+
+        private void EmitRemovals()
+        {
+            ReadOnlySpan<PresentationEvent> events = _events.GetSpan();
+            for (int i = 0; i < events.Length; i++)
+            {
+                ref readonly PresentationEvent evt = ref events[i];
+                if (evt.Kind != PresentationEventKind.PerformerDestroyed ||
+                    evt.PerformerEntity == Entity.Null ||
+                    !_definitions.TryGet(evt.KeyId, out PerformerDefinition definition) ||
+                    !definition.HasInstancedBatchBindings)
+                {
+                    continue;
+                }
+
+                _submissionRuntime.Remove(evt.PerformerEntity, (int)evt.Magnitude);
+                _removedThisFrame.Add(new RemovedPerformerKey(evt.PerformerEntity, (int)evt.Magnitude));
+                InstancedBatchBinding[] bindings = definition.InstancedBatches;
+                for (int bindingIndex = 0; bindingIndex < bindings.Length; bindingIndex++)
+                {
+                    int batchAssetId = bindings[bindingIndex].BatchAssetId;
+                    if (!_batchAssets.TryGet(batchAssetId, out InstancedBatchAsset asset))
+                    {
+                        continue;
+                    }
+
+                    InstancedBatchGroup[] groups = asset.Groups;
+                    for (int groupIndex = 0; groupIndex < groups.Length; groupIndex++)
+                    {
+                        ref readonly InstancedBatchGroup group = ref groups[groupIndex];
+                        InstancedBatchAddress address = group.Address;
+                        if (!address.IsValid)
+                        {
+                            throw new InvalidOperationException(
+                                $"Instanced batch asset '{asset.Key}' group '{group.Id}' has not been compiled to a stable address.");
+                        }
+
+                        _requests.Add(new InstancedBatchRequest(
+                            InstancedBatchRequestKind.Remove,
+                            batchAssetId,
+                            (int)evt.Magnitude,
+                            evt.Source,
+                            evt.PerformerEntity,
+                            address,
+                            asset.RenderPath,
+                            group.MeshAssetId,
+                            group.MaterialId,
+                            0,
+                            0,
+                            finalChunk: true));
+                    }
+                }
+            }
+        }
+
+        private bool WasRemovedThisFrame(Entity performer, int performerStableId)
+        {
+            for (int i = 0; i < _removedThisFrame.Count; i++)
+            {
+                if (_removedThisFrame[i].Performer == performer &&
+                    _removedThisFrame[i].PerformerStableId == performerStableId)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private readonly struct RemovedPerformerKey
+        {
+            public readonly Entity Performer;
+            public readonly int PerformerStableId;
+
+            public RemovedPerformerKey(Entity performer, int performerStableId)
+            {
+                Performer = performer;
+                PerformerStableId = performerStableId;
+            }
+        }
+    }
+}

--- a/src/Core/Scripting/CoreServiceKeys.cs
+++ b/src/Core/Scripting/CoreServiceKeys.cs
@@ -48,6 +48,7 @@ using Ludots.Core.Presentation.Config;
 using Ludots.Core.Presentation.DebugDraw;
 using Ludots.Core.Presentation.Events;
 using Ludots.Core.Presentation.Hud;
+using Ludots.Core.Presentation.Instancing;
 using Ludots.Core.Presentation.Minimap;
 using Ludots.Core.Presentation.Performers;
 using Ludots.Core.Presentation.Requests;
@@ -209,6 +210,9 @@ namespace Ludots.Core.Scripting
         public static readonly ServiceKey<PrefabRegistry> PresentationPrefabRegistry = new("PresentationPrefabRegistry");
         public static readonly ServiceKey<MeshAssetRegistry> PresentationMeshAssetRegistry = new("PresentationMeshAssetRegistry");
         public static readonly ServiceKey<PresentationMaterialRegistry> PresentationMaterialRegistry = new("PresentationMaterialRegistry");
+        public static readonly ServiceKey<InstancedBatchAssetRegistry> InstancedBatchAssetRegistry = new("InstancedBatchAssetRegistry");
+        public static readonly ServiceKey<InstancedBatchRequestBuffer> InstancedBatchRequestBuffer = new("InstancedBatchRequestBuffer");
+        public static readonly ServiceKey<InstancedBatchOperationBuffer> InstancedBatchOperationBuffer = new("InstancedBatchOperationBuffer");
         public static readonly ServiceKey<PresentationBehaviorRegistry> PresentationBehaviorRegistry = new("PresentationBehaviorRegistry");
         public static readonly ServiceKey<PresentationBehaviorResolver> PresentationBehaviorResolver = new("PresentationBehaviorResolver");
         public static readonly ServiceKey<AnimatorControllerRegistry> AnimatorControllerRegistry = new("AnimatorControllerRegistry");

--- a/src/Tests/PresentationTests/InstancedBatchContractTests.cs
+++ b/src/Tests/PresentationTests/InstancedBatchContractTests.cs
@@ -1,0 +1,1336 @@
+using System;
+using System.IO;
+using System.Numerics;
+using Arch.Core;
+using Ludots.Core.Config;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.Modding;
+using Ludots.Core.Presentation.Assets;
+using Ludots.Core.Presentation.Commands;
+using Ludots.Core.Presentation.Components;
+using Ludots.Core.Presentation.Config;
+using Ludots.Core.Presentation.Events;
+using Ludots.Core.Presentation.Instancing;
+using Ludots.Core.Presentation.Performers;
+using Ludots.Core.Presentation.Rendering;
+using Ludots.Core.Presentation.Systems;
+using NUnit.Framework;
+
+namespace Ludots.Tests.Presentation
+{
+    [TestFixture]
+    public sealed class InstancedBatchContractTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            AttributeRegistry.Clear();
+            AbilityIdRegistry.Clear();
+            EffectTemplateIdRegistry.Clear();
+            TagRegistry.Clear();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            AttributeRegistry.Clear();
+            AbilityIdRegistry.Clear();
+            EffectTemplateIdRegistry.Clear();
+            TagRegistry.Clear();
+        }
+
+        [Test]
+        public void Load_RegistersBatchWithStableAddressesAndProgressivePolicy()
+        {
+            string root = CreateTempCoreRoot();
+            WritePresentationFile(root, "instanced_batches.json",
+                """
+                [
+                  {
+                    "id": "batch.large",
+                    "renderPath": "HierarchicalInstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "customDataChannels": [
+                      { "key": "visual.amount", "slot": 0, "type": "Float" }
+                    ],
+                    "progressiveSubmission": { "maxInstancesPerFlush": 2 },
+                    "groups": [
+                      {
+                        "id": "group.a",
+                        "meshAssetId": "mesh.unit",
+                        "materialId": "material.unit",
+                        "bucketId": "bucket.a",
+                        "instanceSpanId": "span.a",
+                        "transforms": [
+                          { "positionCm": { "x": 1, "y": 2, "z": 3 } },
+                          { "positionCm": [4, 5, 6], "rotation": [0, 0, 0, 1], "scale": [1, 2, 1] }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+                """);
+
+            var loader = BuildLoader(root, out InstancedBatchAssetRegistry registry);
+            loader.Load(BuildCatalog());
+
+            int id = registry.GetId("batch.large");
+            Assert.That(registry.TryGet(id, out InstancedBatchAsset asset), Is.True);
+            Assert.That(asset.RenderPath, Is.EqualTo(VisualRenderPath.HierarchicalInstancedStaticMesh));
+            Assert.That(asset.Groups.Length, Is.EqualTo(1));
+            Assert.That(asset.Groups[0].BucketId, Is.EqualTo("bucket.a"));
+            Assert.That(asset.CustomDataChannels[0].Lane, Is.EqualTo(MaterialCustomDataLane.Float));
+            Assert.That(asset.ProgressiveSubmission.MaxInstancesPerFlush, Is.EqualTo(2));
+            Assert.That(asset.AddressTable.TryResolve("group.a", "bucket.a", "span.a", out InstancedBatchAddress address), Is.True);
+            Assert.That(address.IsValid, Is.True);
+            Assert.That(asset.Groups[0].Address.Equals(address), Is.True);
+        }
+
+        [TestCase("unknown mesh asset 'missing.mesh'", "{ \"id\": \"group.a\", \"meshAssetId\": \"missing.mesh\", \"bucketId\": \"bucket.a\", \"instanceSpanId\": \"span.a\", \"transforms\": [ { \"positionCm\": [1,2,3] } ] }")]
+        [TestCase("unknown material asset 'missing.material'", "{ \"id\": \"group.a\", \"meshAssetId\": \"mesh.unit\", \"materialId\": \"missing.material\", \"bucketId\": \"bucket.a\", \"instanceSpanId\": \"span.a\", \"transforms\": [ { \"positionCm\": [1,2,3] } ] }")]
+        [TestCase("non-empty groups array", "")]
+        [TestCase("bucketId must be a string", "{ \"id\": \"group.a\", \"meshAssetId\": \"mesh.unit\", \"instanceSpanId\": \"span.a\", \"transforms\": [ { \"positionCm\": [1,2,3] } ] }")]
+        [TestCase("requires exactly 3 numeric array entries", "{ \"id\": \"group.a\", \"meshAssetId\": \"mesh.unit\", \"bucketId\": \"bucket.a\", \"instanceSpanId\": \"span.a\", \"transforms\": [ { \"positionCm\": [1,2] } ] }")]
+        public void Load_RejectsMalformedBatchData(string expectedMessage, string groupJson)
+        {
+            string root = CreateTempCoreRoot();
+            string groups = groupJson.Length == 0 ? "[]" : $"[ {groupJson} ]";
+            WritePresentationFile(root, "instanced_batches.json",
+                $$"""
+                [
+                  {
+                    "id": "batch.bad",
+                    "renderPath": "InstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "groups": {{groups}}
+                  }
+                ]
+                """);
+
+            var loader = BuildLoader(root, out _);
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => loader.Load(BuildCatalog()))!;
+            Assert.That(ex.Message, Does.Contain(expectedMessage));
+        }
+
+        [Test]
+        public void Load_RejectsUnsupportedInstancedBatchSchemaFields()
+        {
+            AttributeRegistry.Register("attr.health");
+
+            AssertUnsupportedField(
+                "unknownTop",
+                """
+                [
+                  {
+                    "id": "batch.strict",
+                    "renderPath": "InstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "unknownTop": true,
+                    "groups": [
+                      {
+                        "id": "group.a",
+                        "meshAssetId": "mesh.unit",
+                        "bucketId": "bucket.a",
+                        "instanceSpanId": "span.a",
+                        "transforms": [ { "positionCm": [1,2,3] } ]
+                      }
+                    ]
+                  }
+                ]
+                """);
+            AssertUnsupportedField(
+                "unknownGroup",
+                """
+                [
+                  {
+                    "id": "batch.strict",
+                    "renderPath": "InstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "groups": [
+                      {
+                        "id": "group.a",
+                        "meshAssetId": "mesh.unit",
+                        "bucketId": "bucket.a",
+                        "instanceSpanId": "span.a",
+                        "unknownGroup": true,
+                        "transforms": [ { "positionCm": [1,2,3] } ]
+                      }
+                    ]
+                  }
+                ]
+                """);
+            AssertUnsupportedField(
+                "unknownSource",
+                """
+                [
+                  {
+                    "id": "batch.strict",
+                    "renderPath": "InstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "groups": [
+                      {
+                        "id": "group.a",
+                        "meshAssetId": "mesh.unit",
+                        "bucketId": "bucket.a",
+                        "instanceSpanId": "span.a",
+                        "transforms": [ { "positionCm": [1,2,3] } ]
+                      }
+                    ],
+                    "behaviors": [
+                      {
+                        "id": "bad-source",
+                        "source": { "kind": "Attribute", "key": "attr.health", "unknownSource": true },
+                        "target": { "operation": "SetVisibility", "group": "group.a", "bucket": "bucket.a", "span": "span.a" }
+                      }
+                    ]
+                  }
+                ]
+                """);
+            AssertUnsupportedField(
+                "unknownTarget",
+                """
+                [
+                  {
+                    "id": "batch.strict",
+                    "renderPath": "InstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "groups": [
+                      {
+                        "id": "group.a",
+                        "meshAssetId": "mesh.unit",
+                        "bucketId": "bucket.a",
+                        "instanceSpanId": "span.a",
+                        "transforms": [ { "positionCm": [1,2,3] } ]
+                      }
+                    ],
+                    "behaviors": [
+                      {
+                        "id": "bad-target",
+                        "source": { "kind": "Attribute", "key": "attr.health" },
+                        "target": {
+                          "operation": "SetVisibility",
+                          "group": "group.a",
+                          "bucket": "bucket.a",
+                          "span": "span.a",
+                          "unknownTarget": true
+                        }
+                      }
+                    ]
+                  }
+                ]
+                """);
+            AssertUnsupportedField(
+                "unknownMapping",
+                """
+                [
+                  {
+                    "id": "batch.strict",
+                    "renderPath": "InstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "groups": [
+                      {
+                        "id": "group.a",
+                        "meshAssetId": "mesh.unit",
+                        "bucketId": "bucket.a",
+                        "instanceSpanId": "span.a",
+                        "transforms": [ { "positionCm": [1,2,3] } ]
+                      }
+                    ],
+                    "behaviors": [
+                      {
+                        "id": "bad-mapping",
+                        "source": { "kind": "Attribute", "key": "attr.health" },
+                        "target": { "operation": "SetVisibility", "group": "group.a", "bucket": "bucket.a", "span": "span.a" },
+                        "mapping": { "kind": "Constant", "constantValue": 1, "unknownMapping": true }
+                      }
+                    ]
+                  }
+                ]
+                """);
+
+            static void AssertUnsupportedField(string fieldName, string json)
+            {
+                string root = CreateTempCoreRoot();
+                WritePresentationFile(root, "instanced_batches.json", json);
+
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                    () => BuildLoader(root, out _).Load(BuildCatalog()))!;
+                Assert.That(ex.Message, Does.Contain($"unsupported field '{fieldName}'"));
+            }
+        }
+
+        [Test]
+        public void Load_RejectsPayloadFieldsOnWrongOperationTarget()
+        {
+            AttributeRegistry.Register("attr.health");
+
+            AssertInvalidTarget(
+                "presentationStateId is only valid for SetPresentationState",
+                """
+                [
+                  {
+                    "id": "batch.invalid.target",
+                    "renderPath": "InstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "groups": [
+                      {
+                        "id": "group.a",
+                        "meshAssetId": "mesh.unit",
+                        "bucketId": "bucket.a",
+                        "instanceSpanId": "span.a",
+                        "transforms": [ { "positionCm": [1,2,3] } ]
+                      }
+                    ],
+                    "behaviors": [
+                      {
+                        "id": "bad-state-payload",
+                        "source": { "kind": "Attribute", "key": "attr.health" },
+                        "target": {
+                          "operation": "SetVisibility",
+                          "group": "group.a",
+                          "bucket": "bucket.a",
+                          "span": "span.a",
+                          "presentationStateId": 7
+                        }
+                      }
+                    ]
+                  }
+                ]
+                """);
+            AssertInvalidTarget(
+                "effectAssetId is only valid for AttachEffect, UpdateEffect, or RemoveEffect",
+                """
+                [
+                  {
+                    "id": "batch.invalid.target",
+                    "renderPath": "InstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "customDataChannels": [
+                      { "key": "visual.amount", "slot": 0, "type": "Float" }
+                    ],
+                    "groups": [
+                      {
+                        "id": "group.a",
+                        "meshAssetId": "mesh.unit",
+                        "bucketId": "bucket.a",
+                        "instanceSpanId": "span.a",
+                        "transforms": [ { "positionCm": [1,2,3] } ]
+                      }
+                    ],
+                    "behaviors": [
+                      {
+                        "id": "bad-effect-payload",
+                        "source": { "kind": "Attribute", "key": "attr.health" },
+                        "target": {
+                          "operation": "WriteCustomData",
+                          "group": "group.a",
+                          "bucket": "bucket.a",
+                          "span": "span.a",
+                          "customDataSlot": 0,
+                          "effectAssetId": "effect.batch.spark"
+                        }
+                      }
+                    ]
+                  }
+                ]
+                """);
+            AssertInvalidTarget(
+                "customDataSlot is only valid for WriteCustomData",
+                """
+                [
+                  {
+                    "id": "batch.invalid.target",
+                    "renderPath": "InstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "groups": [
+                      {
+                        "id": "group.a",
+                        "meshAssetId": "mesh.unit",
+                        "bucketId": "bucket.a",
+                        "instanceSpanId": "span.a",
+                        "transforms": [ { "positionCm": [1,2,3] } ]
+                      }
+                    ],
+                    "behaviors": [
+                      {
+                        "id": "bad-custom-data-slot",
+                        "source": { "kind": "Attribute", "key": "attr.health" },
+                        "target": {
+                          "operation": "SetPresentationState",
+                          "group": "group.a",
+                          "bucket": "bucket.a",
+                          "span": "span.a",
+                          "customDataSlot": 0,
+                          "presentationStateId": 7
+                        }
+                      }
+                    ]
+                  }
+                ]
+                """);
+
+            static void AssertInvalidTarget(string expectedMessage, string json)
+            {
+                string root = CreateTempCoreRoot();
+                WritePresentationFile(root, "instanced_batches.json", json);
+
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                    () => BuildLoader(root, out _).Load(BuildCatalog()))!;
+                Assert.That(ex.Message, Does.Contain(expectedMessage));
+            }
+        }
+
+        [Test]
+        public void Load_CompilesBehaviorTargetAndRejectsInvalidSelectorsOrSlots()
+        {
+            string root = CreateTempCoreRoot();
+            int attributeId = AttributeRegistry.Register("attr.health");
+            WritePresentationFile(root, "instanced_batches.json",
+                """
+                [
+                  {
+                    "id": "batch.behavior",
+                    "renderPath": "InstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "customDataChannels": [
+                      { "key": "visual.amount", "slot": 0, "type": "Float" }
+                    ],
+                    "groups": [
+                      {
+                        "id": "group.a",
+                        "meshAssetId": "mesh.unit",
+                        "bucketId": "bucket.a",
+                        "instanceSpanId": "span.a",
+                        "transforms": [ { "positionCm": [1,2,3] } ]
+                      }
+                    ],
+                    "behaviors": [
+                      {
+                        "id": "health-to-custom-data",
+                        "source": { "kind": "Attribute", "key": "attr.health" },
+                        "target": {
+                          "operation": "WriteCustomData",
+                          "group": "group.a",
+                          "bucket": "bucket.a",
+                          "span": "span.a",
+                          "customDataSlot": 0
+                        },
+                        "mapping": { "kind": "Linear", "inputMin": 0, "inputMax": 100, "outputMin": 0, "outputMax": 1 }
+                      }
+                    ]
+                  }
+                ]
+                """);
+
+            var loader = BuildLoader(root, out InstancedBatchAssetRegistry registry);
+            loader.Load(BuildCatalog());
+
+            Assert.That(registry.TryGet(registry.GetId("batch.behavior"), out InstancedBatchAsset asset), Is.True);
+            Assert.That(asset.Behaviors.Length, Is.EqualTo(1));
+            Assert.That(asset.Behaviors[0].SourceKeyId, Is.EqualTo(attributeId));
+            Assert.That(asset.Behaviors[0].HasCompiledAddress, Is.True);
+            Assert.That(asset.Behaviors[0].Address.Bucket.Value, Is.EqualTo(1));
+
+            string invalidRoot = CreateTempCoreRoot();
+            WritePresentationFile(invalidRoot, "instanced_batches.json",
+                """
+                [
+                  {
+                    "id": "batch.invalid",
+                    "renderPath": "InstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "customDataChannels": [
+                      { "key": "visual.amount", "slot": 0, "type": "Float" }
+                    ],
+                    "groups": [
+                      {
+                        "id": "group.a",
+                        "meshAssetId": "mesh.unit",
+                        "bucketId": "bucket.a",
+                        "instanceSpanId": "span.a",
+                        "transforms": [ { "positionCm": [1,2,3] } ]
+                      }
+                    ],
+                    "behaviors": [
+                      {
+                        "id": "bad-selector",
+                        "source": { "kind": "Attribute", "key": "attr.health" },
+                        "target": {
+                          "operation": "WriteCustomData",
+                          "group": "group.a",
+                          "bucket": "bucket.missing",
+                          "span": "span.a",
+                          "customDataSlot": 0
+                        }
+                      }
+                    ]
+                  }
+                ]
+                """);
+
+            InvalidOperationException selectorEx = Assert.Throws<InvalidOperationException>(
+                () => BuildLoader(invalidRoot, out _).Load(BuildCatalog()))!;
+            Assert.That(selectorEx.Message, Does.Contain("bucket='bucket.missing'"));
+
+            string slotRoot = CreateTempCoreRoot();
+            WritePresentationFile(slotRoot, "instanced_batches.json",
+                """
+                [
+                  {
+                    "id": "batch.invalid.slot",
+                    "renderPath": "InstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "customDataChannels": [
+                      { "key": "visual.amount", "slot": 0, "type": "Float" }
+                    ],
+                    "groups": [
+                      {
+                        "id": "group.a",
+                        "meshAssetId": "mesh.unit",
+                        "bucketId": "bucket.a",
+                        "instanceSpanId": "span.a",
+                        "transforms": [ { "positionCm": [1,2,3] } ]
+                      }
+                    ],
+                    "behaviors": [
+                      {
+                        "id": "bad-slot",
+                        "source": { "kind": "Attribute", "key": "attr.health" },
+                        "target": {
+                          "operation": "WriteCustomData",
+                          "group": "group.a",
+                          "bucket": "bucket.a",
+                          "span": "span.a",
+                          "customDataSlot": 1
+                        }
+                      }
+                    ]
+                  }
+                ]
+                """);
+
+            InvalidOperationException slotEx = Assert.Throws<InvalidOperationException>(
+                () => BuildLoader(slotRoot, out _).Load(BuildCatalog()))!;
+            Assert.That(slotEx.Message, Does.Contain("undeclared customDataSlot 1"));
+        }
+
+        [Test]
+        public void Load_ParsesEventVisibilityStateAndEffectBehaviorPayloads()
+        {
+            string root = CreateTempCoreRoot();
+            int tagId = TagRegistry.Register("event.visibility");
+            int effectId = EffectTemplateIdRegistry.Register("effect.spark");
+            int abilityId = AbilityIdRegistry.Register("ability.cast");
+            WritePresentationFile(root, "instanced_batches.json",
+                """
+                [
+                  {
+                    "id": "batch.events",
+                    "renderPath": "InstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "groups": [
+                      {
+                        "id": "group.a",
+                        "meshAssetId": "mesh.unit",
+                        "bucketId": "bucket.a",
+                        "instanceSpanId": "span.a",
+                        "transforms": [ { "positionCm": [1,2,3] } ]
+                      }
+                    ],
+                    "behaviors": [
+                      {
+                        "id": "event-to-visibility",
+                        "source": { "kind": "PresentationEvent", "eventKind": "GameplayEvent", "key": "event.visibility" },
+                        "target": { "operation": "SetVisibility", "group": "group.a", "bucket": "bucket.a", "span": "span.a" },
+                        "mapping": { "kind": "Constant", "constantValue": 1 }
+                      },
+                      {
+                        "id": "effect-attach",
+                        "source": { "kind": "GasEvent", "eventKind": "EffectApplied", "key": "effect.spark" },
+                        "target": { "operation": "AttachEffect", "group": "group.a", "bucket": "bucket.a", "span": "span.a", "effectAssetId": "effect.batch.spark" }
+                      },
+                      {
+                        "id": "cast-state",
+                        "source": { "kind": "GasEvent", "eventKind": "CastCommitted", "key": "ability.cast" },
+                        "target": { "operation": "SetPresentationState", "group": "group.a", "bucket": "bucket.a", "span": "span.a", "presentationStateId": 7 }
+                      }
+                    ]
+                  }
+                ]
+                """);
+
+            var loader = BuildLoader(root, out InstancedBatchAssetRegistry registry);
+            loader.Load(BuildCatalog());
+
+            Assert.That(registry.TryGet(registry.GetId("batch.events"), out InstancedBatchAsset asset), Is.True);
+            Assert.That(asset.Behaviors[0].SourceEventKind, Is.EqualTo(PresentationEventKind.GameplayEvent));
+            Assert.That(asset.Behaviors[0].SourceKeyId, Is.EqualTo(tagId));
+            Assert.That(asset.Behaviors[1].SourceEventKind, Is.EqualTo(PresentationEventKind.EffectApplied));
+            Assert.That(asset.Behaviors[1].SourceKeyId, Is.EqualTo(effectId));
+            Assert.That(asset.Behaviors[1].TargetPayloadId, Is.GreaterThan(0));
+            Assert.That(asset.Behaviors[2].SourceEventKind, Is.EqualTo(PresentationEventKind.CastCommitted));
+            Assert.That(asset.Behaviors[2].SourceKeyId, Is.EqualTo(abilityId));
+            Assert.That(asset.Behaviors[2].TargetPayloadId, Is.EqualTo(7));
+        }
+
+        [Test]
+        public void Load_RejectsUnknownEffectAssetBehaviorPayload()
+        {
+            string root = CreateTempCoreRoot();
+            EffectTemplateIdRegistry.Register("effect.spark");
+            WritePresentationFile(root, "instanced_batches.json",
+                """
+                [
+                  {
+                    "id": "batch.bad.effect",
+                    "renderPath": "InstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "groups": [
+                      {
+                        "id": "group.a",
+                        "meshAssetId": "mesh.unit",
+                        "bucketId": "bucket.a",
+                        "instanceSpanId": "span.a",
+                        "transforms": [ { "positionCm": [1,2,3] } ]
+                      }
+                    ],
+                    "behaviors": [
+                      {
+                        "id": "missing-effect-asset",
+                        "source": { "kind": "GasEvent", "eventKind": "EffectApplied", "key": "effect.spark" },
+                        "target": {
+                          "operation": "AttachEffect",
+                          "group": "group.a",
+                          "bucket": "bucket.a",
+                          "span": "span.a",
+                          "effectAssetId": "effect.missing"
+                        }
+                      }
+                    ]
+                  }
+                ]
+                """);
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                () => BuildLoader(root, out _).Load(BuildCatalog()))!;
+            Assert.That(ex.Message, Does.Contain("unknown effect asset 'effect.missing'"));
+        }
+
+        [Test]
+        public void Load_SortsBehaviorsByOrderAndCarriesLifecycleDeclarations()
+        {
+            string root = CreateTempCoreRoot();
+            AttributeRegistry.Register("attr.health");
+            WritePresentationFile(root, "instanced_batches.json",
+                """
+                [
+                  {
+                    "id": "batch.ordered",
+                    "renderPath": "InstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "customDataChannels": [
+                      { "key": "visual.amount", "slot": 0, "type": "Float" }
+                    ],
+                    "groups": [
+                      {
+                        "id": "group.a",
+                        "meshAssetId": "mesh.unit",
+                        "bucketId": "bucket.a",
+                        "instanceSpanId": "span.a",
+                        "transforms": [ { "positionCm": [1,2,3] } ]
+                      }
+                    ],
+                    "behaviors": [
+                      {
+                        "id": "later",
+                        "order": 20,
+                        "coalescing": "None",
+                        "lifecycle": "Transient",
+                        "source": { "kind": "Attribute", "key": "attr.health" },
+                        "target": {
+                          "operation": "WriteCustomData",
+                          "group": "group.a",
+                          "bucket": "bucket.a",
+                          "span": "span.a",
+                          "customDataSlot": 0
+                        }
+                      },
+                      {
+                        "id": "earlier",
+                        "order": 10,
+                        "coalescing": "LastWriteWins",
+                        "lifecycle": "UntilOwnerDestroyed",
+                        "source": { "kind": "Attribute", "key": "attr.health" },
+                        "target": {
+                          "operation": "WriteCustomData",
+                          "group": "group.a",
+                          "bucket": "bucket.a",
+                          "span": "span.a",
+                          "customDataSlot": 0
+                        }
+                      }
+                    ]
+                  }
+                ]
+                """);
+
+            var loader = BuildLoader(root, out InstancedBatchAssetRegistry registry);
+            loader.Load(BuildCatalog());
+
+            Assert.That(registry.TryGet(registry.GetId("batch.ordered"), out InstancedBatchAsset asset), Is.True);
+            Assert.That(asset.Behaviors[0].Key, Is.EqualTo("earlier"));
+            Assert.That(asset.Behaviors[0].Order, Is.EqualTo(10));
+            Assert.That(asset.Behaviors[0].Coalescing, Is.EqualTo(InstancedBatchCoalescingMode.LastWriteWins));
+            Assert.That(asset.Behaviors[0].Lifecycle, Is.EqualTo(InstancedBatchLifecycleMode.UntilOwnerDestroyed));
+            Assert.That(asset.Behaviors[1].Key, Is.EqualTo("later"));
+            Assert.That(asset.Behaviors[1].Coalescing, Is.EqualTo(InstancedBatchCoalescingMode.None));
+            Assert.That(asset.Behaviors[1].Lifecycle, Is.EqualTo(InstancedBatchLifecycleMode.Transient));
+        }
+
+        [Test]
+        public void AddressTable_RejectsDuplicateAndCrossGroupSelectors()
+        {
+            var inputs = new[]
+            {
+                new InstancedBatchAddressGroupInput("group.a", "bucket.a", "span.a"),
+                new InstancedBatchAddressGroupInput("group.b", "bucket.b", "span.b"),
+            };
+
+            InstancedBatchAddressTable table = InstancedBatchAddressTable.Build(7, "owner.alpha", inputs);
+
+            Assert.That(table.TryResolve("group.a", "bucket.a", "span.a", out InstancedBatchAddress first), Is.True);
+            Assert.That(first.Group.Value, Is.EqualTo(1));
+            Assert.That(table.TryResolve("group.a", "bucket.b", "span.a", out _), Is.False);
+            Assert.That(
+                () => InstancedBatchAddressTable.Build(
+                    7,
+                    "owner.alpha",
+                    new[]
+                    {
+                        new InstancedBatchAddressGroupInput("group.a", "bucket.a", "span.a"),
+                        new InstancedBatchAddressGroupInput("group.a", "bucket.b", "span.b"),
+                    }),
+                Throws.InvalidOperationException.With.Message.Contains("duplicated"));
+        }
+
+        [Test]
+        public void SubmissionRuntime_SplitsAndResumesDeterministically()
+        {
+            var runtime = new InstancedBatchSubmissionRuntime();
+
+            Assert.That(runtime.ShouldSubmit(default, 10, 20, 0, 5, out int start, out int count, budget: 2), Is.True);
+            Assert.That((start, count), Is.EqualTo((0, 2)));
+            Assert.That(runtime.ShouldSubmit(default, 10, 20, 0, 5, out start, out count, budget: 2), Is.True);
+            Assert.That((start, count), Is.EqualTo((2, 2)));
+            Assert.That(runtime.ShouldSubmit(default, 10, 20, 0, 5, out start, out count, budget: 2), Is.True);
+            Assert.That((start, count), Is.EqualTo((4, 1)));
+            Assert.That(runtime.ShouldSubmit(default, 10, 20, 0, 5, out _, out _, budget: 2), Is.False);
+        }
+
+        [Test]
+        public void SubmissionRuntime_SubmitsSmallBatchInOneFinalChunk()
+        {
+            var runtime = new InstancedBatchSubmissionRuntime();
+
+            Assert.That(runtime.ShouldSubmit(default, 10, 20, 0, 3, out int start, out int count, budget: 0), Is.True);
+            Assert.That((start, count), Is.EqualTo((0, 3)));
+            Assert.That(runtime.ShouldSubmit(default, 10, 20, 0, 3, out _, out _, budget: 0), Is.False);
+        }
+
+        [Test]
+        public void CapabilityValidator_RejectsUnsupportedRenderPathAndOperation()
+        {
+            var requests = new InstancedBatchRequestBuffer();
+            var operations = new InstancedBatchOperationBuffer();
+            requests.Add(new InstancedBatchRequest(
+                InstancedBatchRequestKind.CreateOrUpdate,
+                1,
+                100,
+                default,
+                default,
+                new InstancedBatchAddress(1, new InstancedBatchOwnerId(1), new InstancedBatchGroupId(1), new InstancedBatchBucketId(1), new InstancedBatchSpanId(1)),
+                VisualRenderPath.HierarchicalInstancedStaticMesh,
+                10,
+                20,
+                0,
+                1,
+                finalChunk: true));
+            operations.Add(new InstancedBatchOperation(
+                InstancedBatchOperationKind.WriteCustomData,
+                1,
+                100,
+                default,
+                default,
+                new InstancedBatchAddress(1, new InstancedBatchOwnerId(1), new InstancedBatchGroupId(1), new InstancedBatchBucketId(1), new InstancedBatchSpanId(1)),
+                0,
+                new Vector4(1f, 0f, 0f, 0f)));
+
+            var capabilities = new PresentationAdapterCapabilities(PresentationVisualCapabilities.InstancedStaticMeshBatch);
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                () => InstancedBatchCapabilityValidator.Validate(requests, operations, capabilities))!;
+            Assert.That(ex.Message, Does.Contain("HierarchicalInstancedStaticMesh"));
+        }
+
+        [Test]
+        public void CapabilityValidator_AcceptsSupportedRequestAndOperationPayloads()
+        {
+            var requests = new InstancedBatchRequestBuffer();
+            var operations = new InstancedBatchOperationBuffer();
+            InstancedBatchAddress address = new(1, new InstancedBatchOwnerId(1), new InstancedBatchGroupId(1), new InstancedBatchBucketId(1), new InstancedBatchSpanId(1));
+            requests.Add(new InstancedBatchRequest(
+                InstancedBatchRequestKind.CreateOrUpdate,
+                1,
+                100,
+                default,
+                default,
+                address,
+                VisualRenderPath.InstancedStaticMesh,
+                10,
+                20,
+                0,
+                1,
+                finalChunk: true));
+            operations.Add(new InstancedBatchOperation(
+                InstancedBatchOperationKind.AttachEffect,
+                1,
+                100,
+                default,
+                default,
+                address,
+                -1,
+                Vector4.Zero,
+                payloadId: 77,
+                state: 1));
+
+            var capabilities = new PresentationAdapterCapabilities(
+                PresentationVisualCapabilities.InstancedStaticMeshBatch |
+                PresentationVisualCapabilities.InstancedBatchEffect);
+
+            Assert.DoesNotThrow(() => InstancedBatchCapabilityValidator.Validate(requests, operations, capabilities));
+        }
+
+        [Test]
+        public void CapabilityValidator_RejectsUnsupportedOperation()
+        {
+            var requests = new InstancedBatchRequestBuffer();
+            var operations = new InstancedBatchOperationBuffer();
+            InstancedBatchAddress address = new(1, new InstancedBatchOwnerId(1), new InstancedBatchGroupId(1), new InstancedBatchBucketId(1), new InstancedBatchSpanId(1));
+            operations.Add(new InstancedBatchOperation(
+                InstancedBatchOperationKind.Refresh,
+                1,
+                100,
+                default,
+                default,
+                address,
+                -1,
+                Vector4.Zero));
+
+            var capabilities = new PresentationAdapterCapabilities(PresentationVisualCapabilities.InstancedStaticMeshBatch);
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                () => InstancedBatchCapabilityValidator.Validate(requests, operations, capabilities))!;
+            Assert.That(ex.Message, Does.Contain("operation 'Refresh'"));
+        }
+
+        [Test]
+        public void OperationBuffer_CoalescesLastWriteWinsDeterministically()
+        {
+            var operations = new InstancedBatchOperationBuffer();
+            InstancedBatchAddress address = new(1, new InstancedBatchOwnerId(1), new InstancedBatchGroupId(1), new InstancedBatchBucketId(1), new InstancedBatchSpanId(1));
+            operations.Add(new InstancedBatchOperation(
+                InstancedBatchOperationKind.SetVisibility,
+                1,
+                100,
+                default,
+                default,
+                address,
+                -1,
+                Vector4.Zero,
+                state: 0,
+                coalescing: InstancedBatchCoalescingMode.LastWriteWins));
+            operations.Add(new InstancedBatchOperation(
+                InstancedBatchOperationKind.SetVisibility,
+                1,
+                100,
+                default,
+                default,
+                address,
+                -1,
+                Vector4.One,
+                state: 1,
+                coalescing: InstancedBatchCoalescingMode.LastWriteWins));
+
+            ReadOnlySpan<InstancedBatchOperation> span = operations.GetSpan();
+            Assert.That(span.Length, Is.EqualTo(1));
+            Assert.That(span[0].State, Is.EqualTo(1));
+            Assert.That(span[0].Value.X, Is.EqualTo(1f));
+
+            operations.Clear();
+            operations.Add(new InstancedBatchOperation(
+                InstancedBatchOperationKind.SetPresentationState,
+                1,
+                100,
+                default,
+                default,
+                address,
+                -1,
+                Vector4.Zero,
+                payloadId: 7,
+                coalescing: InstancedBatchCoalescingMode.LastWriteWins));
+            operations.Add(new InstancedBatchOperation(
+                InstancedBatchOperationKind.SetPresentationState,
+                1,
+                100,
+                default,
+                default,
+                address,
+                -1,
+                Vector4.Zero,
+                payloadId: 8,
+                coalescing: InstancedBatchCoalescingMode.LastWriteWins));
+
+            span = operations.GetSpan();
+            Assert.That(span.Length, Is.EqualTo(1));
+            Assert.That(span[0].PayloadId, Is.EqualTo(8));
+
+            AssertEffectPayloadsDoNotCoalesce(InstancedBatchOperationKind.AttachEffect);
+            AssertEffectPayloadsDoNotCoalesce(InstancedBatchOperationKind.UpdateEffect);
+            AssertEffectPayloadsDoNotCoalesce(InstancedBatchOperationKind.RemoveEffect);
+
+            void AssertEffectPayloadsDoNotCoalesce(InstancedBatchOperationKind kind)
+            {
+                operations.Clear();
+                operations.Add(new InstancedBatchOperation(
+                    kind,
+                    1,
+                    100,
+                    default,
+                    default,
+                    address,
+                    -1,
+                    Vector4.Zero,
+                    payloadId: 7,
+                    coalescing: InstancedBatchCoalescingMode.LastWriteWins));
+                operations.Add(new InstancedBatchOperation(
+                    kind,
+                    1,
+                    100,
+                    default,
+                    default,
+                    address,
+                    -1,
+                    Vector4.Zero,
+                    payloadId: 8,
+                    coalescing: InstancedBatchCoalescingMode.LastWriteWins));
+
+                ReadOnlySpan<InstancedBatchOperation> effectSpan = operations.GetSpan();
+                Assert.That(effectSpan.Length, Is.EqualTo(2));
+                Assert.That(effectSpan[0].PayloadId, Is.EqualTo(7));
+                Assert.That(effectSpan[1].PayloadId, Is.EqualTo(8));
+            }
+        }
+
+        [Test]
+        public void BehaviorSystem_EmitsAttributeAndEventOperationsWithCompiledAddresses()
+        {
+            string root = CreateTempCoreRoot();
+            int attributeId = AttributeRegistry.Register("attr.health");
+            int eventId = TagRegistry.Register("event.visibility");
+            WritePresentationFile(root, "instanced_batches.json",
+                """
+                [
+                  {
+                    "id": "batch.runtime",
+                    "renderPath": "InstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "customDataChannels": [
+                      { "key": "visual.amount", "slot": 0, "type": "Float" }
+                    ],
+                    "groups": [
+                      {
+                        "id": "group.a",
+                        "meshAssetId": "mesh.unit",
+                        "bucketId": "bucket.a",
+                        "instanceSpanId": "span.a",
+                        "transforms": [ { "positionCm": [1,2,3] } ]
+                      }
+                    ],
+                    "behaviors": [
+                      {
+                        "id": "health-to-custom-data",
+                        "source": { "kind": "Attribute", "key": "attr.health" },
+                        "target": {
+                          "operation": "WriteCustomData",
+                          "group": "group.a",
+                          "bucket": "bucket.a",
+                          "span": "span.a",
+                          "customDataSlot": 0
+                        },
+                        "mapping": { "kind": "Linear", "inputMin": 0, "inputMax": 100, "outputMin": 0, "outputMax": 1 }
+                      },
+                      {
+                        "id": "event-to-visibility",
+                        "source": { "kind": "PresentationEvent", "eventKind": "GameplayEvent", "key": "event.visibility" },
+                        "target": { "operation": "SetVisibility", "group": "group.a", "bucket": "bucket.a", "span": "span.a" },
+                        "mapping": { "kind": "Constant", "constantValue": 1 }
+                      }
+                    ]
+                  }
+                ]
+                """);
+            var loader = BuildLoader(root, out InstancedBatchAssetRegistry batches);
+            loader.Load(BuildCatalog());
+
+            using var world = World.Create();
+            var definitions = new PerformerDefinitionRegistry();
+            int batchId = batches.GetId("batch.runtime");
+            int defId = definitions.Register("performer.batch", new PerformerDefinition
+            {
+                InstancedBatches = new[] { new InstancedBatchBinding(batchId) },
+            });
+            var runtime = new PerformerEntityRuntime(world);
+            var owner = world.Create(new AttributeBuffer());
+            ref AttributeBuffer attributes = ref world.Get<AttributeBuffer>(owner);
+            attributes.SetCurrent(attributeId, 50f);
+            Entity performer = runtime.Create(defId, owner, 0, PresentationAnchorKind.Entity, Vector3.Zero, stableId: 500, Entity.Null, definitions.Get(defId));
+            var operations = new InstancedBatchOperationBuffer();
+            var events = new PresentationEventStream(8);
+            var ownerChanges = new PresentationOwnerChangeBuffer(8);
+            Assert.That(ownerChanges.TryAdd(new PresentationOwnerChange(owner, PresentationOwnerChangeKind.Attribute, attributeId)), Is.True);
+            Assert.That(events.TryAdd(new PresentationEvent
+            {
+                Kind = PresentationEventKind.GameplayEvent,
+                KeyId = eventId,
+                Source = owner,
+                Magnitude = 1f,
+            }), Is.True);
+
+            using var system = new InstancedBatchBehaviorSystem(world, definitions, runtime, batches, operations, events, ownerChanges);
+            system.Update(0.016f);
+
+            ReadOnlySpan<InstancedBatchOperation> span = operations.GetSpan();
+            Assert.That(span.Length, Is.EqualTo(2));
+            Assert.That(span[0].Kind, Is.EqualTo(InstancedBatchOperationKind.WriteCustomData));
+            Assert.That(span[0].Performer, Is.EqualTo(performer));
+            Assert.That(span[0].Address.IsValid, Is.True);
+            Assert.That(span[0].Value.X, Is.EqualTo(0.5f).Within(0.001f));
+            Assert.That(span[1].Kind, Is.EqualTo(InstancedBatchOperationKind.SetVisibility));
+            Assert.That(span[1].State, Is.EqualTo(1));
+        }
+
+        [TestCase(PresentationEventKind.PerformerCreated)]
+        [TestCase(PresentationEventKind.PerformerDestroyed)]
+        public void BehaviorSystem_MatchesLifecyclePresentationEventWildcardBindings(PresentationEventKind eventKind)
+        {
+            string root = CreateTempCoreRoot();
+            WritePresentationFile(root, "instanced_batches.json",
+                $$"""
+                [
+                  {
+                    "id": "batch.lifecycle",
+                    "renderPath": "InstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "groups": [
+                      {
+                        "id": "group.a",
+                        "meshAssetId": "mesh.unit",
+                        "bucketId": "bucket.a",
+                        "instanceSpanId": "span.a",
+                        "transforms": [ { "positionCm": [1,2,3] } ]
+                      }
+                    ],
+                    "behaviors": [
+                      {
+                        "id": "any-lifecycle-event",
+                        "source": { "kind": "PresentationEvent", "eventKind": "{{eventKind}}", "key": "*" },
+                        "target": { "operation": "SetVisibility", "group": "group.a", "bucket": "bucket.a", "span": "span.a" },
+                        "mapping": { "kind": "Constant", "constantValue": 1 }
+                      }
+                    ]
+                  }
+                ]
+                """);
+            var loader = BuildLoader(root, out InstancedBatchAssetRegistry batches);
+            loader.Load(BuildCatalog());
+            Assert.That(batches.TryGet(batches.GetId("batch.lifecycle"), out InstancedBatchAsset asset), Is.True);
+            Assert.That(asset.Behaviors[0].SourceKeyId, Is.EqualTo(-1));
+
+            using var world = World.Create();
+            var definitions = new PerformerDefinitionRegistry();
+            int batchId = batches.GetId("batch.lifecycle");
+            int defId = definitions.Register("performer.lifecycle", new PerformerDefinition
+            {
+                InstancedBatches = new[] { new InstancedBatchBinding(batchId) },
+            });
+            var runtime = new PerformerEntityRuntime(world);
+            Entity owner = world.Create();
+            Entity performer = runtime.Create(defId, owner, 0, PresentationAnchorKind.Entity, Vector3.Zero, stableId: 700, Entity.Null, definitions.Get(defId));
+            var operations = new InstancedBatchOperationBuffer();
+            var events = new PresentationEventStream(8);
+            var ownerChanges = new PresentationOwnerChangeBuffer(8);
+            Assert.That(events.TryAdd(new PresentationEvent
+            {
+                Kind = eventKind,
+                KeyId = defId,
+                Source = owner,
+                PerformerEntity = performer,
+                Magnitude = 700f,
+            }), Is.True);
+
+            using var system = new InstancedBatchBehaviorSystem(world, definitions, runtime, batches, operations, events, ownerChanges);
+            system.Update(0.016f);
+
+            ReadOnlySpan<InstancedBatchOperation> span = operations.GetSpan();
+            Assert.That(span.Length, Is.EqualTo(1));
+            Assert.That(span[0].Kind, Is.EqualTo(InstancedBatchOperationKind.SetVisibility));
+            Assert.That(span[0].PerformerStableId, Is.EqualTo(700));
+            Assert.That(span[0].Address.IsValid, Is.True);
+        }
+
+        [Test]
+        public void PerformerLoader_ParsesInstancedBatchReferencesAndRejectsUnknownAssets()
+        {
+            string root = CreateTempCoreRoot();
+            Directory.CreateDirectory(Path.Combine(root, "Configs", "Presentation"));
+            WritePresentationFile(root, "performers.json",
+                """
+                [
+                  {
+                    "id": "performer.batch",
+                    "instancedBatches": [
+                      { "batchAssetId": "batch.runtime" }
+                    ]
+                  }
+                ]
+                """);
+
+            var vfs = new VirtualFileSystem();
+            vfs.Mount("Core", root);
+            var pipeline = new ConfigPipeline(vfs, modLoader: null!);
+            var catalog = new ConfigCatalog();
+            catalog.Add(new ConfigCatalogEntry("Presentation/performers.json", ConfigMergePolicy.ArrayById, "id"));
+            var definitions = new PerformerDefinitionRegistry();
+            var loader = new PerformerDefinitionConfigLoader(
+                pipeline,
+                definitions,
+                resolveInstancedBatchAssetId: key => key == "batch.runtime" ? 42 : 0);
+
+            loader.Load(catalog);
+
+            Assert.That(definitions.TryGet(definitions.GetId("performer.batch"), out PerformerDefinition definition), Is.True);
+            Assert.That(definition.InstancedBatches.Length, Is.EqualTo(1));
+            Assert.That(definition.InstancedBatches[0].BatchAssetId, Is.EqualTo(42));
+
+            string badRoot = CreateTempCoreRoot();
+            WritePresentationFile(badRoot, "performers.json",
+                """
+                [
+                  {
+                    "id": "performer.bad",
+                    "instancedBatches": [
+                      { "batchAssetId": "batch.missing" }
+                    ]
+                  }
+                ]
+                """);
+            var badVfs = new VirtualFileSystem();
+            badVfs.Mount("Core", badRoot);
+            var badPipeline = new ConfigPipeline(badVfs, modLoader: null!);
+            var badDefinitions = new PerformerDefinitionRegistry();
+            var badLoader = new PerformerDefinitionConfigLoader(
+                badPipeline,
+                badDefinitions,
+                resolveInstancedBatchAssetId: _ => 0);
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => badLoader.Load(catalog))!;
+            Assert.That(ex.Message, Does.Contain("unknown instanced batch asset 'batch.missing'"));
+        }
+
+        [Test]
+        public void EmissionSystem_EmitsCreateChunksAndDeterministicRemovals()
+        {
+            string root = CreateTempCoreRoot();
+            WritePresentationFile(root, "instanced_batches.json",
+                """
+                [
+                  {
+                    "id": "batch.emit",
+                    "renderPath": "InstancedStaticMesh",
+                    "ownerStableId": "owner.alpha",
+                    "progressiveSubmission": { "maxInstancesPerFlush": 1 },
+                    "groups": [
+                      {
+                        "id": "group.a",
+                        "meshAssetId": "mesh.unit",
+                        "bucketId": "bucket.a",
+                        "instanceSpanId": "span.a",
+                        "transforms": [
+                          { "positionCm": [1,2,3] },
+                          { "positionCm": [4,5,6] }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+                """);
+            var loader = BuildLoader(root, out InstancedBatchAssetRegistry batches);
+            loader.Load(BuildCatalog());
+            int batchId = batches.GetId("batch.emit");
+
+            using var world = World.Create();
+            var definitions = new PerformerDefinitionRegistry();
+            int defId = definitions.Register("performer.batch", new PerformerDefinition
+            {
+                InstancedBatches = new[] { new InstancedBatchBinding(batchId) },
+            });
+            Entity owner = world.Create();
+            Entity performer = world.Create(new PerformerState
+            {
+                DefId = defId,
+                StableId = 900,
+                OwnerEntity = owner,
+                AnchorKind = PresentationAnchorKind.Entity,
+            });
+            var requests = new InstancedBatchRequestBuffer();
+            var events = new PresentationEventStream(8);
+            var runtime = new InstancedBatchSubmissionRuntime();
+            using var system = new InstancedBatchEmissionSystem(world, definitions, batches, requests, runtime, events);
+
+            system.Update(0.016f);
+            Assert.That(requests.Count, Is.EqualTo(1));
+            Assert.That(requests.GetSpan()[0].Kind, Is.EqualTo(InstancedBatchRequestKind.CreateOrUpdate));
+            Assert.That(requests.GetSpan()[0].InstanceStart, Is.EqualTo(0));
+            Assert.That(requests.GetSpan()[0].InstanceCount, Is.EqualTo(1));
+            Assert.That(requests.GetSpan()[0].FinalChunk, Is.False);
+
+            requests.Clear();
+            system.Update(0.016f);
+            Assert.That(requests.Count, Is.EqualTo(1));
+            Assert.That(requests.GetSpan()[0].InstanceStart, Is.EqualTo(1));
+            Assert.That(requests.GetSpan()[0].FinalChunk, Is.True);
+
+            requests.Clear();
+            Assert.That(events.TryAdd(new PresentationEvent
+            {
+                Kind = PresentationEventKind.PerformerDestroyed,
+                KeyId = defId,
+                Source = owner,
+                PerformerEntity = performer,
+                Magnitude = 900,
+            }), Is.True);
+            system.Update(0.016f);
+            Assert.That(requests.Count, Is.EqualTo(1));
+            Assert.That(requests.GetSpan()[0].Kind, Is.EqualTo(InstancedBatchRequestKind.Remove));
+            Assert.That(requests.GetSpan()[0].PerformerStableId, Is.EqualTo(900));
+        }
+
+        [Test]
+        public void RequestAndOperationBuffers_ClearTransientFrameData()
+        {
+            var requests = new InstancedBatchRequestBuffer();
+            var operations = new InstancedBatchOperationBuffer();
+            InstancedBatchAddress address = new(1, new InstancedBatchOwnerId(1), new InstancedBatchGroupId(1), new InstancedBatchBucketId(1), new InstancedBatchSpanId(1));
+            requests.Add(new InstancedBatchRequest(
+                InstancedBatchRequestKind.Remove,
+                1,
+                100,
+                default,
+                default,
+                address,
+                VisualRenderPath.InstancedStaticMesh,
+                10,
+                0,
+                0,
+                0,
+                finalChunk: true));
+            operations.Add(new InstancedBatchOperation(
+                InstancedBatchOperationKind.SetVisibility,
+                1,
+                100,
+                default,
+                default,
+                address,
+                -1,
+                Vector4.Zero,
+                state: 0));
+
+            requests.Clear();
+            operations.Clear();
+
+            Assert.That(requests.Count, Is.EqualTo(0));
+            Assert.That(operations.Count, Is.EqualTo(0));
+        }
+
+        private static InstancedBatchAssetConfigLoader BuildLoader(string root, out InstancedBatchAssetRegistry registry)
+        {
+            var pipeline = BuildCorePipeline(root);
+            var meshes = new MeshAssetRegistry();
+            var materials = new PresentationMaterialRegistry();
+            registry = new InstancedBatchAssetRegistry();
+
+            meshes.Register("mesh.unit", MeshAssetDescriptor.Model(0));
+            meshes.Register("effect.batch.spark", MeshAssetDescriptor.Billboard(0));
+
+            materials.Register("material.unit", MaterialAssetDomain.Surface, Array.Empty<string>(), MaterialAssetFlags.None);
+            return new InstancedBatchAssetConfigLoader(
+                pipeline,
+                registry,
+                meshes,
+                materials,
+                AttributeRegistry.GetId,
+                ResolveGasEventKey,
+                ResolvePresentationEventKey);
+        }
+
+        private static int ResolveGasEventKey(PresentationEventKind eventKind, string key)
+        {
+            return eventKind == PresentationEventKind.EffectApplied
+                ? EffectTemplateIdRegistry.GetId(key)
+                : AbilityIdRegistry.GetId(key);
+        }
+
+        private static int ResolvePresentationEventKey(PresentationEventKind eventKind, string key)
+        {
+            return eventKind switch
+            {
+                PresentationEventKind.GameplayEvent => TagRegistry.GetId(key),
+                PresentationEventKind.TagEffectiveChanged => TagRegistry.GetId(key),
+                PresentationEventKind.EffectApplied => EffectTemplateIdRegistry.GetId(key),
+                PresentationEventKind.CastCommitted => AbilityIdRegistry.GetId(key),
+                PresentationEventKind.CastFailed => AbilityIdRegistry.GetId(key),
+                PresentationEventKind.PerformerCreated => key == "*" ? -1 : 0,
+                PresentationEventKind.PerformerDestroyed => key == "*" ? -1 : 0,
+                _ => 0,
+            };
+        }
+
+        private static string CreateTempCoreRoot()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "Ludots_InstancedBatchTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(root, "Configs", "Presentation"));
+            return root;
+        }
+
+        private static void WritePresentationFile(string root, string fileName, string content)
+        {
+            File.WriteAllText(Path.Combine(root, "Configs", "Presentation", fileName), content);
+        }
+
+        private static ConfigPipeline BuildCorePipeline(string coreRoot)
+        {
+            var vfs = new VirtualFileSystem();
+            vfs.Mount("Core", coreRoot);
+            return new ConfigPipeline(vfs, modLoader: null!);
+        }
+
+        private static ConfigCatalog BuildCatalog()
+        {
+            var catalog = new ConfigCatalog();
+            catalog.Add(new ConfigCatalogEntry("Presentation/instanced_batches.json", ConfigMergePolicy.ArrayById, "id"));
+            return catalog;
+        }
+    }
+}

--- a/src/Tests/PresentationTests/PresentationFoundationTests.cs
+++ b/src/Tests/PresentationTests/PresentationFoundationTests.cs
@@ -550,6 +550,7 @@ namespace Ludots.Tests.Presentation
                 {
                     DefaultStateIndex = 0,
                     States = [ new AnimatorStateDefinition { PackedStateIndex = 3, DurationSeconds = 1f, PlaybackSpeed = 1f, Loop = true } ],
+                    Transitions = Array.Empty<AnimatorTransitionDefinition>(),
                 });
 
             var definitions = new PerformerDefinitionRegistry();


### PR DESCRIPTION
## Summary
- Add core-owned instanced batch asset/config contracts, stable compact addressing, request/operation buffers, capability validation, emission and behavior systems.
- Wire instanced batch config loading into the engine and performer definitions without adapter-specific UE/HISM leakage.
- Address audit findings: strict `instanced_batches.json` schema, real last-write-wins for `SetPresentationState`, compile-time group addresses for emission hot paths, and lifecycle presentation event wildcard bindings.

## Verification
- `dotnet test src/Tests/PresentationTests/PresentationTests.csproj --filter InstancedBatchContractTests` (25/25 passed)
- `dotnet build src/Core/Ludots.Core.csproj --no-restore` (0 warnings, 0 errors)
- `git diff --check` (no whitespace errors; existing LF/CRLF warnings only)

Closes #148