### PR TITLE
feat(physics2d): separate static obstacle materialization

### DIFF
--- a/src/Core/Ludots.Physics2D/Systems/AdaptiveSpatialSystem2D.cs
+++ b/src/Core/Ludots.Physics2D/Systems/AdaptiveSpatialSystem2D.cs
@@ -28,7 +28,8 @@ namespace Ludots.Core.Physics2D.Systems
         private readonly HashSet<long> _usedPairKeys;
         private readonly List<long> _unusedPairKeys;
 
-        private ISpatialPartitionStrategy _currentStrategy;
+        private ISpatialPartitionStrategy _currentStrategy = null!;
+        private int _observedStaticBodyVersion = -1;
 
         public CollisionPairOverflowPolicy2D OverflowPolicy { get; set; } = CollisionPairOverflowPolicy2D.Throw;
         public int DroppedPairsLastUpdate { get; private set; }
@@ -60,10 +61,31 @@ namespace Ludots.Core.Physics2D.Systems
         public override void Update(in float deltaTime)
         {
             DroppedPairsLastUpdate = 0;
-            var rigidBodies = _buildPhysicsWorld.RigidBodyDescriptors;
-            if (rigidBodies.Count == 0) return;
+            var dynamicBodies = _buildPhysicsWorld.DynamicRigidBodyDescriptors;
+            var staticBodies = _buildPhysicsWorld.StaticRigidBodyDescriptors;
+            bool rebuildStatic = _observedStaticBodyVersion != _buildPhysicsWorld.StaticBodyVersion;
+            if (dynamicBodies.Count == 0)
+            {
+                if (rebuildStatic)
+                {
+                    _currentStrategy.Build(
+                        CollectionsMarshal.AsSpan(dynamicBodies),
+                        CollectionsMarshal.AsSpan(staticBodies),
+                        rebuildStatic: true);
+                    _observedStaticBodyVersion = _buildPhysicsWorld.StaticBodyVersion;
+                }
 
-            _currentStrategy.Build(CollectionsMarshal.AsSpan(rigidBodies));
+                _potentialPairs.Clear();
+                _usedPairKeys.Clear();
+                RecycleUnusedPairs();
+                return;
+            }
+
+            _currentStrategy.Build(
+                CollectionsMarshal.AsSpan(dynamicBodies),
+                CollectionsMarshal.AsSpan(staticBodies),
+                rebuildStatic);
+            _observedStaticBodyVersion = _buildPhysicsWorld.StaticBodyVersion;
 
             _potentialPairs.Clear();
             _currentStrategy.QueryPotentialCollisions(_potentialPairs);
@@ -81,18 +103,30 @@ namespace Ludots.Core.Physics2D.Systems
 
         private void ActivateCollisionPairs(List<(int indexA, int indexB)> pairs)
         {
-            var entities = _buildPhysicsWorld.Entities;
             int needed = 0;
             _usedPairKeys.Clear();
 
             for (int i = 0; i < pairs.Count; i++)
             {
-                var (rigidBodyIndexA, rigidBodyIndexB) = pairs[i];
-                if ((uint)rigidBodyIndexA >= (uint)entities.Count) continue;
-                if ((uint)rigidBodyIndexB >= (uint)entities.Count) continue;
+                var (bodyHandleA, bodyHandleB) = pairs[i];
+                if (!_buildPhysicsWorld.TryResolveBody(
+                        bodyHandleA,
+                        out Entity entityA,
+                        out PhysicsBodyColliderDesc2D colliderA,
+                        out _) ||
+                    !_buildPhysicsWorld.TryResolveBody(
+                        bodyHandleB,
+                        out Entity entityB,
+                        out PhysicsBodyColliderDesc2D colliderB,
+                        out _))
+                {
+                    continue;
+                }
 
-                var entityA = entities[rigidBodyIndexA];
-                var entityB = entities[rigidBodyIndexB];
+                if (entityA.Id == entityB.Id)
+                {
+                    continue;
+                }
 
                 if (World.Has<SleepingTag>(entityA) && World.Has<SleepingTag>(entityB))
                 {
@@ -102,9 +136,11 @@ namespace Ludots.Core.Physics2D.Systems
                 if (entityB.Id < entityA.Id)
                 {
                     (entityA, entityB) = (entityB, entityA);
+                    (colliderA, colliderB) = (colliderB, colliderA);
+                    (bodyHandleA, bodyHandleB) = (bodyHandleB, bodyHandleA);
                 }
 
-                long key = MakePairKey(entityA.Id, entityB.Id);
+                long key = MakePairKey(bodyHandleA, bodyHandleB);
                 if (!_usedPairKeys.Add(key))
                 {
                     continue;
@@ -117,6 +153,12 @@ namespace Ludots.Core.Physics2D.Systems
                     collisionPair.IsActive = true;
                     collisionPair.EntityA = entityA;
                     collisionPair.EntityB = entityB;
+                    collisionPair.BodyHandleA = bodyHandleA;
+                    collisionPair.BodyHandleB = bodyHandleB;
+                    collisionPair.ColliderTypeA = colliderA.Type;
+                    collisionPair.ColliderTypeB = colliderB.Type;
+                    collisionPair.ShapeDataIndexA = colliderA.ShapeDataIndex;
+                    collisionPair.ShapeDataIndexB = colliderB.ShapeDataIndex;
                     collisionPair.ContactCount = 0;
                     collisionPair.Penetration = Fix64.Zero;
                     if (!World.Has<ActiveCollisionPairTag>(pairEntity))
@@ -142,6 +184,12 @@ namespace Ludots.Core.Physics2D.Systems
                     collisionPair.IsActive = true;
                     collisionPair.EntityA = entityA;
                     collisionPair.EntityB = entityB;
+                    collisionPair.BodyHandleA = bodyHandleA;
+                    collisionPair.BodyHandleB = bodyHandleB;
+                    collisionPair.ColliderTypeA = colliderA.Type;
+                    collisionPair.ColliderTypeB = colliderB.Type;
+                    collisionPair.ShapeDataIndexA = colliderA.ShapeDataIndex;
+                    collisionPair.ShapeDataIndexB = colliderB.ShapeDataIndex;
                     collisionPair.ContactCount = 0;
                     collisionPair.Penetration = Fix64.Zero;
                     collisionPair.AccumulatedNormalImpulse0 = Fix64.Zero;
@@ -178,6 +226,8 @@ namespace Ludots.Core.Physics2D.Systems
                 pair.IsActive = false;
                 pair.EntityA = default;
                 pair.EntityB = default;
+                pair.BodyHandleA = 0;
+                pair.BodyHandleB = 0;
                 _pairPool.Push(entity);
             }
         }

--- a/src/Core/Ludots.Physics2D/Systems/ManifestationObstacleBridge2DSystem.cs
+++ b/src/Core/Ludots.Physics2D/Systems/ManifestationObstacleBridge2DSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using Arch.Core;
+using Arch.Core.Extensions;
 using Arch.System;
 using Ludots.Core.Components;
 using Ludots.Core.Gameplay.Spawning;
@@ -12,12 +13,19 @@ namespace Ludots.Core.Physics2D.Systems
 {
     /// <summary>
     /// Bridges runtime manifestation blocker intent into lower-layer physics and navigation components.
-    /// This keeps spell/runtime authoring declarative while collision and nav remain owned by their subsystems.
+    /// Static manifestations are materialized once and revisited only through explicit dirty state.
     /// </summary>
     public sealed class ManifestationObstacleBridge2DSystem : BaseSystem<World, float>
     {
-        private static readonly QueryDescription _query = new QueryDescription()
-            .WithAll<WorldPositionCm, ManifestationObstacleIntent2D>();
+        private static readonly QueryDescription _newQuery = new QueryDescription()
+            .WithAll<WorldPositionCm, ManifestationObstacleIntent2D>()
+            .WithNone<ManifestationObstacleBridge2DState>();
+
+        private static readonly QueryDescription _dirtyQuery = new QueryDescription()
+            .WithAll<WorldPositionCm, ManifestationObstacleIntent2D, ManifestationObstacleBridge2DState, ManifestationObstacleBridge2DDirty>();
+
+        private static readonly QueryDescription _movingQuery = new QueryDescription()
+            .WithAll<WorldPositionCm, ManifestationObstacleIntent2D, ManifestationObstacleBridge2DState, ManifestationMotion2D>();
 
         public ManifestationObstacleBridge2DSystem(World world) : base(world)
         {
@@ -25,65 +33,167 @@ namespace Ludots.Core.Physics2D.Systems
 
         public override void Update(in float dt)
         {
-            World.Query(in _query, (Entity entity, ref WorldPositionCm worldPosition, ref ManifestationObstacleIntent2D intent) =>
+            World.Query(in _newQuery, (Entity entity, ref WorldPositionCm worldPosition, ref ManifestationObstacleIntent2D intent) =>
             {
-                Upsert(entity, new Position2D { Value = worldPosition.Value });
+                Materialize(entity, in worldPosition, in intent, removeDirty: false);
+            });
 
-                if (World.TryGet(entity, out FacingDirection facing))
+            World.Query(in _dirtyQuery, (Entity entity, ref WorldPositionCm worldPosition, ref ManifestationObstacleIntent2D intent) =>
+            {
+                Materialize(entity, in worldPosition, in intent, removeDirty: true);
+            });
+
+            World.Query(in _movingQuery, (Entity entity, ref WorldPositionCm worldPosition, ref ManifestationObstacleIntent2D intent) =>
+            {
+                Materialize(entity, in worldPosition, in intent, removeDirty: false);
+            });
+        }
+
+        private void Materialize(
+            Entity entity,
+            in WorldPositionCm worldPosition,
+            in ManifestationObstacleIntent2D intent,
+            bool removeDirty)
+        {
+            int shapeSignature = ComputeShapeSignature(in intent, entity);
+            int poseSignature = ComputePoseSignature(in worldPosition, entity);
+            int sinkSignature = ComputeSinkSignature(in intent);
+
+            bool hasState = World.TryGet(entity, out ManifestationObstacleBridge2DState previousState);
+            if (hasState &&
+                previousState.ShapeSignature == shapeSignature &&
+                previousState.PoseSignature == poseSignature &&
+                previousState.SinkSignature == sinkSignature &&
+                !removeDirty)
+            {
+                return;
+            }
+
+            bool shapeChanged = !hasState || previousState.ShapeSignature != shapeSignature;
+
+            Upsert(entity, new Position2D { Value = worldPosition.Value });
+
+            if (World.TryGet(entity, out FacingDirection facing))
+            {
+                Upsert(entity, new Rotation2D { Value = Fix64.FromFloat(facing.AngleRad) });
+            }
+
+            int shapeDataIndex = intent.Shape == ManifestationObstacleShape2D.GeometryProfile
+                ? -1
+                : EnsureShapeRegistered(entity, in intent, shapeSignature, in previousState, hasState);
+
+            if (intent.SinkPhysicsCollider != 0)
+            {
+                if (intent.Shape == ManifestationObstacleShape2D.GeometryProfile)
                 {
-                    Upsert(entity, new Rotation2D { Value = Fix64.FromFloat(facing.AngleRad) });
+                    if (shapeChanged || !World.Has<CompoundCollider2D>(entity))
+                    {
+                        var compound = RegisterCompoundCollider(entity, in intent);
+                        Upsert(entity, compound);
+                    }
+
+                    RemoveIfPresent<Collider2D>(entity);
                 }
-
-                int signature = ComputeShapeSignature(in intent, entity);
-                int shapeDataIndex = EnsureShapeRegistered(entity, in intent, signature);
-
-                if (intent.SinkPhysicsCollider != 0)
+                else
                 {
                     Upsert(entity, new Collider2D
                     {
                         Type = ToColliderType(intent.Shape),
                         ShapeDataIndex = shapeDataIndex
                     });
-                    Upsert(entity, Mass2D.Static);
-                    Upsert(entity, Velocity2D.Zero);
+                    RemoveIfPresent<CompoundCollider2D>(entity);
                 }
 
-                if (intent.SinkNavigationObstacle != 0)
+                Upsert(entity, Mass2D.Static);
+                Upsert(entity, Velocity2D.Zero);
+            }
+            else
+            {
+                RemoveIfPresent<Collider2D>(entity);
+                RemoveIfPresent<CompoundCollider2D>(entity);
+            }
+
+            if (intent.SinkNavigationObstacle != 0)
+            {
+                if (intent.Shape == ManifestationObstacleShape2D.GeometryProfile)
+                {
+                    if (shapeChanged || !World.Has<NavCompoundObstacle2D>(entity))
+                    {
+                        CompoundCollider2D compound = World.TryGet(entity, out CompoundCollider2D existingCompound)
+                            ? existingCompound
+                            : RegisterCompoundCollider(entity, in intent);
+                        var navCompound = ToNavCompoundObstacle(in compound);
+                        Upsert(entity, navCompound);
+                    }
+
+                    RemoveIfPresent<NavObstacle2D>(entity);
+                }
+                else
                 {
                     Upsert(entity, new NavObstacle2D
                     {
                         Shape = ToNavObstacleShape(intent.Shape),
                         ShapeDataIndex = shapeDataIndex
                     });
-                    Upsert(entity, new NavKinematics2D
-                    {
-                        MaxSpeedCmPerSec = Fix64.Zero,
-                        MaxAccelCmPerSec2 = Fix64.Zero,
-                        RadiusCm = ResolveNavRadiusCm(entity, in intent, shapeDataIndex),
-                        NeighborDistCm = Fix64.Zero,
-                        TimeHorizonSec = Fix64.Zero,
-                        MaxNeighbors = 0
-                    });
+                    RemoveIfPresent<NavCompoundObstacle2D>(entity);
                 }
-            });
-        }
 
-        private int EnsureShapeRegistered(Entity entity, in ManifestationObstacleIntent2D intent, int signature)
-        {
-            if (World.TryGet(entity, out ManifestationObstacleBridge2DState bridgeState) &&
-                bridgeState.ShapeSignature == signature &&
-                bridgeState.ShapeDataIndex >= 0)
+                Upsert(entity, new NavKinematics2D
+                {
+                    MaxSpeedCmPerSec = Fix64.Zero,
+                    MaxAccelCmPerSec2 = Fix64.Zero,
+                    RadiusCm = ResolveNavRadiusCm(entity, in intent, shapeDataIndex),
+                    NeighborDistCm = Fix64.Zero,
+                    TimeHorizonSec = Fix64.Zero,
+                    MaxNeighbors = 0
+                });
+            }
+            else
             {
-                return bridgeState.ShapeDataIndex;
+                RemoveIfPresent<NavObstacle2D>(entity);
+                RemoveIfPresent<NavCompoundObstacle2D>(entity);
+                RemoveIfPresent<NavKinematics2D>(entity);
             }
 
-            int shapeDataIndex = RegisterShape(entity, in intent);
             Upsert(entity, new ManifestationObstacleBridge2DState
             {
                 ShapeDataIndex = shapeDataIndex,
-                ShapeSignature = signature
+                ShapeSignature = shapeSignature,
+                PoseSignature = poseSignature,
+                SinkSignature = sinkSignature
             });
-            return shapeDataIndex;
+
+            bool hasStaticPhysicsState = World.Has<Physics2DStaticBodyState>(entity);
+            if (intent.SinkPhysicsCollider != 0 || hasStaticPhysicsState)
+            {
+                MarkStaticBodyDirty(entity);
+            }
+            else
+            {
+                RemoveIfPresent<Physics2DStaticBodyDirty>(entity);
+            }
+
+            if (removeDirty)
+            {
+                RemoveIfPresent<ManifestationObstacleBridge2DDirty>(entity);
+            }
+        }
+
+        private int EnsureShapeRegistered(
+            Entity entity,
+            in ManifestationObstacleIntent2D intent,
+            int signature,
+            in ManifestationObstacleBridge2DState previousState,
+            bool hasState)
+        {
+            if (hasState &&
+                previousState.ShapeSignature == signature &&
+                previousState.ShapeDataIndex >= 0)
+            {
+                return previousState.ShapeDataIndex;
+            }
+
+            return RegisterShape(entity, in intent);
         }
 
         private int RegisterShape(Entity entity, in ManifestationObstacleIntent2D intent)
@@ -97,12 +207,12 @@ namespace Ludots.Core.Physics2D.Systems
                     Fix64.FromInt(intent.HalfWidthCm),
                     Fix64.FromInt(intent.HalfHeightCm),
                     Fix64Vec2.FromInt(intent.LocalOffsetXCm, intent.LocalOffsetYCm)),
-                ManifestationObstacleShape2D.Polygon => RegisterPolygon(entity),
+                ManifestationObstacleShape2D.Polygon => RegisterPolygon(entity, intent.LocalOffsetXCm, intent.LocalOffsetYCm),
                 _ => throw new InvalidOperationException($"Unsupported manifestation obstacle shape '{intent.Shape}'.")
             };
         }
 
-        private int RegisterPolygon(Entity entity)
+        private int RegisterPolygon(Entity entity, int localOffsetXCm, int localOffsetYCm)
         {
             if (!World.TryGet(entity, out ManifestationObstaclePolygon2D polygon))
             {
@@ -118,7 +228,98 @@ namespace Ludots.Core.Physics2D.Systems
             var vertices = new Fix64Vec2[count];
             for (int i = 0; i < count; i++)
             {
-                vertices[i] = ToFix64Vec2(polygon.GetVertex(i));
+                WorldCmInt2 vertex = polygon.GetVertex(i);
+                vertices[i] = Fix64Vec2.FromInt(vertex.X + localOffsetXCm, vertex.Y + localOffsetYCm);
+            }
+
+            return ShapeDataStorage2D.RegisterPolygon(vertices);
+        }
+
+        private CompoundCollider2D RegisterCompoundCollider(Entity entity, in ManifestationObstacleIntent2D intent)
+        {
+            if (!World.TryGet(entity, out ObstacleGeometryProfile2D profile))
+            {
+                throw new InvalidOperationException("ManifestationObstacleIntent2D with GeometryProfile shape requires ObstacleGeometryProfile2D.");
+            }
+
+            if (profile.PieceCount == 0 || profile.PieceCount > ObstacleGeometryProfile2D.MaxPieces)
+            {
+                throw new InvalidOperationException($"ObstacleGeometryProfile2D pieces count must be between 1 and {ObstacleGeometryProfile2D.MaxPieces}.");
+            }
+
+            var compound = new CompoundCollider2D();
+            for (int i = 0; i < profile.PieceCount; i++)
+            {
+                int shapeDataIndex = RegisterGeometryPiece(in profile, i, in intent, out ColliderType2D colliderType);
+                compound.SetPiece(i, colliderType, shapeDataIndex);
+            }
+
+            return compound;
+        }
+
+        private static NavCompoundObstacle2D ToNavCompoundObstacle(in CompoundCollider2D source)
+        {
+            var compound = new NavCompoundObstacle2D();
+            for (int i = 0; i < source.PieceCount; i++)
+            {
+                var (colliderType, shapeDataIndex) = source.GetPiece(i);
+                compound.SetPiece(i, ToNavObstacleShape(colliderType), shapeDataIndex);
+            }
+
+            return compound;
+        }
+
+        private static int RegisterGeometryPiece(
+            in ObstacleGeometryProfile2D profile,
+            int pieceIndex,
+            in ManifestationObstacleIntent2D intent,
+            out ColliderType2D colliderType)
+        {
+            ObstacleGeometryPiece2D piece = profile.GetPiece(pieceIndex);
+            int offsetX = intent.LocalOffsetXCm + piece.LocalOffsetXCm;
+            int offsetY = intent.LocalOffsetYCm + piece.LocalOffsetYCm;
+
+            switch (piece.Shape)
+            {
+                case ObstacleGeometryPieceShape2D.Circle:
+                    colliderType = ColliderType2D.Circle;
+                    return ShapeDataStorage2D.RegisterCircle(
+                        Fix64.FromInt(piece.RadiusCm),
+                        Fix64Vec2.FromInt(offsetX, offsetY));
+
+                case ObstacleGeometryPieceShape2D.Box:
+                    colliderType = ColliderType2D.Box;
+                    return ShapeDataStorage2D.RegisterBox(
+                        Fix64.FromInt(piece.HalfWidthCm),
+                        Fix64.FromInt(piece.HalfHeightCm),
+                        Fix64Vec2.FromInt(offsetX, offsetY));
+
+                case ObstacleGeometryPieceShape2D.Polygon:
+                    colliderType = ColliderType2D.Polygon;
+                    return RegisterGeometryPolygon(in profile, pieceIndex, piece.VertexCount, offsetX, offsetY);
+
+                default:
+                    throw new InvalidOperationException($"Unsupported ObstacleGeometryProfile2D piece shape '{piece.Shape}'.");
+            }
+        }
+
+        private static int RegisterGeometryPolygon(
+            in ObstacleGeometryProfile2D profile,
+            int pieceIndex,
+            int vertexCount,
+            int offsetX,
+            int offsetY)
+        {
+            if (vertexCount < 3 || vertexCount > ObstacleGeometryProfile2D.MaxPolygonVertices)
+            {
+                throw new InvalidOperationException($"ObstacleGeometryProfile2D polygon vertex count must be between 3 and {ObstacleGeometryProfile2D.MaxPolygonVertices}.");
+            }
+
+            var vertices = new Fix64Vec2[vertexCount];
+            for (int i = 0; i < vertexCount; i++)
+            {
+                WorldCmInt2 vertex = profile.GetPolygonVertex(pieceIndex, i);
+                vertices[i] = Fix64Vec2.FromInt(vertex.X + offsetX, vertex.Y + offsetY);
             }
 
             return ShapeDataStorage2D.RegisterPolygon(vertices);
@@ -126,28 +327,93 @@ namespace Ludots.Core.Physics2D.Systems
 
         private int ComputeShapeSignature(in ManifestationObstacleIntent2D intent, Entity entity)
         {
-            var hash = new HashCode();
-            hash.Add((byte)intent.Shape);
-            hash.Add(intent.RadiusCm);
-            hash.Add(intent.HalfWidthCm);
-            hash.Add(intent.HalfHeightCm);
-            hash.Add(intent.LocalOffsetXCm);
-            hash.Add(intent.LocalOffsetYCm);
-            hash.Add(intent.NavRadiusCm);
+            int hash = BeginSignature();
+            hash = MixSignature(hash, (byte)intent.Shape);
+            hash = MixSignature(hash, intent.RadiusCm);
+            hash = MixSignature(hash, intent.HalfWidthCm);
+            hash = MixSignature(hash, intent.HalfHeightCm);
+            hash = MixSignature(hash, intent.LocalOffsetXCm);
+            hash = MixSignature(hash, intent.LocalOffsetYCm);
+            hash = MixSignature(hash, intent.NavRadiusCm);
 
             if (intent.Shape == ManifestationObstacleShape2D.Polygon &&
                 World.TryGet(entity, out ManifestationObstaclePolygon2D polygon))
             {
-                hash.Add(polygon.VertexCount);
+                hash = MixSignature(hash, polygon.VertexCount);
                 for (int i = 0; i < polygon.VertexCount; i++)
                 {
                     var vertex = polygon.GetVertex(i);
-                    hash.Add(vertex.X);
-                    hash.Add(vertex.Y);
+                    hash = MixSignature(hash, vertex.X);
+                    hash = MixSignature(hash, vertex.Y);
+                }
+            }
+            else if (intent.Shape == ManifestationObstacleShape2D.GeometryProfile &&
+                World.TryGet(entity, out ObstacleGeometryProfile2D profile))
+            {
+                hash = MixSignature(hash, profile.PieceCount);
+                for (int i = 0; i < profile.PieceCount; i++)
+                {
+                    ObstacleGeometryPiece2D piece = profile.GetPiece(i);
+                    hash = MixSignature(hash, (byte)piece.Shape);
+                    hash = MixSignature(hash, piece.RadiusCm);
+                    hash = MixSignature(hash, piece.HalfWidthCm);
+                    hash = MixSignature(hash, piece.HalfHeightCm);
+                    hash = MixSignature(hash, piece.LocalOffsetXCm);
+                    hash = MixSignature(hash, piece.LocalOffsetYCm);
+                    hash = MixSignature(hash, piece.VertexCount);
+                    for (int vertexIndex = 0; vertexIndex < piece.VertexCount; vertexIndex++)
+                    {
+                        WorldCmInt2 vertex = profile.GetPolygonVertex(i, vertexIndex);
+                        hash = MixSignature(hash, vertex.X);
+                        hash = MixSignature(hash, vertex.Y);
+                    }
                 }
             }
 
-            return hash.ToHashCode();
+            return hash;
+        }
+
+        private int ComputePoseSignature(in WorldPositionCm worldPosition, Entity entity)
+        {
+            int hash = BeginSignature();
+            hash = MixSignature(hash, worldPosition.Value.X.RawValue);
+            hash = MixSignature(hash, worldPosition.Value.Y.RawValue);
+            if (World.TryGet(entity, out FacingDirection facing))
+            {
+                hash = MixSignature(hash, BitConverter.SingleToInt32Bits(facing.AngleRad));
+            }
+            else
+            {
+                hash = MixSignature(hash, 0);
+            }
+
+            return hash;
+        }
+
+        private static int BeginSignature()
+        {
+            return unchecked((int)2166136261);
+        }
+
+        private static int MixSignature(int hash, int value)
+        {
+            unchecked
+            {
+                hash ^= value;
+                return hash * 16777619;
+            }
+        }
+
+        private static int MixSignature(int hash, long value)
+        {
+            hash = MixSignature(hash, (int)value);
+            return MixSignature(hash, (int)(value >> 32));
+        }
+
+        private static int ComputeSinkSignature(in ManifestationObstacleIntent2D intent)
+        {
+            return (intent.SinkPhysicsCollider & 0x1) |
+                   ((intent.SinkNavigationObstacle & 0x1) << 1);
         }
 
         private static Fix64 ResolveNavRadiusCm(Entity entity, in ManifestationObstacleIntent2D intent, int shapeDataIndex)
@@ -155,6 +421,21 @@ namespace Ludots.Core.Physics2D.Systems
             if (intent.NavRadiusCm > 0)
             {
                 return Fix64.FromInt(intent.NavRadiusCm);
+            }
+
+            if (intent.Shape == ManifestationObstacleShape2D.GeometryProfile)
+            {
+                if (entity.TryGet(out CompoundCollider2D compound))
+                {
+                    return ResolveCompoundRadius(in compound);
+                }
+
+                if (entity.TryGet(out NavCompoundObstacle2D navCompound))
+                {
+                    return ResolveNavCompoundRadius(in navCompound);
+                }
+
+                throw new InvalidOperationException("GeometryProfile navigation obstacle requires materialized CompoundCollider2D or NavCompoundObstacle2D.");
             }
 
             return intent.Shape switch
@@ -167,6 +448,58 @@ namespace Ludots.Core.Physics2D.Systems
             };
         }
 
+        private static Fix64 ResolveCompoundRadius(in CompoundCollider2D compound)
+        {
+            Fix64 maxRadius = Fix64.Zero;
+            for (int i = 0; i < compound.PieceCount; i++)
+            {
+                var (shape, shapeDataIndex) = compound.GetPiece(i);
+                Fix64 radius = shape switch
+                {
+                    ColliderType2D.Circle when ShapeDataStorage2D.TryGetCircle(shapeDataIndex, out var circle) =>
+                        circle.LocalCenter.Length() + circle.Radius,
+                    ColliderType2D.Box when ShapeDataStorage2D.TryGetBox(shapeDataIndex, out var box) =>
+                        box.LocalCenter.Length() + Fix64Math.Sqrt(box.HalfWidth * box.HalfWidth + box.HalfHeight * box.HalfHeight),
+                    ColliderType2D.Polygon when ShapeDataStorage2D.TryGetPolygon(shapeDataIndex, out var polygon) =>
+                        ResolvePolygonWorldRadius(polygon),
+                    _ => Fix64.Zero
+                };
+
+                if (radius > maxRadius)
+                {
+                    maxRadius = radius;
+                }
+            }
+
+            return maxRadius;
+        }
+
+        private static Fix64 ResolveNavCompoundRadius(in NavCompoundObstacle2D compound)
+        {
+            Fix64 maxRadius = Fix64.Zero;
+            for (int i = 0; i < compound.PieceCount; i++)
+            {
+                var (shape, shapeDataIndex) = compound.GetPiece(i);
+                Fix64 radius = shape switch
+                {
+                    NavObstacleShape2D.Circle when ShapeDataStorage2D.TryGetCircle(shapeDataIndex, out var circle) =>
+                        circle.LocalCenter.Length() + circle.Radius,
+                    NavObstacleShape2D.Box when ShapeDataStorage2D.TryGetBox(shapeDataIndex, out var box) =>
+                        box.LocalCenter.Length() + Fix64Math.Sqrt(box.HalfWidth * box.HalfWidth + box.HalfHeight * box.HalfHeight),
+                    NavObstacleShape2D.Polygon when ShapeDataStorage2D.TryGetPolygon(shapeDataIndex, out var polygon) =>
+                        ResolvePolygonWorldRadius(polygon),
+                    _ => Fix64.Zero
+                };
+
+                if (radius > maxRadius)
+                {
+                    maxRadius = radius;
+                }
+            }
+
+            return maxRadius;
+        }
+
         private static Fix64 ResolvePolygonRadius(in PolygonShapeData polygon)
         {
             Fix64 maxDistanceSq = Fix64.Zero;
@@ -174,6 +507,21 @@ namespace Ludots.Core.Physics2D.Systems
             {
                 Fix64Vec2 delta = polygon.Vertices[i] - polygon.LocalCenter;
                 Fix64 distanceSq = delta.LengthSquared();
+                if (distanceSq > maxDistanceSq)
+                {
+                    maxDistanceSq = distanceSq;
+                }
+            }
+
+            return maxDistanceSq > Fix64.Zero ? Fix64Math.Sqrt(maxDistanceSq) : Fix64.Zero;
+        }
+
+        private static Fix64 ResolvePolygonWorldRadius(in PolygonShapeData polygon)
+        {
+            Fix64 maxDistanceSq = Fix64.Zero;
+            for (int i = 0; i < polygon.VertexCount; i++)
+            {
+                Fix64 distanceSq = polygon.Vertices[i].LengthSquared();
                 if (distanceSq > maxDistanceSq)
                 {
                     maxDistanceSq = distanceSq;
@@ -205,9 +553,15 @@ namespace Ludots.Core.Physics2D.Systems
             };
         }
 
-        private static Fix64Vec2 ToFix64Vec2(in WorldCmInt2 point)
+        private static NavObstacleShape2D ToNavObstacleShape(ColliderType2D shape)
         {
-            return Fix64Vec2.FromInt(point.X, point.Y);
+            return shape switch
+            {
+                ColliderType2D.Circle => NavObstacleShape2D.Circle,
+                ColliderType2D.Box => NavObstacleShape2D.Box,
+                ColliderType2D.Polygon => NavObstacleShape2D.Polygon,
+                _ => throw new ArgumentOutOfRangeException(nameof(shape))
+            };
         }
 
         private void Upsert<T>(Entity entity, in T component)
@@ -219,6 +573,22 @@ namespace Ludots.Core.Physics2D.Systems
             else
             {
                 World.Add(entity, component);
+            }
+        }
+
+        private void RemoveIfPresent<T>(Entity entity)
+        {
+            if (World.Has<T>(entity))
+            {
+                World.Remove<T>(entity);
+            }
+        }
+
+        private void MarkStaticBodyDirty(Entity entity)
+        {
+            if (!World.Has<Physics2DStaticBodyDirty>(entity))
+            {
+                World.Add(entity, new Physics2DStaticBodyDirty());
             }
         }
     }

--- a/src/Core/Systems/MapLoader.cs
+++ b/src/Core/Systems/MapLoader.cs
@@ -245,22 +245,57 @@ namespace Ludots.Core.Systems
             out TemplateEntityBatchSpawner.TemplateBatchSpawnRequest request)
         {
             request = default;
-            if (entityData.Overrides == null || entityData.Overrides.Count == 0)
+            var worldPosition = default(Ludots.Core.Mathematics.FixedPoint.Fix64Vec2);
+            bool hasWorldPosition = false;
+            float facingAngleRad = 0f;
+            bool hasFacing = false;
+
+            if (entityData.Overrides != null && entityData.Overrides.Count > 0)
             {
-                request = new TemplateEntityBatchSpawner.TemplateBatchSpawnRequest(
-                    default,
-                    hasWorldPosition: false,
-                    mapEntity: mapEntity,
-                    hasMapEntity: true);
-                return true;
+                bool containsWorldPosition = entityData.Overrides.ContainsKey("WorldPositionCm");
+                bool containsFacing = entityData.Overrides.ContainsKey("FacingDirection");
+                int supportedOverrideCount = (containsWorldPosition ? 1 : 0) + (containsFacing ? 1 : 0);
+                if (entityData.Overrides.Count != supportedOverrideCount)
+                {
+                    return false;
+                }
+
+                if (containsWorldPosition)
+                {
+                    worldPosition = ParseWorldPositionOverride(
+                        mapId,
+                        entityData,
+                        entityData.Overrides["WorldPositionCm"]);
+                    hasWorldPosition = true;
+                }
+
+                if (containsFacing)
+                {
+                    facingAngleRad = ParseFacingOverride(
+                        mapId,
+                        entityData,
+                        entityData.Overrides["FacingDirection"]);
+                    hasFacing = true;
+                }
             }
 
-            if (entityData.Overrides.Count != 1 ||
-                !entityData.Overrides.TryGetValue("WorldPositionCm", out var worldPositionNode))
-            {
-                return false;
-            }
+            // Map-authored placement yaw is authored as core FacingDirection.
+            // Presentation VisualTransform.Rotation remains derived by presentation sync/static lowering.
+            request = new TemplateEntityBatchSpawner.TemplateBatchSpawnRequest(
+                worldPosition,
+                hasWorldPosition,
+                facingAngleRad,
+                hasFacing,
+                mapEntity,
+                hasMapEntity: true);
+            return true;
+        }
 
+        private static Ludots.Core.Mathematics.FixedPoint.Fix64Vec2 ParseWorldPositionOverride(
+            string mapId,
+            EntitySpawnData entityData,
+            JsonNode worldPositionNode)
+        {
             if (worldPositionNode is not JsonObject obj)
             {
                 throw new InvalidOperationException(
@@ -301,12 +336,32 @@ namespace Ludots.Core.Systems
 
             int x = xNode.GetValue<int>();
             int y = yNode.GetValue<int>();
-            request = new TemplateEntityBatchSpawner.TemplateBatchSpawnRequest(
-                Ludots.Core.Mathematics.FixedPoint.Fix64Vec2.FromInt(x, y),
-                hasWorldPosition: true,
-                mapEntity: mapEntity,
-                hasMapEntity: true);
-            return true;
+            return Ludots.Core.Mathematics.FixedPoint.Fix64Vec2.FromInt(x, y);
+        }
+
+        private static float ParseFacingOverride(
+            string mapId,
+            EntitySpawnData entityData,
+            JsonNode facingNode)
+        {
+            if (facingNode is not JsonObject obj)
+            {
+                throw new InvalidOperationException(
+                    $"Map '{mapId}' entity template '{entityData.Template}' FacingDirection override requires an object payload.");
+            }
+
+            ValidateProperties(obj, $"Map '{mapId}' entity template '{entityData.Template}' FacingDirection", "AngleRad");
+            JsonNode angleNode = RequireProperty(
+                obj,
+                "AngleRad",
+                $"Map '{mapId}' entity template '{entityData.Template}' FacingDirection");
+            if (angleNode.GetValueKind() != System.Text.Json.JsonValueKind.Number)
+            {
+                throw new InvalidOperationException(
+                    $"Map '{mapId}' entity template '{entityData.Template}' FacingDirection.AngleRad requires a numeric value.");
+            }
+
+            return angleNode.GetValue<float>();
         }
 
         private static void ValidateProperties(JsonObject obj, string context, params string[] allowedNames)

--- a/src/Tests/GasTests/MapLoaderBatchPlacementTests.cs
+++ b/src/Tests/GasTests/MapLoaderBatchPlacementTests.cs
@@ -1,0 +1,293 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text.Json.Nodes;
+using Arch.Core;
+using Arch.Core.Extensions;
+using Ludots.Core.Components;
+using Ludots.Core.Config;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Map;
+using Ludots.Core.Mathematics.FixedPoint;
+using Ludots.Core.Modding;
+using Ludots.Core.Presentation.Components;
+using Ludots.Core.Scripting;
+using Ludots.Core.Systems;
+using NUnit.Framework;
+using static NUnit.Framework.Assert;
+
+namespace GasTests
+{
+    [TestFixture]
+    public sealed class MapLoaderBatchPlacementTests
+    {
+        private const string TemplateId = "test.map.batch.unit";
+        private const string TemplateName = "Template:MapBatchUnit";
+        private const string MapId = "map_batch_placement";
+
+        [TestCase(null, true, false, 0f)]
+        [TestCase("position", true, false, 0f)]
+        [TestCase("facing", true, true, 1.25f)]
+        [TestCase("position-facing", true, true, 2.5f)]
+        [TestCase("position-facing-health", false, false, 0f)]
+        public void TryBuildBatchRequest_ClassifiesPlacementOverrides(
+            string? overrideShape,
+            bool expectedFastPath,
+            bool expectedHasFacing,
+            float expectedFacing)
+        {
+            var spawn = CreateSpawn(CreateOverrides(overrideShape));
+            bool fastPath = InvokeTryBuildBatchRequest(spawn, out object request);
+
+            That(fastPath, Is.EqualTo(expectedFastPath));
+            if (!expectedFastPath)
+            {
+                return;
+            }
+
+            That(GetRequestBool(request, "HasFacing"), Is.EqualTo(expectedHasFacing));
+            if (expectedHasFacing)
+            {
+                That(GetRequestFloat(request, "FacingAngleRad"), Is.EqualTo(expectedFacing).Within(0.0001f));
+            }
+        }
+
+        [Test]
+        public void LoadEntities_BatchTemplate_AcceptsSupportedPlacementOverrides()
+        {
+            using var world = World.Create();
+            var loader = CreateLoader(world);
+            var map = new MapConfig { Id = MapId };
+            map.Entities.Add(CreateSpawn(null));
+            map.Entities.Add(CreateSpawn(new Dictionary<string, JsonNode>
+            {
+                ["WorldPositionCm"] = WorldPosition(1000, 2000),
+            }));
+            map.Entities.Add(CreateSpawn(new Dictionary<string, JsonNode>
+            {
+                ["FacingDirection"] = Facing(1.25f),
+            }));
+            map.Entities.Add(CreateSpawn(new Dictionary<string, JsonNode>
+            {
+                ["WorldPositionCm"] = WorldPosition(-300, 400),
+                ["FacingDirection"] = Facing(2.5f),
+            }));
+
+            loader.LoadEntities(map);
+
+            var entities = FindTemplateEntities(world);
+            That(entities.Count, Is.EqualTo(4));
+            AssertPlacement(world, entities[0], 10, 20, 0.5f);
+            AssertPlacement(world, entities[1], 1000, 2000, 0.5f);
+            AssertPlacement(world, entities[2], 10, 20, 1.25f);
+            AssertPlacement(world, entities[3], -300, 400, 2.5f);
+        }
+
+        [Test]
+        public void LoadEntities_UnsupportedExtraOverride_StaysOnComponentApplicationPath()
+        {
+            using var world = World.Create();
+            var loader = CreateLoader(world);
+            var map = new MapConfig { Id = MapId };
+            map.Entities.Add(CreateSpawn(new Dictionary<string, JsonNode>
+            {
+                ["WorldPositionCm"] = WorldPosition(777, 888),
+                ["FacingDirection"] = Facing(3.25f),
+                ["Health"] = JsonNode.Parse(@"{ ""Current"": 7, ""Max"": 11 }")!,
+            }));
+
+            loader.LoadEntities(map);
+
+            var entities = FindTemplateEntities(world);
+            That(entities.Count, Is.EqualTo(1));
+            Entity entity = entities[0];
+            AssertPlacement(world, entity, 777, 888, 3.25f);
+            That(world.Has<Health>(entity), Is.True);
+            ref readonly Health health = ref world.Get<Health>(entity);
+            That(health.Current, Is.EqualTo(7));
+            That(health.Max, Is.EqualTo(11));
+        }
+
+        [Test]
+        public void LoadEntities_FacingOverride_UsesTemplateFacingAuthoringValidation()
+        {
+            using var world = World.Create();
+            var loader = CreateLoader(world);
+            var map = new MapConfig { Id = MapId };
+            map.Entities.Add(CreateSpawn(new Dictionary<string, JsonNode>
+            {
+                ["FacingDirection"] = JsonNode.Parse(@"{ ""AngleRad"": ""east"" }")!,
+            }));
+
+            InvalidOperationException ex = Throws<InvalidOperationException>(() => loader.LoadEntities(map))!;
+            That(ex.Message, Does.Contain("FacingDirection.AngleRad requires a numeric value"));
+        }
+
+        private static MapLoader CreateLoader(World world)
+        {
+            string root = Path.Combine(Path.GetTempPath(), "Ludots_MapLoaderBatchPlacementTests", Guid.NewGuid().ToString("N"));
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(root, "Configs", "Entities"));
+                File.WriteAllText(
+                    Path.Combine(root, "Configs", "config_catalog.json"),
+                    @"[{ ""Path"": ""Entities/templates.json"", ""Policy"": ""ArrayById"", ""IdField"": ""id"" }]");
+                File.WriteAllText(
+                    Path.Combine(root, "Configs", "Entities", "templates.json"),
+                    $$"""
+                    [
+                      {
+                        "id": "{{TemplateId}}",
+                        "components": {
+                          "Name": { "Value": "{{TemplateName}}" },
+                          "WorldPositionCm": { "Value": { "X": 10, "Y": 20 } },
+                          "FacingDirection": { "AngleRad": 0.5 },
+                          "AttributeBuffer": { "base": {} },
+                          "GameplayTagContainer": {},
+                          "TagCountContainer": {}
+                        }
+                      }
+                    ]
+                    """);
+
+                var vfs = new VirtualFileSystem();
+                vfs.Mount("Core", root);
+                var pipeline = new ConfigPipeline(vfs, new ModLoader(vfs, new FunctionRegistry(), new TriggerManager()));
+                var loader = new MapLoader(world, new WorldMap(), pipeline);
+                loader.LoadTemplates(ConfigCatalogLoader.Load(pipeline));
+                return loader;
+            }
+            finally
+            {
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, recursive: true);
+                }
+            }
+        }
+
+        private static EntitySpawnData CreateSpawn(Dictionary<string, JsonNode>? overrides)
+        {
+            var spawn = new EntitySpawnData
+            {
+                Template = TemplateId,
+            };
+            if (overrides != null)
+            {
+                spawn.Overrides = overrides;
+            }
+
+            return spawn;
+        }
+
+        private static Dictionary<string, JsonNode>? CreateOverrides(string? shape)
+        {
+            return shape switch
+            {
+                null => null,
+                "position" => new Dictionary<string, JsonNode>
+                {
+                    ["WorldPositionCm"] = WorldPosition(1000, 2000),
+                },
+                "facing" => new Dictionary<string, JsonNode>
+                {
+                    ["FacingDirection"] = Facing(1.25f),
+                },
+                "position-facing" => new Dictionary<string, JsonNode>
+                {
+                    ["WorldPositionCm"] = WorldPosition(-300, 400),
+                    ["FacingDirection"] = Facing(2.5f),
+                },
+                "position-facing-health" => new Dictionary<string, JsonNode>
+                {
+                    ["WorldPositionCm"] = WorldPosition(777, 888),
+                    ["FacingDirection"] = Facing(3.25f),
+                    ["Health"] = JsonNode.Parse(@"{ ""Current"": 7, ""Max"": 11 }")!,
+                },
+                _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, null),
+            };
+        }
+
+        private static JsonNode WorldPosition(int x, int y)
+        {
+            return JsonNode.Parse(@$"{{ ""Value"": {{ ""X"": {x}, ""Y"": {y} }} }}")!;
+        }
+
+        private static JsonNode Facing(float angleRad)
+        {
+            return JsonNode.Parse(FormattableString.Invariant(@$"{{ ""AngleRad"": {angleRad} }}"))!;
+        }
+
+        private static bool InvokeTryBuildBatchRequest(EntitySpawnData spawn, out object request)
+        {
+            MethodInfo method = typeof(MapLoader).GetMethod(
+                "TryBuildBatchRequest",
+                BindingFlags.NonPublic | BindingFlags.Static)!;
+            That(method, Is.Not.Null);
+
+            object[] args =
+            {
+                MapId,
+                spawn,
+                new MapEntity { MapId = new MapId(MapId) },
+                null!,
+            };
+            bool result = (bool)method.Invoke(null, args)!;
+            request = args[3];
+            return result;
+        }
+
+        private static bool GetRequestBool(object request, string propertyName)
+        {
+            PropertyInfo property = request.GetType().GetProperty(propertyName)!;
+            That(property, Is.Not.Null);
+            return (bool)property.GetValue(request)!;
+        }
+
+        private static float GetRequestFloat(object request, string propertyName)
+        {
+            PropertyInfo property = request.GetType().GetProperty(propertyName)!;
+            That(property, Is.Not.Null);
+            return (float)property.GetValue(request)!;
+        }
+
+        private static List<Entity> FindTemplateEntities(World world)
+        {
+            var found = new List<Entity>();
+            var query = new QueryDescription().WithAll<Name, MapEntity>();
+            world.Query(in query, (Entity entity, ref Name name, ref MapEntity mapEntity) =>
+            {
+                if (string.Equals(name.Value, TemplateName, StringComparison.Ordinal) &&
+                    string.Equals(mapEntity.MapId.Value, MapId, StringComparison.Ordinal))
+                {
+                    found.Add(entity);
+                }
+            });
+
+            found.Sort((left, right) => left.Id.CompareTo(right.Id));
+            return found;
+        }
+
+        private static void AssertPlacement(
+            World world,
+            Entity entity,
+            int expectedX,
+            int expectedY,
+            float expectedFacing)
+        {
+            That(world.Has<WorldPositionCm>(entity), Is.True);
+            That(world.Has<PreviousWorldPositionCm>(entity), Is.True);
+            That(world.Has<VisualTransform>(entity), Is.True);
+            That(world.Has<CullState>(entity), Is.True);
+            That(world.Has<AttributeBuffer>(entity), Is.True);
+            That(world.Has<GameplayTagContainer>(entity), Is.True);
+            That(world.Has<TagCountContainer>(entity), Is.True);
+
+            var expectedPosition = Fix64Vec2.FromInt(expectedX, expectedY);
+            That(world.Get<WorldPositionCm>(entity).Value, Is.EqualTo(expectedPosition));
+            That(world.Get<PreviousWorldPositionCm>(entity).Value, Is.EqualTo(expectedPosition));
+            That(world.Get<FacingDirection>(entity).AngleRad, Is.EqualTo(expectedFacing).Within(0.0001f));
+        }
+    }
+}

--- a/src/Tests/GasTests/Physics2DIntegrationTests.cs
+++ b/src/Tests/GasTests/Physics2DIntegrationTests.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using Arch.Core;
+using Ludots.Core.Components;
 using Ludots.Core.Mathematics.FixedPoint;
+using Ludots.Core.Gameplay.Spawning;
 using Ludots.Physics.Broadphase;
 using Ludots.Core.Physics2D;
 using Ludots.Core.Physics2D.Components;
@@ -110,6 +112,104 @@ namespace GasTests
             var e = build.Entities[results[0]];
             Assert.That(world.TryGet(e, out Position2D pos), Is.True);
             Assert.That(pos.Value.X.ToFloat(), Is.EqualTo(0f).Within(0.001f));
+        }
+
+        [Test]
+        public void StaticBodies_AreCachedAcrossSteadyStateBuilds()
+        {
+            using var world = World.Create();
+
+            int shape = ShapeDataStorage2D.RegisterBox(100f, 100f);
+            var obstacle = world.Create(
+                new Position2D { Value = Fix64Vec2.FromInt(500, 0) },
+                Mass2D.Static,
+                new Collider2D { Type = ColliderType2D.Box, ShapeDataIndex = shape });
+
+            var build = new BuildPhysicsWorldSystem2D(world);
+            var spatial = new AdaptiveSpatialSystem2D(world, build, maxCollisionPairs: 8);
+
+            build.Update(0f);
+            spatial.Update(0f);
+
+            Assert.That(build.StaticRigidBodyDescriptors.Count, Is.EqualTo(1));
+            Assert.That(build.DynamicRigidBodyDescriptors.Count, Is.EqualTo(0));
+            Assert.That(build.DirtyStaticBodyCountLastUpdate, Is.EqualTo(1));
+            int staticVersion = build.StaticBodyVersion;
+
+            var results = new List<int>();
+            var query = new Aabb
+            {
+                Min = Fix64Vec2.FromInt(450, -50),
+                Max = Fix64Vec2.FromInt(550, 50)
+            };
+            spatial.CurrentStrategy.QueryAABB(in query, results);
+            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(build.ResolveBodyEntity(results[0]), Is.EqualTo(obstacle));
+
+            build.Update(0f);
+            spatial.Update(0f);
+
+            Assert.That(build.StaticBodyVersion, Is.EqualTo(staticVersion));
+            Assert.That(build.DirtyStaticBodyCountLastUpdate, Is.EqualTo(0));
+            Assert.That(build.StaticRigidBodyDescriptors.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void GeometryProfileObstacle_ProducesPieceLevelCollisionPairs()
+        {
+            using var world = World.Create();
+
+            var profile = new ObstacleGeometryProfile2D();
+            profile.SetBox(0, 40, 40, -220, 0);
+            profile.SetBox(1, 40, 40, -110, 0);
+            profile.SetBox(2, 40, 40, 0, 0);
+            profile.SetBox(3, 40, 40, 110, 0);
+            profile.SetBox(4, 40, 40, 220, 0);
+
+            var obstacle = world.Create(
+                WorldPositionCm.FromCm(0, 0),
+                new ManifestationObstacleIntent2D
+                {
+                    Shape = ManifestationObstacleShape2D.GeometryProfile,
+                    SinkPhysicsCollider = 1,
+                    SinkNavigationObstacle = 0,
+                    NavRadiusCm = 0,
+                    LocalOffsetXCm = 0,
+                    LocalOffsetYCm = 0
+                },
+                profile);
+
+            var bridge = new ManifestationObstacleBridge2DSystem(world);
+            bridge.Update(0f);
+
+            int dynamicShape = ShapeDataStorage2D.RegisterBox(320f, 120f);
+            world.Create(
+                new Position2D { Value = Fix64Vec2.FromInt(0, 0) },
+                new Velocity2D { Linear = Fix64Vec2.Zero, Angular = Fix64.Zero },
+                Mass2D.FromFloat(1f, 1f),
+                new Collider2D { Type = ColliderType2D.Box, ShapeDataIndex = dynamicShape });
+
+            var build = new BuildPhysicsWorldSystem2D(world);
+            var spatial = new AdaptiveSpatialSystem2D(world, build, maxCollisionPairs: 32);
+            var narrow = new NarrowPhaseSystem2D(world);
+
+            build.Update(0f);
+            spatial.Update(0f);
+            narrow.Update(0f);
+
+            int activeWithContact = 0;
+            var q = new QueryDescription().WithAll<CollisionPair, ActiveCollisionPairTag>();
+            world.Query(in q, (ref CollisionPair pair) =>
+            {
+                if (pair.ContactCount > 0)
+                {
+                    activeWithContact++;
+                }
+            });
+
+            Assert.That(activeWithContact, Is.EqualTo(5));
+            Assert.That(world.Has<CompoundCollider2D>(obstacle), Is.True);
+            Assert.That(world.Has<Collider2D>(obstacle), Is.False);
         }
     }
 }

--- a/src/Tests/GasTests/RuntimeManifestationBridgeTests.cs
+++ b/src/Tests/GasTests/RuntimeManifestationBridgeTests.cs
@@ -124,6 +124,138 @@ namespace Ludots.Tests.GAS
         }
 
         [Test]
+        public void ComponentRegistry_ParsesObstacleGeometryProfile_AndBridgeCreatesCompoundObstacle()
+        {
+            using var world = World.Create();
+            var entity = world.Create(WorldPositionCm.FromCm(1200, 900));
+
+            Ludots.Core.Config.ComponentRegistry.Apply(
+                entity,
+                "ManifestationObstacleIntent2D",
+                JsonNode.Parse("""
+                {
+                  "shape": "GeometryProfile",
+                  "sinkPhysicsCollider": true,
+                  "sinkNavigationObstacle": true,
+                  "navRadiusCm": 420,
+                  "localOffsetCm": { "x": 0, "y": 0 }
+                }
+                """)!);
+            Ludots.Core.Config.ComponentRegistry.Apply(
+                entity,
+                "ObstacleGeometryProfile2D",
+                JsonNode.Parse("""
+                {
+                  "pieces": [
+                    { "shape": "Box", "halfWidthCm": 90, "halfHeightCm": 20, "localOffsetCm": { "x": 0, "y": 0 } },
+                    { "shape": "Box", "halfWidthCm": 90, "halfHeightCm": 20, "localOffsetCm": { "x": 120, "y": 0 } },
+                    { "shape": "Circle", "radiusCm": 48, "localOffsetCm": { "x": -110, "y": 0 } },
+                    { "shape": "Circle", "radiusCm": 48, "localOffsetCm": { "x": 0, "y": 120 } },
+                    { "shape": "Polygon", "localOffsetCm": { "x": 0, "y": -120 }, "vertices": [
+                        { "x": -40, "y": -20 },
+                        { "x": 40, "y": -20 },
+                        { "x": 60, "y": 20 },
+                        { "x": 0, "y": 60 },
+                        { "x": -60, "y": 20 }
+                    ] }
+                  ]
+                }
+                """)!);
+
+            var system = new ManifestationObstacleBridge2DSystem(world);
+            system.Update(0f);
+
+            That(world.Has<CompoundCollider2D>(entity), Is.True);
+            That(world.Has<Collider2D>(entity), Is.False);
+            That(world.Has<NavCompoundObstacle2D>(entity), Is.True);
+
+            var collider = world.Get<CompoundCollider2D>(entity);
+            That(collider.PieceCount, Is.EqualTo(5));
+            var nav = world.Get<NavCompoundObstacle2D>(entity);
+            That(nav.PieceCount, Is.EqualTo(5));
+            That(world.Has<ManifestationObstacleBridge2DState>(entity), Is.True);
+            That(world.Has<Physics2DStaticBodyDirty>(entity), Is.True);
+            That(world.Has<NavKinematics2D>(entity), Is.True);
+        }
+
+        [Test]
+        public void ManifestationObstacleBridge2D_NavigationOnlyProfile_DoesNotLeavePhysicsDirty()
+        {
+            using var world = World.Create();
+            var profile = new ObstacleGeometryProfile2D();
+            profile.SetBox(0, 90, 20, 0, 0);
+
+            var entity = world.Create(
+                WorldPositionCm.FromCm(1200, 900),
+                new ManifestationObstacleIntent2D
+                {
+                    Shape = ManifestationObstacleShape2D.GeometryProfile,
+                    SinkPhysicsCollider = 0,
+                    SinkNavigationObstacle = 1,
+                    NavRadiusCm = 120,
+                    LocalOffsetXCm = 0,
+                    LocalOffsetYCm = 0
+                },
+                profile);
+
+            var system = new ManifestationObstacleBridge2DSystem(world);
+            system.Update(0f);
+
+            That(world.Has<NavCompoundObstacle2D>(entity), Is.True);
+            That(world.Has<NavKinematics2D>(entity), Is.True);
+            That(world.Has<CompoundCollider2D>(entity), Is.False);
+            That(world.Has<Collider2D>(entity), Is.False);
+            That(world.Has<Physics2DStaticBodyState>(entity), Is.False);
+            That(world.Has<Physics2DStaticBodyDirty>(entity), Is.False);
+        }
+
+        [Test]
+        public void ManifestationObstacleBridge2D_DisablingPhysicsSink_DirtiesAndRemovesStaticBody()
+        {
+            using var world = World.Create();
+            var entity = world.Create(
+                WorldPositionCm.FromCm(1200, 900),
+                new ManifestationObstacleIntent2D
+                {
+                    Shape = ManifestationObstacleShape2D.Box,
+                    SinkPhysicsCollider = 1,
+                    SinkNavigationObstacle = 0,
+                    HalfWidthCm = 90,
+                    HalfHeightCm = 20
+                });
+
+            var bridge = new ManifestationObstacleBridge2DSystem(world);
+            var build = new BuildPhysicsWorldSystem2D(world);
+
+            bridge.Update(0f);
+            build.Update(0f);
+
+            That(world.Has<Physics2DStaticBodyState>(entity), Is.True);
+            That(world.Has<Physics2DStaticBodyDirty>(entity), Is.False);
+
+            world.Set(entity, new ManifestationObstacleIntent2D
+            {
+                Shape = ManifestationObstacleShape2D.Box,
+                SinkPhysicsCollider = 0,
+                SinkNavigationObstacle = 0,
+                HalfWidthCm = 90,
+                HalfHeightCm = 20
+            });
+            world.Add(entity, new ManifestationObstacleBridge2DDirty());
+
+            bridge.Update(0f);
+
+            That(world.Has<Collider2D>(entity), Is.False);
+            That(world.Has<Physics2DStaticBodyDirty>(entity), Is.True);
+
+            build.Update(0f);
+
+            That(world.Has<Physics2DStaticBodyState>(entity), Is.False);
+            That(world.Has<Physics2DStaticBodyDirty>(entity), Is.False);
+            That(build.StaticRigidBodyDescriptors.Count, Is.EqualTo(0));
+        }
+
+        [Test]
         public void ComponentRegistry_RequiresExactSpatialBoundsKind()
         {
             using var world = World.Create();


### PR DESCRIPTION
Issue #168: split static obstacle materialization from dynamic physics, add explicit dirty/static cache handling, and cover the bridge/broadphase behavior with tests.