### PR TITLE
Fix rotated obstacle geometry sinks

### DIFF
--- a/src/Core/Config/ComponentRegistry.cs
+++ b/src/Core/Config/ComponentRegistry.cs
@@ -605,6 +605,11 @@ namespace Ludots.Core.Config
                 NavRadiusCm = ReadIntProperty(obj, "navRadiusCm", "ManifestationObstacleIntent2D"),
             };
 
+            if (intent.SinkPhysicsCollider == 0 && intent.SinkNavigationObstacle == 0)
+            {
+                throw new InvalidOperationException("ManifestationObstacleIntent2D requires at least one sink intent.");
+            }
+
             if (intent.Shape == ManifestationObstacleShape2D.Circle)
             {
                 RequireAbsentProperties(obj, "ManifestationObstacleIntent2D Circle", "halfWidthCm", "halfHeightCm");

--- a/src/Core/Gameplay/Spawning/ManifestationObstacleIntent2D.cs
+++ b/src/Core/Gameplay/Spawning/ManifestationObstacleIntent2D.cs
@@ -299,5 +299,7 @@ namespace Ludots.Core.Gameplay.Spawning
     {
         public int ShapeDataIndex;
         public int ShapeSignature;
+        public byte SinkPhysicsCollider;
+        public byte SinkNavigationObstacle;
     }
 }

--- a/src/Core/Ludots.Physics2D/Collision/CollisionAlgorithms2D.cs
+++ b/src/Core/Ludots.Physics2D/Collision/CollisionAlgorithms2D.cs
@@ -1,4 +1,5 @@
 using Ludots.Core.Mathematics.FixedPoint;
+using Ludots.Core.Physics2D;
 using Ludots.Core.Physics2D.Components;
 
 namespace Ludots.Core.Physics2D.Collision
@@ -22,17 +23,17 @@ namespace Ludots.Core.Physics2D.Collision
 
             if (colliderA.Type == ColliderType2D.Circle && colliderB.Type == ColliderType2D.Circle)
             {
-                return CircleCircle(posA, colliderA.ShapeDataIndex, posB, colliderB.ShapeDataIndex, out normal, out penetration, out contactPoint);
+                return CircleCircle(posA, rotA.Value, colliderA.ShapeDataIndex, posB, rotB.Value, colliderB.ShapeDataIndex, out normal, out penetration, out contactPoint);
             }
 
             if (colliderA.Type == ColliderType2D.Circle && colliderB.Type == ColliderType2D.Box)
             {
-                return CircleBox(posA, colliderA.ShapeDataIndex, posB, rotB.Value, colliderB.ShapeDataIndex, out normal, out penetration, out contactPoint);
+                return CircleBox(posA, rotA.Value, colliderA.ShapeDataIndex, posB, rotB.Value, colliderB.ShapeDataIndex, out normal, out penetration, out contactPoint);
             }
 
             if (colliderA.Type == ColliderType2D.Box && colliderB.Type == ColliderType2D.Circle)
             {
-                bool hit = CircleBox(posB, colliderB.ShapeDataIndex, posA, rotA.Value, colliderA.ShapeDataIndex, out normal, out penetration, out contactPoint);
+                bool hit = CircleBox(posB, rotB.Value, colliderB.ShapeDataIndex, posA, rotA.Value, colliderA.ShapeDataIndex, out normal, out penetration, out contactPoint);
                 normal = -normal;
                 return hit;
             }
@@ -49,12 +50,12 @@ namespace Ludots.Core.Physics2D.Collision
 
             if (colliderA.Type == ColliderType2D.Polygon && colliderB.Type == ColliderType2D.Circle)
             {
-                return PolygonCircle(posA, rotA.Value, colliderA.ShapeDataIndex, posB, colliderB.ShapeDataIndex, out normal, out penetration, out contactPoint);
+                return PolygonCircle(posA, rotA.Value, colliderA.ShapeDataIndex, posB, rotB.Value, colliderB.ShapeDataIndex, out normal, out penetration, out contactPoint);
             }
 
             if (colliderA.Type == ColliderType2D.Circle && colliderB.Type == ColliderType2D.Polygon)
             {
-                bool hit = PolygonCircle(posB, rotB.Value, colliderB.ShapeDataIndex, posA, colliderA.ShapeDataIndex, out normal, out penetration, out contactPoint);
+                bool hit = PolygonCircle(posB, rotB.Value, colliderB.ShapeDataIndex, posA, rotA.Value, colliderA.ShapeDataIndex, out normal, out penetration, out contactPoint);
                 normal = -normal;
                 return hit;
             }
@@ -75,8 +76,8 @@ namespace Ludots.Core.Physics2D.Collision
         }
 
         private static bool CircleCircle(
-            Fix64Vec2 posA, int shapeIndexA,
-            Fix64Vec2 posB, int shapeIndexB,
+            Fix64Vec2 posA, Fix64 rotA, int shapeIndexA,
+            Fix64Vec2 posB, Fix64 rotB, int shapeIndexB,
             out Fix64Vec2 normal,
             out Fix64 penetration,
             out Fix64Vec2 contactPoint)
@@ -91,8 +92,8 @@ namespace Ludots.Core.Physics2D.Collision
                 return false;
             }
 
-            Fix64Vec2 centerA = posA + a.LocalCenter;
-            Fix64Vec2 centerB = posB + b.LocalCenter;
+            Fix64Vec2 centerA = ShapeWorldTransform2D.GetCircleCenter(posA, rotA, a);
+            Fix64Vec2 centerB = ShapeWorldTransform2D.GetCircleCenter(posB, rotB, b);
             Fix64Vec2 delta = centerB - centerA;
             Fix64 distSq = delta.LengthSquared();
             Fix64 radiusSum = a.Radius + b.Radius;
@@ -118,7 +119,7 @@ namespace Ludots.Core.Physics2D.Collision
         }
 
         private static bool CircleBox(
-            Fix64Vec2 circlePos, int circleShapeIndex,
+            Fix64Vec2 circlePos, Fix64 circleRotation, int circleShapeIndex,
             Fix64Vec2 boxPos, Fix64 boxRotation, int boxShapeIndex,
             out Fix64Vec2 normal,
             out Fix64 penetration,
@@ -134,8 +135,8 @@ namespace Ludots.Core.Physics2D.Collision
                 return false;
             }
 
-            Fix64Vec2 circleCenter = circlePos + circle.LocalCenter;
-            Fix64Vec2 boxCenter = boxPos + box.LocalCenter;
+            Fix64Vec2 circleCenter = ShapeWorldTransform2D.GetCircleCenter(circlePos, circleRotation, circle);
+            Fix64Vec2 boxCenter = ShapeWorldTransform2D.GetBoxCenter(boxPos, boxRotation, box);
 
             Fix64Vec2 rel = circleCenter - boxCenter;
             Fix64Vec2 relLocal = rel;
@@ -217,8 +218,8 @@ namespace Ludots.Core.Physics2D.Collision
                 return false;
             }
 
-            Fix64Vec2 centerA = posA + a.LocalCenter;
-            Fix64Vec2 centerB = posB + b.LocalCenter;
+            Fix64Vec2 centerA = ShapeWorldTransform2D.GetBoxCenter(posA, rotA, a);
+            Fix64Vec2 centerB = ShapeWorldTransform2D.GetBoxCenter(posB, rotB, b);
             Fix64Vec2 d = centerB - centerA;
 
             Fix64 sinA = Fix64.Zero;
@@ -283,8 +284,8 @@ namespace Ludots.Core.Physics2D.Collision
             if (!TestPolygonAxes(posA, rotA, a, posB, rotB, b, ref minOverlap, ref bestAxis)) return false;
             if (!TestPolygonAxes(posB, rotB, b, posA, rotA, a, ref minOverlap, ref bestAxis)) return false;
 
-            Fix64Vec2 centerA = posA + a.LocalCenter;
-            Fix64Vec2 centerB = posB + b.LocalCenter;
+            Fix64Vec2 centerA = ShapeWorldTransform2D.GetPolygonCenter(posA, rotA, a);
+            Fix64Vec2 centerB = ShapeWorldTransform2D.GetPolygonCenter(posB, rotB, b);
             Fix64Vec2 d = centerB - centerA;
 
             Fix64 sign = Fix64Vec2.Dot(d, bestAxis) >= Fix64.Zero ? Fix64.OneValue : -Fix64.OneValue;
@@ -330,8 +331,8 @@ namespace Ludots.Core.Physics2D.Collision
                 return false;
             }
 
-            Fix64Vec2 boxCenter = boxPos + box.LocalCenter;
-            Fix64Vec2 polyCenter = polyPos + poly.LocalOffset;
+            Fix64Vec2 boxCenter = ShapeWorldTransform2D.GetBoxCenter(boxPos, boxRot, box);
+            Fix64Vec2 polyCenter = ShapeWorldTransform2D.GetPolygonCenter(polyPos, polyRot, poly);
             Fix64Vec2 d = polyCenter - boxCenter;
             if (Fix64Vec2.Dot(d, normal) < Fix64.Zero)
             {
@@ -343,7 +344,7 @@ namespace Ludots.Core.Physics2D.Collision
 
         private static bool PolygonCircle(
             Fix64Vec2 polyPos, Fix64 polyRot, int polyShapeIndex,
-            Fix64Vec2 circlePos, int circleShapeIndex,
+            Fix64Vec2 circlePos, Fix64 circleRot, int circleShapeIndex,
             out Fix64Vec2 normal,
             out Fix64 penetration,
             out Fix64Vec2 contactPoint)
@@ -358,7 +359,7 @@ namespace Ludots.Core.Physics2D.Collision
                 return false;
             }
 
-            Fix64Vec2 circleCenter = circlePos + circle.LocalCenter;
+            Fix64Vec2 circleCenter = ShapeWorldTransform2D.GetCircleCenter(circlePos, circleRot, circle);
 
             Fix64 sin = Fix64.Zero;
             Fix64 cos = Fix64.OneValue;
@@ -373,8 +374,8 @@ namespace Ludots.Core.Physics2D.Collision
 
             for (int i = 0; i < poly.VertexCount; i++)
             {
-                Fix64Vec2 a = poly.Vertices[i] - poly.LocalCenter;
-                Fix64Vec2 b = poly.Vertices[(i + 1) % poly.VertexCount] - poly.LocalCenter;
+                Fix64Vec2 a = ShapeWorldTransform2D.GetPolygonLocalVertex(poly, i);
+                Fix64Vec2 b = ShapeWorldTransform2D.GetPolygonLocalVertex(poly, (i + 1) % poly.VertexCount);
                 if (polyRot != Fix64.Zero)
                 {
                     a = Rotate(a, sin, cos);
@@ -418,7 +419,7 @@ namespace Ludots.Core.Physics2D.Collision
                 }
             }
 
-            Fix64Vec2 polyCenter = polyPos + poly.LocalOffset;
+            Fix64Vec2 polyCenter = ShapeWorldTransform2D.GetPolygonCenter(polyPos, polyRot, poly);
             Fix64Vec2 d = circleCenter - polyCenter;
             Fix64 sign = Fix64Vec2.Dot(d, bestAxis) >= Fix64.Zero ? Fix64.OneValue : -Fix64.OneValue;
             normal = bestAxis * sign;
@@ -443,8 +444,8 @@ namespace Ludots.Core.Physics2D.Collision
 
             for (int i = 0; i < a.VertexCount; i++)
             {
-                Fix64Vec2 va = a.Vertices[i] - a.LocalCenter;
-                Fix64Vec2 vb = a.Vertices[(i + 1) % a.VertexCount] - a.LocalCenter;
+                Fix64Vec2 va = ShapeWorldTransform2D.GetPolygonLocalVertex(a, i);
+                Fix64Vec2 vb = ShapeWorldTransform2D.GetPolygonLocalVertex(a, (i + 1) % a.VertexCount);
                 if (rotA != Fix64.Zero)
                 {
                     va = Rotate(va, sinA, cosA);
@@ -486,26 +487,26 @@ namespace Ludots.Core.Physics2D.Collision
                 cos = Fix64Math.Cos(rot);
             }
 
-            Fix64Vec2 v0 = poly.Vertices[0] - poly.LocalCenter;
+            Fix64Vec2 v0 = ShapeWorldTransform2D.GetPolygonLocalVertex(poly, 0);
             if (rot != Fix64.Zero)
             {
                 v0 = Rotate(v0, sin, cos);
             }
 
-            Fix64Vec2 w0 = polyPos + poly.LocalOffset + v0;
+            Fix64Vec2 w0 = polyPos + v0;
             Fix64 p0 = Fix64Vec2.Dot(w0, axis);
             min = p0;
             max = p0;
 
             for (int i = 1; i < poly.VertexCount; i++)
             {
-                Fix64Vec2 v = poly.Vertices[i] - poly.LocalCenter;
+                Fix64Vec2 v = ShapeWorldTransform2D.GetPolygonLocalVertex(poly, i);
                 if (rot != Fix64.Zero)
                 {
                     v = Rotate(v, sin, cos);
                 }
 
-                Fix64Vec2 w = polyPos + poly.LocalOffset + v;
+                Fix64Vec2 w = polyPos + v;
                 Fix64 p = Fix64Vec2.Dot(w, axis);
                 min = Fix64.Min(min, p);
                 max = Fix64.Max(max, p);
@@ -527,13 +528,13 @@ namespace Ludots.Core.Physics2D.Collision
 
             for (int i = 0; i < poly.VertexCount; i++)
             {
-                Fix64Vec2 v = poly.Vertices[i] - poly.LocalCenter;
+                Fix64Vec2 v = ShapeWorldTransform2D.GetPolygonLocalVertex(poly, i);
                 if (rot != Fix64.Zero)
                 {
                     v = Rotate(v, sin, cos);
                 }
 
-                Fix64Vec2 w = polyPos + poly.LocalOffset + v;
+                Fix64Vec2 w = polyPos + v;
                 Fix64 d = Fix64Vec2.Dot(w, direction);
                 if (d > best)
                 {
@@ -558,21 +559,21 @@ namespace Ludots.Core.Physics2D.Collision
             Fix64 bestDistSq = Fix64.MaxValue;
             Fix64Vec2 best = Fix64Vec2.Zero;
 
-            Fix64Vec2 prev = poly.Vertices[poly.VertexCount - 1] - poly.LocalCenter;
+            Fix64Vec2 prev = ShapeWorldTransform2D.GetPolygonLocalVertex(poly, poly.VertexCount - 1);
             if (rot != Fix64.Zero)
             {
                 prev = Rotate(prev, sin, cos);
             }
-            prev = polyPos + poly.LocalOffset + prev;
+            prev = polyPos + prev;
 
             for (int i = 0; i < poly.VertexCount; i++)
             {
-                Fix64Vec2 curr = poly.Vertices[i] - poly.LocalCenter;
+                Fix64Vec2 curr = ShapeWorldTransform2D.GetPolygonLocalVertex(poly, i);
                 if (rot != Fix64.Zero)
                 {
                     curr = Rotate(curr, sin, cos);
                 }
-                curr = polyPos + poly.LocalOffset + curr;
+                curr = polyPos + curr;
 
                 Fix64Vec2 closest = ClosestPointOnSegment(prev, curr, point);
                 Fix64 distSq = (point - closest).LengthSquared();
@@ -657,7 +658,7 @@ namespace Ludots.Core.Physics2D.Collision
                 cos = Fix64Math.Cos(boxRot);
             }
 
-            Fix64Vec2 c = boxPos + box.LocalCenter;
+            Fix64Vec2 c = ShapeWorldTransform2D.GetBoxCenter(boxPos, boxRot, box);
             Fix64Vec2 v0 = new Fix64Vec2(-box.HalfWidth, -box.HalfHeight);
             Fix64Vec2 v1 = new Fix64Vec2(box.HalfWidth, -box.HalfHeight);
             Fix64Vec2 v2 = new Fix64Vec2(box.HalfWidth, box.HalfHeight);
@@ -690,12 +691,12 @@ namespace Ludots.Core.Physics2D.Collision
 
             for (int i = 0; i < poly.VertexCount; i++)
             {
-                Fix64Vec2 v = poly.Vertices[i] - poly.LocalCenter;
+                Fix64Vec2 v = ShapeWorldTransform2D.GetPolygonLocalVertex(poly, i);
                 if (polyRot != Fix64.Zero)
                 {
                     v = Rotate(v, sin, cos);
                 }
-                dst[i] = polyPos + poly.LocalOffset + v;
+                dst[i] = polyPos + v;
             }
 
             return poly.VertexCount;

--- a/src/Core/Ludots.Physics2D/ShapeWorldTransform2D.cs
+++ b/src/Core/Ludots.Physics2D/ShapeWorldTransform2D.cs
@@ -1,0 +1,87 @@
+using System.Runtime.CompilerServices;
+using Ludots.Core.Mathematics.FixedPoint;
+using Ludots.Core.Physics2D.Components;
+
+namespace Ludots.Core.Physics2D
+{
+    internal static class ShapeWorldTransform2D
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Fix64Vec2 RotateLocal(in Fix64Vec2 local, Fix64 rotation)
+        {
+            if (rotation == Fix64.Zero)
+            {
+                return local;
+            }
+
+            Fix64 sin = Fix64Math.Sin(rotation);
+            Fix64 cos = Fix64Math.Cos(rotation);
+            return RotateLocal(local, sin, cos);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Fix64Vec2 RotateLocal(in Fix64Vec2 local, Fix64 sin, Fix64 cos)
+        {
+            return new Fix64Vec2(
+                (cos * local.X) - (sin * local.Y),
+                (sin * local.X) + (cos * local.Y));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Fix64Vec2 ToWorld(in Fix64Vec2 worldPosition, in Fix64Vec2 local, Fix64 rotation)
+        {
+            return worldPosition + RotateLocal(local, rotation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Fix64Vec2 ToWorld(in Fix64Vec2 worldPosition, in Fix64Vec2 local, Fix64 sin, Fix64 cos)
+        {
+            return worldPosition + RotateLocal(local, sin, cos);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Fix64Vec2 GetCircleCenter(in Fix64Vec2 worldPosition, Fix64 rotation, in CircleShapeData circle)
+        {
+            return ToWorld(worldPosition, circle.LocalCenter, rotation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Fix64Vec2 GetBoxCenter(in Fix64Vec2 worldPosition, Fix64 rotation, in BoxShapeData box)
+        {
+            return ToWorld(worldPosition, box.LocalCenter, rotation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Fix64Vec2 GetPolygonCenter(in Fix64Vec2 worldPosition, Fix64 rotation, in PolygonShapeData polygon)
+        {
+            return ToWorld(worldPosition, polygon.LocalOffset, rotation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Fix64Vec2 GetPolygonLocalVertex(in PolygonShapeData polygon, int vertexIndex)
+        {
+            return polygon.LocalOffset + polygon.Vertices[vertexIndex] - polygon.LocalCenter;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Fix64Vec2 GetPolygonWorldVertex(
+            in Fix64Vec2 worldPosition,
+            Fix64 rotation,
+            in PolygonShapeData polygon,
+            int vertexIndex)
+        {
+            Fix64Vec2 local = GetPolygonLocalVertex(polygon, vertexIndex);
+            return ToWorld(worldPosition, local, rotation);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Fix64Vec2 GetPolygonWorldVertex(
+            in Fix64Vec2 worldPosition,
+            in Fix64Vec2 localVertex,
+            Fix64 sin,
+            Fix64 cos)
+        {
+            return ToWorld(worldPosition, localVertex, sin, cos);
+        }
+    }
+}

--- a/src/Core/Ludots.Physics2D/Systems/BuildPhysicsWorldSystem2D.cs
+++ b/src/Core/Ludots.Physics2D/Systems/BuildPhysicsWorldSystem2D.cs
@@ -48,7 +48,7 @@ namespace Ludots.Core.Physics2D.Systems
                     rotation = rot.Value;
                 }
 
-                var aabb = CalculateAabb(in position, rotation, in collider);
+                var aabb = CalculateAabb(position.Value, rotation, in collider);
                 AddRigidBody(entity, shapeSlot: 0, in aabb, mass.IsStatic);
             });
 
@@ -72,7 +72,7 @@ namespace Ludots.Core.Physics2D.Systems
                         Type = ToColliderType(state.GetShape(i)),
                         ShapeDataIndex = state.GetShapeDataIndex(i)
                     };
-                    var aabb = CalculateAabb(in position, rotation, in collider);
+                    var aabb = CalculateAabb(position.Value, rotation, in collider);
                     AddRigidBody(entity, checked((byte)i), in aabb, mass.IsStatic);
                 }
             });
@@ -92,25 +92,25 @@ namespace Ludots.Core.Physics2D.Systems
             ShapeSlots.Add(shapeSlot);
         }
 
-        private static Aabb CalculateAabb(in Position2D position, Fix64 rotation, in Collider2D collider)
+        private static Aabb CalculateAabb(Fix64Vec2 worldPos, Fix64 rotation, in Collider2D collider)
         {
             return collider.Type switch
             {
-                ColliderType2D.Circle => CalculateCircleAabb(position.Value, collider.ShapeDataIndex),
-                ColliderType2D.Box => CalculateBoxAabb(position.Value, rotation, collider.ShapeDataIndex),
-                ColliderType2D.Polygon => CalculatePolygonAabb(position.Value, rotation, collider.ShapeDataIndex),
+                ColliderType2D.Circle => CalculateCircleAabb(worldPos, rotation, collider.ShapeDataIndex),
+                ColliderType2D.Box => CalculateBoxAabb(worldPos, rotation, collider.ShapeDataIndex),
+                ColliderType2D.Polygon => CalculatePolygonAabb(worldPos, rotation, collider.ShapeDataIndex),
                 _ => throw new ArgumentOutOfRangeException(nameof(collider.Type), collider.Type, "Unknown collider type")
             };
         }
 
-        private static Aabb CalculateCircleAabb(Fix64Vec2 worldPos, int shapeIndex)
+        private static Aabb CalculateCircleAabb(Fix64Vec2 worldPos, Fix64 rotation, int shapeIndex)
         {
             if (!ShapeDataStorage2D.TryGetCircle(shapeIndex, out var circleData))
             {
                 throw new InvalidOperationException($"Circle shape not found: {shapeIndex}");
             }
 
-            var center = worldPos + circleData.LocalCenter;
+            var center = ShapeWorldTransform2D.GetCircleCenter(worldPos, rotation, circleData);
             var radiusVec = new Fix64Vec2(circleData.Radius, circleData.Radius);
 
             return new Aabb
@@ -127,7 +127,7 @@ namespace Ludots.Core.Physics2D.Systems
                 throw new InvalidOperationException($"Box shape not found: {shapeIndex}");
             }
 
-            var center = worldPos + boxData.LocalCenter;
+            var center = ShapeWorldTransform2D.GetBoxCenter(worldPos, rotation, boxData);
             var halfSize = new Fix64Vec2(boxData.HalfWidth, boxData.HalfHeight);
 
             if (rotation != Fix64.Zero)
@@ -168,8 +168,7 @@ namespace Ludots.Core.Physics2D.Systems
                 cos = Fix64Math.Cos(rotation);
             }
 
-            var localCenter = polygonData.LocalCenter;
-            var v0 = polygonData.Vertices[0] - localCenter;
+            var v0 = ShapeWorldTransform2D.GetPolygonLocalVertex(polygonData, 0);
             if (rotation != Fix64.Zero)
             {
                 v0 = Rotate(v0, sin, cos);
@@ -180,7 +179,7 @@ namespace Ludots.Core.Physics2D.Systems
 
             for (int i = 1; i < polygonData.VertexCount; i++)
             {
-                var v = polygonData.Vertices[i] - localCenter;
+                var v = ShapeWorldTransform2D.GetPolygonLocalVertex(polygonData, i);
                 if (rotation != Fix64.Zero)
                 {
                     v = Rotate(v, sin, cos);
@@ -192,8 +191,8 @@ namespace Ludots.Core.Physics2D.Systems
 
             return new Aabb
             {
-                Min = worldPos + polygonData.LocalOffset + min,
-                Max = worldPos + polygonData.LocalOffset + max
+                Min = worldPos + min,
+                Max = worldPos + max
             };
         }
 

--- a/src/Core/Ludots.Physics2D/Systems/ManifestationObstacleBridge2DSystem.cs
+++ b/src/Core/Ludots.Physics2D/Systems/ManifestationObstacleBridge2DSystem.cs
@@ -38,15 +38,26 @@ namespace Ludots.Core.Physics2D.Systems
                     Upsert(entity, new Rotation2D { Value = Fix64.FromFloat(facing.AngleRad) });
                 }
 
+                bool hadPreviousBridgeState = World.TryGet(entity, out ManifestationObstacleBridge2DState previousBridgeState);
                 int signature = ComputeShapeSignature(in intent, entity);
-                int shapeDataIndex = EnsureShapeRegistered(entity, in intent, signature);
+                bool wantsPhysicsSink = intent.SinkPhysicsCollider != 0;
+                bool wantsNavigationSink = intent.SinkNavigationObstacle != 0;
+                int shapeDataIndex = -1;
+                if (wantsPhysicsSink || wantsNavigationSink)
+                {
+                    shapeDataIndex = EnsureShapeRegistered(entity, in intent, signature);
+                }
+                else if (hadPreviousBridgeState && previousBridgeState.ShapeSignature == signature)
+                {
+                    shapeDataIndex = previousBridgeState.ShapeDataIndex;
+                }
 
                 if (World.Has<CompoundObstacle2DState>(entity))
                 {
                     World.Remove<CompoundObstacle2DState>(entity);
                 }
 
-                if (intent.SinkPhysicsCollider != 0)
+                if (wantsPhysicsSink)
                 {
                     Upsert(entity, new Collider2D
                     {
@@ -56,8 +67,15 @@ namespace Ludots.Core.Physics2D.Systems
                     Upsert(entity, Mass2D.Static);
                     Upsert(entity, Velocity2D.Zero);
                 }
+                else
+                {
+                    if (previousBridgeState.SinkPhysicsCollider != 0)
+                    {
+                        RemovePhysicsDerivedState(entity);
+                    }
+                }
 
-                if (intent.SinkNavigationObstacle != 0)
+                if (wantsNavigationSink)
                 {
                     Upsert(entity, new NavObstacle2D
                     {
@@ -74,6 +92,21 @@ namespace Ludots.Core.Physics2D.Systems
                         MaxNeighbors = 0
                     });
                 }
+                else
+                {
+                    if (previousBridgeState.SinkNavigationObstacle != 0)
+                    {
+                        RemoveNavigationDerivedState(entity);
+                    }
+                }
+
+                Upsert(entity, new ManifestationObstacleBridge2DState
+                {
+                    ShapeDataIndex = shapeDataIndex,
+                    ShapeSignature = signature,
+                    SinkPhysicsCollider = intent.SinkPhysicsCollider,
+                    SinkNavigationObstacle = intent.SinkNavigationObstacle
+                });
             });
 
             World.Query(in _compoundQuery, (Entity entity, ref WorldPositionCm worldPosition, ref CompoundObstacle2D obstacle) =>
@@ -90,8 +123,16 @@ namespace Ludots.Core.Physics2D.Systems
                     Upsert(entity, new Rotation2D { Value = Fix64.FromFloat(facing.AngleRad) });
                 }
 
+                bool hadPreviousCompoundState = World.TryGet(entity, out CompoundObstacle2DState previousCompoundState);
                 int signature = ComputeCompoundShapeSignature(in obstacle);
                 CompoundObstacle2DState state = EnsureCompoundStateRegistered(entity, in obstacle, signature);
+                if (state.SinkPhysicsCollider != obstacle.SinkPhysicsCollider ||
+                    state.SinkNavigationObstacle != obstacle.SinkNavigationObstacle)
+                {
+                    state.SinkPhysicsCollider = obstacle.SinkPhysicsCollider;
+                    state.SinkNavigationObstacle = obstacle.SinkNavigationObstacle;
+                    Upsert(entity, state);
+                }
 
                 if (World.Has<Collider2D>(entity))
                 {
@@ -113,6 +154,13 @@ namespace Ludots.Core.Physics2D.Systems
                     Upsert(entity, Mass2D.Static);
                     Upsert(entity, Velocity2D.Zero);
                 }
+                else
+                {
+                    if (hadPreviousCompoundState && previousCompoundState.SinkPhysicsCollider != 0)
+                    {
+                        RemovePhysicsDerivedState(entity);
+                    }
+                }
 
                 if (obstacle.SinkNavigationObstacle != 0)
                 {
@@ -125,6 +173,13 @@ namespace Ludots.Core.Physics2D.Systems
                         TimeHorizonSec = Fix64.Zero,
                         MaxNeighbors = 0
                     });
+                }
+                else
+                {
+                    if (hadPreviousCompoundState && previousCompoundState.SinkNavigationObstacle != 0)
+                    {
+                        RemoveNavigationDerivedState(entity);
+                    }
                 }
             });
         }
@@ -139,11 +194,6 @@ namespace Ludots.Core.Physics2D.Systems
             }
 
             int shapeDataIndex = RegisterShape(entity, in intent);
-            Upsert(entity, new ManifestationObstacleBridge2DState
-            {
-                ShapeDataIndex = shapeDataIndex,
-                ShapeSignature = signature
-            });
             return shapeDataIndex;
         }
 
@@ -297,8 +347,6 @@ namespace Ludots.Core.Physics2D.Systems
         private static int ComputeCompoundShapeSignature(in CompoundObstacle2D obstacle)
         {
             var hash = new HashCode();
-            hash.Add(obstacle.SinkPhysicsCollider);
-            hash.Add(obstacle.SinkNavigationObstacle);
             hash.Add(obstacle.PieceCount);
             for (int i = 0; i < obstacle.PieceCount; i++)
             {
@@ -349,7 +397,7 @@ namespace Ludots.Core.Physics2D.Systems
             Fix64 maxDistanceSq = Fix64.Zero;
             for (int i = 0; i < polygon.VertexCount; i++)
             {
-                Fix64Vec2 delta = polygon.LocalOffset + polygon.Vertices[i] - polygon.LocalCenter;
+                Fix64Vec2 delta = ShapeWorldTransform2D.GetPolygonLocalVertex(polygon, i);
                 Fix64 distanceSq = delta.LengthSquared();
                 if (distanceSq > maxDistanceSq)
                 {
@@ -430,6 +478,37 @@ namespace Ludots.Core.Physics2D.Systems
             else
             {
                 World.Add(entity, component);
+            }
+        }
+
+        private void RemovePhysicsDerivedState(Entity entity)
+        {
+            if (World.Has<Collider2D>(entity))
+            {
+                World.Remove<Collider2D>(entity);
+            }
+
+            if (World.Has<Mass2D>(entity))
+            {
+                World.Remove<Mass2D>(entity);
+            }
+
+            if (World.Has<Velocity2D>(entity))
+            {
+                World.Remove<Velocity2D>(entity);
+            }
+        }
+
+        private void RemoveNavigationDerivedState(Entity entity)
+        {
+            if (World.Has<NavObstacle2D>(entity))
+            {
+                World.Remove<NavObstacle2D>(entity);
+            }
+
+            if (World.Has<NavKinematics2D>(entity))
+            {
+                World.Remove<NavKinematics2D>(entity);
             }
         }
     }

--- a/src/Core/Ludots.Physics2D/Systems/Navigation2DSteeringSystem2D.cs
+++ b/src/Core/Ludots.Physics2D/Systems/Navigation2DSteeringSystem2D.cs
@@ -1664,13 +1664,13 @@ namespace Ludots.Core.Physics2D.Systems
                 foreach (var index in chunk)
                 {
                     var entity = System.Runtime.CompilerServices.Unsafe.Add(ref entityFirst, index);
-                    float haloCenterRadiusCm = StampFlowObstacleShape(entity, positions[index], obstacles[index]);
+                    float haloCenterRadiusCm = StampFlowObstacleShape(entity, positions[index], obstacles[index], out Vector2 haloCenterCm);
 
                     var discomfort = _runtime.Config.FlowCrowd.Discomfort;
                     if (discomfort.Enabled && discomfort.ObstacleHaloRadiusCm > 0 && discomfort.ObstacleHaloValue > 0f)
                     {
                         _runtime.Surface.SplatDiscomfortCircle(
-                            positions[index].Value.ToVector2(),
+                            haloCenterCm,
                             MathF.Max(haloCenterRadiusCm, kinematics[index].RadiusCm.ToFloat()) + discomfort.ObstacleHaloRadiusCm,
                             discomfort.ObstacleHaloValue,
                             discomfort.ObstacleHaloEdgeValue,
@@ -1700,13 +1700,13 @@ namespace Ludots.Core.Physics2D.Systems
                             Shape = ToNavObstacleShape(state.GetShape(pieceIndex)),
                             ShapeDataIndex = state.GetShapeDataIndex(pieceIndex)
                         };
-                        float haloCenterRadiusCm = StampFlowObstacleShape(entity, positions[index], obstacle);
+                        float haloCenterRadiusCm = StampFlowObstacleShape(entity, positions[index], obstacle, out Vector2 haloCenterCm);
 
                         var discomfort = _runtime.Config.FlowCrowd.Discomfort;
                         if (discomfort.Enabled && discomfort.ObstacleHaloRadiusCm > 0 && discomfort.ObstacleHaloValue > 0f)
                         {
                             _runtime.Surface.SplatDiscomfortCircle(
-                                positions[index].Value.ToVector2(),
+                                haloCenterCm,
                                 MathF.Max(haloCenterRadiusCm, state.GetNavRadiusCm(pieceIndex)) + discomfort.ObstacleHaloRadiusCm,
                                 discomfort.ObstacleHaloValue,
                                 discomfort.ObstacleHaloEdgeValue,
@@ -1719,16 +1719,23 @@ namespace Ludots.Core.Physics2D.Systems
 
         private float StampFlowObstacleShape(Entity entity, in Position2D position, in NavObstacle2D obstacle)
         {
+            return StampFlowObstacleShape(entity, position, obstacle, out _);
+        }
+
+        private float StampFlowObstacleShape(Entity entity, in Position2D position, in NavObstacle2D obstacle, out Vector2 centerCm)
+        {
             var rotation = World.TryGet(entity, out Rotation2D obstacleRotation) ? obstacleRotation : Rotation2D.Identity;
+            centerCm = position.Value.ToVector2();
 
             switch (obstacle.Shape)
             {
                 case NavObstacleShape2D.Circle:
                     if (ShapeDataStorage2D.TryGetCircle(obstacle.ShapeDataIndex, out var circle))
                     {
-                        Vector2 center = (position.Value + circle.LocalCenter).ToVector2();
+                        Vector2 center = ShapeWorldTransform2D.GetCircleCenter(position.Value, rotation.Value, circle).ToVector2();
                         float radiusCm = circle.Radius.ToFloat();
                         _runtime.Surface.SplatObstacleCircle(center, radiusCm, createTilesIfMissing: false);
+                        centerCm = center;
                         return radiusCm;
                     }
                     break;
@@ -1736,13 +1743,14 @@ namespace Ludots.Core.Physics2D.Systems
                 case NavObstacleShape2D.Box:
                     if (ShapeDataStorage2D.TryGetBox(obstacle.ShapeDataIndex, out var box))
                     {
-                        Vector2 center = (position.Value + box.LocalCenter).ToVector2();
+                        Vector2 center = ShapeWorldTransform2D.GetBoxCenter(position.Value, rotation.Value, box).ToVector2();
                         _runtime.Surface.SplatObstacleOrientedBox(
                             center,
                             box.HalfWidth.ToFloat(),
                             box.HalfHeight.ToFloat(),
                             rotation.Value.ToFloat(),
                             createTilesIfMissing: false);
+                        centerCm = center;
                         return MathF.Sqrt((box.HalfWidth * box.HalfWidth + box.HalfHeight * box.HalfHeight).ToFloat());
                     }
                     break;
@@ -1755,6 +1763,7 @@ namespace Ludots.Core.Physics2D.Systems
                         Span<Vector2> vertices = stackalloc Vector2[polygon.VertexCount];
                         FillPolygonWorldVertices(position.Value, rotation.Value, polygon, vertices);
                         _runtime.Surface.SplatObstaclePolygon(vertices.Slice(0, polygon.VertexCount), createTilesIfMissing: false);
+                        centerCm = ShapeWorldTransform2D.GetPolygonCenter(position.Value, rotation.Value, polygon).ToVector2();
                         return ComputePolygonBoundingRadiusCm(polygon);
                     }
                     break;
@@ -1775,7 +1784,7 @@ namespace Ludots.Core.Physics2D.Systems
 
             for (int i = 0; i < polygon.VertexCount; i++)
             {
-                Fix64Vec2 local = polygon.Vertices[i] - polygon.LocalCenter;
+                Fix64Vec2 local = ShapeWorldTransform2D.GetPolygonLocalVertex(polygon, i);
                 if (rotation != Fix64.Zero)
                 {
                     local = new Fix64Vec2(
@@ -1783,7 +1792,7 @@ namespace Ludots.Core.Physics2D.Systems
                         (sin * local.X) + (cos * local.Y));
                 }
 
-                destination[i] = (worldPosition + polygon.LocalOffset + local).ToVector2();
+                destination[i] = (worldPosition + local).ToVector2();
             }
         }
 
@@ -1792,7 +1801,7 @@ namespace Ludots.Core.Physics2D.Systems
             float maxDistanceSq = 0f;
             for (int i = 0; i < polygon.VertexCount; i++)
             {
-                Vector2 delta = (polygon.LocalOffset + polygon.Vertices[i] - polygon.LocalCenter).ToVector2();
+                Vector2 delta = ShapeWorldTransform2D.GetPolygonLocalVertex(polygon, i).ToVector2();
                 float distanceSq = delta.LengthSquared();
                 if (distanceSq > maxDistanceSq)
                 {

--- a/src/Core/Ludots.Physics2D/Systems/Physics2DDebugDrawSystem.cs
+++ b/src/Core/Ludots.Physics2D/Systems/Physics2DDebugDrawSystem.cs
@@ -136,6 +136,12 @@ namespace Ludots.Core.Physics2D.Systems
 
         private void DrawRigidBodyMeters(Entity entity, ref Collider2D collider, ref Mass2D mass, Vector2 drawPosM)
         {
+            Fix64 rotation = Fix64.Zero;
+            if (World.TryGet(entity, out Rotation2D rotationComponent))
+            {
+                rotation = rotationComponent.Value;
+            }
+
             DebugDrawColor color;
             if (World.Has<SleepingTag>(entity))
             {
@@ -154,7 +160,7 @@ namespace Ludots.Core.Physics2D.Systems
                     // Fix64 → float 渲染边界
                     _buffer.Circles.Add(new DebugDrawCircle2D
                     {
-                        Center = drawPosM + circle.LocalCenter.ToVector2() * CmToM,
+                        Center = drawPosM + ShapeWorldTransform2D.RotateLocal(circle.LocalCenter, rotation).ToVector2() * CmToM,
                         Radius = circle.Radius.ToFloat() * CmToM,
                         Thickness = DefaultThickness,
                         Color = color
@@ -166,10 +172,10 @@ namespace Ludots.Core.Physics2D.Systems
                     if (!ShapeDataStorage2D.TryGetBox(collider.ShapeDataIndex, out var box)) return;
                     _buffer.Boxes.Add(new DebugDrawBox2D
                     {
-                        Center = drawPosM + box.LocalCenter.ToVector2() * CmToM,
+                        Center = drawPosM + ShapeWorldTransform2D.RotateLocal(box.LocalCenter, rotation).ToVector2() * CmToM,
                         HalfWidth = box.HalfWidth.ToFloat() * CmToM,
                         HalfHeight = box.HalfHeight.ToFloat() * CmToM,
-                        RotationRadians = 0f,
+                        RotationRadians = rotation.ToFloat(),
                         Thickness = DefaultThickness,
                         Color = color
                     });
@@ -178,10 +184,24 @@ namespace Ludots.Core.Physics2D.Systems
                 case ColliderType2D.Polygon:
                 {
                     if (!ShapeDataStorage2D.TryGetPolygon(collider.ShapeDataIndex, out var poly) || poly.Vertices == null || poly.VertexCount < 3) return;
+                    Fix64 sin = Fix64.Zero;
+                    Fix64 cos = Fix64.OneValue;
+                    if (rotation != Fix64.Zero)
+                    {
+                        sin = Fix64Math.Sin(rotation);
+                        cos = Fix64Math.Cos(rotation);
+                    }
+
                     for (int i = 0; i < poly.VertexCount; i++)
                     {
-                        var aLocal = poly.LocalOffset + poly.Vertices[i] - poly.LocalCenter;
-                        var bLocal = poly.LocalOffset + poly.Vertices[(i + 1) % poly.VertexCount] - poly.LocalCenter;
+                        var aLocal = ShapeWorldTransform2D.GetPolygonLocalVertex(poly, i);
+                        var bLocal = ShapeWorldTransform2D.GetPolygonLocalVertex(poly, (i + 1) % poly.VertexCount);
+                        if (rotation != Fix64.Zero)
+                        {
+                            aLocal = ShapeWorldTransform2D.RotateLocal(aLocal, sin, cos);
+                            bLocal = ShapeWorldTransform2D.RotateLocal(bLocal, sin, cos);
+                        }
+
                         var a = drawPosM + aLocal.ToVector2() * CmToM;
                         var b = drawPosM + bLocal.ToVector2() * CmToM;
                         _buffer.Lines.Add(new DebugDrawLine2D

--- a/src/Tests/GasTests/Physics2DIntegrationTests.cs
+++ b/src/Tests/GasTests/Physics2DIntegrationTests.cs
@@ -4,6 +4,10 @@ using Ludots.Core.Components;
 using Ludots.Core.Gameplay.Spawning;
 using Ludots.Core.Mathematics;
 using Ludots.Core.Mathematics.FixedPoint;
+using Ludots.Core.Navigation2D.Components;
+using Ludots.Core.Navigation2D.Config;
+using Ludots.Core.Navigation2D.Runtime;
+using Ludots.Core.Navigation2D.Spatial;
 using Ludots.Physics.Broadphase;
 using Ludots.Core.Physics2D;
 using Ludots.Core.Physics2D.Components;
@@ -147,6 +151,198 @@ namespace GasTests
             });
 
             Assert.That(activeWithContact, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void CompoundObstaclePieces_RotateLocalOffsetsForCollision()
+        {
+            using var world = World.Create();
+
+            var obstacle = new CompoundObstacle2D
+            {
+                SinkPhysicsCollider = 1,
+                SinkNavigationObstacle = 0
+            };
+            obstacle.SetPiece(
+                0,
+                ManifestationObstacleShape2D.Box,
+                radiusCm: 0,
+                halfWidthCm: 50,
+                halfHeightCm: 50,
+                localOffsetXCm: 200,
+                localOffsetYCm: 0,
+                navRadiusCm: 0);
+
+            var compoundEntity = world.Create(
+                WorldPositionCm.FromCm(0, 0),
+                new FacingDirection { AngleRad = MathF.PI / 2f },
+                obstacle);
+
+            var dynamicShape = ShapeDataStorage2D.RegisterBox(Fix64.FromInt(25), Fix64.FromInt(25));
+            world.Create(
+                new Position2D { Value = Fix64Vec2.FromInt(0, 200) },
+                new Velocity2D { Linear = Fix64Vec2.Zero, Angular = Fix64.Zero },
+                Mass2D.FromFloat(1f, 1f),
+                new Collider2D { Type = ColliderType2D.Box, ShapeDataIndex = dynamicShape });
+
+            var bridge = new ManifestationObstacleBridge2DSystem(world);
+            var build = new BuildPhysicsWorldSystem2D(world);
+            var spatial = new AdaptiveSpatialSystem2D(world, build, maxCollisionPairs: 16);
+            var narrow = new NarrowPhaseSystem2D(world);
+
+            bridge.Update(0f);
+            build.Update(0f);
+            spatial.Update(0f);
+            narrow.Update(0f);
+
+            int activeWithContact = 0;
+            var q = new QueryDescription().WithAll<CollisionPair>();
+            world.Query(in q, (ref CollisionPair pair) =>
+            {
+                if (pair.IsActive && pair.ContactCount > 0 && pair.Penetration > Fix64.Zero)
+                {
+                    activeWithContact++;
+                    Assert.That(pair.EntityA == compoundEntity || pair.EntityB == compoundEntity, Is.True);
+                }
+            });
+
+            Assert.That(activeWithContact, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void CompoundObstacleFlowDiscomfortHalo_UsesRotatedPieceCenter()
+        {
+            using var world = World.Create();
+
+            var obstacle = new CompoundObstacle2D
+            {
+                SinkPhysicsCollider = 0,
+                SinkNavigationObstacle = 1
+            };
+            obstacle.SetPiece(
+                0,
+                ManifestationObstacleShape2D.Circle,
+                radiusCm: 20,
+                halfWidthCm: 0,
+                halfHeightCm: 0,
+                localOffsetXCm: 200,
+                localOffsetYCm: 0,
+                navRadiusCm: 20);
+
+            world.Create(
+                WorldPositionCm.FromCm(0, 0),
+                new FacingDirection { AngleRad = MathF.PI / 2f },
+                obstacle);
+            world.Create(
+                new NavAgent2D(),
+                new Position2D { Value = Fix64Vec2.FromInt(1000, 1000) },
+                new Velocity2D { Linear = Fix64Vec2.Zero, Angular = Fix64.Zero },
+                new NavKinematics2D
+                {
+                    MaxSpeedCmPerSec = Fix64.FromInt(100),
+                    MaxAccelCmPerSec2 = Fix64.FromInt(100),
+                    RadiusCm = Fix64.FromInt(20),
+                    NeighborDistCm = Fix64.FromInt(100),
+                    TimeHorizonSec = Fix64.OneValue,
+                    MaxNeighbors = 0
+                });
+
+            var config = new Navigation2DConfig
+            {
+                Enabled = true,
+                MaxAgents = 8,
+                FlowIterationsPerTick = 0,
+                FlowCrowd = new Navigation2DFlowCrowdConfig
+                {
+                    Enabled = true,
+                    Discomfort = new Navigation2DFlowCrowdDiscomfortConfig
+                    {
+                        Enabled = true,
+                        ObstacleHaloRadiusCm = 120,
+                        ObstacleHaloValue = 10f,
+                        ObstacleHaloEdgeValue = 0f,
+                    },
+                },
+            };
+            using var runtime = new Navigation2DRuntime(config, gridCellSizeCm: 100, loadedChunks: null)
+            {
+                FlowEnabled = true,
+            };
+            runtime.Surface.GetOrCreateTile(Nav2DKeyPacking.PackInt2(0, 0));
+
+            var bridge = new ManifestationObstacleBridge2DSystem(world);
+            using var steering = new Navigation2DSteeringSystem2D(world, runtime);
+
+            bridge.Update(0f);
+            steering.Update(0.016f);
+
+            Assert.That(runtime.Surface.TryGetDiscomfortCell(1, 2, out float rotatedPieceHalo), Is.True);
+            Assert.That(rotatedPieceHalo, Is.GreaterThan(0f));
+        }
+
+        [Test]
+        public void SingleObstacleFlowDiscomfortHalo_UsesRotatedShapeCenter()
+        {
+            using var world = World.Create();
+
+            world.Create(
+                WorldPositionCm.FromCm(0, 0),
+                new FacingDirection { AngleRad = MathF.PI / 2f },
+                new ManifestationObstacleIntent2D
+                {
+                    Shape = ManifestationObstacleShape2D.Circle,
+                    SinkPhysicsCollider = 0,
+                    SinkNavigationObstacle = 1,
+                    RadiusCm = 20,
+                    NavRadiusCm = 20,
+                    LocalOffsetXCm = 200,
+                    LocalOffsetYCm = 0,
+                });
+            world.Create(
+                new NavAgent2D(),
+                new Position2D { Value = Fix64Vec2.FromInt(1000, 1000) },
+                new Velocity2D { Linear = Fix64Vec2.Zero, Angular = Fix64.Zero },
+                new NavKinematics2D
+                {
+                    MaxSpeedCmPerSec = Fix64.FromInt(100),
+                    MaxAccelCmPerSec2 = Fix64.FromInt(100),
+                    RadiusCm = Fix64.FromInt(20),
+                    NeighborDistCm = Fix64.FromInt(100),
+                    TimeHorizonSec = Fix64.OneValue,
+                    MaxNeighbors = 0
+                });
+
+            var config = new Navigation2DConfig
+            {
+                Enabled = true,
+                MaxAgents = 8,
+                FlowIterationsPerTick = 0,
+                FlowCrowd = new Navigation2DFlowCrowdConfig
+                {
+                    Enabled = true,
+                    Discomfort = new Navigation2DFlowCrowdDiscomfortConfig
+                    {
+                        Enabled = true,
+                        ObstacleHaloRadiusCm = 120,
+                        ObstacleHaloValue = 10f,
+                        ObstacleHaloEdgeValue = 0f,
+                    },
+                },
+            };
+            using var runtime = new Navigation2DRuntime(config, gridCellSizeCm: 100, loadedChunks: null)
+            {
+                FlowEnabled = true,
+            };
+            runtime.Surface.GetOrCreateTile(Nav2DKeyPacking.PackInt2(0, 0));
+
+            var bridge = new ManifestationObstacleBridge2DSystem(world);
+            using var steering = new Navigation2DSteeringSystem2D(world, runtime);
+
+            bridge.Update(0f);
+            steering.Update(0.016f);
+
+            Assert.That(runtime.Surface.TryGetDiscomfortCell(1, 2, out float rotatedShapeHalo), Is.True);
+            Assert.That(rotatedShapeHalo, Is.GreaterThan(0f));
         }
 
         [Test]

--- a/src/Tests/GasTests/RuntimeManifestationBridgeTests.cs
+++ b/src/Tests/GasTests/RuntimeManifestationBridgeTests.cs
@@ -78,6 +78,90 @@ namespace Ludots.Tests.GAS
         }
 
         [Test]
+        public void ManifestationObstacleBridge2D_SingleSinkTogglesRemoveDerivedState()
+        {
+            using var world = World.Create();
+            var system = new ManifestationObstacleBridge2DSystem(world);
+            var entity = world.Create(
+                WorldPositionCm.FromCm(0, 0),
+                new ManifestationObstacleIntent2D
+                {
+                    Shape = ManifestationObstacleShape2D.Circle,
+                    SinkPhysicsCollider = 1,
+                    SinkNavigationObstacle = 1,
+                    RadiusCm = 50,
+                    NavRadiusCm = 50,
+                });
+
+            system.Update(0f);
+
+            That(world.Has<Collider2D>(entity), Is.True);
+            That(world.Has<Mass2D>(entity), Is.True);
+            That(world.Has<Velocity2D>(entity), Is.True);
+            That(world.Has<NavObstacle2D>(entity), Is.True);
+            That(world.Has<NavKinematics2D>(entity), Is.True);
+
+            var intent = world.Get<ManifestationObstacleIntent2D>(entity);
+            intent.SinkPhysicsCollider = 0;
+            intent.SinkNavigationObstacle = 0;
+            world.Set(entity, intent);
+
+            system.Update(0f);
+
+            That(world.Has<Collider2D>(entity), Is.False);
+            That(world.Has<Mass2D>(entity), Is.False);
+            That(world.Has<Velocity2D>(entity), Is.False);
+            That(world.Has<NavObstacle2D>(entity), Is.False);
+            That(world.Has<NavKinematics2D>(entity), Is.False);
+        }
+
+        [Test]
+        public void ManifestationObstacleBridge2D_DisabledInitialSinksDoNotRemoveAuthoredRuntimeComponents()
+        {
+            using var world = World.Create();
+            int authoredShapeIndex = ShapeDataStorage2D.RegisterBox(Fix64.FromInt(10), Fix64.FromInt(20));
+            var authoredVelocity = Velocity2D.FromCmPerSec(7f, 8f, 0.5f);
+            var authoredMass = Mass2D.FromFloat(1f, 2f);
+            var authoredNav = new NavKinematics2D
+            {
+                MaxSpeedCmPerSec = Fix64.FromInt(300),
+                MaxAccelCmPerSec2 = Fix64.FromInt(400),
+                RadiusCm = Fix64.FromInt(30),
+                NeighborDistCm = Fix64.FromInt(500),
+                TimeHorizonSec = Fix64.OneValue,
+                MaxNeighbors = 4
+            };
+
+            var entity = world.Create(
+                WorldPositionCm.FromCm(0, 0),
+                new Collider2D { Type = ColliderType2D.Box, ShapeDataIndex = authoredShapeIndex },
+                authoredMass,
+                authoredVelocity,
+                new NavObstacle2D { Shape = NavObstacleShape2D.Box, ShapeDataIndex = authoredShapeIndex },
+                authoredNav,
+                new ManifestationObstacleIntent2D
+                {
+                    Shape = ManifestationObstacleShape2D.Circle,
+                    SinkPhysicsCollider = 0,
+                    SinkNavigationObstacle = 0,
+                    RadiusCm = 50,
+                    NavRadiusCm = 50,
+                });
+
+            var system = new ManifestationObstacleBridge2DSystem(world);
+            system.Update(0f);
+
+            That(world.Get<Collider2D>(entity).ShapeDataIndex, Is.EqualTo(authoredShapeIndex));
+            That(world.Get<Mass2D>(entity).InverseMass, Is.EqualTo(authoredMass.InverseMass));
+            That(world.Get<Mass2D>(entity).InverseInertia, Is.EqualTo(authoredMass.InverseInertia));
+            That(world.Get<Velocity2D>(entity).Linear, Is.EqualTo(authoredVelocity.Linear));
+            That(world.Get<Velocity2D>(entity).Angular, Is.EqualTo(authoredVelocity.Angular));
+            That(world.Get<NavObstacle2D>(entity).ShapeDataIndex, Is.EqualTo(authoredShapeIndex));
+            That(world.Get<NavKinematics2D>(entity).MaxSpeedCmPerSec, Is.EqualTo(authoredNav.MaxSpeedCmPerSec));
+            That(world.Get<NavKinematics2D>(entity).MaxNeighbors, Is.EqualTo(authoredNav.MaxNeighbors));
+        }
+
+        [Test]
         public void ComponentRegistry_ParsesPolygonManifestationObstacle_AndBridgeCreatesPolygonObstacle()
         {
             using var world = World.Create();
@@ -287,6 +371,11 @@ namespace Ludots.Tests.GAS
                 "ManifestationObstacleIntent2D",
                 """{ "shape": "Circle", "sinkPhysicsCollider": 1, "sinkNavigationObstacle": true, "navRadiusCm": 10 }""",
                 "requires a boolean value");
+            AssertRejects(
+                world,
+                "ManifestationObstacleIntent2D",
+                """{ "shape": "Circle", "sinkPhysicsCollider": false, "sinkNavigationObstacle": false, "radiusCm": 10, "navRadiusCm": 10, "localOffsetCm": { "x": 0, "y": 0 } }""",
+                "requires at least one sink intent");
             AssertRejects(
                 world,
                 "CompoundObstacle2D",


### PR DESCRIPTION
## Summary
- centralize 2D shape local-to-world transforms for obstacle geometry
- rotate local offsets consistently in physics broadphase, collision, nav obstacle stamping, and debug draw
- clean bridge-derived physics/nav state when sinks are toggled off without deleting pre-authored runtime components
- reject no-sink single obstacle config and add regression coverage for single/compound obstacle halos

## Validation
- dotnet test src\Tests\GasTests\GasTests.csproj --filter Physics2DIntegrationTests|RuntimeManifestationBridgeTests --no-restore --logger console;verbosity=minimal (20/20 passed)
- dotnet test src\Tests\GasTests\GasTests.csproj --filter targeted new/sensitive cases --no-restore --logger console;verbosity=minimal (5/5 passed)
- dotnet build src\Core\Ludots.Core.csproj --no-restore -v minimal (0 warnings, 0 errors)
- git diff --check (no whitespace errors; CRLF warnings only)

## Note
Navigation2DTests project-level run is blocked by pre-existing SelectionBuffer compile errors in Navigation2DPlaygroundPlayableAcceptanceTests.cs.