### PR TITLE
docs(ai): utility AI + autocast arbitration SSOT plan and reference set

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -20,6 +20,24 @@
   * `ChampionSkillSandboxMod` 的复用基线、交付内容与当前实现切片回写
 * [关系系统：市场案例抽象与 Ludots 复用设计](relationship_system_market_abstraction.md)
   * CRPG / JRPG / 自走棋 / 三国英雄题材的关系机制抽象、Ludots 基建复用清单、配置与 showcase 验收口径
+* [OpenRA AI 底层系统源码分析](openra_ai_system_analysis.md)
+  * OpenRA skirmish AI 的 Player trait 入口、BotModule 组合、Order 边界、分队状态机与 Ludots 可借鉴点
+* [OpenRA AI 分层架构剖面](openra_ai_layered_architecture.html)
+  * 以可视化 HTML 拆解 OpenRA AI 从大厅配置、Player 激活、BotModule 调度到 Order 执行的完整分层
+* [OpenRA AI 与 Ludots 架构对比分析](openra_ludots_ai_comparison.html)
+  * 对比 OpenRA RTS bot 模块群与 Ludots 现有 AI / Mod / ConfigPipeline / Order 基建，列出优势、缺口与建议路线
+* [OpenRA 用户输入动作与基础单位指令源码剖面](openra_unit_behavior_attack_move_analysis.html)
+  * 从玩家输入动作、屏幕反馈、命令生成、trait 解析和 Activity 树角度拆解 Move / Attack / Stop / Guard / Stance / Deploy / Harvest / Repair / Capture / Transport / Minefield 等基础指令
+* [OpenRA 索敌优先级、脱战警戒与炮台机制源码剖面](openra_targeting_priority_guard_turret_analysis.html)
+  * 聚焦 AutoTarget / AutoTargetPriority / AttackFollow / Guard / Turreted / Armament，拆解索敌优先级、脱战、警戒范围和炮台 gameplay 约束
+* [Ludots 索敌、警戒、炮台与 Order/GAS 映射缺口分析](ludots_targeting_order_gas_gap_analysis.html)
+  * 对照 OpenRA 单位自动战斗链路，审视 Ludots 当前 Order / GAS / Navigation / Team / TargetResolver 基建，列出缺口与映射路线
+* [Ludots 通用 Utility AI SoA 架构方案](ludots_utility_ai_soa_openra_behavior_architecture.html)
+  * 对照 Uintel Utility Intelligence ECS/GO 文档和 Ludots 现有 AI / Order / GAS / Graph 基建，提出 SoA、0Alloc、配置驱动 OpenRA 基础行为的通用 AI 系统方案
+* [Ludots AI 现状、困境与参考地图](ludots_ai_status_reference_map.html)
+  * 汇总当前 AI 相关现状文档、困境、取舍方向和参考资料，作为后续设计和实现的入口总图
+* [Ludots 通用 Utility AI 与 Autocast 仲裁 SSOT 方案](ludots_ai_utility_autocast_ssot_plan.html)
+  * 以"普攻=autocast 能力、多能力仲裁=Utility 决策入口"为核心命题，完整复刻 Uintel 架构并把 OpenRA stance/基础 order 作为业务语义行为包；给出三层模型、SoA/0Alloc 运行时、分层 SSOT 边界、SystemGroup 排布、Epic + 10 个 sub-issue 拆解与验收标准
 
 ## 2 相关文档
 

--- a/docs/reference/ludots_ai_status_reference_map.html
+++ b/docs/reference/ludots_ai_status_reference_map.html
@@ -1,0 +1,553 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ludots AI 现状、困境与参考地图</title>
+  <style>
+    :root {
+      --bg: #ffffff;
+      --ink: #17202a;
+      --muted: #66717e;
+      --line: #d9e1ea;
+      --soft: #f5f7fa;
+      --blue-soft: #edf4ff;
+      --green-soft: #edf7f1;
+      --amber-soft: #fff4df;
+      --red-soft: #fff0ee;
+      --blue: #2563eb;
+      --green: #2f855a;
+      --amber: #b45309;
+      --red: #b42318;
+      --violet: #6d28d9;
+      --radius: 8px;
+      --shadow: 0 8px 24px rgba(23, 32, 42, 0.07);
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      font-family: "Segoe UI", "Microsoft YaHei", Arial, sans-serif;
+      color: var(--ink);
+      background: var(--bg);
+      line-height: 1.72;
+      letter-spacing: 0;
+    }
+
+    a { color: var(--blue); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    code {
+      font-family: Consolas, "Cascadia Mono", "SFMono-Regular", monospace;
+      font-size: 0.92em;
+      background: #eef2f6;
+      border: 1px solid #d8e0e8;
+      border-radius: 6px;
+      padding: 0.08rem 0.32rem;
+      overflow-wrap: anywhere;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: #fff;
+      font-size: 0.94rem;
+    }
+
+    th, td {
+      border: 1px solid var(--line);
+      padding: 10px 12px;
+      vertical-align: top;
+      text-align: left;
+    }
+
+    th {
+      background: #f0f4f8;
+      font-weight: 750;
+    }
+
+    .hero {
+      background: #17202a;
+      color: #f8fafc;
+      border-bottom: 6px solid var(--blue);
+    }
+
+    .hero-inner {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: 46px 0 40px;
+      display: grid;
+      grid-template-columns: minmax(0, 1.16fr) minmax(300px, 0.84fr);
+      gap: 28px;
+      align-items: end;
+    }
+
+    .hero h1 {
+      margin: 0 0 16px;
+      max-width: 900px;
+      font-size: 2.24rem;
+      line-height: 1.16;
+      font-weight: 850;
+      letter-spacing: 0;
+    }
+
+    .hero p {
+      margin: 0;
+      max-width: 900px;
+      color: #dfe7f0;
+      font-size: 1.02rem;
+    }
+
+    .summary {
+      display: grid;
+      gap: 12px;
+      padding: 18px;
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      border-radius: var(--radius);
+      background: rgba(255, 255, 255, 0.08);
+      box-shadow: var(--shadow);
+    }
+
+    .summary b { color: #ffffff; font-size: 1.02rem; }
+    .summary span { color: #dfe7f0; font-size: 0.93rem; }
+
+    .layout {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: 276px minmax(0, 1fr);
+      gap: 28px;
+      padding: 32px 0 72px;
+    }
+
+    .toc {
+      position: sticky;
+      top: 18px;
+      align-self: start;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #fff;
+      box-shadow: var(--shadow);
+      padding: 18px;
+      max-height: calc(100vh - 36px);
+      overflow: auto;
+    }
+
+    .toc strong {
+      display: block;
+      margin-bottom: 10px;
+      font-size: 0.96rem;
+    }
+
+    .toc a {
+      display: block;
+      padding: 7px 0;
+      color: #334155;
+      border-top: 1px solid #eef2f6;
+      font-size: 0.92rem;
+    }
+
+    .content { display: grid; gap: 28px; min-width: 0; }
+
+    section {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #fff;
+      box-shadow: var(--shadow);
+      padding: 24px;
+    }
+
+    section h2 {
+      margin: 0 0 14px;
+      font-size: 1.46rem;
+      line-height: 1.28;
+      letter-spacing: 0;
+    }
+
+    section h3 {
+      margin: 22px 0 10px;
+      font-size: 1.1rem;
+      letter-spacing: 0;
+    }
+
+    section p { margin: 10px 0; }
+    section ul { margin: 10px 0 0; padding-left: 1.25rem; }
+    section li { margin: 6px 0; }
+
+    .lead {
+      color: #39495a;
+      font-size: 1.02rem;
+    }
+
+    .grid-3 {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 14px;
+    }
+
+    .card {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 14px;
+      background: #fff;
+    }
+
+    .card b {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 1.02rem;
+    }
+
+    .card span {
+      display: block;
+      color: var(--muted);
+      font-size: 0.93rem;
+    }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      min-height: 26px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 2px 8px;
+      margin: 2px 4px 2px 0;
+      background: #fff;
+      color: #334155;
+      font-size: 0.82rem;
+    }
+
+    .tag.green { background: var(--green-soft); border-color: #b7dfc6; color: #1f6844; }
+    .tag.red { background: var(--red-soft); border-color: #f0b8b1; color: #8f1f16; }
+    .tag.amber { background: var(--amber-soft); border-color: #f2d19a; color: #8a4a05; }
+    .tag.blue { background: var(--blue-soft); border-color: #bfd3fb; color: #1e4fc4; }
+    .tag.violet { background: #f1edff; border-color: #d5c9ff; color: #5421aa; }
+
+    .pill-row { display: flex; flex-wrap: wrap; gap: 4px; }
+
+    .warn {
+      border-left: 5px solid var(--amber);
+      background: var(--amber-soft);
+      padding: 14px 16px;
+      border-radius: 0 var(--radius) var(--radius) 0;
+      margin: 16px 0;
+    }
+
+    .ok {
+      border-left: 5px solid var(--green);
+      background: var(--green-soft);
+      padding: 14px 16px;
+      border-radius: 0 var(--radius) var(--radius) 0;
+      margin: 16px 0;
+    }
+
+    .bad {
+      border-left: 5px solid var(--red);
+      background: var(--red-soft);
+      padding: 14px 16px;
+      border-radius: 0 var(--radius) var(--radius) 0;
+      margin: 16px 0;
+    }
+
+    .flow {
+      display: grid;
+      gap: 8px;
+      margin-top: 12px;
+    }
+
+    .flow-row {
+      display: grid;
+      grid-template-columns: 190px minmax(0, 1fr);
+      gap: 10px;
+      align-items: stretch;
+    }
+
+    .flow-key {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 10px;
+      background: #f8fafc;
+      font-weight: 750;
+      text-align: center;
+      min-height: 52px;
+    }
+
+    .flow-val {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 10px 12px;
+      background: #fff;
+      min-height: 52px;
+    }
+
+    @media (max-width: 980px) {
+      .hero-inner, .layout, .grid-3 { grid-template-columns: 1fr; }
+      .toc { position: relative; top: auto; max-height: none; }
+      .flow-row { grid-template-columns: 1fr; }
+    }
+
+    @media (max-width: 560px) {
+      .hero h1 { font-size: 1.72rem; }
+      section { padding: 18px; }
+    }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <div class="hero-inner">
+      <div>
+        <h1>Ludots AI 现状、困境与参考地图</h1>
+        <p>
+          这是一个上层总览文档，不再讲单点实现，而是把现状、问题、取舍和所有相关分析文档串成一张图。
+          目标是让后续任何 AI 架构决策先看到已知事实，再看还没定下来的地方。
+        </p>
+      </div>
+      <div class="summary">
+        <b>当前结论</b>
+        <span>AI 骨架已存在，缺的是通用化的 target / score / readiness / execution 分层。业务语义要留在 behavior pack 和 adapter 里，别把炮台、采集器、建造者写进 AI Core。</span>
+      </div>
+    </div>
+  </header>
+
+  <div class="layout">
+    <nav class="toc">
+      <strong>目录</strong>
+      <a href="#snapshot">1. 现状快照</a>
+      <a href="#map">2. 现状文档地图</a>
+      <a href="#dilemmas">3. 困境与问题</a>
+      <a href="#tradeoffs">4. 取舍方向</a>
+      <a href="#reading">5. 建议阅读顺序</a>
+      <a href="#refs">6. 参考文档</a>
+    </nav>
+
+    <main class="content">
+      <section id="snapshot">
+        <h2>1. 现状快照</h2>
+        <p class="lead">
+          这部分已经可以算“总结到位”，但不是最终定论。当前最重要的事实是：Ludots 不是没 AI，而是已有一条骨架链路，缺一个能承载 OpenRA 基础行为和 Uintel 式 decision-target 评分的通用 AI Module。
+        </p>
+
+        <div class="grid-3">
+          <div class="card">
+            <b>已经有的</b>
+            <span>Utility / GOAP / HTN 编译结构、256-bit world state、AI plan 到 OrderQueue、AI demo 配置、benchmark。</span>
+          </div>
+          <div class="card">
+            <b>还缺的</b>
+            <span>通用 target filter、input/normalization/curve、decision-target pair、combat memory、stance policy、readiness gate、主循环接入。</span>
+          </div>
+          <div class="card">
+            <b>不能做的</b>
+            <span>不能让 AI 直接发 Effect 或扣血，不能把业务名词写进 AI Core，不能用 fallback 代替显式决策。</span>
+          </div>
+        </div>
+      </section>
+
+      <section id="map">
+        <h2>2. 现状文档地图</h2>
+        <p class="lead">下面这些是当前已经形成的“现状文档”。它们不是重复劳动，而是分别回答不同层面的同一个问题。</p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>文档</th>
+              <th>它在说什么</th>
+              <th>当前状态</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="openra_ai_system_analysis.md">OpenRA AI 底层系统源码分析</a></td>
+              <td>OpenRA skirmish AI 的 Player trait 入口、BotModule、Order 边界、分队状态机。</td>
+              <td>已完成基础剖面。</td>
+            </tr>
+            <tr>
+              <td><a href="openra_ai_layered_architecture.html">OpenRA AI 分层架构剖面</a></td>
+              <td>从大厅配置、Player 激活、BotModule 调度到 Order 执行的完整分层。</td>
+              <td>已完成可视化版。</td>
+            </tr>
+            <tr>
+              <td><a href="openra_ludots_ai_comparison.html">OpenRA AI 与 Ludots 架构对比分析</a></td>
+              <td>对比 OpenRA RTS bot 与 Ludots 现有 AI / Mod / ConfigPipeline / Order 基建。</td>
+              <td>已完成对比版。</td>
+            </tr>
+            <tr>
+              <td><a href="openra_unit_behavior_attack_move_analysis.html">OpenRA 用户输入动作与基础单位指令源码剖面</a></td>
+              <td>Move / Attack / Stop / Guard / Stance / Deploy / Harvest / Repair / Capture / Transport 等基础指令。</td>
+              <td>已完成基础行为拆解。</td>
+            </tr>
+            <tr>
+              <td><a href="openra_targeting_priority_guard_turret_analysis.html">OpenRA 索敌优先级、脱战警戒与炮台机制源码剖面</a></td>
+              <td>AutoTarget / AutoTargetPriority / AttackFollow / Guard / Turreted / Armament 的实际行为规则。</td>
+              <td>已完成索敌与门控拆解。</td>
+            </tr>
+            <tr>
+              <td><a href="ludots_targeting_order_gas_gap_analysis.html">Ludots 索敌、警戒、炮台与 Order/GAS 映射缺口分析</a></td>
+              <td>把 OpenRA 的单位行为映射到 Ludots 现有 Order / GAS / Navigation / Team / TargetResolver。</td>
+              <td>已完成缺口分析。</td>
+            </tr>
+            <tr>
+              <td><a href="ludots_utility_ai_soa_openra_behavior_architecture.html">Ludots 通用 Utility AI SoA 架构方案</a></td>
+              <td>把 Uintel 式 Utility AI 思路复刻到 Ludots：SoA、0Alloc、decision-target pair、OpenRA 行为包。</td>
+              <td>已完成主方案。</td>
+            </tr>
+            <tr>
+              <td><a href="ludots_ai_utility_autocast_ssot_plan.html">Ludots 通用 Utility AI 与 Autocast 仲裁 SSOT 方案</a></td>
+              <td>核心命题"普攻=autocast、多能力仲裁=Utility 入口"，复刻 Uintel + OpenRA stance/order 业务包，给出 Epic + 10 sub-issue 拆解与验收。</td>
+              <td>已完成交付方案（待 issue 开单）。</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="dilemmas">
+        <h2>3. 困境与问题</h2>
+        <p class="lead">
+          这些不是实现 bug，而是架构取舍点。它们决定这套 AI 会不会变成一堆局部特化，还是一个能长期复用的深 Module。
+        </p>
+
+        <div class="flow">
+          <div class="flow-row">
+            <div class="flow-key">AI Core vs 业务能力</div>
+            <div class="flow-val">核心必须抽象，业务能力要沉到 behavior pack / adapter。炮台、采集器、建造者都不该进 Core。</div>
+          </div>
+          <div class="flow-row">
+            <div class="flow-key">stance 放哪</div>
+            <div class="flow-val">stance 是战斗政策状态，不是行为树，也不是 utility 本体；它更像 target filter 的输入和 order/AI state。</div>
+          </div>
+          <div class="flow-row">
+            <div class="flow-key">Graph 作用边界</div>
+            <div class="flow-val">Graph 适合做 score / validation / read-only query，不适合当执行总线，更不能绕过 Order/GAS。</div>
+          </div>
+          <div class="flow-row">
+            <div class="flow-key">Order vs Ability</div>
+            <div class="flow-val">Order 是 intent，Ability 是执行。AI 只产出 intent，不负责伤害、特效和投射物。</div>
+          </div>
+          <div class="flow-row">
+            <div class="flow-key">OpenRA 行为包</div>
+            <div class="flow-val">AttackMove / Guard / Stance / AutoTarget 应该作为行为包提供，不作为 AI Core 特例。</div>
+          </div>
+          <div class="flow-row">
+            <div class="flow-key">主循环接入</div>
+            <div class="flow-val">AiRuntime 已能加载，但还没看到它进入主 simulation loop；这意味着“有配置”不等于“有运行”。</div>
+          </div>
+        </div>
+      </section>
+
+      <section id="tradeoffs">
+        <h2>4. 取舍方向</h2>
+        <p class="lead">
+          这里给的是我目前的判断，不是死规矩。后续如果要改，也应该是改这张表，而不是让单个系统偷偷长歪。
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>取舍点</th>
+              <th>建议方向</th>
+              <th>原因</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>stance</td>
+              <td>放在 AI state / target policy / order 语义里</td>
+              <td>它是交战规则，不是具体执行动作。</td>
+            </tr>
+            <tr>
+              <td>炮台</td>
+              <td>放在 actuator / readiness adapter 里</td>
+              <td>炮台是一个业务案例，不应变成 AI Core 的通用词表。</td>
+            </tr>
+            <tr>
+              <td>utility</td>
+              <td>负责评分，不负责执行</td>
+              <td>utility 选谁去做，不替代 task / FSM / Ability。</td>
+            </tr>
+            <tr>
+              <td>Graph</td>
+              <td>用于可自定义 score / condition</td>
+              <td>图适合扩展规则，不适合接管副作用。</td>
+            </tr>
+            <tr>
+              <td>行为包</td>
+              <td>OpenRA 基础行为做成可配置 pack</td>
+              <td>Move / Guard / AttackMove / Stance 等要能被别的 mod 复用。</td>
+            </tr>
+            <tr>
+              <td>fallback</td>
+              <td>不用平台 fallback，改成显式决策</td>
+              <td>缺省行为会把问题藏起来，和当前规范冲突。</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="warn">
+          <b>目前最容易混进去的业务语义</b>
+          <p>
+            炮台、采集器、建造者、正面攻击、蓄力施法这些词都很具体。它们应该留在业务能力层，AI Core 只保留更通用的词：<code>ActuatorReadiness</code>、<code>AimGate</code>、<code>ExecutionPrecondition</code>、<code>TargetFilter</code>、<code>DecisionIntent</code>。
+          </p>
+        </div>
+      </section>
+
+      <section id="reading">
+        <h2>5. 建议阅读顺序</h2>
+        <div class="ok">
+          <b>先看这个顺序，最省时间</b>
+          <p>
+            1. <a href="openra_unit_behavior_attack_move_analysis.html">OpenRA 用户输入动作与基础单位指令源码剖面</a><br>
+            2. <a href="openra_targeting_priority_guard_turret_analysis.html">OpenRA 索敌优先级、脱战警戒与炮台机制源码剖面</a><br>
+            3. <a href="ludots_targeting_order_gas_gap_analysis.html">Ludots 索敌、警戒、炮台与 Order/GAS 映射缺口分析</a><br>
+            4. <a href="ludots_utility_ai_soa_openra_behavior_architecture.html">Ludots 通用 Utility AI SoA 架构方案</a><br>
+            5. 再回头看 <a href="openra_ai_system_analysis.md">OpenRA AI 底层系统源码分析</a> 和 <a href="openra_ai_layered_architecture.html">OpenRA AI 分层架构剖面</a>。
+          </p>
+        </div>
+      </section>
+
+      <section id="refs">
+        <h2>6. 参考文档</h2>
+        <p class="lead">这些是这张地图背后的支撑文档，不是 AI 本体，但决定了最终实现要怎么落。</p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>文档</th>
+              <th>用途</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="relationship_system_market_abstraction.md">关系系统：市场案例抽象与 Ludots 复用设计</a></td>
+              <td>Threat / Focus / relationship metric 的概念底座。</td>
+            </tr>
+            <tr>
+              <td><a href="config_data_merge_best_practices.md">配置数据合并最佳实践</a></td>
+              <td>AI 配置必须走 ConfigPipeline 和 fail-fast 合并，不另起一套解析器。</td>
+            </tr>
+            <tr>
+              <td><a href="arch_ecs_libraries.md">Arch ECS 外部依赖入口</a></td>
+              <td>确认底层 ECS 约束，避免把库能力想象得比实际更强。</td>
+            </tr>
+            <tr>
+              <td><a href="README.md">docs/reference/README.md</a></td>
+              <td>所有参考文档的入口索引，后续新文档应先补这里。</td>
+            </tr>
+            <tr>
+              <td><a href="https://uintel-ecs.utilityworlds.com/Documentation/">Uintel ECS 文档</a></td>
+              <td>Utility Intelligence 的原始思想来源。</td>
+            </tr>
+            <tr>
+              <td><a href="https://uintel-ecs.utilityworlds.com/sitemap.xml">Uintel ECS sitemap</a></td>
+              <td>确认文档结构和页面范围。</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/reference/ludots_ai_utility_autocast_ssot_plan.html
+++ b/docs/reference/ludots_ai_utility_autocast_ssot_plan.html
@@ -1,0 +1,401 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ludots 通用 Utility AI 与 Autocast 仲裁 SSOT 方案</title>
+  <style>
+    :root {
+      --bg:#fff; --ink:#17202a; --muted:#66717e; --line:#d9e1ea; --soft:#f5f7fa;
+      --blue:#2563eb; --blue-soft:#edf4ff; --green:#2f855a; --green-soft:#edf7f1;
+      --amber:#b45309; --amber-soft:#fff4df; --red:#b42318; --red-soft:#fff0ee;
+      --teal:#0f766e; --teal-soft:#e9f7f5; --violet:#6d28d9; --violet-soft:#f1edff;
+      --radius:8px; --shadow:0 8px 24px rgba(23,32,42,.07);
+    }
+    *{box-sizing:border-box;} html{scroll-behavior:smooth;}
+    body{margin:0;font-family:"Segoe UI","Microsoft YaHei",Arial,sans-serif;color:var(--ink);background:var(--bg);line-height:1.72;}
+    a{color:var(--blue);text-decoration:none;} a:hover{text-decoration:underline;}
+    code{font-family:Consolas,"Cascadia Mono",monospace;font-size:.92em;background:#eef2f6;border:1px solid #d8e0e8;border-radius:6px;padding:.08rem .32rem;overflow-wrap:anywhere;}
+    pre{margin:0;overflow-x:auto;white-space:pre;font-family:Consolas,"Cascadia Mono",monospace;font-size:.86rem;line-height:1.56;background:#111827;color:#e5edf7;border-radius:var(--radius);padding:16px;}
+    table{width:100%;border-collapse:collapse;background:#fff;font-size:.94rem;}
+    th,td{border:1px solid var(--line);padding:10px 12px;vertical-align:top;text-align:left;}
+    th{background:#f0f4f8;font-weight:750;}
+    .hero{background:#17202a;color:#f8fafc;border-bottom:6px solid var(--teal);}
+    .hero-inner{width:min(1180px,calc(100% - 32px));margin:0 auto;padding:46px 0 40px;display:grid;grid-template-columns:minmax(0,1.16fr) minmax(300px,.84fr);gap:28px;align-items:end;}
+    .hero h1{margin:0 0 16px;max-width:900px;font-size:2.2rem;line-height:1.16;font-weight:850;}
+    .hero p{margin:0;max-width:900px;color:#dfe7f0;font-size:1.02rem;}
+    .summary{display:grid;gap:12px;padding:18px;border:1px solid rgba(255,255,255,.18);border-radius:var(--radius);background:rgba(255,255,255,.08);box-shadow:var(--shadow);}
+    .summary b{color:#fff;font-size:1.02rem;} .summary span{color:#dfe7f0;font-size:.93rem;}
+    .layout{width:min(1180px,calc(100% - 32px));margin:0 auto;display:grid;grid-template-columns:276px minmax(0,1fr);gap:28px;padding:32px 0 72px;}
+    .toc{position:sticky;top:18px;align-self:start;border:1px solid var(--line);border-radius:var(--radius);background:#fff;box-shadow:var(--shadow);padding:18px;max-height:calc(100vh - 36px);overflow:auto;}
+    .toc strong{display:block;margin-bottom:10px;font-size:.96rem;}
+    .toc a{display:block;padding:7px 0;color:#334155;border-top:1px solid #eef2f6;font-size:.92rem;}
+    .content{display:grid;gap:28px;min-width:0;}
+    section{border:1px solid var(--line);border-radius:var(--radius);background:#fff;box-shadow:var(--shadow);padding:24px;}
+    section h2{margin:0 0 14px;font-size:1.44rem;line-height:1.28;}
+    section h3{margin:22px 0 10px;font-size:1.1rem;}
+    section p{margin:10px 0;} section ul,section ol{margin:10px 0 0;padding-left:1.25rem;} section li{margin:6px 0;}
+    .lead{color:#39495a;font-size:1.02rem;}
+    .ok{border-left:5px solid var(--green);background:var(--green-soft);padding:14px 16px;border-radius:0 var(--radius) var(--radius) 0;margin:16px 0;}
+    .note{border-left:5px solid var(--blue);background:var(--blue-soft);padding:14px 16px;border-radius:0 var(--radius) var(--radius) 0;margin:16px 0;}
+    .warn{border-left:5px solid var(--amber);background:var(--amber-soft);padding:14px 16px;border-radius:0 var(--radius) var(--radius) 0;margin:16px 0;}
+    .bad{border-left:5px solid var(--red);background:var(--red-soft);padding:14px 16px;border-radius:0 var(--radius) var(--radius) 0;margin:16px 0;}
+    .grid-3{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:14px;}
+    .card{border:1px solid var(--line);border-radius:var(--radius);padding:14px;background:#fff;}
+    .card b{display:block;margin-bottom:6px;font-size:1.02rem;} .card span{display:block;color:var(--muted);font-size:.93rem;}
+    .pipe{display:grid;grid-template-columns:repeat(7,minmax(110px,1fr));gap:8px;margin:16px 0;}
+    .pipe div{min-height:74px;padding:10px;border:1px solid var(--line);border-radius:var(--radius);background:#f8fafc;}
+    .pipe b{display:block;margin-bottom:6px;color:#0f172a;} .pipe span{display:block;color:var(--muted);font-size:.86rem;}
+    .flow{display:grid;gap:8px;margin:16px 0;}
+    .flow-row{display:grid;grid-template-columns:200px minmax(0,1fr);gap:10px;align-items:stretch;}
+    .flow-key{display:flex;align-items:center;justify-content:center;border:1px solid var(--line);border-radius:var(--radius);padding:10px;background:#f8fafc;font-weight:750;text-align:center;min-height:52px;}
+    .flow-val{border:1px solid var(--line);border-radius:var(--radius);padding:10px 12px;background:#fff;min-height:52px;}
+    .stack{display:grid;gap:8px;}
+    .band{border:1px solid var(--line);border-left:6px solid var(--blue);border-radius:var(--radius);background:#fff;padding:10px 12px;}
+    .band.green{border-left-color:var(--green);background:var(--green-soft);}
+    .band.amber{border-left-color:var(--amber);background:var(--amber-soft);}
+    .band.red{border-left-color:var(--red);background:var(--red-soft);}
+    .band.teal{border-left-color:var(--teal);background:var(--teal-soft);}
+    .band.violet{border-left-color:var(--violet);background:var(--violet-soft);}
+    .tag{display:inline-flex;align-items:center;min-height:26px;border:1px solid var(--line);border-radius:6px;padding:2px 8px;margin:2px 4px 2px 0;background:#fff;color:#334155;font-size:.82rem;}
+    .tag.green{background:var(--green-soft);border-color:#b7dfc6;color:#1f6844;}
+    .tag.red{background:var(--red-soft);border-color:#f0b8b1;color:#8f1f16;}
+    .tag.amber{background:var(--amber-soft);border-color:#f2d19a;color:#8a4a05;}
+    .tag.blue{background:var(--blue-soft);border-color:#bfd3fb;color:#1e4fc4;}
+    .tag.teal{background:var(--teal-soft);border-color:#b5e2dc;color:#0c5c55;}
+    .tag.violet{background:var(--violet-soft);border-color:#d5c9ff;color:#5421aa;}
+    .phase{display:grid;grid-template-columns:68px minmax(0,1fr);gap:12px;border-top:1px solid #eef2f6;padding:14px 0;}
+    .phase:first-child{border-top:0;}
+    .phase-num{width:50px;height:50px;border-radius:var(--radius);display:flex;align-items:center;justify-content:center;background:#17202a;color:#fff;font-weight:800;}
+    .phase h3{margin:0 0 6px;}
+    @media (max-width:980px){.hero-inner,.layout,.grid-3{grid-template-columns:1fr;}.toc{position:relative;top:auto;max-height:none;}.flow-row{grid-template-columns:1fr;}.pipe{grid-template-columns:repeat(2,minmax(0,1fr));}}
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <div class="hero-inner">
+      <div>
+        <h1>Ludots 通用 Utility AI 与 Autocast 仲裁 SSOT 方案</h1>
+        <p>把 Uintel 的 Utility AI 架构思路完整复刻进 Ludots，并把 OpenRA 一整套 stance / 基础 order 作为业务语义行为包实现。核心命题：普通攻击就是一种 autocast 能力；当多个 autocast 争抢共享 GCD / mana / 施法槽时，仲裁器就是 Utility AI 的决策入口。</p>
+      </div>
+      <div class="summary">
+        <b>SSOT 结论</b>
+        <span>反应式行为(attack-move/hold/stop/autocast/普攻)是机制层，由 policy 数据驱动；Utility AI 坐在其上，只产 Order intent。两者共享 target-acquisition/filter 底座与 Order 词汇表，唯一区别是最终选择函数：优先级排序(机制) vs 加权打分(utility)。</span>
+      </div>
+    </div>
+  </header>
+  <div class="layout">
+    <nav class="toc">
+      <strong>目录</strong>
+      <a href="#thesis">1. 核心命题与三层模型</a>
+      <a href="#arbitration">2. 多能力仲裁 = Utility 决策入口</a>
+      <a href="#uintel">3. Uintel 架构忠实复刻</a>
+      <a href="#openra">4. OpenRA Stance/Order 业务包</a>
+      <a href="#boundary">5. 分层与 SSOT 边界</a>
+      <a href="#systems">6. SystemGroup 排布</a>
+      <a href="#issues">7. SSOT Issue 拆解</a>
+      <a href="#accept">8. 验收标准</a>
+      <a href="#refs">9. 参考文档</a>
+    </nav>
+    <main class="content">
+      <section id="thesis">
+        <h2>1. 核心命题与三层模型</h2>
+        <p class="lead">人们口中的"AI"其实混了三层。把它们分清，attack-move / hold / stop / approach / 自动施法 的归属就一目了然。</p>
+        <table>
+          <thead><tr><th>层</th><th>回答的问题</th><th>谁需要它</th><th>本方案归属</th></tr></thead>
+          <tbody>
+            <tr><td><b>Intent（意图 / Order）</b></td><td>"我被命令做什么"</td><td>玩家与 AI 都发</td><td>统一 <code>OrderQueue</code> 入口</td></tr>
+            <tr><td><b>Behavior / 机制（执行）</b></td><td>"怎么把命令执行出来"</td><td>谁控制单位都要，纯人操也要</td><td>OpenRA 行为包 + GAS（policy 数据驱动）</td></tr>
+            <tr><td><b>Deliberation（Utility AI）</b></td><td>"在多个有价值选项里此刻选哪个"</td><td>只有"有脑子"的一方需要</td><td>Utility AI Core（只产 intent）</td></tr>
+          </tbody>
+        </table>
+
+        <h3>命题 A：普通攻击就是一种 autocast 能力</h3>
+        <p>不再有"攻击系统"和"技能系统"两套东西。单位会做的一切反应式行为 = 一个带 autocast policy 的 ability。普攻只是其中<b>优先级最低、前置最宽松、会自动重复</b>的候选——"没有更值得做的事时占用动作槽的默认项"。于是 attack-move 的 engage 步骤，本质就是"普攻这个候选赢得了动作槽"。</p>
+
+        <h3>命题 B：一条可操作的判定规则</h3>
+        <p>判断任何行为该放哪层，问一句：<b>"选哪个"能不能写成确定性的全序策略？</b></p>
+        <div class="grid-3">
+          <div class="card"><b>能 → 机制 / policy</b><span>"最高优先级桶取最近"、"最近的敌人"、"血量最低的友军"。放进 behavior pack，用共享 target-acquisition + filter + priority 基建，不需要 utility 评分。</span></div>
+          <div class="card"><b>不能 → Utility 决策</b><span>需要把"远但残血但威胁高、而且大招好了"这类软因素互相权衡。放进 Utility AI Core。</span></div>
+          <div class="card"><b>共享底座</b><span>两者用同一套候选获取 + filter；区别只在最终选择函数：priority-sort vs weighted-score。</span></div>
+        </div>
+
+        <h3>逐项归类</h3>
+        <table>
+          <thead><tr><th>行为</th><th>归属</th><th>理由</th></tr></thead>
+          <tbody>
+            <tr><td>Stop</td><td>纯机制（Order）</td><td>清执行状态，没有任何"选择"。</td></tr>
+            <tr><td>Hold</td><td>机制（stance 标志）</td><td><code>allowMove=false</code> + auto-target 门控，是约束不是判断。</td></tr>
+            <tr><td>Approach / 追到射程</td><td>纯机制</td><td>attack 执行的子状态(chase-until-in-range)，leash 是 policy 数据。</td></tr>
+            <tr><td>Attack-Move</td><td>机制状态机 + auto-target policy</td><td>移动是机制；"途中遇敌打哪个"是确定性 <code>AutoTargetPriority</code>，不是 utility。</td></tr>
+            <tr><td>单个 / 互不冲突的 autocast</td><td>机制（反应式触发）</td><td>各放各的，谁都不挡谁（如被动光环 + 普攻）。</td></tr>
+            <tr><td>多个 autocast 抢共享 GCD/mana</td><td>需要仲裁器 → Utility 入口</td><td>见第 2 节。</td></tr>
+          </tbody>
+        </table>
+        <div class="bad"><b>不违反 no-fallback</b><p>普攻作为"最低优先级显式候选"<b>不是平台兜底</b>，而是配置里显式声明的默认 decision。候选池为空就什么都不放（显式），不是运行时偷偷兜底。Idle / HoldFire / ReturnFire 都是显式配置的 stance / decision，缺配置时 fail-fast。</p></div>
+      </section>
+
+      <section id="arbitration">
+        <h2>2. 多能力仲裁 = Utility 决策入口</h2>
+        <p class="lead">这是机制层与 Utility AI 边界真正发生迁移的点。一旦多个 autocast 争抢共享资源，就不能再各放各的，必须有人"选"，而"选"就是评分。</p>
+
+        <h3>场景：法师（加血 + 诅咒 + CC + 普攻，共享 GCD）</h3>
+        <p>四个能力都是 autocast 候选。共享 GCD 意味着这一窗口<b>最多放一个</b>，因此"放哪个、对谁"是一个带约束的选择问题。每个决策窗口收集候选：</p>
+        <pre><code>candidate(ability, target) 进入池的条件:
+  (autocast 开关开) 且 (有合法目标 via 自身 target filter)
+  且 (个体 cooldown 就绪) 且 (mana 可负担) 且 (GCD 就绪)
+  且 (precondition graph 通过)</code></pre>
+
+        <h3>同一条流水线，两种仲裁器（只换最终选择函数）</h3>
+        <table>
+          <thead><tr><th>仲裁方式</th><th>选择函数</th><th>归属</th><th>类比</th></tr></thead>
+          <tbody>
+            <tr><td>固定优先级 / 简单条件</td><td>priority list / if-else 链</td><td><b>机制</b>（便宜、确定性、好默认）</td><td>War3 autocast 实际做法</td></tr>
+            <tr><td>价值 vs 成本加权打分</td><td><code>argmax(score)</code></td><td><b>Utility AI</b></td><td>真正"有脑子"</td></tr>
+          </tbody>
+        </table>
+        <pre><code>// 便宜版（机制 / 优先级表）
+if   友军 HP&lt;50% 且 heal 就绪   -&gt; cast Heal  on 最低血友军
+elif 敌人正在读条 且 CC 就绪      -&gt; cast CC    on 那个敌人
+elif 敌对在射程 且 curse 就绪     -&gt; cast Curse on 最高价值敌人
+else                            -&gt; 普攻 on auto-target policy 选中目标
+
+// 升级版（utility）：同一候选池，给每个 (ability,target) 打分，argmax
+//   heal 分 ~ 友军缺血 × 该友军是否会死
+//   CC   分 ~ 打断的是否致命技能
+//   curse分 ~ 目标价值
+//   普攻 = 基线分
+// 换的只是 else-if 链 -&gt; argmax(score)，流水线一字不改</code></pre>
+
+        <h3>GCD / mana / 冷却不是独立系统，是仲裁器的 veto/gate 输入</h3>
+        <table>
+          <thead><tr><th>约束</th><th>形状</th><th>映射到现有 GAS 原语</th></tr></thead>
+          <tbody>
+            <tr><td>个体冷却</td><td>该能力可用性门</td><td><code>AbilityCooldown { CooldownValueAttributeId, CooldownTagId }</code></td></tr>
+            <tr><td>公共 CD（GCD）</td><td>互斥 / 单槽：选中者消耗，本窗口其余 GCD 能力全 veto</td><td><b>共享 cooldown tag</b>（复用 <code>CooldownTagId</code> + <code>AbilityActivationBlockTags</code>）</td></tr>
+            <tr><td>mana / 资源</td><td>预算门：先按可负担过滤候选</td><td>ability cost + <code>AbilityActivationPrecondition.ValidationGraphId</code></td></tr>
+            <tr><td>执行器就绪（朝向/弹药等）</td><td>readiness 门</td><td>新增 <code>ActuatorReadiness</code>（见第 5 节），炮台为 adapter 案例</td></tr>
+          </tbody>
+        </table>
+        <div class="note"><b>边界要点</b><ul>
+          <li><b>多个 autocast 同时生效 ≠ 同时释放</b>：开关都开只是都进候选池；不抢资源的可真并行，抢 GCD/mana 的是互斥候选集，一窗口选一个。</li>
+          <li><b>玩家/AI 显式命令优先级最高、抢占 autocast</b>：显式 Order 抢占本窗口仲裁，autocast 只在空闲/自动时填槽（与 War3 一致）。</li>
+          <li><b>性能：不要每帧重新仲裁</b>。普攻作为默认赢家由执行层 auto-repeat；仲裁器只在决策间隔或中断事件（目标死、友军掉阈值、大招转好）时重选。对应 think bucket + keepRunning + interrupt policy。</li>
+        </ul></div>
+        <div class="ok"><b>结论</b><p>单个 autocast 是机制；多个 autocast 抢共享 GCD/mana 的那一刻，就需要一个仲裁器，而这个仲裁器就是 Utility AI 的 decision-target 评分机缩到"我自己的能力"上。便宜的优先级表与完整 utility 打分是<b>同一条流水线的两个选择函数</b>。</p></div>
+      </section>
+      <section id="uintel">
+        <h2>3. Uintel 架构忠实复刻</h2>
+        <p class="lead">复刻的是 Uintel 的<b>职责链与数据形状</b>，不是 Unity DOTS 细节。完整链路：感知输入 → 归一化 → consideration → decision → decision maker → state machine → action task；运行时拆成决策阶段与执行阶段。</p>
+        <div class="pipe">
+          <div><b>Input</b><span>读 agent/target/环境/blackboard，输出 raw input。</span></div>
+          <div><b>Normalization</b><span>raw input 归一到 0..1。</span></div>
+          <div><b>Consideration</b><span>input + normalization + response curve。</span></div>
+          <div><b>Decision</b><span>considerations + target filter + action tasks。</span></div>
+          <div><b>DecisionMaker</b><span>在 decision-target pair 中选最高分（= 仲裁器）。</span></div>
+          <div><b>StateMachine</b><span>控制 decision 切换，处理 momentum/hysteresis。</span></div>
+          <div><b>ActionTask</b><span>Sequence / Parallel / ParallelComplete 执行。</span></div>
+        </div>
+
+        <h3>Module 切分（Interface / Implementation）</h3>
+        <table>
+          <thead><tr><th>Module</th><th>Interface</th><th>Implementation 要点</th></tr></thead>
+          <tbody>
+            <tr><td><code>AIConfigCompiler</code></td><td>输入 <code>ConfigCatalog</code>，输出 <code>AICompiledRuntime</code></td><td>解析 AI/*.json，注册 ids，编译 flat arrays / range tables，所有引用 fail-fast。</td></tr>
+            <tr><td><code>AIAgentRuntimeSoA</code></td><td>按 agent index 读写状态</td><td>profileId、currentDecisionId、currentTarget、thinkBucket、score、executor pc、combatMemory。</td></tr>
+            <tr><td><code>AITargetAcquisition</code></td><td>返回候选目标 span</td><td>spatial query + target filter + target cache + last-seen，无副作用。</td></tr>
+            <tr><td><code>AIInputSampling</code></td><td>按 inputId 读 raw value</td><td>距离、生命、tag、attribute、cooldown、threat、actuator readiness、order state、graph score。</td></tr>
+            <tr><td><code>AIUtilityEvaluator</code></td><td>输出 best decision-target pair</td><td>normalization、curve、veto、multiply、weighted sum、priority bucket、momentum、hysteresis。</td></tr>
+            <tr><td><code>AIDecisionStateMachine</code></td><td>是否切换 current decision</td><td>keep running、min duration、cooldown、interrupt policy、score margin。</td></tr>
+            <tr><td><code>AIExecution</code></td><td>decision intent → running tasks</td><td>Sequence / Parallel / ParallelComplete；任务只提交 Order intent 或维护 AI runtime state。</td></tr>
+            <tr><td><code>AIOrderAdapter</code></td><td>task intent → <code>Order</code></td><td>填 Actor/Target/Spatial/Args/SubmitMode，交给 <code>OrderQueue</code>。</td></tr>
+          </tbody>
+        </table>
+
+        <h3>SoA / 0Alloc 数据布局</h3>
+        <pre><code>AICompiledRuntime（只读）
+  DecisionMakerRanges[]          // offset+count -> Decisions
+  DecisionTargetFilterId[]
+  DecisionConsiderationRanges[]  // -> Considerations
+  DecisionTaskRanges[]           // -> Tasks
+  ConsiderationInputId[] / NormalizationId[] / CurveId[] / Weight[] / Flags[]
+  TargetFilterOps[] / InputDefs[] / NormalizationDefs[] / CurveDefs[]
+  TaskDefs[] / OrderAdapterDefs[] / GraphProgramIds[]
+
+AIAgentRuntimeSoA（可写）
+  Entity[] Agents; int[] ProfileId; int[] CurrentDecisionId; Entity[] CurrentTarget
+  int[] CurrentTaskOffset; byte[] CurrentTaskStatus; float[] CurrentScore
+  int[] LastSwitchStep; int[] NextThinkStep; int[] CombatMemoryHead</code></pre>
+        <ul>
+          <li>配置加载阶段可用 List/JSON；编译后热路径只读 arrays / spans。</li>
+          <li>Update 内禁止 LINQ / new List / 闭包 / 字符串查找 / 反射；所有 string id 在 compile 阶段变 int。</li>
+          <li>候选用固定容量 <code>Span&lt;Entity&gt;</code> scratch（<code>maxCandidates</code> 来自 profile）；top 选择用单 pass best 或小容量插入排序。</li>
+          <li>Graph score 用 stackalloc registers；AI 侧 Graph adapter 只允许 pure read / math / query / relationship read，禁 effect/attribute/event write。</li>
+          <li>多 agent 分桶（<code>NextThinkStep</code>）跨帧分摊；结构变化集中到 CommandBuffer / OrderQueue。</li>
+        </ul>
+        <div class="warn"><b>与 Ludots 规范冲突的一点</b><p>Uintel 的 fallback decision / idle fallback 不照搬。Idle / Hold / ReturnFire 都是显式配置的 decision 或 order state；配置缺失时 fail-fast，不运行时兜底。Unity Burst / BlobAssetReference / Baker / SubScene 等专属项不照搬。</p></div>
+      </section>
+
+      <section id="openra">
+        <h2>4. OpenRA Stance / Order 业务包</h2>
+        <p class="lead">OpenRA 基础行为的核心：命令薄、行为编排薄、索敌策略数据化、攻击执行交给 attack trait。映射到 Ludots = order 薄、AI task 薄、target/score 数据化、攻击执行交给 Ability/GAS。这些作为<b>可复用 behavior pack mod</b>交付，不写进 AI Core。OpenRA 的关键原则："<b>索敌是单位能力，不是 bot 特权</b>"——人类、AI、脚本单位都复用同一套。</p>
+
+        <h3>4.1 基础 Order 全集</h3>
+        <table>
+          <thead><tr><th>OpenRA 命令</th><th>语义</th><th>Ludots Order 映射 / 必要规则</th></tr></thead>
+          <tbody>
+            <tr><td><code>Move</code></td><td>移动到点，不主动扫描</td><td>复用 moveTo → <code>NavGoal2D</code>。</td></tr>
+            <tr><td><code>Stop</code> / <code>Scatter</code></td><td>停止 / 短距避让</td><td>复用 <code>StopOrderSystem</code>；Stop 必须清 current target、guard anchor、attackMove runtime、turret aim desire。</td></tr>
+            <tr><td><code>Attack</code> / <code>ForceAttack</code></td><td>锁定目标，进射程后攻击</td><td>attack order 写 <code>Attack.TargetEntity</code>；ForceAttack 允许地面/友军强攻。</td></tr>
+            <tr><td><code>AttackMove</code> / <code>AssaultMove</code></td><td>向目的地移动，途中按 auto-target 接战；Assault 切更激进 priority profile</td><td><b>新增 <code>attackMove</code> order</b>，runtime 持有 authored destination；可恢复 activity（非简单排队）。</td></tr>
+            <tr><td><code>Guard</code></td><td>跟随保护目标，途中插入攻击后恢复跟随</td><td><b>新增 <code>guard</code> order</b>，payload = guarded entity + guard radius；复用 attack-move 交战逻辑。</td></tr>
+            <tr><td><code>SetUnitStance</code></td><td>切换交战姿态</td><td><b>新增 <code>setCombatStance</code> order</b>，写 <code>CombatStance</code> 组件；不能只是 UI 状态，必须参与 target scan / 反击 / profile 切换。</td></tr>
+            <tr><td>Deploy / Repair / Capture / Harvest / Transport</td><td>不同 target filter + ability/order task</td><td>作为 behavior pack 可选 decisions，不写入 AI core 特例。</td></tr>
+          </tbody>
+        </table>
+
+        <h3>4.2 四种姿态（默认人类 = Defend）</h3>
+        <table>
+          <thead><tr><th>Stance</th><th>autoAcquire</th><th>retaliate</th><th>allowMoveChase</th><th>targetSource</th></tr></thead>
+          <tbody>
+            <tr><td>HoldFire</td><td>false</td><td>false</td><td>false</td><td>—</td></tr>
+            <tr><td>ReturnFire</td><td>false</td><td>true</td><td>false</td><td>RecentAttackers</td></tr>
+            <tr><td>Defend（默认）</td><td>true</td><td>true</td><td>false</td><td>ScanRadius</td></tr>
+            <tr><td>AttackAnything</td><td>true</td><td>true</td><td>true</td><td>ScanRadius（含 Structure）</td></tr>
+          </tbody>
+        </table>
+
+        <h3>4.3 目标优先级数据化（OpenRA AutoTargetPriority）</h3>
+        <p>先按 priority 桶选更高优先级，再用距离 tie-break。不写死在 attack-move 里，而作为 target scoring profile：</p>
+        <pre><code>{
+  "id": "TargetScore.OpenRA.Ground",
+  "mode": "PriorityBucketThenDistance",
+  "buckets": [
+    { "tag": "TargetType.Defense",  "relationship": "Hostile", "priority": 60 },
+    { "tag": "TargetType.Vehicle",  "relationship": "Hostile", "priority": 50 },
+    { "tag": "TargetType.Infantry", "relationship": "Hostile", "priority": 40 }
+  ],
+  "tieBreak": "Nearest"
+}</code></pre>
+
+        <h3>4.4 AttackMove task 状态机</h3>
+        <div class="flow">
+          <div class="flow-row"><div class="flow-key">Moving</div><div class="flow-val">维持目的地 NavGoal；按 scan interval 扫候选。</div></div>
+          <div class="flow-row"><div class="flow-key">Acquire</div><div class="flow-val">target filter + priority profile 选目标；无目标继续 Moving。</div></div>
+          <div class="flow-row"><div class="flow-key">Engage</div><div class="flow-val">暂停移动；提交 attack/castAbility order；跟踪 target validity。</div></div>
+          <div class="flow-row"><div class="flow-key">Disengage</div><div class="flow-val">目标死亡/失效/超 leash/不可见/不可攻击/攻击 order 完成。</div></div>
+          <div class="flow-row"><div class="flow-key">Resume</div><div class="flow-val">回到原 attack-move 目的地；刚脱战可立即再扫一次避免空走。</div></div>
+        </div>
+        <div class="note"><b>脱战 / 警戒 / 记忆</b><p>需要通用 <code>AICombatMemory</code>：last-seen、leash radius、target invalidation、target memory TTL、scan interval。被打反击：伤害事件转 retaliate intent，只有 idle 或可中断 order 才提交 castAbility——<b>不能在 damage effect 里直接开火</b>（绕过分层）。</p></div>
+      </section>
+      <section id="boundary">
+        <h2>5. 分层与 SSOT 边界</h2>
+        <p class="lead">SSOT 的关键是每个概念只有一个归属层。最容易出错的是把业务名词写进 AI Core。</p>
+        <div class="stack">
+          <div class="band red"><b>Authoring Layer（Mod 配置）</b><br>AI profile、target filters、inputs、curves、decisions、tasks、stances、actuator readiness adapters、autocast policy。</div>
+          <div class="band amber"><b>Compile Layer</b><br>ConfigPipeline 合并后编译为 id / array / range / programId；热路径不保留 string；全引用 fail-fast。</div>
+          <div class="band teal"><b>Decision Layer（AI Core）</b><br>target candidates、raw inputs、normalization、consideration、decision-target pair score、仲裁、state machine。只认通用词。</div>
+          <div class="band violet"><b>Execution Layer（AI Core）</b><br>Sequence/Parallel task executor，输出 Order intent，不直接触发 Effect。</div>
+          <div class="band green"><b>Gameplay Layer（GAS / 行为包）</b><br>OrderBufferSystem、AbilityExecSystem、EffectProcessing、ProjectileRuntime、Turret/Stance/AttackMove runtime 执行实际 gameplay。</div>
+        </div>
+
+        <h3>什么进 Core、什么进 behavior pack、什么归 GAS</h3>
+        <table>
+          <thead><tr><th>概念</th><th>归属</th><th>理由</th></tr></thead>
+          <tbody>
+            <tr><td>TargetFilter / DecisionIntent / ActuatorReadiness / AimGate / ExecutionPrecondition</td><td><b>AI Core 通用词</b></td><td>跨题材可复用，无业务语义。</td></tr>
+            <tr><td>Stance（HoldFire/ReturnFire/Defend/AttackAnything）</td><td><b>behavior pack</b>（OpenRA 包）+ AI state</td><td>交战政策状态，不是 AI 本体；影响 target filter 与 allowMove。</td></tr>
+            <tr><td>AttackMove / Guard / Patrol / AutoTarget profile</td><td><b>behavior pack</b></td><td>作为可配置行为包，别的 mod 可复用，不作 AI Core 特例。</td></tr>
+            <tr><td>炮台 / 采集器 / 建造者 / 蓄力施法</td><td><b>actuator adapter</b>（gameplay 能力 mod）</td><td>业务案例。AI Core 只认 readiness，不认炮台。</td></tr>
+            <tr><td>伤害 / buff / projectile / cost / cooldown / block tag</td><td><b>GAS</b></td><td>执行权归 GAS，AI 只读 readiness、只提交 Order。</td></tr>
+          </tbody>
+        </table>
+
+        <h3>炮台只是 readiness 的一个 adapter 案例</h3>
+        <table>
+          <thead><tr><th>抽象 Module（Core）</th><th>Core 语义</th><th>炮台案例如何挂接</th></tr></thead>
+          <tbody>
+            <tr><td><code>ActuatorReadiness</code></td><td>只暴露 <code>ready01</code> / <code>blockReason</code> / <code>etaSteps</code> / <code>requiresPreparation</code></td><td><code>TurretState</code>(yaw/turnSpeed/readyCheck/muzzle) adapter 把 yaw delta 转成 readiness。</td></tr>
+            <tr><td><code>AimGate</code></td><td>面向所有需要朝向的执行器</td><td><code>TurretFacingSystem</code> 是它的一个 gameplay implementation。</td></tr>
+            <tr><td><code>AbilityPrecondition</code></td><td>最终执行门控归 GAS</td><td>炮台未对准时攻击 ability 阻塞/等待/进入准备。</td></tr>
+          </tbody>
+        </table>
+        <div class="bad"><b>不该做的实现</b><p>不在某 showcase 里硬写 AttackMove；不让 AI 直接扣血或发 Effect；不新增平行配置加载器；不把 Idle 做成平台 fallback；不把 Unity DOTS/Burst/BlobAssetReference 当 Ludots 架构；不把炮台/采集器/建造者写进 AI Core。</p></div>
+      </section>
+
+      <section id="systems">
+        <h2>6. SystemGroup 排布</h2>
+        <p class="lead">AI 必须在 <code>OrderBufferSystem</code> 前产出 order 才能同 tick 进入现有 Order/GAS 链路；感知必须在空间索引更新之后运行，避免用上一帧位置索敌。</p>
+        <table>
+          <thead><tr><th>SystemGroup</th><th>AI 系统</th><th>原因</th></tr></thead>
+          <tbody>
+            <tr><td><code>SchemaUpdate</code></td><td><code>AIConfigReloadApplySystem</code>（可选）</td><td>只处理配置版本切换与 runtime swap。</td></tr>
+            <tr><td><code>InputCollection</code></td><td><code>AIThinkScheduleSystem</code> + 低成本 blackboard projection</td><td>确定本 tick 哪些 agent 思考（think bucket）。</td></tr>
+            <tr><td><code>PostMovement</code></td><td><code>AIPerceptionSystem</code> → <code>AITargetAcquisitionSystem</code> → <code>AIDecisionSystem</code>（含 autocast 仲裁）→ <code>AIExecutionSystem</code> → <code>AIOrderIntentSubmitSystem</code></td><td>在 <code>SpatialPartitionUpdateSystem</code> 后、<code>OrderBufferSystem</code> 前，用最新索引且让 order 同 tick 生效。</td></tr>
+            <tr><td><code>Cleanup</code></td><td><code>AICombatMemoryCleanupSystem</code></td><td>清死亡 target、过期 last-seen / threat cache。</td></tr>
+          </tbody>
+        </table>
+      </section>
+      <section id="issues">
+        <h2>7. SSOT Issue 拆解</h2>
+        <p class="lead">一个 Epic + 10 个分阶段 sub-issue。每个 sub-issue 对应本文档一节，有明确 Interface 契约和 0Alloc / fail-fast 验收。开发由下属 agent 执行，方案与审计由架构侧负责。</p>
+        <div class="note"><b>Epic</b><p><b>通用 Utility AI + OpenRA Stance 行为包：autocast / 多能力仲裁统一模型（SSOT）</b><br>把 <code>src/Core/Gameplay/AI</code> 深化成深 Module：配置编译为只读数组、SoA 0Alloc runtime、decision 只产 intent、execution 只提交 Order、Ability/Effect 仍归 GAS。OpenRA stance/order 作为 behavior pack mod 交付。</p></div>
+
+        <div class="phase"><div class="phase-num">1</div><div><h3>RFC 与契约收敛</h3><p>定稿三层模型(Intent/Behavior/Deliberation)与"普攻=autocast ability"决议；统一 <code>OrderTypeId</code>/<code>OrderTypeKey</code>；<b>修复 <code>mods/AIDemoMod/.../goap_actions.json</code> 的 <code>OrderTagId</code> → <code>OrderTypeId</code> 并加 fail-fast 校验</b>；定义 GCD=shared cooldown tag 契约；确认 no-fallback。</p><span class="tag red">必须先做</span><span class="tag blue">文档+schema</span></div></div>
+        <div class="phase"><div class="phase-num">2</div><div><h3>AI Config Compiler v2（SoA / 0Alloc）</h3><p>扩展 <code>AiConfigLoader</code> 或新增 <code>AiUtilityConfigCompiler</code>，把 Uintel 链路编译成 flat arrays：profiles / decision_makers / decisions / target_filters / inputs / normalizations / curves / tasks / stances / actuators，全引用 fail-fast，走 ConfigPipeline。</p><span class="tag teal">ConfigPipeline</span><span class="tag green">0Alloc ready</span></div></div>
+        <div class="phase"><div class="phase-num">3</div><div><h3>Target Acquisition + Filter（无副作用）</h3><p>复刻 Uintel TargetFilters + OpenRA AutoTargetPriority：spatial query + relationship/layer/tag/距离/视野/weapon eligibility filter + priority bucket + nearest tie-break + target cache + last-seen。禁 managed LINQ/临时 List。</p><span class="tag amber">索敌核心</span><span class="tag violet">OpenRA priority</span></div></div>
+        <div class="phase"><div class="phase-num">4</div><div><h3>Decision-Target Evaluator + DecisionMaker + StateMachine</h3><p>input sampling、normalization、curve、consideration aggregation(veto/multiply/weighted/priority bucket)、decision-target pair argmax、momentum/hysteresis、min-duration/interrupt policy。</p><span class="tag teal">评分核心</span></div></div>
+        <div class="phase"><div class="phase-num">5</div><div><h3>Autocast 候选收集 + 多能力仲裁器</h3><p>把每个 autocast-enabled ability(含普攻)作为 decision-target 候选；GCD/mana/cooldown/precondition 作为 veto/gate（映射 <code>AbilityActivationPrecondition</code> / <code>AbilityCooldown</code> 共享 tag）；仲裁 = fixed priority 或 utility score；玩家显式 order 抢占；普攻 auto-repeat running task。</p><span class="tag red">本方案核心</span><span class="tag green">GAS 复用</span></div></div>
+        <div class="phase"><div class="phase-num">6</div><div><h3>Execution Tasks + Order Adapters</h3><p>Sequence / Parallel / ParallelComplete；SubmitOrder task；Move / Attack / CastAbility / Guard / SetStance adapters → <code>OrderQueue</code>。禁止直接发 Effect。</p><span class="tag green">Order 同构</span><span class="tag red">禁直接 Effect</span></div></div>
+        <div class="phase"><div class="phase-num">7</div><div><h3>OpenRA Stance 基础 Order 业务包</h3><p>新增 orders：<code>attackMove</code> / <code>assaultMove</code> / <code>guard</code> / <code>setCombatStance</code> / <code>scatter</code>；stances HoldFire/ReturnFire/Defend/AttackAnything；retaliate-on-damage；AttackMove 可恢复 runtime；Guard follow+resume；disengage/leash/target memory TTL。作为 behavior pack mod，不进 AI Core。</p><span class="tag blue">行为包</span><span class="tag teal">可复用 Mod</span></div></div>
+        <div class="phase"><div class="phase-num">8</div><div><h3>Actuator Readiness + Turret AimGate adapter</h3><p>通用 <code>ActuatorReadiness</code>(ready01/blockReason/etaSteps/requiresPreparation) + <code>AimGate</code> + Ability precondition gate；<code>TurretState</code> gameplay authority(yaw/turnSpeed/readyCheck/muzzle offset)。炮台只是一个 adapter 案例。</p><span class="tag amber">Readiness</span><span class="tag green">Ability gate</span></div></div>
+        <div class="phase"><div class="phase-num">9</div><div><h3>主循环接入（SystemGroup 排布）</h3><p>把 AI systems 注册进 <code>GameEngine</code>：InputCollection(think schedule)、PostMovement(perception/acquisition/decision/execution/orderSubmit) 在 <code>SpatialPartitionUpdateSystem</code> 后、<code>OrderBufferSystem</code> 前；Cleanup(combat memory)。<b>解决"有配置不等于有运行"。</b></p><span class="tag red">从未接入</span></div></div>
+        <div class="phase"><div class="phase-num">10</div><div><h3>调试 + 验收（0Alloc + deterministic tests）</h3><p>AI inspector 显示每个 decision-target pair 的候选 / 过滤原因 / 分数 / 当前 task / 提交 order；补齐第 8 节全部验收测试。</p><span class="tag violet">debug</span><span class="tag green">tests</span></div></div>
+      </section>
+
+      <section id="accept">
+        <h2>8. 验收标准</h2>
+        <p class="lead">系统是否成立不看 demo 演得像不像，看这些测试能否稳定通过。</p>
+        <table>
+          <thead><tr><th>验收项</th><th>必须证明</th></tr></thead>
+          <tbody>
+            <tr><td>0Alloc</td><td>10k agent 在 fixed iterations 中 Perception+Decision+Execution+OrderSubmit 分配 ≤ 现有 AI benchmark 级别。</td></tr>
+            <tr><td>Autocast 仲裁</td><td>多 autocast 抢共享 GCD 时一窗口只放一个；选中者消耗 GCD/mana 后其余被 veto；优先级表与 utility 打分两种模式都可配。</td></tr>
+            <tr><td>普攻=能力</td><td>普攻作为最低优先级候选，无更优候选时 auto-repeat；被更高价值候选抢占时让出动作槽。</td></tr>
+            <tr><td>显式抢占</td><td>玩家/AI 显式 order 抢占本窗口 autocast；autocast 只在空闲/自动时填槽。</td></tr>
+            <tr><td>OpenRA priority</td><td>高 priority target 永远胜过低 priority；同 priority 下最近者胜。</td></tr>
+            <tr><td>Stance</td><td>HoldFire 不索敌不还击；ReturnFire 只打 recent attacker；Defend 扫描但不追出 leash；AttackAnything 可追击。</td></tr>
+            <tr><td>AttackMove</td><td>移动途中遇敌暂停、攻击 order 完成后恢复原目的地；目标死亡/失效/超 leash 正确脱战。</td></tr>
+            <tr><td>Guard</td><td>跟随保护目标；附近有 hostile/recent attacker 时攻击；离开 guard range 后回位。</td></tr>
+            <tr><td>Order/GAS 同构</td><td>AI 与玩家用同一 OrderQueue/OrderBufferSystem/AbilityExecSystem；AI 不能直接发 EffectRequest。</td></tr>
+            <tr><td>Graph score policy</td><td>自定义 Graph 可影响 score；AI Graph policy 拒绝 effect/attribute/event write。</td></tr>
+            <tr><td>Actuator readiness gate</td><td>执行器未 ready 时 ability 被阻塞/等待/先准备；ready 后同 target 能执行；表现读 gameplay state。</td></tr>
+            <tr><td>主循环接入</td><td>AI systems 在 SpatialPartitionUpdateSystem 后、OrderBufferSystem 前运行；同 tick order 可被消费。</td></tr>
+            <tr><td>配置 fail-fast</td><td>未知 input/filter/order type/ability id/graph id/blackboard key/cooldown tag 均在加载阶段报错。</td></tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="refs">
+        <h2>9. 参考文档</h2>
+        <ul>
+          <li><a href="ludots_ai_status_reference_map.html">Ludots AI 现状、困境与参考地图</a></li>
+          <li><a href="ludots_utility_ai_soa_openra_behavior_architecture.html">Ludots 通用 Utility AI SoA 架构方案</a>（本方案的架构底座）</li>
+          <li><a href="ludots_targeting_order_gas_gap_analysis.html">Ludots 索敌、警戒、炮台与 Order/GAS 映射缺口分析</a></li>
+          <li><a href="openra_unit_behavior_attack_move_analysis.html">OpenRA 用户输入动作与基础单位指令源码剖面</a></li>
+          <li><a href="openra_targeting_priority_guard_turret_analysis.html">OpenRA 索敌优先级、脱战警戒与炮台机制源码剖面</a></li>
+          <li><a href="https://uintel-ecs.utilityworlds.com/Documentation/">Utility Intelligence ECS Documentation</a>（架构思想来源）</li>
+        </ul>
+        <h3>关键现有源码锚点</h3>
+        <ul>
+          <li><code>src/Core/Gameplay/AI/Config/AiConfigLoader.cs</code>（OrderTypeId 读取，contract 收敛点）</li>
+          <li><code>src/Core/Gameplay/GAS/Components/AbilityActivationPrecondition.cs</code> / <code>AbilityCooldown.cs</code> / <code>AbilityActivationBlockTags.cs</code>（autocast 门控原语）</li>
+          <li><code>src/Core/Input/Orders/InputOrderMapping.cs</code>（AutoTargetPolicy vs ContextScored，玩家侧已有的策略/评分二分）</li>
+          <li><code>src/Core/Engine/GameEngine.cs</code>（AiRuntime 加载点 / 主循环接入缺口）</li>
+        </ul>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/reference/ludots_targeting_order_gas_gap_analysis.html
+++ b/docs/reference/ludots_targeting_order_gas_gap_analysis.html
@@ -1,0 +1,909 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ludots 索敌、警戒、炮台与 Order/GAS 映射缺口分析</title>
+  <style>
+    :root {
+      --bg: #ffffff;
+      --ink: #17202a;
+      --muted: #66717e;
+      --line: #d9e2ec;
+      --soft: #f5f7fa;
+      --blue-soft: #edf4ff;
+      --green-soft: #edf7f1;
+      --amber-soft: #fff4df;
+      --red-soft: #fff0ee;
+      --blue: #2563eb;
+      --teal: #0f766e;
+      --green: #2f855a;
+      --amber: #b45309;
+      --red: #b42318;
+      --violet: #6d28d9;
+      --radius: 8px;
+      --shadow: 0 8px 24px rgba(23, 32, 42, 0.07);
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+
+    body {
+      margin: 0;
+      font-family: "Segoe UI", "Microsoft YaHei", Arial, sans-serif;
+      color: var(--ink);
+      background: var(--bg);
+      line-height: 1.72;
+      letter-spacing: 0;
+    }
+
+    a { color: var(--blue); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    code {
+      font-family: Consolas, "Cascadia Mono", "SFMono-Regular", monospace;
+      font-size: 0.92em;
+      background: #eef2f6;
+      border: 1px solid #d8e0e8;
+      border-radius: 6px;
+      padding: 0.08rem 0.32rem;
+      overflow-wrap: anywhere;
+    }
+
+    .hero {
+      border-bottom: 6px solid var(--red);
+      background: #17202a;
+      color: #f8fafc;
+    }
+
+    .hero-inner {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: 48px 0 42px;
+      display: grid;
+      grid-template-columns: minmax(0, 1.16fr) minmax(300px, 0.84fr);
+      gap: 28px;
+      align-items: end;
+    }
+
+    .hero h1 {
+      margin: 0 0 16px;
+      max-width: 900px;
+      font-size: 2.24rem;
+      line-height: 1.16;
+      font-weight: 850;
+      letter-spacing: 0;
+    }
+
+    .hero p {
+      margin: 0;
+      max-width: 870px;
+      color: #dfe7f0;
+      font-size: 1.02rem;
+    }
+
+    .hero code {
+      color: #f8fafc;
+      background: rgba(255, 255, 255, 0.1);
+      border-color: rgba(255, 255, 255, 0.22);
+    }
+
+    .summary {
+      display: grid;
+      gap: 12px;
+      padding: 18px;
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      border-radius: var(--radius);
+      background: rgba(255, 255, 255, 0.08);
+      box-shadow: var(--shadow);
+    }
+
+    .summary b {
+      color: #ffffff;
+      font-size: 1.02rem;
+    }
+
+    .summary span {
+      color: #dfe7f0;
+      font-size: 0.93rem;
+    }
+
+    .layout {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: 266px minmax(0, 1fr);
+      gap: 28px;
+      padding: 32px 0 72px;
+    }
+
+    .toc {
+      position: sticky;
+      top: 18px;
+      align-self: start;
+      padding: 14px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #ffffff;
+      box-shadow: var(--shadow);
+    }
+
+    .toc h2 {
+      margin: 0 0 10px;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    .toc a {
+      display: block;
+      padding: 8px;
+      border-radius: 6px;
+      color: #263442;
+      font-size: 0.9rem;
+    }
+
+    .toc a:hover {
+      background: var(--soft);
+      text-decoration: none;
+    }
+
+    main { min-width: 0; }
+
+    section {
+      margin-bottom: 34px;
+      padding: 30px 0;
+      border-top: 1px solid var(--line);
+    }
+
+    section:first-child {
+      border-top: 0;
+      padding-top: 0;
+    }
+
+    h2 {
+      margin: 0 0 16px;
+      font-size: 1.46rem;
+      line-height: 1.25;
+      letter-spacing: 0;
+    }
+
+    h3 {
+      margin: 0 0 10px;
+      font-size: 1.05rem;
+      line-height: 1.35;
+      letter-spacing: 0;
+    }
+
+    p { margin: 0 0 13px; }
+    ul { margin: 0; padding-left: 1.16rem; }
+    li { margin: 6px 0; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      overflow: hidden;
+      background: #ffffff;
+      font-size: 0.94rem;
+    }
+
+    th, td {
+      padding: 11px 12px;
+      border-bottom: 1px solid var(--line);
+      vertical-align: top;
+      text-align: left;
+    }
+
+    th {
+      background: #f1f5f9;
+      color: #334155;
+      font-weight: 750;
+    }
+
+    tr:last-child td { border-bottom: 0; }
+
+    .table-wrap {
+      width: 100%;
+      overflow-x: auto;
+      margin: 16px 0;
+      border-radius: var(--radius);
+    }
+
+    .label {
+      display: inline-block;
+      margin-bottom: 10px;
+      color: var(--red);
+      font-size: 0.78rem;
+      font-weight: 800;
+      text-transform: uppercase;
+      letter-spacing: 0;
+    }
+
+    .callout {
+      margin: 16px 0;
+      padding: 16px 18px;
+      border: 1px solid var(--line);
+      border-left: 5px solid var(--blue);
+      border-radius: var(--radius);
+      background: var(--blue-soft);
+    }
+
+    .callout.warn {
+      border-left-color: var(--amber);
+      background: var(--amber-soft);
+    }
+
+    .callout.danger {
+      border-left-color: var(--red);
+      background: var(--red-soft);
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 14px;
+      margin: 16px 0;
+    }
+
+    .tile {
+      min-width: 0;
+      padding: 16px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #ffffff;
+      box-shadow: var(--shadow);
+    }
+
+    .tile.blue { border-top: 4px solid var(--blue); }
+    .tile.green { border-top: 4px solid var(--green); }
+    .tile.amber { border-top: 4px solid var(--amber); }
+    .tile.red { border-top: 4px solid var(--red); }
+    .tile.teal { border-top: 4px solid var(--teal); }
+    .tile.violet { border-top: 4px solid var(--violet); }
+
+    .flow {
+      display: grid;
+      grid-template-columns: repeat(7, minmax(0, 1fr));
+      gap: 10px;
+      margin: 18px 0;
+    }
+
+    .flow-step {
+      min-height: 128px;
+      padding: 13px;
+      border: 1px solid var(--line);
+      border-top: 4px solid var(--blue);
+      border-radius: var(--radius);
+      background: #ffffff;
+      box-shadow: var(--shadow);
+    }
+
+    .flow-step:nth-child(2) { border-top-color: var(--teal); }
+    .flow-step:nth-child(3) { border-top-color: var(--green); }
+    .flow-step:nth-child(4) { border-top-color: var(--amber); }
+    .flow-step:nth-child(5) { border-top-color: var(--violet); }
+    .flow-step:nth-child(6) { border-top-color: var(--red); }
+    .flow-step:nth-child(7) { border-top-color: #475569; }
+
+    .flow-step strong {
+      display: block;
+      margin-bottom: 7px;
+      line-height: 1.3;
+    }
+
+    .flow-step span {
+      color: var(--muted);
+      font-size: 0.89rem;
+    }
+
+    .two-col {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+      margin: 16px 0;
+    }
+
+    .source-list {
+      columns: 2;
+      column-gap: 24px;
+    }
+
+    .source-list li {
+      break-inside: avoid;
+      margin-bottom: 8px;
+    }
+
+    .status-gap {
+      color: var(--red);
+      font-weight: 780;
+    }
+
+    .status-partial {
+      color: var(--amber);
+      font-weight: 780;
+    }
+
+    .status-good {
+      color: var(--green);
+      font-weight: 780;
+    }
+
+    @media (max-width: 980px) {
+      .hero-inner,
+      .layout,
+      .two-col {
+        grid-template-columns: 1fr;
+      }
+
+      .toc {
+        position: static;
+      }
+
+      .grid,
+      .flow {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .source-list {
+        columns: 1;
+      }
+    }
+
+    @media (max-width: 640px) {
+      .hero-inner,
+      .layout {
+        width: min(100% - 24px, 1180px);
+      }
+
+      .hero h1 {
+        font-size: 1.72rem;
+      }
+
+      .grid,
+      .flow {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <div class="hero-inner">
+      <div>
+        <span class="label">Ludots Gap Report</span>
+        <h1>Ludots 索敌、警戒、炮台与 Order/GAS 映射缺口分析</h1>
+        <p>
+          这份报告按 OpenRA 的基础单位战斗模型反查 Ludots。结论不绕：Ludots 已有 Order、GAS、Team、TargetResolver、
+          Projectile、Navigation2D 的关键基础设施，但缺少一个可复用的单位级自动索敌模块，也缺少把 attack-move、guard、脱战、
+          炮台朝向纳入 Order/GAS 的正式合同。
+        </p>
+      </div>
+      <div class="summary" aria-label="结论摘要">
+        <b>直接结论</b>
+        <span>现有 FireballDuel 是 showcase-local 目标派发，不是通用 auto-target。</span>
+        <span>GAS Search 是效果命中 fan-out，不等于单位 idle 扫描和目标选择。</span>
+        <span>Order 管线足够承载结果，但还没有 attackMove / guard / stance 的标准 order 语义。</span>
+        <span>炮台目前主要停在表现和动画原型，没有 gameplay-authoritative turret state。</span>
+      </div>
+    </div>
+  </header>
+
+  <div class="layout">
+    <nav class="toc" aria-label="目录">
+      <h2>目录</h2>
+      <a href="#scope">1. 分析口径</a>
+      <a href="#existing">2. 现有可复用模块</a>
+      <a href="#not-enough">3. 不能误判为已具备</a>
+      <a href="#gap-table">4. 缺口表</a>
+      <a href="#order-map">5. 映射到 Order</a>
+      <a href="#gas-map">6. 映射到 GAS</a>
+      <a href="#targeting-module">7. Targeting 模块形状</a>
+      <a href="#turret">8. 炮台缺口</a>
+      <a href="#phases">9. 系统相位</a>
+      <a href="#acceptance">10. 验收测试</a>
+      <a href="#sequence">11. 建议顺序</a>
+      <a href="#sources">12. 证据索引</a>
+    </nav>
+
+    <main>
+      <section id="scope">
+        <span class="label">Scope</span>
+        <h2>1. 分析口径</h2>
+        <p>
+          这里不评价 Ludots 是否“有战斗系统”。Ludots 已经有 GAS、Effect、Projectile、Search、Team 关系、OrderQueue。
+          问题是：能不能像 OpenRA 一样，让任意 RTS 单位在 idle、被打、attack-move、guard、炮塔开火场景下，用同一套可配置规则完成自动战斗。
+        </p>
+        <div class="callout danger">
+          <p>
+            当前答案是不能。现有模块能执行“已知目标的能力释放”和“效果命中后的目标分发”，但没有生产级的“单位自行找目标并决定是否把能力释放 order 提交出去”的模块。
+          </p>
+        </div>
+      </section>
+
+      <section id="existing">
+        <span class="label">Existing Infrastructure</span>
+        <h2>2. 现有可复用模块</h2>
+        <div class="grid">
+          <div class="tile blue">
+            <h3>OrderQueue / OrderBuffer</h3>
+            <p><code>OrderQueue</code> 是跨系统入口；<code>OrderBufferSystem</code> 写 active/queued/pending，并把空间、实体、int 参数写进 blackboard。</p>
+          </div>
+          <div class="tile green">
+            <h3>CompositeOrderPlanner</h3>
+            <p>已支持范围外 <code>castAbility</code> 拆成 <code>moveTo</code> + continuation cast，说明“移动到施法点再放技能”的基础已经存在。</p>
+          </div>
+          <div class="tile teal">
+            <h3>MoveTo + Navigation2D</h3>
+            <p><code>MoveToWorldCmOrderSystem</code> 已能把 <code>moveTo</code> 转成 <code>NavGoal2D</code>，不是直接改速度或位置。</p>
+          </div>
+          <div class="tile violet">
+            <h3>AbilityExecSystem</h3>
+            <p>从 <code>OrderBuffer</code> 与 blackboard 读取 slot、target entity、target position，创建 <code>AbilityExecInstance</code>，再发布 EffectRequest。</p>
+          </div>
+          <div class="tile amber">
+            <h3>GAS Search / TargetResolver</h3>
+            <p><code>TargetResolverFanOutHelper</code> 支持空间查询、关系过滤、layer filter、max targets 和 payload effect fan-out。</p>
+          </div>
+          <div class="tile red">
+            <h3>Team / RelationshipFilter</h3>
+            <p><code>TeamManager</code> 与 <code>RelationshipFilter</code> 已能表达 Friendly、Hostile、Neutral、NotFriendly、NotHostile。</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="not-enough">
+        <span class="label">False Positives</span>
+        <h2>3. 不能误判为已具备</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>已有东西</th>
+                <th>为什么不等于 OpenRA 的能力</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>TargetSelector</code></td>
+                <td>它描述 ability target shape、relationship filter、range、radius，不保存单位当前目标、扫描间隔、警戒半径、last-seen、stance 或 priority profile。</td>
+              </tr>
+              <tr>
+                <td>GAS <code>Search</code></td>
+                <td>它发生在 effect resolve/apply 期间，用于“技能命中谁”。OpenRA 的 <code>AutoTarget</code> 发生在能力释放之前，用于“单位要不要提交攻击 order”。</td>
+              </tr>
+              <tr>
+                <td><code>CapabilityStandardFireballDuelSystem</code></td>
+                <td>它按固定红蓝队、anchor 和 wave cursor 提交 <code>castAbility</code>，目标是固定 anchor，不扫描周围敌人，不处理 stance、警戒、脱战、target priority。</td>
+              </tr>
+              <tr>
+                <td><code>RtsRelationRuntimeSystem</code></td>
+                <td>它处理施工挂接、出驻、亲子关系和选择可用性，不是战斗索敌或威胁系统。</td>
+              </tr>
+              <tr>
+                <td><code>AbilityExecAimSyncSystem</code></td>
+                <td>它是本地输入侧持续刷新瞄准点并可同步整机 <code>FacingDirection</code>，不是多炮塔 gameplay ready 检查。</td>
+              </tr>
+              <tr>
+                <td>Raylib tank turret rendering</td>
+                <td><code>RaylibPrimitiveRenderer</code> 里有 turret yaw 和 recoil 绘制，但动画验收文档明确说 tank turret yaw/recoil 仍在 adapter prototype layer，不是 gameplay authority。</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="gap-table">
+        <span class="label">Gap Table</span>
+        <h2>4. 缺口表</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>能力</th>
+                <th>当前状态</th>
+                <th>缺口</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>单位自动索敌</td>
+                <td><span class="status-gap">缺失</span></td>
+                <td>没有通用 <code>TargetingState</code> / scan system / scan interval / priority profile。现有 showcase 自己决定目标。</td>
+              </tr>
+              <tr>
+                <td>目标优先级</td>
+                <td><span class="status-gap">缺失</span></td>
+                <td>没有等价 <code>AutoTargetPriority</code> 的数据合同，无法按关系、target tag/layer、priority、条件切换 profile。</td>
+              </tr>
+              <tr>
+                <td>姿态</td>
+                <td><span class="status-gap">缺失</span></td>
+                <td>没有 entity-level <code>HoldFire / ReturnFire / Defend / AttackAnything</code> 语义，也没有 <code>setCombatStance</code> order。</td>
+              </tr>
+              <tr>
+                <td>被打反击</td>
+                <td><span class="status-gap">缺失</span></td>
+                <td>Effect/Gameplay event 有基础，但没有“受到敌对伤害后，如果 idle 且 stance 允许，则反击或重新扫描高优先级目标”的系统。</td>
+              </tr>
+              <tr>
+                <td>AttackMove</td>
+                <td><span class="status-partial">部分具备基础</span></td>
+                <td>移动与 cast continuation 已有，但缺少“移动过程中插入攻击，攻击结束恢复同一 attackMove 目标”的 active-order runtime。</td>
+              </tr>
+              <tr>
+                <td>Guard</td>
+                <td><span class="status-gap">缺失</span></td>
+                <td>没有 <code>guard</code> order、<code>GuardAnchor</code>、跟随半径、保护目标失效策略、守卫中插入攻击后恢复跟随。</td>
+              </tr>
+              <tr>
+                <td>脱战/放弃</td>
+                <td><span class="status-gap">缺失</span></td>
+                <td>没有 last-seen target、leash radius、target invalidation、target memory TTL、combat exit tag 或 idle transition。</td>
+              </tr>
+              <tr>
+                <td>炮台 gameplay</td>
+                <td><span class="status-partial">表现层有原型</span></td>
+                <td>没有 <code>TurretState</code>、turn speed、desired yaw、ready check、muzzle offset、ability activation 前的 turret gate。</td>
+              </tr>
+              <tr>
+                <td>GAS 发射与伤害</td>
+                <td><span class="status-good">可复用</span></td>
+                <td>这块不应该重写。自动索敌只应提交 <code>castAbility</code>，伤害、投射物、Search fan-out 继续走 GAS。</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="order-map">
+        <span class="label">Order Mapping</span>
+        <h2>5. 映射到 Order</h2>
+        <p>
+          OpenRA 的单位行为落到 Ludots，不应该让 targeting system 直接调用 GAS 内部实现，也不应该直接写 <code>NavDesiredVelocity2D</code>。
+          它应该把结果表达为标准 order 或 active-order runtime 状态。
+        </p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>OpenRA 概念</th>
+                <th>Ludots Order 映射</th>
+                <th>必要规则</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>SetUnitStance</code></td>
+                <td>新增 <code>setCombatStance</code> order；写入 <code>CombatStance</code> 或同等组件。</td>
+                <td>不能只作为 UI 状态。姿态必须参与 target scan、反击、attackMove profile 切换。</td>
+              </tr>
+              <tr>
+                <td>Idle auto-target</td>
+                <td>Targeting system 在单位 idle 且 stance 允许时提交 <code>castAbility</code> 或写入 auto-attack intent。</td>
+                <td>优先走 <code>OrderQueue</code> / <code>CompositeOrderPlanner</code>，让现有 blackboard 和 ability activation 接管。</td>
+              </tr>
+              <tr>
+                <td>AttackMove</td>
+                <td>新增 <code>attackMove</code> order，payload 使用 <code>OrderSpatialKind.WorldCm</code> 目标点，runtime 持有 authored destination。</td>
+                <td>移动子过程写 <code>NavGoal2D</code>；发现目标时提交/激活攻击；攻击结束后恢复同一个 attackMove destination。</td>
+              </tr>
+              <tr>
+                <td>Guard</td>
+                <td>新增 <code>guard</code> order，payload 使用 <code>Target</code> entity 和 guard radius。</td>
+                <td>目标失效时 order 完成或取消；守卫移动仍通过 <code>NavGoal2D</code>，不直接改位置。</td>
+              </tr>
+              <tr>
+                <td>Stop</td>
+                <td>复用 <code>StopOrderSystem</code> 与 <code>OrderSubmitter.CancelAll/CancelCurrent</code>。</td>
+                <td>Stop 必须清理 current target、guard anchor、attackMove runtime、turret aim desire。</td>
+              </tr>
+              <tr>
+                <td>被打反击</td>
+                <td>伤害事件转换为 retaliate intent；只有 idle 或可中断 order 才提交 <code>castAbility</code>。</td>
+                <td>不能在 damage effect 里直接开火，否则会绕过 Order/GAS 分层。</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="gas-map">
+        <span class="label">GAS Mapping</span>
+        <h2>6. 映射到 GAS</h2>
+        <p>
+          GAS 负责“能力释放之后发生什么”，Targeting/Order 负责“什么时候释放什么能力、朝谁释放”。这条线要分清，否则会把单位 AI 写进 effect phase。
+        </p>
+        <div class="flow" aria-label="建议链路">
+          <div class="flow-step">
+            <strong>Targeting Scan</strong>
+            <span>扫描 candidate，按 profile 选出 target entity 或 target point。</span>
+          </div>
+          <div class="flow-step">
+            <strong>OrderQueue</strong>
+            <span>提交 <code>castAbility</code>，携带 slot、target entity、target position。</span>
+          </div>
+          <div class="flow-step">
+            <strong>OrderBufferSystem</strong>
+            <span>把目标写进 <code>Cast_TargetEntity</code> / <code>Cast_TargetPosition</code> blackboard。</span>
+          </div>
+          <div class="flow-step">
+            <strong>AbilityExecSystem</strong>
+            <span>读取 blackboard，创建 <code>AbilityExecInstance</code>，执行 block tag 和 precondition。</span>
+          </div>
+          <div class="flow-step">
+            <strong>EffectRequest</strong>
+            <span>能力 timeline 发布 <code>LaunchProjectile</code>、<code>InstantDamage</code> 或其他 effect。</span>
+          </div>
+          <div class="flow-step">
+            <strong>Effect Processing</strong>
+            <span><code>Search</code> / TargetResolver 做命中 fan-out，关系过滤与 payload dispatch 在这里发生。</span>
+          </div>
+          <div class="flow-step">
+            <strong>Runtime Spawn</strong>
+            <span>投射物继续走 <code>RuntimeEntitySpawnQueue</code> 与 <code>ProjectileRuntimeSystem</code>。</span>
+          </div>
+        </div>
+        <div class="callout warn">
+          <p>
+            不要把 OpenRA 的 <code>ChooseTarget</code> 直接塞进 GAS <code>Search</code>。Search 是 effect 内部“命中谁”的解析；
+            auto-target 是 effect 之前“谁值得被释放能力”的解析。两者都用空间查询和关系过滤，但生命周期和输出完全不同。
+          </p>
+        </div>
+      </section>
+
+      <section id="targeting-module">
+        <span class="label">Targeting Module</span>
+        <h2>7. Targeting 模块形状</h2>
+        <p>
+          这里需要的是 Core 或可复用 capability 级模块，不是某个 showcase 里临时扫描。至少需要以下运行时状态与 authoring 配置。
+        </p>
+        <div class="two-col">
+          <div class="tile blue">
+            <h3>运行时组件</h3>
+            <ul>
+              <li><code>CombatStance</code>：HoldFire、ReturnFire、Defend、AttackAnything。</li>
+              <li><code>TargetingProfileRef</code>：实体使用哪套索敌配置。</li>
+              <li><code>TargetingState</code>：next scan tick、current target、source、reason。</li>
+              <li><code>TargetMemory</code>：last seen position、last valid tick、target owner/team snapshot。</li>
+              <li><code>AttackMoveState</code>：authored destination、当前是否被攻击子行为打断。</li>
+              <li><code>GuardAnchor</code>：被保护 entity、follow radius、leash policy。</li>
+              <li><code>CombatLeash</code>：最大追击距离、超出后放弃并返回原 order。</li>
+            </ul>
+          </div>
+          <div class="tile green">
+            <h3>配置字段</h3>
+            <ul>
+              <li><code>scanRadiusCm</code>、<code>scanIntervalMin/MaxTicks</code>。</li>
+              <li><code>validRelationship</code>，复用 <code>RelationshipFilter</code>。</li>
+              <li><code>validTags</code>、<code>invalidTags</code>、<code>layerMask</code>。</li>
+              <li><code>priority</code>，高优先级先于距离。</li>
+              <li><code>requiresTags</code> 或 condition，用于 stance / attackMove profile 切换。</li>
+              <li><code>abilitySlot</code> 或 attack ability id，用来提交 <code>castAbility</code>。</li>
+              <li><code>allowMove</code>、<code>allowTurn</code>、<code>leashRadiusCm</code>。</li>
+            </ul>
+          </div>
+        </div>
+        <div class="callout danger">
+          <p>
+            这里的缺口不是“缺一个函数”。缺的是一条 pipeline：空间候选、关系/tag/layer 过滤、priority 排序、距离 tie-break、
+            target memory、order 提交、order 完成后恢复。把这些散写在 AI showcase 里，会很快复制出多套不一致的自动攻击。
+          </p>
+        </div>
+      </section>
+
+      <section id="turret">
+        <span class="label">Turret Gap</span>
+        <h2>8. 炮台缺口</h2>
+        <p>
+          Ludots 已有 <code>FacingDirection</code>、<code>AbilityExecAimSync</code>、动画 <code>AimYawOffset</code>、Raylib tank turret 绘制。
+          这些不足以支撑 OpenRA 式炮台，因为它们没有决定“能不能开火”。
+        </p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>需要补的 gameplay 合同</th>
+                <th>原因</th>
+                <th>映射点</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>TurretState</code></td>
+                <td>保存当前 yaw、desired yaw、turn speed、ready tolerance、realign delay、turret name。</td>
+                <td>放在 gameplay ECS，不放在 Raylib renderer。</td>
+              </tr>
+              <tr>
+                <td><code>WeaponMount</code> / ability mount</td>
+                <td>能力或武器需要知道自己绑定哪个 turret，以及 muzzle offset。</td>
+                <td>可挂在 ability authoring 或 entity equipment/mount 配置上。</td>
+              </tr>
+              <tr>
+                <td>Turret Aim System</td>
+                <td>根据 current target 或 active cast target 逐 tick 转向，写 ready flag。</td>
+                <td>在 AbilityActivation 前运行，保证是否 ready 可被 order/ability 检查。</td>
+              </tr>
+              <tr>
+                <td>Ability precondition</td>
+                <td>炮塔未对准时，自动攻击不能直接释放 projectile。</td>
+                <td>走 <code>AbilityActivationPrecondition</code> 或新增标准 precondition，不绕过 <code>AbilityExecSystem</code>。</td>
+              </tr>
+              <tr>
+                <td>Muzzle resolve</td>
+                <td>投射物起点应来自炮塔/炮管 offset，而不是总从 actor 中心发射。</td>
+                <td><code>LaunchProjectile</code> caller params 或 spawn request 需要接收 resolved muzzle。</td>
+              </tr>
+              <tr>
+                <td>Presentation bridge</td>
+                <td>表现应消费 gameplay turret yaw/recoil，而不是自己推导一个并影响不了开火。</td>
+                <td>Animator / performer 读取 <code>TurretState</code> 快照，Raylib/UE5/Unity 都同源。</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="phases">
+        <span class="label">System Phase</span>
+        <h2>9. 系统相位</h2>
+        <p>
+          目标选择应该在 Order 和 Ability 之前完成，但不要写进输入系统。建议拆成两个系统层次。
+        </p>
+        <div class="grid">
+          <div class="tile blue">
+            <h3>Intent 生成</h3>
+            <p><code>AutoTargetAcquisitionSystem</code> 在 <code>InputCollection</code> 或紧邻 order intake 前运行，扫描并提交 <code>OrderQueue</code>。</p>
+          </div>
+          <div class="tile teal">
+            <h3>Order runtime</h3>
+            <p><code>AttackMoveOrderSystem</code> / <code>GuardOrderSystem</code> 维护 active order 的恢复、跟随、完成、取消。</p>
+          </div>
+          <div class="tile green">
+            <h3>Navigation sink</h3>
+            <p>需要移动时只写 <code>NavGoal2D</code>，不直接写 <code>NavDesiredVelocity2D</code>、<code>ForceInput2D</code> 或位置。</p>
+          </div>
+          <div class="tile amber">
+            <h3>Ability gate</h3>
+            <p>炮塔 ready、silence/disarm/stun、射程预条件进入 <code>AbilityActivation</code>，失败则 cancel/promote order。</p>
+          </div>
+          <div class="tile violet">
+            <h3>Effect</h3>
+            <p>伤害、Search、投射物、on-hit 继续放在 <code>EffectProcessing</code>。不要让 targeting system 私算伤害。</p>
+          </div>
+          <div class="tile red">
+            <h3>Cleanup</h3>
+            <p>Stop、死亡、目标失效、team 改变时清理 target memory、guard anchor、turret desired aim 和 continuation。</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="acceptance">
+        <span class="label">Acceptance</span>
+        <h2>10. 验收测试</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>测试</th>
+                <th>必须证明什么</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>priority 高于距离</td>
+                <td>高优先级远目标压过低优先级近目标；同优先级才选最近。</td>
+              </tr>
+              <tr>
+                <td>stance gate</td>
+                <td>HoldFire 不扫，ReturnFire 只反击，Defend 不主动追，AttackAnything 可追击。</td>
+              </tr>
+              <tr>
+                <td>attackMove 恢复</td>
+                <td>单位移动途中发现敌人，攻击结束后继续原 attackMove destination。</td>
+              </tr>
+              <tr>
+                <td>guard 跟随</td>
+                <td>守卫单位保持 guard radius；插入攻击后回到保护目标；保护目标死亡后 order 清理。</td>
+              </tr>
+              <tr>
+                <td>last-seen 脱战</td>
+                <td>目标失效或离视野后追到最后位置；超时或到达后放弃。</td>
+              </tr>
+              <tr>
+                <td>炮塔 ready</td>
+                <td>目标在射程内但炮塔未转到位时不产生 <code>LaunchProjectile</code>；转到位后才释放。</td>
+              </tr>
+              <tr>
+                <td>Order/GAS 合同</td>
+                <td>自动索敌只能通过 <code>OrderQueue(castAbility)</code> 进入 <code>AbilityExecSystem</code>，不能直接发布 effect 或 spawn projectile。</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="sequence">
+        <span class="label">Implementation Sequence</span>
+        <h2>11. 建议顺序</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>优先级</th>
+                <th>切片</th>
+                <th>理由</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>P0</td>
+                <td>Target identity 与 profile</td>
+                <td>先定义 <code>CombatStance</code>、<code>TargetingProfile</code>、<code>TargetingState</code>，否则 attackMove/guard 都会各写一套。</td>
+              </tr>
+              <tr>
+                <td>P0</td>
+                <td>AutoTargetAcquisitionSystem</td>
+                <td>实现空间候选、关系/tag/layer 过滤、priority、scan interval，并提交 <code>castAbility</code>。</td>
+              </tr>
+              <tr>
+                <td>P1</td>
+                <td>attackMove active order runtime</td>
+                <td>复用 <code>moveTo</code> / <code>NavGoal2D</code>，补“攻击插入后恢复移动”的运行时状态。</td>
+              </tr>
+              <tr>
+                <td>P1</td>
+                <td>guard runtime</td>
+                <td>在 attackMove runtime 上增加 protected target 和 follow radius，不独立造一套战斗循环。</td>
+              </tr>
+              <tr>
+                <td>P1</td>
+                <td>disengage / leash</td>
+                <td>补 last-seen、TTL、leash、target invalidation，避免单位无限追杀或目标失效后卡 active order。</td>
+              </tr>
+              <tr>
+                <td>P1</td>
+                <td>gameplay turret</td>
+                <td>炮台一旦影响开火，就必须先有 authoritative state，再接表现。</td>
+              </tr>
+              <tr>
+                <td>P2</td>
+                <td>UI 与 debug overlay</td>
+                <td>显示 stance、current target、scan radius、guard link、turret ready，用来调试但不能先于核心语义。</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="sources">
+        <span class="label">Evidence</span>
+        <h2>12. 证据索引</h2>
+        <ul class="source-list">
+          <li><a href="../architecture/gas_layered_architecture.md">gas_layered_architecture.md</a></li>
+          <li><a href="../architecture/gas_combat_infrastructure.md">gas_combat_infrastructure.md</a></li>
+          <li><a href="../architecture/order_navigation_movement.md">order_navigation_movement.md</a></li>
+          <li><a href="../architecture/interaction/order_continuation_and_composite_planning.md">order_continuation_and_composite_planning.md</a></li>
+          <li><a href="../architecture/interaction/order_navigation_backed_move_runtime.md">order_navigation_backed_move_runtime.md</a></li>
+          <li><a href="../../gitbook/architecture/capability-standard-showcases.md">capability-standard-showcases.md</a></li>
+          <li><a href="../../src/Core/Gameplay/GAS/Orders/OrderQueue.cs">OrderQueue.cs</a></li>
+          <li><a href="../../src/Core/Gameplay/GAS/Systems/OrderBufferSystem.cs">OrderBufferSystem.cs</a></li>
+          <li><a href="../../src/Core/Gameplay/GAS/Orders/OrderSubmitter.cs">OrderSubmitter.cs</a></li>
+          <li><a href="../../src/Core/Gameplay/GAS/Orders/CompositeOrderPlanner.cs">CompositeOrderPlanner.cs</a></li>
+          <li><a href="../../src/Core/Gameplay/GAS/Systems/MoveToWorldCmOrderSystem.cs">MoveToWorldCmOrderSystem.cs</a></li>
+          <li><a href="../../src/Core/Gameplay/GAS/Systems/AbilityExecSystem.cs">AbilityExecSystem.cs</a></li>
+          <li><a href="../../src/Core/Gameplay/GAS/TargetResolverFanOutHelper.cs">TargetResolverFanOutHelper.cs</a></li>
+          <li><a href="../../src/Core/Gameplay/Teams/RelationshipFilter.cs">RelationshipFilter.cs</a></li>
+          <li><a href="../../src/Core/Gameplay/Teams/TeamManager.cs">TeamManager.cs</a></li>
+          <li><a href="../../mods/showcases/capability_standard/CapabilityStandardFireballDuelMod/Systems/CapabilityStandardFireballDuelSystem.cs">CapabilityStandardFireballDuelSystem.cs</a></li>
+          <li><a href="../../mods/showcases/capability_standard/CapabilityStandardFireballDuelMod/assets/GAS/effects.json">FireballDuel effects.json</a></li>
+          <li><a href="../../mods/RtsDemoMod/Systems/RtsRelationRuntimeSystem.cs">RtsRelationRuntimeSystem.cs</a></li>
+          <li><a href="../../mods/CoreInputMod/Systems/AbilityExecAimSyncSystem.cs">AbilityExecAimSyncSystem.cs</a></li>
+          <li><a href="../../src/Client/Ludots.Client.Raylib/Rendering/RaylibPrimitiveRenderer.cs">RaylibPrimitiveRenderer.cs</a></li>
+          <li><a href="../../mods/fixtures/animation/AnimationAcceptanceMod/Runtime/AnimationAcceptanceRigCatalog.cs">AnimationAcceptanceRigCatalog.cs</a></li>
+        </ul>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/reference/ludots_utility_ai_soa_openra_behavior_architecture.html
+++ b/docs/reference/ludots_utility_ai_soa_openra_behavior_architecture.html
@@ -1,0 +1,1486 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ludots 通用 Utility AI SoA 架构方案</title>
+  <style>
+    :root {
+      --ink: #18212a;
+      --muted: #5f6d7a;
+      --line: #d9e1ea;
+      --soft: #f5f7fa;
+      --paper: #ffffff;
+      --night: #17202a;
+      --blue: #2563eb;
+      --blue-soft: #edf4ff;
+      --green: #2f855a;
+      --green-soft: #edf7f1;
+      --amber: #b45309;
+      --amber-soft: #fff4df;
+      --red: #b42318;
+      --red-soft: #fff0ee;
+      --teal: #0f766e;
+      --teal-soft: #e9f7f5;
+      --violet: #6d28d9;
+      --violet-soft: #f1edff;
+      --radius: 8px;
+      --shadow: 0 8px 24px rgba(24, 33, 42, 0.07);
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      font-family: "Segoe UI", "Microsoft YaHei", Arial, sans-serif;
+      color: var(--ink);
+      background: var(--paper);
+      line-height: 1.72;
+      letter-spacing: 0;
+    }
+
+    a { color: var(--blue); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    code {
+      font-family: Consolas, "Cascadia Mono", "SFMono-Regular", monospace;
+      font-size: 0.92em;
+      background: #eef2f6;
+      border: 1px solid #d8e0e8;
+      border-radius: 6px;
+      padding: 0.08rem 0.32rem;
+      overflow-wrap: anywhere;
+    }
+
+    pre {
+      margin: 0;
+      overflow-x: auto;
+      white-space: pre;
+      font-family: Consolas, "Cascadia Mono", "SFMono-Regular", monospace;
+      font-size: 0.86rem;
+      line-height: 1.56;
+      background: #111827;
+      color: #e5edf7;
+      border-radius: var(--radius);
+      padding: 16px;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.94rem;
+      background: #fff;
+    }
+
+    th, td {
+      border: 1px solid var(--line);
+      padding: 10px 12px;
+      vertical-align: top;
+      text-align: left;
+    }
+
+    th {
+      background: #f0f4f8;
+      font-weight: 750;
+    }
+
+    .hero {
+      color: #f8fafc;
+      background: var(--night);
+      border-bottom: 6px solid var(--teal);
+    }
+
+    .hero-inner {
+      width: min(1220px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: 46px 0 40px;
+      display: grid;
+      grid-template-columns: minmax(0, 1.15fr) minmax(300px, 0.85fr);
+      gap: 28px;
+      align-items: end;
+    }
+
+    .hero h1 {
+      margin: 0 0 16px;
+      max-width: 900px;
+      font-size: 2.24rem;
+      line-height: 1.16;
+      font-weight: 850;
+      letter-spacing: 0;
+    }
+
+    .hero p {
+      margin: 0;
+      max-width: 900px;
+      color: #dfe7f0;
+      font-size: 1.02rem;
+    }
+
+    .summary {
+      display: grid;
+      gap: 12px;
+      padding: 18px;
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      border-radius: var(--radius);
+      background: rgba(255, 255, 255, 0.08);
+      box-shadow: var(--shadow);
+    }
+
+    .summary b { color: #ffffff; font-size: 1.02rem; }
+    .summary span { color: #dfe7f0; font-size: 0.93rem; }
+
+    .layout {
+      width: min(1220px, calc(100% - 32px));
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: 278px minmax(0, 1fr);
+      gap: 28px;
+      padding: 32px 0 72px;
+    }
+
+    .toc {
+      position: sticky;
+      top: 18px;
+      align-self: start;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #fff;
+      box-shadow: var(--shadow);
+      padding: 18px;
+      max-height: calc(100vh - 36px);
+      overflow: auto;
+    }
+
+    .toc strong {
+      display: block;
+      margin-bottom: 10px;
+      font-size: 0.96rem;
+    }
+
+    .toc a {
+      display: block;
+      padding: 7px 0;
+      color: #334155;
+      border-top: 1px solid #eef2f6;
+      font-size: 0.92rem;
+    }
+
+    .content { display: grid; gap: 28px; min-width: 0; }
+
+    section {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #fff;
+      box-shadow: var(--shadow);
+      padding: 24px;
+    }
+
+    section h2 {
+      margin: 0 0 14px;
+      font-size: 1.46rem;
+      line-height: 1.28;
+      letter-spacing: 0;
+    }
+
+    section h3 {
+      margin: 22px 0 10px;
+      font-size: 1.1rem;
+      letter-spacing: 0;
+    }
+
+    section p { margin: 10px 0; }
+    section ul, section ol { margin: 10px 0 0; padding-left: 1.25rem; }
+    section li { margin: 6px 0; }
+
+    .lead {
+      color: #39495a;
+      font-size: 1.02rem;
+    }
+
+    .verdict {
+      border-left: 5px solid var(--red);
+      background: var(--red-soft);
+      padding: 14px 16px;
+      border-radius: 0 var(--radius) var(--radius) 0;
+      margin: 16px 0;
+    }
+
+    .ok {
+      border-left: 5px solid var(--green);
+      background: var(--green-soft);
+      padding: 14px 16px;
+      border-radius: 0 var(--radius) var(--radius) 0;
+      margin: 16px 0;
+    }
+
+    .note {
+      border-left: 5px solid var(--blue);
+      background: var(--blue-soft);
+      padding: 14px 16px;
+      border-radius: 0 var(--radius) var(--radius) 0;
+      margin: 16px 0;
+    }
+
+    .warn {
+      border-left: 5px solid var(--amber);
+      background: var(--amber-soft);
+      padding: 14px 16px;
+      border-radius: 0 var(--radius) var(--radius) 0;
+      margin: 16px 0;
+    }
+
+    .grid-2 {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+    }
+
+    .grid-3 {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 14px;
+    }
+
+    .metric {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 14px;
+      background: #fff;
+    }
+
+    .metric b {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 1.02rem;
+    }
+
+    .metric span {
+      display: block;
+      color: var(--muted);
+      font-size: 0.93rem;
+    }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      min-height: 26px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 2px 8px;
+      margin: 2px 4px 2px 0;
+      background: #fff;
+      color: #334155;
+      font-size: 0.82rem;
+      letter-spacing: 0;
+    }
+
+    .tag.green { background: var(--green-soft); border-color: #b7dfc6; color: #1f6844; }
+    .tag.red { background: var(--red-soft); border-color: #f0b8b1; color: #8f1f16; }
+    .tag.amber { background: var(--amber-soft); border-color: #f2d19a; color: #8a4a05; }
+    .tag.blue { background: var(--blue-soft); border-color: #bfd3fb; color: #1e4fc4; }
+    .tag.teal { background: var(--teal-soft); border-color: #b5e2dc; color: #0c5c55; }
+    .tag.violet { background: var(--violet-soft); border-color: #d5c9ff; color: #5421aa; }
+
+    .flow {
+      display: grid;
+      gap: 8px;
+      margin: 16px 0;
+    }
+
+    .flow-row {
+      display: grid;
+      grid-template-columns: 180px minmax(0, 1fr);
+      gap: 10px;
+      align-items: stretch;
+    }
+
+    .flow-key {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 10px;
+      background: #f8fafc;
+      font-weight: 750;
+      text-align: center;
+      min-height: 52px;
+    }
+
+    .flow-val {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 10px 12px;
+      background: #fff;
+      min-height: 52px;
+    }
+
+    .pipe {
+      display: grid;
+      grid-template-columns: repeat(7, minmax(110px, 1fr));
+      gap: 8px;
+      margin: 16px 0;
+    }
+
+    .pipe div {
+      min-height: 74px;
+      padding: 10px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #f8fafc;
+    }
+
+    .pipe b {
+      display: block;
+      margin-bottom: 6px;
+      color: #0f172a;
+    }
+
+    .pipe span {
+      display: block;
+      color: var(--muted);
+      font-size: 0.88rem;
+    }
+
+    .layer-map {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 14px;
+      margin: 16px 0;
+    }
+
+    .stack {
+      display: grid;
+      gap: 8px;
+    }
+
+    .band {
+      border: 1px solid var(--line);
+      border-left: 6px solid var(--blue);
+      border-radius: var(--radius);
+      background: #fff;
+      padding: 10px 12px;
+    }
+
+    .band.green { border-left-color: var(--green); background: var(--green-soft); }
+    .band.amber { border-left-color: var(--amber); background: var(--amber-soft); }
+    .band.red { border-left-color: var(--red); background: var(--red-soft); }
+    .band.teal { border-left-color: var(--teal); background: var(--teal-soft); }
+    .band.violet { border-left-color: var(--violet); background: var(--violet-soft); }
+
+    .decision-card {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 14px;
+      background: #fff;
+    }
+
+    .decision-card h3 { margin-top: 0; }
+
+    .matrix td:first-child, .matrix th:first-child {
+      width: 22%;
+      font-weight: 750;
+    }
+
+    .phase {
+      display: grid;
+      grid-template-columns: 68px minmax(0, 1fr);
+      gap: 12px;
+      border-top: 1px solid #eef2f6;
+      padding: 14px 0;
+    }
+
+    .phase:first-child { border-top: 0; }
+
+    .phase-num {
+      width: 50px;
+      height: 50px;
+      border-radius: var(--radius);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--night);
+      color: #fff;
+      font-weight: 800;
+    }
+
+    .phase h3 {
+      margin: 0 0 6px;
+    }
+
+    .compact-list {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 8px 16px;
+      padding-left: 0;
+      list-style: none;
+    }
+
+    .compact-list li {
+      border: 1px solid #e5ebf2;
+      border-radius: var(--radius);
+      padding: 8px 10px;
+      margin: 0;
+      background: #fbfdff;
+    }
+
+    .sources li { overflow-wrap: anywhere; }
+
+    @media (max-width: 980px) {
+      .hero-inner, .layout, .grid-2, .grid-3, .layer-map {
+        grid-template-columns: 1fr;
+      }
+
+      .toc { position: relative; top: auto; max-height: none; }
+      .pipe { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .compact-list { grid-template-columns: 1fr; }
+    }
+
+    @media (max-width: 560px) {
+      .hero h1 { font-size: 1.72rem; }
+      section { padding: 18px; }
+      .flow-row { grid-template-columns: 1fr; }
+      .pipe { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <div class="hero-inner">
+      <div>
+        <h1>Ludots 通用 Utility AI SoA 架构方案</h1>
+        <p>
+          目标不是再写一个局部 Bot，而是把现有 Utility / GOAP / HTN 雏形深化成一套通用 AI Module：
+          SoA 热路径、0Alloc 运行、配置驱动 OpenRA 基础单位行为、Order 与 Ability 分离、Decision 与 Execution 分离、评分机制数据驱动、Graph 函数可扩展。
+        </p>
+      </div>
+      <div class="summary">
+        <b>结论</b>
+        <span>远端与本地已有 AI 骨架，但没有覆盖 Uintel 式完整 AI 基建。应复用现有 AI / Order / GAS / Graph / Team / Spatial 基建，补齐目标过滤、感知、decision-target pair 评分、执行器、姿态、索敌、执行前置条件和 OpenRA 行为包。</span>
+      </div>
+    </div>
+  </header>
+
+  <div class="layout">
+    <nav class="toc">
+      <strong>目录</strong>
+      <a href="#answer">1. 直接回答</a>
+      <a href="#evidence">2. 远端 PR 与本地现状</a>
+      <a href="#uintel">3. Uintel 文档拆解</a>
+      <a href="#gap">4. 当前缺口</a>
+      <a href="#target">5. 目标架构</a>
+      <a href="#runtime">6. SoA / 0Alloc 运行时</a>
+      <a href="#scoring">7. 评分与 Graph</a>
+      <a href="#orders">8. Order / Ability 映射</a>
+      <a href="#openra">9. OpenRA 行为配置包</a>
+      <a href="#readiness">10. 执行器就绪门控</a>
+      <a href="#systems">11. SystemGroup 排布</a>
+      <a href="#schema">12. 配置 Schema 草案</a>
+      <a href="#phases">13. 落地阶段</a>
+      <a href="#tests">14. 验收标准</a>
+      <a href="#sources">15. 证据来源</a>
+    </nav>
+
+    <main class="content">
+      <section id="answer">
+        <h2>1. 直接回答</h2>
+        <div class="verdict">
+          <b>远端 PR 有没有已经处理类似 Uintel 的 AI 基建？</b>
+          <p>
+            没有发现一个已经覆盖“完整通用 Utility AI / SoA runtime / decision-target pair / 数据化评分 / OpenRA 基础行为”的远端 PR。
+            但远端 `origin/main` 和当前本地已经有 AI 骨架：`UtilityGoalSelectorCompiled256`、`GoapAStarPlanner256`、`HtnPlanner256`、`AIPlanExecutionSystem`、`AiConfigLoader`、`AIDemoMod`、`AIInspectorMod`。
+          </p>
+        </div>
+        <div class="ok">
+          <b>现有 AI 基建有没有这块内容？</b>
+          <p>
+            有一半：已经有 goal 级 utility、256-bit world state、GOAP/HTN plan、plan 到 `OrderQueue` 的提交、10k agent 0Alloc benchmark。
+            没有另一半：没有通用 target filter、没有 decision-target pair 评分、没有输入归一化与曲线库、没有 OpenRA 式 stance / auto-target / attack-move / guard / disengage / 执行器就绪门控，也没有发现 AI 系统已接进 `GameEngine` 主循环。
+          </p>
+        </div>
+        <div class="note">
+          <b>推荐方向</b>
+          <p>
+            不要另起一套平行 AI。应把 `src/Core/Gameplay/AI` 深化成一个深 Module：配置编译为只读数组，运行时用 SoA runtime 和固定 scratch，decision 只产出 intent，execution 只提交 Order，Ability 和 Effect 仍由 GAS 负责。
+          </p>
+        </div>
+
+        <div class="grid-3">
+          <div class="metric">
+            <b>复用</b>
+            <span>现有 AI / Order / GAS / Graph / Spatial / Team / Relationship / Navigation2D。</span>
+          </div>
+          <div class="metric">
+            <b>新增</b>
+            <span>Perception、TargetFilter、Input、Normalization、Consideration、Decision、Executor、Stance、CombatMemory、ActuatorReadiness。</span>
+          </div>
+          <div class="metric">
+            <b>原则</b>
+            <span>AI 不直接扣血、不生成 Effect、不绕过 Order 校验；所有战斗执行仍走 Order 和 GAS。</span>
+          </div>
+        </div>
+      </section>
+
+      <section id="evidence">
+        <h2>2. 远端 PR 与本地现状</h2>
+        <p class="lead">
+          这里的判断来自 `gh pr list`、`gh search prs`、`git ls-tree origin/main`、本地 `rg` 与源码读取。结论不是“没有 AI”，而是“现有 AI 还不是一套可承载 OpenRA 基础行为的通用 AI Module”。
+        </p>
+
+        <h3>远端 PR 证据</h3>
+        <table>
+          <thead>
+            <tr>
+              <th>项</th>
+              <th>状态</th>
+              <th>判断</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Open PR 搜索 `Utility / GOAP / HTN / Decision / Scoring / AutoTarget / AIPlan`</td>
+              <td>无命中</td>
+              <td>没有看到专门处理 Uintel 式通用 AI 基建的开放 PR。</td>
+            </tr>
+            <tr>
+              <td>PR #39 `feat(ui): ship native runtime showcase baseline`</td>
+              <td>开放</td>
+              <td>历史 diff 涉及 AI glue、OrderQueue、AbilityExec 等，但主题不是完整 AI 基建。</td>
+            </tr>
+            <tr>
+              <td>PR #35 `refactor(gas): converge order and interaction governance`</td>
+              <td>已合并</td>
+              <td>处理过 AI plan 到 Order/GAS 收敛的一部分，是现有骨架来源之一。</td>
+            </tr>
+            <tr>
+              <td>PR #42 / #43 `feat(nav2d-soa-merge`</td>
+              <td>已合并</td>
+              <td>Navigation2D SoA，不是 AI SoA runtime。</td>
+            </tr>
+            <tr>
+              <td>PR #87 Relationship showcase</td>
+              <td>开放</td>
+              <td>Threat / Focus 可作为 AI 输入来源，但不是自动战斗 AI 本体。</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>本地已有 AI 骨架</h3>
+        <div class="grid-2">
+          <div>
+            <ul>
+              <li><code>src/Core/Gameplay/AI/Utility/UtilityGoalSelectorCompiled256.cs</code>：goal 级 utility，多 consideration 乘法，已有 momentum / compensation 开关。</li>
+              <li><code>src/Core/Gameplay/AI/Planning/GoapAStarPlanner256.cs</code>：GOAP A*，用 256-bit world state。</li>
+              <li><code>src/Core/Gameplay/AI/Planning/HtnPlanner256.cs</code>：HTN planning。</li>
+              <li><code>src/Core/Gameplay/AI/Config/AiConfigLoader.cs</code>：从 `ConfigPipeline` 编译 AI 配置。</li>
+              <li><code>src/Core/Gameplay/AI/Systems/AIPlanExecutionSystem.cs</code>：把 action 通过 `PlanExecutor` 提交到 `OrderQueue`。</li>
+            </ul>
+          </div>
+          <div>
+            <ul>
+              <li><code>src/Tests/GasTests/AiBenchmarkTests.cs</code>：覆盖 `Utility+GOAP+OrderSubmit` 10k agent 零分配。</li>
+              <li><code>mods/AIDemoMod/assets/Configs/AI/*.json</code>：有最小 AI 配置样例。</li>
+              <li><code>mods/AIInspectorMod</code>：能打印 AI config。</li>
+              <li><code>GameEngine.AiRuntime</code>：加载和热重建已存在。</li>
+              <li>当前源码搜索未发现 AI 系统注册到主循环的证据。</li>
+            </ul>
+          </div>
+        </div>
+
+        <h3>本地可复用基础设施</h3>
+        <ul class="compact-list">
+          <li><code>ConfigPipeline</code> / <code>ConfigCatalog</code>：AI 配置必须走这里。</li>
+          <li><code>OrderQueue</code> / <code>OrderBufferSystem</code> / <code>OrderSubmitter</code>：AI 执行必须提交 Order。</li>
+          <li><code>OrderTypeRegistry</code> / <code>OrderRuleRegistry</code>：Order 校验、打断、队列策略继续复用。</li>
+          <li><code>AbilityDefinitionRegistry</code> / <code>AbilityExecSystem</code>：攻击、施法、技能执行继续归 GAS。</li>
+          <li><code>GraphExecutor.ExecuteScore</code> / <code>GraphProgramRegistry</code>：AI 自定义评分函数可复用 Graph VM。</li>
+          <li><code>TargetResolverFanOutHelper</code>：目标查询和过滤的分层思想可复用，但 AI 需要自己的无副作用版本。</li>
+          <li><code>ISpatialQueryService</code> / <code>WorldPositionCm</code> / <code>SpatialPartitionUpdateSystem</code>：索敌候选来源。</li>
+          <li><code>TeamManager</code> / <code>RelationshipFilter</code> / Relationship runtime：敌我关系、Threat、Focus 输入来源。</li>
+          <li><code>Navigation2D</code> / <code>NavGoal2D</code> / <code>MoveToWorldCmOrderSystem</code>：移动执行路径。</li>
+          <li><code>BlackboardIntBuffer</code> / <code>BlackboardEntityBuffer</code> / <code>BlackboardSpatialBuffer</code>：Order 参数和 AI runtime 共享槽。</li>
+        </ul>
+      </section>
+
+      <section id="uintel">
+        <h2>3. Uintel 文档拆解</h2>
+        <p class="lead">
+          Uintel ECS 文档的关键不是 Unity DOTS 细节，而是清晰的职责链：感知输入、归一化、consideration、decision、decision maker、action task。运行时再拆成决策阶段和执行阶段。
+        </p>
+
+        <div class="pipe">
+          <div><b>Input</b><span>读取 agent、target、环境、blackboard，输出 raw input。</span></div>
+          <div><b>Normalization</b><span>把 raw input 归一到 0..1。</span></div>
+          <div><b>Consideration</b><span>input + normalization + response curve。</span></div>
+          <div><b>Decision</b><span>一组 considerations + target filters + action tasks。</span></div>
+          <div><b>DecisionMaker</b><span>在 decision-target pair 中选最高分。</span></div>
+          <div><b>State Machine</b><span>控制当前 decision 切换，处理 momentum。</span></div>
+          <div><b>ActionTask</b><span>Sequence / Parallel / ParallelComplete 执行。</span></div>
+        </div>
+
+        <h3>最值得复刻的思想</h3>
+        <table class="matrix">
+          <thead>
+            <tr>
+              <th>Uintel 思路</th>
+              <th>对 Ludots 的价值</th>
+              <th>不能照搬的部分</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Decision-making 与 execution 分离</td>
+              <td>可以保证 scoring 是纯读，execution 才提交 Order，符合 Ludots Order/GAS 职责。</td>
+              <td>不要把 Unity job/executor 类型原样搬进 Ludots。</td>
+            </tr>
+            <tr>
+              <td>Decision-target pair 评分</td>
+              <td>非常适合索敌、守卫、攻击、修理、采集、运输等“动作和目标一起选”的 RTS 行为。</td>
+              <td>不能只做 goal 级评分，否则无法表达“打谁”。</td>
+            </tr>
+            <tr>
+              <td>Target filter 前置裁剪</td>
+              <td>先用关系、layer、tag、距离、视野、武器资格过滤，避免对全场实体跑评分。</td>
+              <td>不要用 managed LINQ / 临时 List 做热路径筛选。</td>
+            </tr>
+            <tr>
+              <td>Blob + runtime executor</td>
+              <td>对应 Ludots 的 compiled arrays + SoA runtime：配置只读，执行状态独立。</td>
+              <td>不照搬 Unity BlobAssetReference / Baker / SubScene。</td>
+            </tr>
+            <tr>
+              <td>Blackboard</td>
+              <td>Ludots 已有黑板 buffer，可承载 Order 参数、感知记忆、target cache。</td>
+              <td>不要新增平行黑板协议；要复用现有 blackboard key registry。</td>
+            </tr>
+            <tr>
+              <td>Optimization tricks</td>
+              <td>决策间隔、跨帧分摊、target filter、并行/分桶、固定内存池都适合 Ludots。</td>
+              <td>“启用 Burst”这类 Unity 专属项不能照搬。</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="warn">
+          <b>和 Ludots 规范冲突的一点</b>
+          <p>
+            Uintel 文档里提到 fallback decision / idle fallback 的设计。在 Ludots 里不应做平台级 fallback。Idle、Hold、ReturnFire 都应是显式配置的 decision 或 order state；配置缺失时 fail-fast，而不是运行时兜底。
+          </p>
+        </div>
+      </section>
+
+      <section id="gap">
+        <h2>4. 当前缺口</h2>
+        <p class="lead">
+          现有 Ludots AI 的 Interface 还偏窄：它能“选 goal、做 plan、提交 order”，但还不能表达“对哪个目标、为什么此时切换、怎么持续执行、什么时候脱战、执行器当前是否满足开火/施法前置条件”。
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>缺口</th>
+              <th>当前表现</th>
+              <th>需要补的 Module</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>目标候选与过滤</td>
+              <td>Input mapping 有 `AutoTargetPolicy`，GAS TargetResolver 有 fan-out，但没有 AI 通用无副作用 target filter。</td>
+              <td><code>AITargetFilterCompiled</code>、<code>AITargetAcquisitionSystem</code>。</td>
+            </tr>
+            <tr>
+              <td>decision-target pair</td>
+              <td>Utility 只选 goal，不选目标。</td>
+              <td><code>AIDecisionEvaluator</code>、<code>AITargetCandidateSoA</code>、<code>AIDecisionIntent</code>。</td>
+            </tr>
+            <tr>
+              <td>输入归一化和曲线</td>
+              <td>目前是 bool consideration，无法表达距离曲线、血量曲线、威胁分、优先级桶。</td>
+              <td><code>AIInputProviderRegistry</code>、<code>AINormalizationCompiled</code>、<code>AIResponseCurveCompiled</code>。</td>
+            </tr>
+            <tr>
+              <td>执行持续性</td>
+              <td>Plan action 提交 Order 后就 advance，缺少 action task 的 running / finished / cancel 语义。</td>
+              <td><code>AIExecutionStateSoA</code>、<code>AITaskExecutor</code>。</td>
+            </tr>
+            <tr>
+              <td>OpenRA 基础行为</td>
+              <td>Order blackboard 已有 Attack/Move/Stop/Hold/Patrol key，但缺 attack-move、guard、stance、retaliate、auto-target runtime。</td>
+              <td><code>OpenRaBehaviorPack</code> 配置和 executor adapters。</td>
+            </tr>
+            <tr>
+              <td>脱战/警戒/索敌</td>
+              <td>没有通用 target memory、last seen、leash、scan interval、target priority。</td>
+              <td><code>AICombatMemory</code>、<code>AIStanceProfile</code>、<code>AIAutoTargetProfile</code>。</td>
+            </tr>
+            <tr>
+              <td>执行器就绪门控</td>
+              <td>攻击、施法、采集、建造、炮台转向都可能有“正在准备但尚不能执行”的 gameplay 状态；目前 AI 没有统一读取这类 readiness 的入口。</td>
+              <td><code>ActuatorReadinessInput</code>、<code>AimGate</code>、<code>AbilityPreconditionAdapter</code>；炮台只是一个 adapter 案例。</td>
+            </tr>
+            <tr>
+              <td>主循环接入</td>
+              <td>`AiRuntime` 会加载，但当前搜索未发现 AI systems 注册到 `GameEngine` simulation loop。</td>
+              <td>AI bootstrap / SystemFactory / SystemGroup 排布。</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="target">
+        <h2>5. 目标架构</h2>
+        <p class="lead">
+          目标是一个深 Module：外部 Interface 是“给 agent 配 AI profile，系统自动产出 Order intent”；内部 Implementation 才包含 perception、filters、inputs、scoring、task executor、OpenRA 行为包。
+        </p>
+
+        <div class="layer-map">
+          <div class="stack">
+            <div class="band red"><b>Authoring Layer</b><br>Mod 配置：AI profile、filters、inputs、curves、decisions、tasks、stance、actuator readiness adapters。</div>
+            <div class="band amber"><b>Compile Layer</b><br>ConfigPipeline 合并后编译为 id、array、range、programId；热路径不保留 string。</div>
+            <div class="band teal"><b>Decision Layer</b><br>target candidates、raw inputs、normalization、consideration、decision-target pair score。</div>
+            <div class="band violet"><b>Execution Layer</b><br>Sequence / Parallel task executor，输出 Order intent，不直接触发 Effect。</div>
+            <div class="band green"><b>Gameplay Layer</b><br>OrderBufferSystem、AbilityExecSystem、EffectProcessing、ProjectileRuntimeSystem 执行实际 gameplay。</div>
+          </div>
+          <div class="stack">
+            <div class="flow-row">
+              <div class="flow-key">Interface</div>
+              <div class="flow-val">`AIAgentProfileRef` + `AICompiledRuntime` + `AIOrderIntentQueue`。调用方只知道配置和 Order，不知道内部评分细节。</div>
+            </div>
+            <div class="flow-row">
+              <div class="flow-key">Seam</div>
+              <div class="flow-val">Input provider、normalization、curve、target filter、task executor、order adapter、graph score adapter。</div>
+            </div>
+            <div class="flow-row">
+              <div class="flow-key">Adapter</div>
+              <div class="flow-val">`OrderTaskAdapter`、`AbilityCastOrderAdapter`、`MoveOrderAdapter`、`GraphConsiderationAdapter`、`RelationshipThreatInputAdapter`。</div>
+            </div>
+            <div class="flow-row">
+              <div class="flow-key">Depth</div>
+              <div class="flow-val">一个配置 profile 覆盖 idle auto-target、attack move、guard、patrol、retaliate、execution readiness、ability cast。</div>
+            </div>
+          </div>
+        </div>
+
+        <h3>Module 切分</h3>
+        <table>
+          <thead>
+            <tr>
+              <th>Module</th>
+              <th>Interface</th>
+              <th>Implementation 要点</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>AIConfigCompiler</code></td>
+              <td>输入 `ConfigCatalog`，输出 `AICompiledRuntime`。</td>
+              <td>解析 AI/*.json，注册 ids，编译 flat arrays 和 range tables，校验所有引用。</td>
+            </tr>
+            <tr>
+              <td><code>AIAgentRuntimeSoA</code></td>
+              <td>按 agent index 读取/写入状态。</td>
+              <td>profileId、lastDecisionId、currentTarget、thinkBucket、cooldown、score、executor pc。</td>
+            </tr>
+            <tr>
+              <td><code>AITargetAcquisition</code></td>
+              <td>给 decision maker 返回候选目标 span。</td>
+              <td>spatial query + target filter + target cache + last seen；不产生 gameplay side effect。</td>
+            </tr>
+            <tr>
+              <td><code>AIInputSampling</code></td>
+              <td>按 inputId 读取 raw value。</td>
+              <td>距离、生命、tag、attribute、cooldown、threat、actuator readiness、order state、graph score。</td>
+            </tr>
+            <tr>
+              <td><code>AIUtilityEvaluator</code></td>
+              <td>输出 best decision-target pair。</td>
+              <td>normalization、curve、veto、multiply、weighted sum、priority bucket、momentum、hysteresis。</td>
+            </tr>
+            <tr>
+              <td><code>AIDecisionStateMachine</code></td>
+              <td>控制是否切换 current decision。</td>
+              <td>keep running、min duration、cooldown、interrupt policy、score margin。</td>
+            </tr>
+            <tr>
+              <td><code>AIExecution</code></td>
+              <td>把 decision intent 转为 running tasks。</td>
+              <td>Sequence / Parallel / ParallelComplete；任务只提交 Order intent 或维护 AI runtime state。</td>
+            </tr>
+            <tr>
+              <td><code>AIOrderAdapter</code></td>
+              <td>把 task intent 转为 `Order`。</td>
+              <td>填 Actor、Target、TargetContext、Spatial、Args、SubmitMode，交给 `OrderQueue`。</td>
+            </tr>
+            <tr>
+              <td><code>OpenRaBehaviorPack</code></td>
+              <td>一套可选配置 profile。</td>
+              <td>Move、Stop、Attack、AttackMove、Guard、Patrol、Hold、Stance、AutoTarget；炮台/采集器/建造器等放到对应 actuator adapter。</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="runtime">
+        <h2>6. SoA / 0Alloc 运行时</h2>
+        <p class="lead">
+          现有 `UtilityGoalSelectorCompiled256` 已经是数组化思路。新系统要把这个思路推到全链路：配置只读数组，运行状态 SoA，scratch 固定容量，Update 内不分配。
+        </p>
+
+        <h3>核心数据布局</h3>
+        <pre><code>AICompiledRuntime
+  DecisionMakerIds[]
+  DecisionMakerRanges[]          // offset + count into DecisionIds
+  DecisionIds[]
+  DecisionTargetFilterId[]
+  DecisionConsiderationRanges[]  // offset + count into Considerations
+  DecisionTaskRanges[]           // offset + count into Tasks
+  ConsiderationInputId[]
+  ConsiderationNormalizationId[]
+  ConsiderationCurveId[]
+  ConsiderationWeight[]
+  ConsiderationFlags[]           // Veto, Targeted, Graph, Invert
+  TargetFilterOps[]
+  InputDefs[]
+  NormalizationDefs[]
+  CurveDefs[]
+  TaskDefs[]
+  OrderAdapterDefs[]
+  GraphProgramIds[]</code></pre>
+
+        <pre><code>AIAgentRuntimeSoA
+  Entity[] Agents
+  int[] ProfileId
+  int[] DecisionMakerCursor
+  int[] CurrentDecisionId
+  Entity[] CurrentTarget
+  int[] CurrentTaskOffset
+  byte[] CurrentTaskStatus
+  float[] CurrentScore
+  int[] LastSwitchStep
+  int[] NextThinkStep
+  int[] CombatMemoryHead
+  int[] TargetCacheOffset
+  int[] TargetCacheCount</code></pre>
+
+        <h3>0Alloc 规则</h3>
+        <ul>
+          <li>配置加载阶段可以用 `List<T>` 和 JSON object；编译完成后热路径只读 arrays / spans。</li>
+          <li>Update 内禁止 LINQ、`new List<>`、闭包、字符串查找、反射、字典枚举。</li>
+          <li>所有 string id 在 compile 阶段变成 int id；运行时只比较 int / bitset / enum。</li>
+          <li>目标候选使用固定 `Entity[]` 或 `Span<Entity>` scratch，容量来自 profile，例如 `maxCandidates=64`。</li>
+          <li>Top target 选择使用单 pass best 或小容量 insertion sort，不做全量排序。</li>
+          <li>Graph score 用 stackalloc registers；AI 侧 Graph adapter 禁止 effect write op，只允许 pure read / math / query / relationship read。</li>
+          <li>多 agent 分桶：`NextThinkStep` 和 `DecisionMakingFrame1..N` 类似 Uintel 的跨帧分摊，避免所有 agent 同帧评分。</li>
+          <li>结构变化集中到 CommandBuffer 或 OrderQueue；decision 阶段不 Add/Remove ECS 数据。</li>
+          <li>QueryDescription 静态缓存；空间查询 buffer 由 system 持有并复用。</li>
+        </ul>
+
+        <h3>热路径伪代码</h3>
+        <pre><code>for each agent in think bucket:
+  candidates = targetAcquisition.Collect(agent, profile, scratch)
+  bestScore = 0
+  bestDecision = None
+  bestTarget = Null
+
+  for each decisionMaker in profile:
+    for each decision in decisionMaker:
+      span = FilterTargets(decision.targetFilter, candidates)
+      for each target in span or NullTarget:
+        score = EvaluateDecision(agent, target, decision)
+        score = ApplyMomentumHysteresis(agent, decision, target, score)
+        if score &gt; bestScore:
+          best = decision-target pair
+
+  stateMachine.TrySwitch(agent, best)
+  executor.Tick(agent, currentDecision, currentTarget)</code></pre>
+      </section>
+
+      <section id="scoring">
+        <h2>7. 评分与 Graph</h2>
+        <p class="lead">
+          Ludots 需要的不是单一乘法公式，而是一套数据驱动 score graph。默认足够快，必要时允许 Graph 函数参与单个 input / consideration / decision score。
+        </p>
+
+        <h3>评分结构</h3>
+        <div class="flow">
+          <div class="flow-row">
+            <div class="flow-key">Target Filter</div>
+            <div class="flow-val">关系、layer、tag、距离、视野、weapon eligibility、是否可被攻击、是否可被 repair/capture/harvest。</div>
+          </div>
+          <div class="flow-row">
+            <div class="flow-key">Input</div>
+            <div class="flow-val">raw value：distanceCm、healthRatio、threat、cooldownElapsed、ammoRatio、readiness01、aimDelta、orderState、blackboard value。</div>
+          </div>
+          <div class="flow-row">
+            <div class="flow-key">Normalization</div>
+            <div class="flow-val">linear、inverse、range、threshold、comparison、cooldown、piecewise、graph。</div>
+          </div>
+          <div class="flow-row">
+            <div class="flow-key">Curve</div>
+            <div class="flow-val">constant、linear、quadratic、logistic、step、remap table、graph。</div>
+          </div>
+          <div class="flow-row">
+            <div class="flow-key">Aggregation</div>
+            <div class="flow-val">veto、multiply、weighted sum、min gate、max bonus、priority bucket、tie nearest。</div>
+          </div>
+        </div>
+
+        <h3>OpenRA 优先级如何表达</h3>
+        <p>
+          OpenRA 的 `AutoTargetPriority` 先按 priority 选更高优先级，再用距离做 tie-break。Ludots 不应把这写死在 attack move 里，而应作为 target scoring profile：
+        </p>
+        <pre><code>{
+  "id": "TargetScore.OpenRA.Ground",
+  "mode": "PriorityBucketThenDistance",
+  "buckets": [
+    { "tag": "TargetType.Defense", "relationship": "Hostile", "priority": 60 },
+    { "tag": "TargetType.Vehicle", "relationship": "Hostile", "priority": 50 },
+    { "tag": "TargetType.Infantry", "relationship": "Hostile", "priority": 40 }
+  ],
+  "tieBreak": "Nearest"
+}</code></pre>
+
+        <h3>Graph 扩展点</h3>
+        <p>
+          现有 `GraphExecutor.ExecuteScore` 返回 `F[0]`，`ExecuteValidation` 返回 `B[0]`，并使用 stackalloc registers。这正好可以成为 AI scoring 的 Adapter，但需要加一层 `AIGraphRuntimeApi` 或 `AIGraphOpPolicy`。
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th>Graph 用途</th>
+              <th>允许</th>
+              <th>禁止</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Input score</td>
+              <td>读 attribute、tag、relationship、blackboard、position、distance、target list。</td>
+              <td>ApplyEffect、ModifyAttribute、WriteBlackboard、SendEvent。</td>
+            </tr>
+            <tr>
+              <td>Target filter</td>
+              <td>返回 `B[0]` 判断候选是否保留。</td>
+              <td>创建实体、发 effect、提交 order。</td>
+            </tr>
+            <tr>
+              <td>Decision score</td>
+              <td>返回 `F[0]` 作为最终补正分。</td>
+              <td>改变 gameplay state。</td>
+            </tr>
+            <tr>
+              <td>Task condition</td>
+              <td>判断 running / finished / cancel。</td>
+              <td>绕过 `OrderQueue` 直接执行 ability。</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="orders">
+        <h2>8. Order / Ability 映射</h2>
+        <p class="lead">
+          AI 的执行层只能表达 intent，不能拥有伤害和技能执行权。真正的 gameplay 变化仍由 Order、Ability、Effect、Projectile 链路完成。
+        </p>
+
+        <div class="pipe">
+          <div><b>Decision</b><span>选中 AttackTarget / Move / Guard / Repair。</span></div>
+          <div><b>Execution</b><span>把 decision 展开成 task。</span></div>
+          <div><b>Order Adapter</b><span>写 Actor / Target / Spatial / Args。</span></div>
+          <div><b>OrderQueue</b><span>进入玩家同构订单入口。</span></div>
+          <div><b>OrderBufferSystem</b><span>打断、排队、黑板写入。</span></div>
+          <div><b>AbilityExec</b><span>按 ability spec 执行 timeline。</span></div>
+          <div><b>Effect</b><span>应用伤害、buff、projectile。</span></div>
+        </div>
+
+        <h3>Order 和 Ability 的切分</h3>
+        <table>
+          <thead>
+            <tr>
+              <th>问题</th>
+              <th>归 Order</th>
+              <th>归 Ability/GAS</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>我要去哪里</td>
+              <td>`moveTo`、`attackMove`、`guardFollow` 写空间目标或跟随目标。</td>
+              <td>不负责寻路。</td>
+            </tr>
+            <tr>
+              <td>我要打谁</td>
+              <td>`attack` order 写 `Attack.TargetEntity`。</td>
+              <td>校验 range、cooldown、ammo、actuator readiness、发射 projectile。</td>
+            </tr>
+            <tr>
+              <td>我要用哪个技能</td>
+              <td>`castAbility` order 写 slot/abilityId/target/position。</td>
+              <td>Ability timeline、effect request、target resolver、cost、block tags。</td>
+            </tr>
+            <tr>
+              <td>我要保护谁</td>
+              <td>`guard` order 写 guarded entity 和 follow range。</td>
+              <td>保护行为选出的攻击动作仍走 attack/cast ability。</td>
+            </tr>
+            <tr>
+              <td>我要停下</td>
+              <td>`stop` order 清 active/queue 和 AI execution state。</td>
+              <td>取消能力实例由 existing stop/ability end 系统处理。</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="warn">
+          <b>当前一个配置契约风险</b>
+          <p>
+            `mods/AIDemoMod/assets/Configs/AI/goap_actions.json` 中样例写了 `OrderTagId`，但 `AiConfigLoader` 读取的是 `OrderTypeId`。这说明现有 AI demo 只能当雏形，正式方案必须先统一 AI action 到 OrderTypeRegistry 的配置契约，并做 fail-fast 校验。
+          </p>
+        </div>
+      </section>
+
+      <section id="openra">
+        <h2>9. OpenRA 行为配置包</h2>
+        <p class="lead">
+          OpenRA 基础行为的核心不是“攻击移动写死”，而是命令薄、行为编排薄、索敌策略数据化、攻击执行交给 attack trait。映射到 Ludots，就是 order 薄、AI task 薄、target/score 数据化、攻击执行交给 Ability/GAS。
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>用户看到的输入动作</th>
+              <th>AI/Order 语义</th>
+              <th>Ludots 配置实现</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>右键地面 / Move</td>
+              <td>移动到目标点，不主动扫描攻击。</td>
+              <td>`Task.SubmitOrder(moveTo)`，写 `Generic.TargetPosition` 或 movement spatial key。</td>
+            </tr>
+            <tr>
+              <td>右键敌人 / Attack</td>
+              <td>锁定目标，必要时跟进，进入攻击距离后 cast attack ability。</td>
+              <td>`Decision.AttackTarget` + `Task.ChaseUntilInRange` + `Task.CastAbility(PrimaryWeapon)`。</td>
+            </tr>
+            <tr>
+              <td>Attack Move</td>
+              <td>向目的地移动，途中按 auto-target 策略找敌；遇敌暂停移动，攻击结束后继续目的地。</td>
+              <td>`Task.Composite.AttackMove`: move subtask + scan subtask + interrupt/resume state。</td>
+            </tr>
+            <tr>
+              <td>Assault Move</td>
+              <td>类似 Attack Move，但允许更积极追击。</td>
+              <td>同一 task，profile 设置 `allowMoveChase=true`、`maxLeashCm` 更大。</td>
+            </tr>
+            <tr>
+              <td>Guard</td>
+              <td>跟随友军或建筑，扫描威胁并攻击，超出 guard range 回到保护目标。</td>
+              <td>`Decision.GuardProtect` 使用 guarded target、nearby hostile、attacker memory。</td>
+            </tr>
+            <tr>
+              <td>Stop</td>
+              <td>停止当前活动，清理攻击/移动子活动。</td>
+              <td>`stop` order + `AIExecution.CancelCurrent` + 清 target memory optional。</td>
+            </tr>
+            <tr>
+              <td>Hold Position</td>
+              <td>不主动移动，可按姿态还击或开火。</td>
+              <td>`AIStanceProfile.HoldPosition` + `allowMove=false` + attack range gate。</td>
+            </tr>
+            <tr>
+              <td>Stance 切换</td>
+              <td>HoldFire / ReturnFire / Defend / AttackAnything。</td>
+              <td>`AIStanceState` + `SetStance` order 或 tag effect，影响 target filter 和 allowMove。</td>
+            </tr>
+            <tr>
+              <td>Patrol</td>
+              <td>沿 waypoint 往返，途中可按 auto-target 策略接战。</td>
+              <td>`Task.PatrolMove` + `Decision.AutoAttackWhileMoving`。</td>
+            </tr>
+            <tr>
+              <td>Deploy / Repair / Capture / Harvest / Transport</td>
+              <td>本质是不同 target filter + ability/order task。</td>
+              <td>作为 OpenRA behavior pack 的可选 decisions，不写入 AI core 特例。</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>Stance 配置</h3>
+        <pre><code>{
+  "id": "Stance.OpenRA.Default",
+  "stances": [
+    {
+      "id": "HoldFire",
+      "autoAcquire": false,
+      "retaliate": false,
+      "allowMoveChase": false
+    },
+    {
+      "id": "ReturnFire",
+      "autoAcquire": false,
+      "retaliate": true,
+      "targetSource": "RecentAttackers",
+      "allowMoveChase": false
+    },
+    {
+      "id": "Defend",
+      "autoAcquire": true,
+      "targetSource": "ScanRadius",
+      "relationship": "Hostile",
+      "allowMoveChase": false
+    },
+    {
+      "id": "AttackAnything",
+      "autoAcquire": true,
+      "targetSource": "ScanRadius",
+      "relationship": "Hostile",
+      "allowMoveChase": true
+    }
+  ]
+}</code></pre>
+
+        <h3>Attack Move task 状态</h3>
+        <div class="flow">
+          <div class="flow-row"><div class="flow-key">Moving</div><div class="flow-val">维持目的地 order 或 NavGoal；按 scan interval 扫描候选。</div></div>
+          <div class="flow-row"><div class="flow-key">Acquire</div><div class="flow-val">通过 target filter + priority profile 选择目标；若无目标继续 Moving。</div></div>
+          <div class="flow-row"><div class="flow-key">Engage</div><div class="flow-val">暂停移动；提交 attack / castAbility order；跟踪 target validity。</div></div>
+          <div class="flow-row"><div class="flow-key">Disengage</div><div class="flow-val">目标死亡、失效、超出 leash、不可见、无法攻击、攻击 order 完成。</div></div>
+          <div class="flow-row"><div class="flow-key">Resume</div><div class="flow-val">回到原 attack-move 目的地；如果刚脱战可立即再扫一次，避免空走。</div></div>
+        </div>
+      </section>
+
+      <section id="readiness">
+        <h2>10. 执行器就绪门控</h2>
+        <p class="lead">
+          这里不能把“炮台”升格为 AI Core 概念。通用架构只需要表达：某个执行器当前是否 ready、为什么不 ready、预计何时 ready、是否需要先执行准备动作。OpenRA 的炮台只是这个抽象下的一个案例。
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>抽象 Module</th>
+              <th>Core 语义</th>
+              <th>炮台案例如何挂接</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>ActuatorProfile</code></td>
+              <td>描述一个可执行能力的准备条件：范围、冷却、资源、弹药、朝向、通道、占用、目标合法性。</td>
+              <td><code>TurretProfile</code> 是 weapon actuator 的配置扩展，不属于 AI Core。</td>
+            </tr>
+            <tr>
+              <td><code>ActuatorReadiness</code></td>
+              <td>运行时只暴露 <code>ready01</code>、<code>blockReason</code>、<code>etaSteps</code>、<code>requiresPreparation</code>。</td>
+              <td>炮台 adapter 把 yaw delta、turn speed、facing tolerance 转成 readiness。</td>
+            </tr>
+            <tr>
+              <td><code>AimGate</code></td>
+              <td>面向所有需要方向/朝向的执行器：炮台、正面攻击、蓄力技能、采集朝向、施工朝向。</td>
+              <td><code>TurretFacingSystem</code> 是 AimGate 的一个 gameplay implementation。</td>
+            </tr>
+            <tr>
+              <td><code>AbilityPrecondition</code></td>
+              <td>最终执行门控仍归 Ability/GAS；AI 只能读取 readiness 或提交准备/执行 order。</td>
+              <td>攻击 ability 在炮台未对准时阻塞、等待或进入准备阶段。</td>
+            </tr>
+            <tr>
+              <td><code>Presentation Adapter</code></td>
+              <td>表现读取 gameplay state，不参与 AI 决策合同。</td>
+              <td>炮管转向和 recoil 从 turret runtime 投影到表现层。</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="note">
+          <b>边界结论</b>
+          <p>
+            AI Core 不认识炮台，只认识执行器 readiness。炮台、正面开火、采集器朝向、建造者占用、施法蓄力都通过 adapter 映射到同一个 readiness 输入。这样业务语义留在能力 Mod / gameplay implementation 里，架构只保留可复用的执行前置条件。
+          </p>
+        </div>
+      </section>
+
+      <section id="systems">
+        <h2>11. SystemGroup 排布</h2>
+        <p class="lead">
+          AI 必须在 `OrderBufferSystem` 前产出 order，才能同 tick 进入现有 Order/GAS 链路。感知又应在空间索引更新之后运行，避免用上一帧位置做索敌。
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>SystemGroup</th>
+              <th>AI 系统</th>
+              <th>原因</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>SchemaUpdate</code></td>
+              <td>`AIConfigReloadApplySystem` 可选</td>
+              <td>只处理配置版本切换和 runtime swap，不做决策。</td>
+            </tr>
+            <tr>
+              <td><code>InputCollection</code></td>
+              <td>`AIThinkScheduleSystem`、低成本 blackboard projection</td>
+              <td>读取输入、cooldown、order state，确定本 tick 哪些 agent 要思考。</td>
+            </tr>
+            <tr>
+              <td><code>PostMovement</code></td>
+              <td>`AIPerceptionSystem`、`AITargetAcquisitionSystem`、`AIDecisionSystem`、`AIExecutionSystem`、`AIOrderIntentSubmitSystem`</td>
+              <td>在 `WorldToGridSyncSystem` / `SpatialPartitionUpdateSystem` 后、`OrderBufferSystem` 前运行，使用最新空间索引，并让 order 同 tick 生效。</td>
+            </tr>
+            <tr>
+              <td><code>AbilityActivation</code></td>
+              <td>不新增 AI 决策；必要时用 `InsertSystemBeforeRequired&lt;OrderBufferSystem&gt;` 放置 order submit adapter</td>
+              <td>避免错过 OrderBufferSystem；AI 不应插在 AbilityExec 后面。</td>
+            </tr>
+            <tr>
+              <td><code>EffectProcessing</code></td>
+              <td>无 AI 决策</td>
+              <td>Effect / projectile 已经是执行结果，AI 不在这里反向改决策。</td>
+            </tr>
+            <tr>
+              <td><code>Cleanup</code></td>
+              <td>`AICombatMemoryCleanupSystem`</td>
+              <td>清理死亡 target、过期 last-seen、过期 threat cache。</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="schema">
+        <h2>12. 配置 Schema 草案</h2>
+        <p class="lead">
+          下面是配置形状，不是最终字段名。关键是所有行为都能由配置表达，Core 只提供通用 Module、Registry、Adapter 和 fail-fast 编译。
+        </p>
+
+        <pre><code>{
+  "profiles": [
+    {
+      "id": "AIProfile.OpenRA.Rifleman",
+      "decisionIntervalSteps": 6,
+      "maxCandidates": 48,
+      "stanceProfile": "Stance.OpenRA.Default",
+      "decisionMakers": ["DM.OpenRA.Combat", "DM.OpenRA.OrderContinuation"]
+    }
+  ],
+  "targetFilters": [
+    {
+      "id": "TF.HostileGroundVisible",
+      "ops": [
+        { "kind": "Relationship", "value": "Hostile" },
+        { "kind": "LayerMask", "value": "GroundUnit|Defense" },
+        { "kind": "Distance", "maxCm": 900 },
+        { "kind": "HasNoneTag", "tags": ["Target.NoAutoTarget"] }
+      ]
+    }
+  ],
+  "inputs": [
+    { "id": "Input.DistanceToTarget", "kind": "DistanceToTarget" },
+    { "id": "Input.TargetPriorityBucket", "kind": "TargetPriority", "profile": "TargetScore.OpenRA.Ground" },
+    { "id": "Input.PrimaryActuatorReady", "kind": "ActuatorReadiness01", "actuator": "PrimaryWeapon" },
+    { "id": "Input.Graph.CustomThreat", "kind": "GraphScore", "graph": "Graph.AI.ThreatScore" }
+  ],
+  "decisions": [
+    {
+      "id": "Decision.AttackVisibleHostile",
+      "targetFilter": "TF.HostileGroundVisible",
+      "weight": 1.0,
+      "momentumBonus": 1.15,
+      "keepRunningUntilFinished": false,
+      "considerations": [
+        { "input": "Input.TargetPriorityBucket", "normalization": "Identity", "curve": "Linear", "aggregate": "PriorityBucket" },
+        { "input": "Input.DistanceToTarget", "normalization": "RangeInverse.0.900", "curve": "Linear", "aggregate": "Multiply" },
+        { "input": "Input.PrimaryActuatorReady", "normalization": "Identity", "curve": "Linear", "aggregate": "Multiply" }
+      ],
+      "tasks": [
+        { "kind": "SubmitOrder", "order": "attack", "target": "DecisionTarget" }
+      ]
+    }
+  ]
+}</code></pre>
+
+        <h3>建议文件分组</h3>
+        <ul class="compact-list">
+          <li><code>assets/Configs/AI/profiles.json</code></li>
+          <li><code>assets/Configs/AI/decision_makers.json</code></li>
+          <li><code>assets/Configs/AI/decisions.json</code></li>
+          <li><code>assets/Configs/AI/target_filters.json</code></li>
+          <li><code>assets/Configs/AI/inputs.json</code></li>
+          <li><code>assets/Configs/AI/normalizations.json</code></li>
+          <li><code>assets/Configs/AI/curves.json</code></li>
+          <li><code>assets/Configs/AI/tasks.json</code></li>
+          <li><code>assets/Configs/AI/stances.json</code></li>
+          <li><code>assets/Configs/AI/actuators.json</code></li>
+        </ul>
+      </section>
+
+      <section id="phases">
+        <h2>13. 落地阶段</h2>
+        <div class="phase">
+          <div class="phase-num">1</div>
+          <div>
+            <h3>RFC 与契约收敛</h3>
+            <p>先写架构 RFC：明确 AI 不绕过 Order/GAS；统一 `OrderTypeId` / `OrderTypeKey`；列出复用基础设施和新增 Module。</p>
+            <span class="tag red">必须先做</span><span class="tag blue">文档 + schema</span>
+          </div>
+        </div>
+        <div class="phase">
+          <div class="phase-num">2</div>
+          <div>
+            <h3>AI config compiler v2</h3>
+            <p>扩展 `AiConfigLoader` 或新增 `AiUtilityConfigCompiler`，把 Uintel 链路编译成 flat arrays，所有引用 fail-fast。</p>
+            <span class="tag teal">ConfigPipeline</span><span class="tag green">0Alloc ready</span>
+          </div>
+        </div>
+        <div class="phase">
+          <div class="phase-num">3</div>
+          <div>
+            <h3>Target filter 与 decision-target evaluator</h3>
+            <p>实现无副作用 target acquisition、priority bucket、distance tie-break、relationship filter、tag/layer filter、score aggregation。</p>
+            <span class="tag amber">索敌核心</span><span class="tag violet">OpenRA priority</span>
+          </div>
+        </div>
+        <div class="phase">
+          <div class="phase-num">4</div>
+          <div>
+            <h3>Execution task 与 Order adapter</h3>
+            <p>实现 Sequence / Parallel / ParallelComplete、SubmitOrder task、Move / Attack / CastAbility adapters，接到 `OrderQueue`。</p>
+            <span class="tag green">Order 同构</span><span class="tag red">禁止直接 Effect</span>
+          </div>
+        </div>
+        <div class="phase">
+          <div class="phase-num">5</div>
+          <div>
+            <h3>OpenRA behavior pack</h3>
+            <p>用配置交付 Move、Attack、AttackMove、AssaultMove、Guard、Stop、Hold、Patrol、Stance、AutoTarget、Disengage。</p>
+            <span class="tag blue">行为包</span><span class="tag teal">可复用 Mod</span>
+          </div>
+        </div>
+        <div class="phase">
+          <div class="phase-num">6</div>
+          <div>
+            <h3>Actuator readiness adapters</h3>
+            <p>先落通用 readiness 输入和 Ability precondition adapter；炮台转向、正面攻击、蓄力施法等业务能力分别提供 adapter。</p>
+            <span class="tag amber">Readiness</span><span class="tag green">Ability gate</span>
+          </div>
+        </div>
+        <div class="phase">
+          <div class="phase-num">7</div>
+          <div>
+            <h3>调试与验收</h3>
+            <p>AI inspector 显示每个 decision-target pair 的候选、过滤原因、分数、当前 task、提交 order；补齐 0Alloc 和 deterministic tests。</p>
+            <span class="tag violet">debug</span><span class="tag green">tests</span>
+          </div>
+        </div>
+      </section>
+
+      <section id="tests">
+        <h2>14. 验收标准</h2>
+        <p class="lead">
+          这套系统是否成立，不看 demo 演得像不像，看这些测试能否稳定通过。
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>验收项</th>
+              <th>必须证明</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>0Alloc</td>
+              <td>10k agent 在 fixed iterations 中 `AIPerception + Decision + Execution + OrderSubmit` allocation 小于等于现有 AI benchmark 级别。</td>
+            </tr>
+            <tr>
+              <td>OpenRA priority</td>
+              <td>高 priority target 永远胜过低 priority target；同 priority 下最近者胜出。</td>
+            </tr>
+            <tr>
+              <td>Stance</td>
+              <td>HoldFire 不索敌不还击；ReturnFire 只打 recent attacker；Defend 扫描但不追出 leash；AttackAnything 可追击。</td>
+            </tr>
+            <tr>
+              <td>AttackMove</td>
+              <td>移动途中遇敌暂停、攻击 order 完成后恢复原目的地；目标死亡/失效/超 leash 正确脱战。</td>
+            </tr>
+            <tr>
+              <td>Guard</td>
+              <td>跟随保护目标；保护目标附近有 hostile 或 recent attacker 时攻击；离开 guard range 后回位。</td>
+            </tr>
+            <tr>
+              <td>Order/GAS 同构</td>
+              <td>AI 和玩家使用同一 `OrderQueue`、`OrderBufferSystem`、`AbilityExecSystem`；AI 不能直接发 EffectRequest。</td>
+            </tr>
+            <tr>
+              <td>Graph score</td>
+              <td>自定义 Graph 可影响 score；AI Graph policy 拒绝 effect write / attribute write / event op。</td>
+            </tr>
+            <tr>
+              <td>Actuator readiness gate</td>
+              <td>执行器未 ready 时 ability 被阻塞、等待或先准备；ready 后同一 target 能执行；表现读取 gameplay state。</td>
+            </tr>
+            <tr>
+              <td>主循环接入</td>
+              <td>AI systems 在 `SpatialPartitionUpdateSystem` 后、`OrderBufferSystem` 前运行；同 tick order 可被消费。</td>
+            </tr>
+            <tr>
+              <td>配置 fail-fast</td>
+              <td>未知 input、filter、order type、ability id、graph id、blackboard key 均在加载阶段报错。</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="verdict">
+          <b>不该做的实现</b>
+          <p>
+            不在某个 showcase 里硬写 AttackMove；不让 AI 直接扣血或发 Effect；不新增平行配置加载器；不把 Idle 做成平台 fallback；不把 Unity DOTS/Burst/BlobAssetReference 当成 Ludots 架构；不把炮台、采集器、建造者这类业务名词写进 AI Core。
+          </p>
+        </div>
+      </section>
+
+      <section id="sources">
+        <h2>15. 证据来源</h2>
+        <h3>本地源码与文档</h3>
+        <ul class="sources">
+          <li><a href="../../src/Core/Gameplay/AI/Utility/UtilityGoalSelectorCompiled256.cs">src/Core/Gameplay/AI/Utility/UtilityGoalSelectorCompiled256.cs</a></li>
+          <li><a href="../../src/Core/Gameplay/AI/Config/AiConfigLoader.cs">src/Core/Gameplay/AI/Config/AiConfigLoader.cs</a></li>
+          <li><a href="../../src/Core/Gameplay/AI/Systems/AIPlanExecutionSystem.cs">src/Core/Gameplay/AI/Systems/AIPlanExecutionSystem.cs</a></li>
+          <li><a href="../../src/Core/Gameplay/AI/Planning/PlanExecutor.cs">src/Core/Gameplay/AI/Planning/PlanExecutor.cs</a></li>
+          <li><a href="../../src/Tests/GasTests/AiBenchmarkTests.cs">src/Tests/GasTests/AiBenchmarkTests.cs</a></li>
+          <li><a href="../../src/Core/Gameplay/GAS/Orders/OrderSubmitter.cs">src/Core/Gameplay/GAS/Orders/OrderSubmitter.cs</a></li>
+          <li><a href="../../src/Core/Gameplay/GAS/Orders/OrderBlackboardKeys.cs">src/Core/Gameplay/GAS/Orders/OrderBlackboardKeys.cs</a></li>
+          <li><a href="../../src/Core/NodeLibraries/GASGraph/GraphExecutor.cs">src/Core/NodeLibraries/GASGraph/GraphExecutor.cs</a></li>
+          <li><a href="../../src/Core/NodeLibraries/GASGraph/GasGraphOpHandlerTable.cs">src/Core/NodeLibraries/GASGraph/GasGraphOpHandlerTable.cs</a></li>
+          <li><a href="openra_unit_behavior_attack_move_analysis.html">OpenRA 用户输入动作与基础单位指令源码剖面</a></li>
+          <li><a href="openra_targeting_priority_guard_turret_analysis.html">OpenRA 索敌优先级、脱战警戒与炮台机制源码剖面</a></li>
+          <li><a href="ludots_targeting_order_gas_gap_analysis.html">Ludots 索敌、警戒、炮台与 Order/GAS 映射缺口分析</a></li>
+        </ul>
+
+        <h3>外部文档</h3>
+        <ul class="sources">
+          <li><a href="https://uintel-ecs.utilityworlds.com/Documentation/">Utility Intelligence ECS Documentation</a></li>
+          <li><a href="https://uintel-ecs.utilityworlds.com/sitemap.xml">Utility Intelligence ECS sitemap</a></li>
+          <li><a href="https://uintel-ecs.utilityworlds.com/Documentation/UtilityIntelligence/">Utility Intelligence</a></li>
+          <li><a href="https://uintel-ecs.utilityworlds.com/Documentation/UtilityIntelligence/Inputs/">Inputs</a></li>
+          <li><a href="https://uintel-ecs.utilityworlds.com/Documentation/UtilityIntelligence/InputNormalizations/">Input Normalizations</a></li>
+          <li><a href="https://uintel-ecs.utilityworlds.com/Documentation/UtilityIntelligence/Considerations/">Considerations</a></li>
+          <li><a href="https://uintel-ecs.utilityworlds.com/Documentation/UtilityIntelligence/Decisions/">Decisions</a></li>
+          <li><a href="https://uintel-ecs.utilityworlds.com/Documentation/UtilityIntelligence/DecisionMakers/">Decision Makers</a></li>
+          <li><a href="https://uintel-ecs.utilityworlds.com/Documentation/UtilityIntelligence/ActionTasks/">Action Tasks</a></li>
+          <li><a href="https://uintel-ecs.utilityworlds.com/Documentation/UtilityIntelligence/TargetFilters/">Target Filters</a></li>
+          <li><a href="https://uintel-ecs.utilityworlds.com/Documentation/UtilityIntelligence/Blackboard/">Blackboard</a></li>
+          <li><a href="https://uintel-ecs.utilityworlds.com/Documentation/TipsAndTricks/OptimizationTricks/">Optimization Tricks</a></li>
+          <li><a href="https://package.uintel-ecs.utilityworlds.com/API/index.html">Utility Intelligence ECS API Reference</a></li>
+          <li><a href="https://uintel-go.utilityworlds.com/sitemap.xml">Utility Intelligence GO sitemap</a></li>
+        </ul>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/reference/openra_ai_layered_architecture.html
+++ b/docs/reference/openra_ai_layered_architecture.html
@@ -1,0 +1,925 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OpenRA AI 分层架构剖面</title>
+  <style>
+    :root {
+      --bg: #ffffff;
+      --ink: #16202a;
+      --muted: #5f6b76;
+      --line: #d7dde3;
+      --soft: #f5f7f9;
+      --soft-2: #eef6f4;
+      --teal: #0f766e;
+      --green: #2f855a;
+      --amber: #b45309;
+      --red: #b42318;
+      --blue: #2563eb;
+      --violet: #6d28d9;
+      --shadow: 0 10px 28px rgba(22, 32, 42, 0.08);
+      --radius: 8px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html {
+      scroll-behavior: smooth;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Segoe UI", "Microsoft YaHei", Arial, sans-serif;
+      color: var(--ink);
+      background: var(--bg);
+      line-height: 1.72;
+      letter-spacing: 0;
+    }
+
+    a {
+      color: var(--blue);
+      text-decoration: none;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    code {
+      font-family: Consolas, "Cascadia Mono", "SFMono-Regular", monospace;
+      font-size: 0.92em;
+      background: #eef2f6;
+      border: 1px solid #d8e0e8;
+      border-radius: 6px;
+      padding: 0.08rem 0.32rem;
+      word-break: break-word;
+    }
+
+    .hero {
+      background:
+        linear-gradient(90deg, rgba(15, 118, 110, 0.16), transparent 32%),
+        linear-gradient(180deg, #18212b, #111820);
+      color: #f8fafc;
+      border-bottom: 6px solid var(--teal);
+    }
+
+    .hero-inner {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: 54px 0 46px;
+      display: grid;
+      grid-template-columns: minmax(0, 1.25fr) minmax(300px, 0.75fr);
+      gap: 28px;
+      align-items: end;
+    }
+
+    .hero h1 {
+      margin: 0 0 18px;
+      font-size: 2.45rem;
+      line-height: 1.16;
+      font-weight: 800;
+      letter-spacing: 0;
+    }
+
+    .hero p {
+      margin: 0;
+      max-width: 780px;
+      color: #dbe4ed;
+      font-size: 1.04rem;
+    }
+
+    .hero strong {
+      color: #ffffff;
+    }
+
+    .stamp {
+      display: grid;
+      gap: 10px;
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      border-radius: var(--radius);
+      padding: 18px;
+      box-shadow: var(--shadow);
+    }
+
+    .stamp span {
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.14);
+      padding-bottom: 8px;
+      color: #dbe4ed;
+      font-size: 0.92rem;
+    }
+
+    .stamp span:last-child {
+      border-bottom: 0;
+      padding-bottom: 0;
+    }
+
+    .stamp b {
+      color: #ffffff;
+      font-weight: 700;
+      text-align: right;
+    }
+
+    .layout {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: 250px minmax(0, 1fr);
+      gap: 28px;
+      padding: 32px 0 72px;
+    }
+
+    .toc {
+      position: sticky;
+      top: 18px;
+      align-self: start;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 14px;
+      background: #ffffff;
+      box-shadow: var(--shadow);
+    }
+
+    .toc h2 {
+      margin: 0 0 10px;
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+
+    .toc a {
+      display: block;
+      padding: 8px 8px;
+      border-radius: 6px;
+      color: #233142;
+      font-size: 0.92rem;
+    }
+
+    .toc a:hover {
+      background: var(--soft);
+      text-decoration: none;
+    }
+
+    main {
+      min-width: 0;
+    }
+
+    section {
+      margin-bottom: 28px;
+      padding: 26px;
+      background: #ffffff;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow);
+    }
+
+    section.band {
+      background: var(--soft);
+      box-shadow: none;
+    }
+
+    h2 {
+      margin: 0 0 16px;
+      font-size: 1.45rem;
+      line-height: 1.25;
+      letter-spacing: 0;
+    }
+
+    h3 {
+      margin: 0 0 10px;
+      font-size: 1.05rem;
+      line-height: 1.35;
+    }
+
+    p {
+      margin: 0 0 13px;
+    }
+
+    ul {
+      margin: 0;
+      padding-left: 1.15rem;
+    }
+
+    li {
+      margin: 6px 0;
+    }
+
+    .thesis {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 14px;
+      margin-top: 16px;
+    }
+
+    .signal {
+      border: 1px solid var(--line);
+      border-top: 4px solid var(--teal);
+      border-radius: var(--radius);
+      padding: 16px;
+      background: #ffffff;
+    }
+
+    .signal:nth-child(2) {
+      border-top-color: var(--amber);
+    }
+
+    .signal:nth-child(3) {
+      border-top-color: var(--green);
+    }
+
+    .signal b {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 1rem;
+    }
+
+    .signal span {
+      color: var(--muted);
+      font-size: 0.94rem;
+    }
+
+    .flow {
+      display: grid;
+      gap: 10px;
+      margin-top: 18px;
+    }
+
+    .flow-row {
+      display: grid;
+      grid-template-columns: 188px minmax(0, 1fr) 132px;
+      gap: 10px;
+      align-items: stretch;
+    }
+
+    .flow-cell {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 13px 14px;
+      background: #ffffff;
+      min-height: 78px;
+    }
+
+    .flow-cell.layer {
+      border-left: 5px solid var(--teal);
+      font-weight: 750;
+    }
+
+    .flow-cell.action {
+      color: #263442;
+    }
+
+    .flow-cell.guard {
+      border-color: rgba(180, 83, 9, 0.45);
+      background: #fff7ed;
+      color: #7c2d12;
+      font-weight: 650;
+    }
+
+    .arrow {
+      height: 12px;
+      margin-left: 92px;
+      border-left: 2px solid var(--line);
+    }
+
+    .layer-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 14px;
+    }
+
+    .layer-card {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 16px;
+      background: #ffffff;
+    }
+
+    .layer-card h3 {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .num {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 26px;
+      height: 26px;
+      border-radius: 50%;
+      background: #e0f2f1;
+      color: var(--teal);
+      font-weight: 800;
+      flex: 0 0 auto;
+      font-size: 0.86rem;
+    }
+
+    .source-list {
+      display: grid;
+      gap: 7px;
+      margin-top: 12px;
+    }
+
+    .source-list a,
+    .source-list span {
+      display: block;
+      color: #36536f;
+      font-size: 0.88rem;
+      overflow-wrap: anywhere;
+    }
+
+    .module-board {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .module {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 14px;
+      background: #ffffff;
+      min-height: 154px;
+    }
+
+    .module b {
+      display: block;
+      margin-bottom: 7px;
+    }
+
+    .module p {
+      color: var(--muted);
+      font-size: 0.93rem;
+      margin-bottom: 0;
+    }
+
+    .tagline {
+      display: inline-flex;
+      align-items: center;
+      border: 1px solid rgba(15, 118, 110, 0.35);
+      border-radius: 999px;
+      padding: 4px 9px;
+      color: var(--teal);
+      background: #eef6f4;
+      font-size: 0.8rem;
+      font-weight: 700;
+      margin-bottom: 10px;
+    }
+
+    .split {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(280px, 0.85fr);
+      gap: 18px;
+      align-items: start;
+    }
+
+    .quote-box {
+      border-left: 5px solid var(--amber);
+      background: #fff7ed;
+      padding: 16px 18px;
+      border-radius: var(--radius);
+      color: #4a2c12;
+    }
+
+    .matrix {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.94rem;
+      background: #ffffff;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      overflow: hidden;
+      display: table;
+    }
+
+    .matrix th,
+    .matrix td {
+      text-align: left;
+      vertical-align: top;
+      padding: 12px 13px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .matrix th {
+      background: #eef2f6;
+      font-weight: 800;
+      color: #243341;
+    }
+
+    .matrix tr:last-child td {
+      border-bottom: 0;
+    }
+
+    .ok {
+      color: var(--green);
+      font-weight: 750;
+    }
+
+    .warn {
+      color: var(--amber);
+      font-weight: 750;
+    }
+
+    .risk {
+      color: var(--red);
+      font-weight: 750;
+    }
+
+    .route {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #ffffff;
+      padding: 16px;
+      display: grid;
+      gap: 10px;
+      font-family: Consolas, "Cascadia Mono", monospace;
+      font-size: 0.9rem;
+      overflow-x: auto;
+    }
+
+    .route span {
+      white-space: nowrap;
+    }
+
+    .note {
+      color: var(--muted);
+      font-size: 0.94rem;
+    }
+
+    footer {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto 38px;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 960px) {
+      .hero-inner,
+      .layout,
+      .split {
+        grid-template-columns: 1fr;
+      }
+
+      .toc {
+        position: static;
+      }
+
+      .thesis,
+      .module-board,
+      .layer-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .flow-row {
+        grid-template-columns: 1fr;
+      }
+
+      .arrow {
+        margin-left: 18px;
+      }
+    }
+
+    @media (max-width: 560px) {
+      .hero-inner {
+        width: min(100% - 22px, 1180px);
+        padding: 34px 0;
+      }
+
+      .hero h1 {
+        font-size: 1.8rem;
+      }
+
+      .layout {
+        width: min(100% - 22px, 1180px);
+        padding-top: 18px;
+      }
+
+      section {
+        padding: 18px;
+      }
+
+      .matrix {
+        display: block;
+        overflow-x: auto;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <div class="hero-inner">
+      <div>
+        <h1>OpenRA AI 分层架构剖面</h1>
+        <p>
+          这份报告把 OpenRA 的 skirmish AI 拆成从大厅配置到世界变更的完整剖面。
+          核心结论很锋利：<strong>AI 不拥有第二套玩法运行时，它只是正式命令链路的生产者。</strong>
+          经济、扩张、建造、分队和技能都被拆成玩家级模块，最后统一排队为 Order。
+        </p>
+      </div>
+      <aside class="stamp" aria-label="版本信息">
+        <span>源码位置 <b>external/reference/OpenRA</b></span>
+        <span>OpenRA 分支 <b>bleed</b></span>
+        <span>下载前 HEAD <b>cb4671f6</b></span>
+        <span>报告类型 <b>外部架构参考</b></span>
+      </aside>
+    </div>
+  </header>
+
+  <div class="layout">
+    <nav class="toc" aria-label="目录">
+      <h2>目录</h2>
+      <a href="#thesis">一句话总览</a>
+      <a href="#pipeline">完整命令剖面</a>
+      <a href="#layers">十层拆解</a>
+      <a href="#modules">模块生态</a>
+      <a href="#profiles">配置性格</a>
+      <a href="#performance">性能与回放</a>
+      <a href="#debug">调试观察</a>
+      <a href="#lessons">给 Ludots 的启发</a>
+      <a href="#evidence">证据索引</a>
+    </nav>
+
+    <main>
+      <section id="thesis" class="band">
+        <span class="tagline">Architecture Thesis</span>
+        <h2>OpenRA AI 的真面目：玩家级模块，命令级出口</h2>
+        <p>
+          OpenRA 的 AI 不是全局大脑，也不是统一行为树。它挂在 <code>SystemActors.Player</code> 上，
+          通过 <code>ModularBot</code> 调度一组 bot module。模块读世界、维护索引、做启发式判断，
+          但不会直接写 gameplay state。所有动作都要变成 <code>Order</code>，再进入和人类玩家相同的
+          <code>World.IssueOrder</code>、<code>OrderManager</code>、<code>UnitOrders</code>、
+          <code>Actor.ResolveOrder</code> 链路。
+        </p>
+        <div class="thesis">
+          <div class="signal">
+            <b>边界漂亮</b>
+            <span>AI 的输出是 Order，不是组件修改。同步、回放、校验都围绕命令流。</span>
+          </div>
+          <div class="signal">
+            <b>模块很实战</b>
+            <span>经济、建筑、生产、采矿、扩张、分队、支援技能各管一块。</span>
+          </div>
+          <div class="signal">
+            <b>策略靠数据调味</b>
+            <span>Rush、Normal、Turtle、Naval 主要通过 YAML condition 和参数组合出来。</span>
+          </div>
+        </div>
+      </section>
+
+      <section id="pipeline">
+        <h2>完整命令剖面</h2>
+        <p>
+          如果把 OpenRA AI 想成一条流水线，它最像一个“参谋部”：参谋部只写命令，真正执行命令的是军队既有系统。
+          这条链路是理解它底层设计的主轴。
+        </p>
+        <div class="flow" aria-label="OpenRA AI 命令流">
+          <div class="flow-row">
+            <div class="flow-cell layer">Lobby / YAML</div>
+            <div class="flow-cell action"><code>IBotInfo.Type</code> 暴露可选 bot，地图规则声明 <code>ModularBot@RushAI</code> 等 profile。</div>
+            <div class="flow-cell guard">数据入口</div>
+          </div>
+          <div class="arrow"></div>
+          <div class="flow-row">
+            <div class="flow-cell layer">Player 激活</div>
+            <div class="flow-cell action"><code>Player.cs</code> 根据 session 中的 bot type，在 host 侧激活 PlayerActor 上的 <code>IBot</code>。</div>
+            <div class="flow-cell guard">只在 host 决策</div>
+          </div>
+          <div class="arrow"></div>
+          <div class="flow-row">
+            <div class="flow-cell layer">ModularBot 调度</div>
+            <div class="flow-cell action"><code>IBotTick</code> 模块在 <code>Sync.RunUnsynced</code> 中被逐个 tick，模块调用 <code>QueueOrder</code>。</div>
+            <div class="flow-cell guard">AI 不改世界</div>
+          </div>
+          <div class="arrow"></div>
+          <div class="flow-row">
+            <div class="flow-cell layer">Order 派发</div>
+            <div class="flow-cell action">pending order 被分批送入 <code>World.IssueOrder</code>，再走 <code>OrderManager</code> 和 <code>UnitOrders</code>。</div>
+            <div class="flow-cell guard">限流与校验</div>
+          </div>
+          <div class="arrow"></div>
+          <div class="flow-row">
+            <div class="flow-cell layer">Actor / Trait 执行</div>
+            <div class="flow-cell action"><code>IResolveOrder</code> trait 解析命令，生成 activity 或 gameplay 变更。</div>
+            <div class="flow-cell guard">正式玩法系统</div>
+          </div>
+        </div>
+      </section>
+
+      <section id="layers">
+        <h2>十层架构拆解</h2>
+        <div class="layer-grid">
+          <article class="layer-card">
+            <h3><span class="num">1</span>大厅与 Bot Profile 层</h3>
+            <p>
+              这一层回答“玩家能选哪种 AI”。<code>IBotInfo</code> 提供 <code>Type</code> 与 <code>Name</code>，
+              RA/CnC/D2k/TS 各自用 YAML 在 Player actor 上声明不同 <code>ModularBot</code>。
+            </p>
+            <p class="note">架构味道：AI 类型不是 C# 继承树，而是规则数据暴露出的 profile。</p>
+            <div class="source-list">
+              <a href="../../external/reference/OpenRA/OpenRA.Game/Traits/TraitsInterfaces.cs">OpenRA.Game/Traits/TraitsInterfaces.cs</a>
+              <a href="../../external/reference/OpenRA/mods/ra/rules/ai.yaml">mods/ra/rules/ai.yaml</a>
+            </div>
+          </article>
+
+          <article class="layer-card">
+            <h3><span class="num">2</span>PlayerActor 激活层</h3>
+            <p>
+              Runtime Player 构造时读取 session 中的 bot type，只在 host 侧找到匹配的 <code>IBot</code> 并调用
+              <code>Activate</code>。其他客户端不跑 AI 决策，只接收 host 发出的 order。
+            </p>
+            <p class="note">架构味道：AI 内部启发式不进入同步模拟，减少 desync 风险。</p>
+            <div class="source-list">
+              <a href="../../external/reference/OpenRA/OpenRA.Game/Player.cs">OpenRA.Game/Player.cs</a>
+              <a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs">CreateMapPlayers.cs</a>
+            </div>
+          </article>
+
+          <article class="layer-card">
+            <h3><span class="num">3</span>ModularBot 调度层</h3>
+            <p>
+              <code>ModularBot</code> 收集 <code>IBotTick</code>、<code>IBotRespondToAttack</code>、
+              <code>IBotEnabled</code> 等模块接口。它像一个很薄的 bot kernel：tick 模块、缓存 order、分批发 order。
+            </p>
+            <p class="note">架构味道：调度器轻，策略厚度下沉到模块。</p>
+            <div class="source-list">
+              <a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Player/ModularBot.cs">ModularBot.cs</a>
+            </div>
+          </article>
+
+          <article class="layer-card">
+            <h3><span class="num">4</span>模块通信层</h3>
+            <p>
+              模块之间不共享一个巨大基类，而是通过小接口互相请求。例如采矿模块请求补矿车，基地建造模块要求暂停单位生产，
+              扩张模块通知新基地位置。
+            </p>
+            <p class="note">架构味道：这是轻量端口模型，代价是调用关系需要追源码。</p>
+            <div class="source-list">
+              <a href="../../external/reference/OpenRA/OpenRA.Mods.Common/TraitsInterfaces.cs">OpenRA.Mods.Common/TraitsInterfaces.cs</a>
+            </div>
+          </article>
+
+          <article class="layer-card">
+            <h3><span class="num">5</span>空间认知层</h3>
+            <p>
+              <code>ResourceMapBotModule</code> 把地图切成粗粒度资源区块，缓存资源中心、矿车、矿厂、敌军、敌方建筑、友方单位等信息。
+              它不像完整 blackboard，但已经承担了 AI 空间记忆的角色。
+            </p>
+            <p class="note">架构味道：低成本、分帧更新、为经济和扩张服务。</p>
+            <div class="source-list">
+              <a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/ResourceMapBotModule.cs">ResourceMapBotModule.cs</a>
+            </div>
+          </article>
+
+          <article class="layer-card">
+            <h3><span class="num">6</span>战略经营层</h3>
+            <p>
+              基地建造、生产比例、采矿维护、MCV 部署和扩张评分都在这里。它们不是通用 planner，
+              而是大量 RTS 老经验：低电先电厂、钱少补矿厂、钱多补产能、建不下就扩张。
+            </p>
+            <p class="note">架构味道：启发式厚，但边界清楚，最后仍然只发 Order。</p>
+            <div class="source-list">
+              <a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs">BaseBuilderBotModule.cs</a>
+              <a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs">UnitBuilderBotModule.cs</a>
+              <a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs">HarvesterBotModule.cs</a>
+            </div>
+          </article>
+
+          <article class="layer-card">
+            <h3><span class="num">7</span>战术分队层</h3>
+            <p>
+              <code>SquadManagerBotModule</code> 把新单位归入空军、海军、突击、防御等 squad。每个 squad 用轻状态机处理 idle、attack、
+              flee，并用局部 fuzzy 判断该打还是撤。
+            </p>
+            <p class="note">架构味道：战术不是逐单位大脑，而是分队级状态机。</p>
+            <div class="source-list">
+              <a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs">SquadManagerBotModule.cs</a>
+              <a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/Squads/Squad.cs">Squads/Squad.cs</a>
+              <a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/Squads/AttackOrFleeFuzzy.cs">AttackOrFleeFuzzy.cs</a>
+            </div>
+          </article>
+
+          <article class="layer-card">
+            <h3><span class="num">8</span>技能与响应层</h3>
+            <p>
+              支援技能、维修、断电管理、占领、布雷等小能力都被拆成独立模块。许多模块是事件触发加周期扫描，
+              避免把所有判断塞进一个巨型 tick。
+            </p>
+            <p class="note">架构味道：能力型模块按玩法边界分拆，接入同一个 order 出口。</p>
+            <div class="source-list">
+              <a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs">SupportPowerBotModule.cs</a>
+              <a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/BuildingRepairBotModule.cs">BuildingRepairBotModule.cs</a>
+              <a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/CaptureManagerBotModule.cs">CaptureManagerBotModule.cs</a>
+            </div>
+          </article>
+
+          <article class="layer-card">
+            <h3><span class="num">9</span>Order 边界层</h3>
+            <p>
+              这是系统最硬的一层。AI 发出的 <code>StartProduction</code>、<code>PlaceBuilding</code>、
+              <code>AttackMove</code>、<code>Harvest</code> 等命令，与玩家 UI 命令同构。校验仍由正式订单链路处理。
+            </p>
+            <p class="note">架构味道：AI 没有暗门，作弊和合法性在 Order 侧统一看。</p>
+            <div class="source-list">
+              <a href="../../external/reference/OpenRA/OpenRA.Game/World.cs">OpenRA.Game/World.cs</a>
+              <a href="../../external/reference/OpenRA/OpenRA.Game/Network/UnitOrders.cs">UnitOrders.cs</a>
+              <a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs">ValidateOrder.cs</a>
+            </div>
+          </article>
+
+          <article class="layer-card">
+            <h3><span class="num">10</span>玩法执行层</h3>
+            <p>
+              最终改变世界的是 actor trait、activity、production queue、movement、support power 等正式系统。
+              AI 不复制这些能力，只是调用它们已经暴露出来的命令入口。
+            </p>
+            <p class="note">架构味道：复用既有 gameplay runtime，避免第二套隐形玩法系统。</p>
+            <div class="source-list">
+              <a href="../../external/reference/OpenRA/OpenRA.Game/Actor.cs">OpenRA.Game/Actor.cs</a>
+              <a href="../../external/reference/OpenRA/OpenRA.Game/Traits/TraitsInterfaces.cs">IResolveOrder interfaces</a>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="modules">
+        <h2>模块生态：一组老练的 RTS 小脑</h2>
+        <p>
+          OpenRA 的模块不是追求抽象优雅，而是追求在真实 RTS 对局里“活下来”。它们各自有缓存、延迟、阈值、比例和失败回退。
+        </p>
+        <div class="module-board">
+          <article class="module">
+            <b>ResourceMap</b>
+            <p>维护资源区块、敌军、矿厂、矿车和基地分布，是经济与扩张的空间底图。</p>
+          </article>
+          <article class="module">
+            <b>BaseBuilder</b>
+            <p>按电力、经济、产能、防御、海军需求决定建筑队列，并寻找合法放置位置。</p>
+          </article>
+          <article class="module">
+            <b>UnitBuilder</b>
+            <p>按配置比例训练单位，支持单位上限、延迟和其他模块的指定生产请求。</p>
+          </article>
+          <article class="module">
+            <b>Harvester</b>
+            <p>给 idle 矿车找资源，被攻击时回矿厂，矿车不足时请求补造。</p>
+          </article>
+          <article class="module">
+            <b>MCV / Expansion</b>
+            <p>部署基地车、评分新资源点、选择扩张位置，必要时让基地搬家。</p>
+          </article>
+          <article class="module">
+            <b>SquadManager</b>
+            <p>组织突击、防御、空军、海军 squad，用状态机和 fuzzy 判断打还是撤。</p>
+          </article>
+          <article class="module">
+            <b>SupportPower</b>
+            <p>扫描候选区域，用 consideration 对目标打分，再发支援技能 order。</p>
+          </article>
+          <article class="module">
+            <b>Repair / PowerDown</b>
+            <p>维修受损建筑，电力不足时关闭指定建筑，电力恢复后再逐步打开。</p>
+          </article>
+          <article class="module">
+            <b>Capture / Minelayer</b>
+            <p>占领高价值目标，或根据冲突位置布雷，体现了能力模块的可插拔性。</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="profiles" class="band">
+        <h2>配置性格：AI 风格来自组合，不来自子类</h2>
+        <div class="split">
+          <div>
+            <p>
+              RA 的 <code>rush</code>、<code>normal</code>、<code>turtle</code>、<code>naval</code>，
+              CnC 的 <code>cabal</code>、<code>watson</code>、<code>hal9001</code>，都是通过 YAML condition 激活模块和参数。
+              <code>GrantConditionOnBotOwner</code> 根据 bot type 授予 condition，模块再用 <code>RequiresCondition</code> 决定是否运行。
+            </p>
+            <p>
+              这意味着 C# 提供能力，YAML 调性格：建筑比例、单位比例、上限、延迟、攻击规模、扩张阈值、技能评分都能由数据层调整。
+            </p>
+          </div>
+          <aside class="quote-box">
+            <strong>像调音台，而不是换发动机。</strong>
+            同一个 <code>BaseBuilderBotModule</code> 可以在 rush 里更激进，也可以在 turtle 里更防御。
+            模块是乐器，condition 和参数是混音台。
+          </aside>
+        </div>
+      </section>
+
+      <section id="performance">
+        <h2>性能与回放：它知道 RTS AI 贵在哪里</h2>
+        <table class="matrix">
+          <thead>
+            <tr>
+              <th>策略</th>
+              <th>OpenRA 做法</th>
+              <th>价值</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><span class="ok">分帧扫描</span></td>
+              <td>ResourceMap 每次更新一个区块，SquadManager 把 pending update 摊到多个 tick。</td>
+              <td>避免全图扫描集中在同一帧。</td>
+            </tr>
+            <tr>
+              <td><span class="ok">索引缓存</span></td>
+              <td>ActorIndex 订阅 actor add/remove，常用集合不靠每帧临时搜。</td>
+              <td>降低查询成本，减少瞬时分配和过滤。</td>
+            </tr>
+            <tr>
+              <td><span class="ok">昂贵操作限流</span></td>
+              <td>采矿寻路、支援技能扫描、建筑放置都有 cooldown 或局部候选。</td>
+              <td>把寻路和目标评分从每 tick 暴力计算中拿出来。</td>
+            </tr>
+            <tr>
+              <td><span class="ok">Order 限流</span></td>
+              <td><code>ModularBot.MinOrderQuotientPerTick</code> 控制 pending order 派发量。</td>
+              <td>防止 bot 瞬间刷爆命令链路。</td>
+            </tr>
+            <tr>
+              <td><span class="warn">回放分离</span></td>
+              <td>Bot 决策不在 replay 中重跑，回放只消费记录过的 order。</td>
+              <td>AI 内部状态无需成为回放确定性的唯一来源。</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="debug">
+        <h2>调试观察：能看到 AI 在想什么，但还不够结构化</h2>
+        <p>
+          OpenRA 有 <code>AIUtils.BotDebug</code>、<code>Game.Settings.Debug.BotDebug</code>、
+          <code>RenderDebugState</code> 等直接工具，可以把 squad 类型和目标画到单位上。这种可视化非常适合 RTS：
+          当一个小队发呆、撤退或乱冲，调试信息能马上告诉你它属于哪个 squad、目标是谁。
+        </p>
+        <p>
+          但 OpenRA 没有统一的结构化 decision trace。很多判断散落在模块内部的比例、阈值、随机扰动、cooldown 和特殊规则里。
+          它是很会打仗的工程系统，不是一本干净的 AI 教科书。
+        </p>
+      </section>
+
+      <section id="lessons" class="band">
+        <h2>给 Ludots 的启发</h2>
+        <div class="route" aria-label="Ludots 可借鉴路径">
+          <span>AI snapshot/query</span>
+          <span>-&gt; AI module / planner produces command intent</span>
+          <span>-&gt; command proposal merge and cap</span>
+          <span>-&gt; formal OrderBuffer / GAS order validation</span>
+          <span>-&gt; existing gameplay systems mutate ECS state</span>
+        </div>
+        <p>
+          最值得借鉴的不是具体模块代码，而是边界设计：<strong>AI 是命令生产者，正式玩法系统才是世界修改者。</strong>
+          如果 Ludots 做 RTS/战略 AI，应把 OpenRA 的经验翻译到自己的 Arch ECS、Mod、ConfigPipeline、SystemGroup 和 Order/GAS 管线里，
+          不应复制 GPL 代码，也不应让 AI 模块跨越职责直接写玩法组件。
+        </p>
+      </section>
+
+      <section id="evidence">
+        <h2>证据索引</h2>
+        <p class="note">以下路径均为本地参考源码或本仓库报告入口，方便继续深挖。</p>
+        <table class="matrix">
+          <thead>
+            <tr>
+              <th>主题</th>
+              <th>路径</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>深度 Markdown 报告</td>
+              <td><a href="openra_ai_system_analysis.md">docs/reference/openra_ai_system_analysis.md</a></td>
+            </tr>
+            <tr>
+              <td>Bot 入口</td>
+              <td><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Player/ModularBot.cs">external/reference/OpenRA/OpenRA.Mods.Common/Traits/Player/ModularBot.cs</a></td>
+            </tr>
+            <tr>
+              <td>Order 链路</td>
+              <td><a href="../../external/reference/OpenRA/OpenRA.Game/Network/UnitOrders.cs">external/reference/OpenRA/OpenRA.Game/Network/UnitOrders.cs</a></td>
+            </tr>
+            <tr>
+              <td>RA AI 配置</td>
+              <td><a href="../../external/reference/OpenRA/mods/ra/rules/ai.yaml">external/reference/OpenRA/mods/ra/rules/ai.yaml</a></td>
+            </tr>
+            <tr>
+              <td>Common BotModules</td>
+              <td><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules">external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules</a></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </main>
+  </div>
+
+  <footer>
+    本 HTML 是 Ludots 仓库中的外部参考材料。OpenRA 为 GPL 项目，本报告只做架构阅读和思想分析，不复制其源码实现。
+  </footer>
+</body>
+</html>

--- a/docs/reference/openra_ai_system_analysis.md
+++ b/docs/reference/openra_ai_system_analysis.md
@@ -1,0 +1,845 @@
+# OpenRA AI 底层系统源码分析
+
+本文是对 OpenRA `bleed` 分支 AI 底层实现的源码级参考分析，面向 Ludots 后续做 RTS / 战略 AI 架构取舍时使用。它不是 Ludots 正式规范，只是外部项目研究材料。
+
+## 1 版本与范围
+
+- 本地源码位置：`external/reference/OpenRA`
+- 下载方式：GitHub codeload zip。`git clone` 两次超时后改用源码归档。
+- OpenRA 分支：`bleed`
+- GitHub API 在下载前报告的 HEAD：`cb4671f6b7b516a30dc49eade03f139cd63a2234`
+- 主要分析范围：
+  - `OpenRA.Game` 的 Player、Order、World、Trait 基础设施
+  - `OpenRA.Mods.Common/Traits/Player/ModularBot.cs`
+  - `OpenRA.Mods.Common/Traits/BotModules/**`
+  - `mods/ra/rules/ai.yaml`
+  - `mods/cnc/rules/ai.yaml`
+- 未展开范围：
+  - 每一张 campaign 地图的 Lua 脚本 AI。OpenRA 的战役图有大量 `*-AI.lua`，那是地图脚本层，不是通用 skirmish bot 底层。
+  - 每个 mod 的所有 AI 配置逐项对比。本文重点看 Common 层和 RA/CnC 两个代表性配置。
+
+## 2 一句话结论
+
+OpenRA 的 skirmish AI 不是一个全局“大脑”，也不是行为树框架。它是挂在 `Player` 系统 actor 上的一组 trait 模块：
+
+```text
+Lobby 选择 BotType
+-> PlayerActor 上的 IBot trait 被 host 激活
+-> ModularBot 每 tick 调用启用的 IBotTick 模块
+-> 模块只读世界、做局部启发式决策、排队 Order
+-> ModularBot 分批把 Order 交给 World.IssueOrder
+-> OrderManager / UnitOrders / Actor.ResolveOrder 进入正常玩家命令链路
+-> 游戏状态由通用 order/activity/trait 系统修改
+```
+
+最关键的底层边界是：Bot 逻辑不直接改世界状态，只能发 order。OpenRA 甚至把 Bot tick 包在 `Sync.RunUnsynced` 中，明确把 AI 决策视为 host-local 的命令生成器，而不是同步世界模拟的一部分。同步、回放和作弊校验依赖的是 order 流，而不是 AI 内部状态。
+
+## 3 AI 的系统入口
+
+### 3.1 Bot 类型从 PlayerActor trait 暴露
+
+OpenRA 用 `IBotInfo` 暴露可选 Bot 类型：
+
+- 源码：`OpenRA.Game/Traits/TraitsInterfaces.cs`
+- 关键接口：
+  - `IBotInfo.Type`
+  - `IBotInfo.Name`
+  - `IBot.Activate(Player p)`
+  - `IBot.QueueOrder(Order order)`
+  - `IBot.Player`
+
+`ModularBotInfo` 和 `DummyBotInfo` 都实现 `IBotInfo`。`ModularBot` 是通用 skirmish AI，`DummyBot` 是占位 bot，常用于地图脚本自己控制行为的场景。
+
+源码入口：
+
+- `OpenRA.Mods.Common/Traits/Player/ModularBot.cs`
+- `OpenRA.Mods.Common/Traits/Player/DummyBot.cs`
+
+### 3.2 大厅只看 PlayerActor 上有哪些 IBotInfo
+
+大厅 UI 和服务端逻辑会从地图的 Player actor 规则里读取 `IBotInfo`：
+
+- `OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs`
+- `OpenRA.Mods.Common/ServerTraits/SkirmishLogic.cs`
+- `OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs`
+
+RA 的配置里直接声明：
+
+```yaml
+Player:
+    ModularBot@RushAI:
+        Name: bot-rush-ai.name
+        Type: rush
+    ModularBot@NormalAI:
+        Name: bot-normal-ai.name
+        Type: normal
+    ModularBot@TurtleAI:
+        Name: bot-turtle-ai.name
+        Type: turtle
+    ModularBot@NavalAI:
+        Name: bot-naval-ai.name
+        Type: naval
+```
+
+对应文件：`mods/ra/rules/ai.yaml`。
+
+CnC 则声明 `cabal`、`watson`、`hal9001`：
+
+```yaml
+Player:
+    ModularBot@Cabal:
+        Type: cabal
+    ModularBot@Watson:
+        Type: watson
+    ModularBot@HAL9001:
+        Type: hal9001
+```
+
+对应文件：`mods/cnc/rules/ai.yaml`。
+
+### 3.3 Player 构造阶段只在 host 激活 Bot
+
+`OpenRA.Game/Player.cs` 负责 runtime Player 构造。它会根据 `Session.Client.Bot` 得到 `BotType`，然后：
+
+```text
+if IsBot && Game.IsHost:
+    在 PlayerActor 上找 Info.Type == BotType 的 IBot
+    调用 logic.Activate(this)
+```
+
+这意味着 Bot 决策只在 host 侧运行。其他客户端不运行 AI 逻辑，只接收 host 发出的 order 流。这样减少同步复杂度，也避免每个客户端因为 AI 内部启发式差异产生 desync。
+
+## 4 ModularBot 的底层循环
+
+`ModularBot` 是整个 AI 系统的调度器。核心逻辑在 `OpenRA.Mods.Common/Traits/Player/ModularBot.cs`。
+
+它有三类职责：
+
+1. 激活时收集模块：
+   - `IBotTick[] tickModules`
+   - `IBotRespondToAttack[] attackResponseModules`
+   - `IBotEnabled`
+2. 每 tick 调用启用模块：
+   - 对每个 `IBotTick` 调 `BotTick(this)`
+   - 放在 `Sync.RunUnsynced(...)`
+3. 把模块排队的 order 分批送入世界：
+   - 模块调用 `bot.QueueOrder(order)`
+   - `ModularBot` 内部用 `Queue<Order>` 缓存
+   - 每 tick 发出最多一部分，受 `MinOrderQuotientPerTick` 控制
+
+它的源码注释写得非常关键：Bot logic 不允许影响 world state，只能 issue orders；这些 orders 会被 replay 记录，所以 replay 中不启用 bots。
+
+这就是 OpenRA AI 最值得学习的系统边界：AI 是“命令生产者”，不是“状态修改者”。
+
+## 5 Order 链路：AI 和玩家走同一套执行系统
+
+### 5.1 订单生成
+
+AI 模块生成的都是正常 `Order`：
+
+- `Order.StartProduction(...)`
+- `new Order("PlaceBuilding", ...)`
+- `new Order("AttackMove", ...)`
+- `new Order("Harvest", ...)`
+- `new Order("DeployTransform", ...)`
+- `new Order("RepairBuilding", ...)`
+- support power 的 order name
+
+这些 order 与玩家 UI 下发的命令同构。
+
+### 5.2 订单派发
+
+链路如下：
+
+```text
+IBot.QueueOrder
+-> ModularBot.orders
+-> World.IssueOrder
+-> OrderManager.IssueOrder
+-> 网络 / 本地 order buffer
+-> UnitOrders.ResolveOrder
+-> world.OrderValidators
+-> Actor.ResolveOrder
+-> IResolveOrder trait
+-> Activity / Trait 修改世界状态
+```
+
+关键源码：
+
+- `OpenRA.Game/World.cs`
+- `OpenRA.Game/Network/OrderManager.cs`
+- `OpenRA.Game/Network/UnitOrders.cs`
+- `OpenRA.Game/Actor.cs`
+- `OpenRA.Mods.Common/Traits/World/ValidateOrder.cs`
+
+### 5.3 订单校验允许 Bot controller 控制 Bot actor
+
+`ValidateOrder` 会检查 order 的 subject owner 是否匹配 client id。Bot 的特殊情况是：
+
+```text
+subjectClient.Bot != null
+&& clientId == subjectClient.BotControllerClientIndex
+```
+
+也就是说，host/admin client 可以作为 Bot controller 为 bot actor 发 order。这保持了安全边界：AI 不能绕过 order validation 去直接改 actor。
+
+## 6 BotModule 组合机制
+
+### 6.1 模块都是 Player actor trait
+
+Common 层的大部分模块都标了：
+
+```csharp
+[TraitLocation(SystemActors.Player)]
+```
+
+它们不是普通单位身上的 AI component，而是玩家级策略模块。这样它们天然能访问：
+
+- `Player`
+- `PlayerActor`
+- 所有己方 actor
+- 世界资源层
+- 生产队列
+- 支援技能管理器
+- shroud / frozen actor 信息
+- pathfinder
+
+### 6.2 用 condition 把 BotType 映射到模块组合
+
+RA 配置先通过 `GrantConditionOnBotOwner` 按 `BotType` 授予 condition：
+
+```yaml
+GrantConditionOnBotOwner@rush:
+    Condition: enable-rush-ai
+    Bots: rush
+```
+
+模块再用 `RequiresCondition` 决定是否启用：
+
+```yaml
+BaseBuilderBotModule@rush:
+    RequiresCondition: enable-rush-ai
+```
+
+源码：`OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs`。
+
+这样同一套 C# 模块可以组合出不同 AI 性格：
+
+- Rush：更大进攻规模、更激进扩张、更早攻击
+- Normal：均衡生产和防守
+- Turtle：高防御、攻击间隔极长、地雷模块启用
+- Naval：优先海军与空军生产
+
+这不是继承体系，而是配置驱动的模块开关。
+
+### 6.3 模块之间通过小接口协作
+
+Common 层定义了一批 bot 专用接口：
+
+- `IBotTick`
+- `IBotEnabled`
+- `IBotRespondToAttack`
+- `IBotPositionsUpdated`
+- `IBotNotifyIdleBaseUnits`
+- `IBotRequestUnitProduction`
+- `IBotRequestPauseUnitProduction`
+- `IBotBaseExpansion`
+- `IBotSuggestRefineryProduction`
+
+源码：`OpenRA.Mods.Common/TraitsInterfaces.cs`。
+
+这些接口形成一个很轻的玩家级“模块总线”：
+
+- `SquadManager` 告诉 `UnitBuilder` 当前基地闲置单位数
+- `BaseBuilder` 在经济不足时让 `UnitBuilder` 暂停生产单位
+- `HarvesterBotModule` 请求 `UnitBuilder` 补造矿车
+- `McvExpansionManager` 通知 `BaseBuilder` 新矿区位置，建议造 refinery
+- `BaseBuilder` 或 `SquadManager` 被攻击时更新 defense center
+
+优点是模块间没有共同大基类；缺点是隐式耦合比较多，需要读接口调用链才能知道谁影响谁。
+
+## 7 核心模块逐个拆解
+
+### 7.1 ResourceMapBotModule：AI 的资源/威胁粗粒度地图
+
+源码：`OpenRA.Mods.Common/Traits/BotModules/ResourceMapBotModule.cs`
+
+职责：
+
+- 把地图按 stride 切成多个 `ResourceIndice`
+- 每个 indice 缓存：
+  - 资源格数量
+  - 资源中心
+  - resource creator 位置
+  - 己方 refinery 数
+  - 己方 harvester 数
+  - 敌方单位数
+  - 敌方基地建筑数
+  - 友方基地/单位数
+- 每隔若干 tick 更新一个 indice，避免一次性扫描全图
+
+它本身不发 order，是给采矿、扩张、基地建造等模块用的空间认知层。
+
+这层非常接近一个低成本 AI blackboard，但 OpenRA 没有把它抽象成通用 blackboard，而是做成具体的 bot module。
+
+### 7.2 BaseBuilderBotModule：基地建造与建筑比例控制
+
+源码：
+
+- `OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs`
+- `OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs`
+
+职责：
+
+- 维护 construction yard、refinery、power、production、defense 等 actor 索引
+- 决定下一栋建筑要造什么
+- 生产完成后寻找放置位置
+- 设置 rally point
+- 修正/记录 base center 和 defense center
+- 经济不足时暂停单位生产
+- refinery 过密或远离资源时卖掉
+- 建筑放不下时触发扩张模块
+
+决策优先级大致是：
+
+```text
+低电力 -> 造 power
+经济不足 -> 造 refinery
+现金太多 -> 造 production
+需要海军且有水 -> 造 naval production
+资源容量满 -> 造 silo
+否则按 BuildingFractions / BuildingLimits / BuildingDelays 选建筑
+```
+
+位置选择也不是随机乱放：
+
+- 普通建筑围绕 base center 找合法位置
+- defense 朝 closest enemy building/attacker 方向靠近
+- refinery 优先靠近资源和 expansion request
+- naval building 会先检查基地附近是否有水域和 buildable area
+
+这个模块很“老派 RTS”：大量启发式、比例、阈值、延迟和特殊规则，而不是通用 planner。
+
+### 7.3 UnitBuilderBotModule：按目标比例训练单位
+
+源码：`OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs`
+
+职责：
+
+- 周期性寻找空闲生产队列
+- 根据 `UnitsToBuild` 的相对比例选择单位
+- 遵守 `UnitLimits`
+- 遵守 `UnitDelays`
+- 响应其他模块的指定单位生产请求
+- 被 `IBotRequestPauseUnitProduction` 暂停时不生产
+
+它不是“我要打什么就精确造什么”的 planner，而是维持一个长期军队构成比例。外部请求只处理少数关键补位，例如矿车、MCV。
+
+### 7.4 HarvesterBotModule：采矿维护与矿车自救
+
+源码：`OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs`
+
+职责：
+
+- 扫描 idle harvester
+- 给 idle harvester 下 `Harvest`
+- 当找不到资源时增加 cooldown
+- 结合 `ResourceMapBotModule` 找低效率矿车并重新分派
+- 矿车数低于 refinery 或初始要求时请求 `UnitBuilder` 补矿车
+- 矿车被攻击时下 `Dock` 命令回最近矿厂
+
+它在寻路时加了敌人规避成本：
+
+```text
+资源目标候选
+-> pathfinder 搜索
+-> 对敌方威胁 bin 增加额外 cost
+-> 找到安全资源格后发 Harvest order
+```
+
+这是 OpenRA AI 里少数比较细的局部路径成本策略。
+
+### 7.5 McvManager / McvExpansionManager：基地部署与扩张
+
+源码：
+
+- `OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs`
+- `OpenRA.Mods.Common/Traits/BotModules/McvExpansionManagerBotModule.cs`
+
+`McvManagerBotModule` 比较简单：
+
+- 管理 MCV
+- 初始或空闲时部署
+- construction yard 数不足时请求建 MCV
+
+`McvExpansionManagerBotModule` 更复杂：
+
+- 依赖 `ResourceMapBotModule`
+- 支持 `CheckResource`、`CheckBase`、`CheckCurrentLocation` 三种扩张模式
+- 为每个资源 indice 计算 attraction
+- 综合考虑：
+  - 到当前 MCV 的距离或 path distance
+  - 资源量
+  - resource creator
+  - 敌方基地/单位威胁
+  - 己方/友方 construction yard 距离
+  - 己方 refinery 距离
+  - 其他 active MCV 目标冲突
+- 找到中心后，再找可部署 cell
+- 失败多次后自动切换扩张模式
+- 可把 construction yard undeploy 成 MCV 再搬家
+
+这是 OpenRA 通用 AI 中最接近“战略位置评分”的模块。
+
+### 7.6 SquadManagerBotModule：作战单位组织
+
+源码：
+
+- `OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs`
+- `OpenRA.Mods.Common/Traits/BotModules/Squads/Squad.cs`
+- `OpenRA.Mods.Common/Traits/BotModules/Squads/StateMachine.cs`
+- `OpenRA.Mods.Common/Traits/BotModules/Squads/States/*.cs`
+- `OpenRA.Mods.Common/Traits/BotModules/Squads/AttackOrFleeFuzzy.cs`
+
+职责：
+
+- 发现新生产出的可作战单位
+- 按单位类型分配：
+  - air squad
+  - naval squad
+  - base idle ground units
+- 满足 `SquadSize + random bonus` 后组建 Assault squad
+- 周期性尝试 Rush
+- 被攻击时组建 Protection squad
+- 管理 squads 更新和清理
+
+Squad 类型：
+
+- `Assault`
+- `Air`
+- `Rush`
+- `Protection`
+- `Naval`
+
+状态机非常轻：
+
+```text
+GroundUnitsIdle
+-> GroundUnitsAttackMove
+-> GroundUnitsAttack
+-> GroundUnitsFlee
+
+AirIdle
+-> AirAttack
+-> AirFlee
+
+ProtectionIdle
+-> ProtectionAttack
+-> ProtectionFlee
+```
+
+攻击或撤退的判断用了 fuzzy logic，但范围很小：`AttackOrFleeFuzzy` 只计算当前己方单位集合 vs 敌方单位集合是否值得打，输入包括：
+
+- 己方血量
+- 敌方血量
+- 相对攻击力
+- 相对速度
+
+它不是全局 fuzzy AI，只是 squad 层局部战斗决策器。
+
+### 7.7 SupportPowerBotModule：支援技能目标选择
+
+源码：
+
+- `OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs`
+- `OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs`
+
+职责：
+
+- 遍历已 ready 的 support powers
+- 先粗粒度扫描地图 region
+- 再在候选 region 内精细扫描 cell
+- 用配置化 `Consideration` 计算吸引力
+- 没找到目标则延迟下一次扫描
+- 找到目标后发 support power order
+
+`SupportPowerDecision` 支持：
+
+- `Against`: Ally / Neutral / Enemy
+- `Types`: 目标 target types
+- `Attractiveness`: 分值
+- `TargetMetric`: Health / Value / None
+- `CheckRadius`
+
+RA 的 nuke 配置会给 enemy structures 正分，给 ally units 负分。这个模式很适合做可调的技能目标评分。
+
+### 7.8 BuildingRepairBotModule：建筑维修
+
+源码：`OpenRA.Mods.Common/Traits/BotModules/BuildingRepairBotModule.cs`
+
+职责：
+
+- 被攻击事件触发
+- 周期性扫描己方受损 `RepairableBuilding`
+- 对单个受损建筑或全部受损建筑发 `RepairBuilding`
+
+它是一个响应型模块，不在每 tick 主动大扫描，借攻击通知做触发入口。
+
+### 7.9 PowerDownBotModule：断电时关停建筑
+
+源码：`OpenRA.Mods.Common/Traits/BotModules/PowerDownBotManager.cs`
+
+职责：
+
+- 监控 `PowerManager.ExcessPower`
+- 低电时对指定建筑发 powerdown order
+- 电力恢复时逐步重新打开
+- 用本地列表追踪被自己关停的建筑
+
+它依赖配置里指定哪些建筑允许 toggle，例如 RA 中 `dome,tsla,mslo,agun,sam`。
+
+### 7.10 CaptureManagerBotModule：占领逻辑
+
+源码：`OpenRA.Mods.Common/Traits/BotModules/CaptureManagerBotModule.cs`
+
+职责：
+
+- 寻找 idle capturer
+- 选择敌方或中立的可占领目标
+- 按 sell value 排序，限制候选数量
+- 检查路径可达
+- 发 `CaptureActor`
+
+它体现了 OpenRA AI 的通用套路：每个小能力都做成独立 bot module，用 actor trait 能力判断是否可用。
+
+### 7.11 MinelayerBotModule：地雷特化逻辑
+
+源码：`OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/MinelayerBotModule.cs`
+
+职责：
+
+- 被攻击时记录 conflict position
+- 把 conflict position 合并成 favorite minefield positions
+- 周期性派 minelayer 去布雷
+- 若无记录，则尝试在己方 minelayer 到随机敌人的路径中点布雷
+- 发 `PlaceMinefield` 和回撤 `Move`
+
+这个模块只在特定 AI 配置中开启，例如 RA turtle。
+
+## 8 配置层：AI 性格主要来自 YAML
+
+OpenRA 的 AI 策略不是硬编码成多个 C# 子类。C# 提供能力模块，YAML 负责组合。
+
+以 RA 为例：
+
+- `ModularBot@RushAI / NormalAI / TurtleAI / NavalAI` 定义 bot 类型
+- `GrantConditionOnBotOwner` 为 bot type 授予 condition
+- 每个模块按 `RequiresCondition` 激活
+- 不同 bot type 各自配置：
+  - `BuildingFractions`
+  - `BuildingLimits`
+  - `BuildingDelays`
+  - `UnitsToBuild`
+  - `UnitLimits`
+  - `UnitDelays`
+  - `SquadSize`
+  - `RushInterval`
+  - `MinimumAttackForceDelay`
+  - `ProtectionScanRadius`
+  - expansion tolerances
+
+这套模式的核心收益：
+
+- 一个模块能服务多个游戏和多个 AI 性格
+- mod 可以只改 YAML 形成差异
+- C# 代码保持能力抽象，数值和偏好在数据层
+
+核心代价：
+
+- actor type 名称在多个配置段重复
+- 策略耦合隐藏在字符串、比例和 condition 中
+- 参数非常多，调试依赖经验和 bot debug
+
+## 9 性能策略
+
+OpenRA AI 里有大量手写性能控制，不是靠框架统一调度：
+
+1. 随机初始 tick offset
+   - 避免所有 AI 同一 tick 扫描。
+2. 分批更新
+   - ResourceMap 每次只更新一个 indice。
+   - SquadManager 把 pending squad update 摊到多个 tick。
+   - BaseBuilder 每次只 tick 一个有效 queue category。
+3. 事件索引
+   - `ActorIndex` 订阅 `World.ActorAdded` / `ActorRemoved`，维护常用 actor 集合。
+4. 昂贵查询限流
+   - Harvester 每 tick 最多做一次 `FindNextResource`。
+   - SupportPower 找不到目标后 delayed rescan。
+5. Order 限流
+   - `ModularBot.MinOrderQuotientPerTick` 让 pending orders 分批发出。
+
+这说明他们很清楚 RTS AI 的瓶颈不在“算法名字”，而在每 tick 全图扫描、寻路、目标过滤和 order spam。
+
+## 10 存档与回放
+
+多个模块实现 `IGameSaveTraitData`：
+
+- `BaseBuilderBotModule`
+- `UnitBuilderBotModule`
+- `SquadManagerBotModule`
+- `McvManagerBotModule`
+- `SupportPowerBotModule`
+- `PowerDownBotModule`
+
+它们会保存内部 tick、队列、squad、base center 等状态。
+
+但 replay 中不启用 bot 决策；replay 只需要记录过的 order。这再次说明 OpenRA 把 AI 内部状态和世界同步状态分开处理。
+
+## 11 调试与可视化
+
+OpenRA 有简单但直接的 AI 调试能力：
+
+- `AIUtils.BotDebug(...)`
+- `Game.Settings.Debug.BotDebug`
+- `Game.Settings.Debug.SyncCheckBotModuleCode`
+- `OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs`
+
+`RenderDebugState` 会显示 actor 所属 AI squad 的类型和目标信息。这种“直接把 AI 内部状态画在单位上”的调试方式，对 RTS AI 特别有效。
+
+## 12 设计优点
+
+1. AI 不直接改世界状态
+   - 保证 multiplayer/replay/debug 都围绕 order 链路。
+
+2. AI 与玩家共享能力入口
+   - AI 用 `AttackMove`、`Harvest`、`StartProduction`、`PlaceBuilding`，不会绕开 gameplay trait。
+
+3. Bot 类型是数据组合
+   - C# 模块复用，YAML 决定 Rush/Normal/Turtle/Naval。
+
+4. 模块职责相对清晰
+   - 经济、建筑、生产、采矿、扩张、作战、支援技能都独立。
+
+5. Player actor 是天然 AI host
+   - 玩家级策略状态不散落到单位身上。
+
+6. 性能策略贴近 RTS 实际
+   - 分帧、缓存、索引、限流，而不是每 tick 大脑全量重算。
+
+7. 支持不同 mod
+   - Common 模块通过 actor names、traits、target types 适配 RA/CnC/D2k/TS。
+
+## 13 设计代价与风险
+
+1. 字符串配置高度分散
+   - `harv`、`proc`、`fact` 等 actor names 在多个模块配置里重复。
+   - 优点是 mod 灵活，缺点是缺少强约束。
+
+2. 模块内部启发式很厚
+   - `BaseBuilderQueueManager` 和 `McvExpansionManager` 都包含大量策略、放置、特例和 retry 逻辑。
+
+3. 没有统一 AI blackboard
+   - `ResourceMapBotModule` 很像局部 blackboard，但不是通用设施。
+   - 模块之间靠接口互调，读源码时需要追踪调用关系。
+
+4. 没有统一决策解释模型
+   - BotDebug 有用，但不是结构化 decision trace。
+
+5. Campaign AI 与 skirmish AI 是两套世界
+   - 通用 bot modules 管 skirmish。
+   - 战役脚本大量 Lua，灵活但不统一。
+
+6. 多处存在 HACK/TODO
+   - 例如 building placement、D2k repair 特例、squad stuck fallback、raw coordinate transform 等。
+   - 这些不是坏事，但说明这套系统是长期演化出来的实战工程，不是干净教科书架构。
+
+## 14 对 Ludots 的借鉴
+
+结合 Ludots 的“六边形架构、一切皆 Mod、禁止跨越职责”的方向，OpenRA 最值得借鉴的是边界，而不是直接照搬模块代码。
+
+### 14.1 借鉴一：AI 只产生命令，不直接写世界
+
+OpenRA 的最强原则是：
+
+```text
+AI Decision -> Order -> 正式 order/activity/system 链路 -> World mutation
+```
+
+如果 Ludots 后续做 RTS/战略 AI，应把 AI Runtime 定义为“正式输入/指令管线的生产者”，而不是让 AI system 直接改组件。
+
+对应 Ludots 思路：
+
+- AI 读 ECS snapshot / query
+- AI 产生 formal command / order / intent
+- order 进入现有输入、能力或命令管线
+- 正式 system group 执行状态变化
+
+### 14.2 借鉴二：Player/Commander 级 AI host
+
+OpenRA 把 skirmish AI 挂在 `SystemActors.Player`。Ludots 如果做战略 AI，也应该优先考虑“玩家/阵营/指挥者实体”作为 AI host，而不是给每个单位塞一个全局策略脑。
+
+单位级行为可以保留局部自动化，但战略层状态应归属阵营级 entity/mod。
+
+### 14.3 借鉴三：模块组合，而不是 bot 子类继承树
+
+OpenRA 的 Rush/Normal/Turtle/Naval 都复用同一套模块。差异来自：
+
+- condition
+- module enable
+- ratio
+- delay
+- limit
+- scan radius
+- target type
+
+Ludots 可用 Mod 配置或 Registry 描述：
+
+- AI module capability
+- AI profile
+- module enable condition
+- decision weight / budget
+- command output type
+
+### 14.4 借鉴四：模块间只暴露窄接口
+
+OpenRA 的 `IBotRequestUnitProduction`、`IBotPositionsUpdated`、`IBotSuggestRefineryProduction` 很朴素，但有效。
+
+Ludots 若要做 AI 模块，应避免模块互相直接拿内部字段，可以用明确的 port/interface/event：
+
+- request production
+- update base center
+- suggest expansion location
+- report idle army
+- request defense response
+
+### 14.5 借鉴五：性能预算内建进模块
+
+OpenRA AI 到处可见：
+
+- staggered tick
+- one expensive search per tick
+- pending update stacks
+- actor indices
+- delayed rescan
+- order throttling
+
+Ludots 的 AI Runtime 如果进入大规模模拟，应该从第一版就有：
+
+- per-module tick budget
+- query cache
+- spatial index
+- delayed scan schedule
+- command output cap
+- debug counters
+
+### 14.6 谨慎点：不要照搬 GPL 代码
+
+OpenRA 是 GPL 项目。本报告只做架构分析和思想参考，不应把 OpenRA 源码复制进 Ludots。若后续实现，应基于 Ludots 现有 ECS、Mod、ConfigPipeline、AI Runtime 和正式 order/ability 管线重新设计。
+
+## 15 如果给 Ludots 设计一个对应骨架
+
+以下不是实现方案，只是把 OpenRA 的经验翻译成 Ludots 风格时的候选结构。
+
+```text
+Faction/Commander Entity
+  Components:
+    AiProfileRef
+    AiBlackboardHandle
+    AiCommandQueue
+    AiBudget
+
+AiRuntime SystemGroup
+  1. Snapshot collection
+  2. Strategic module ticks
+  3. Tactical module ticks
+  4. Command proposal merge
+  5. Command validation
+  6. Dispatch into formal order/input/ability pipeline
+
+Modules
+  EconomyModule
+  ProductionModule
+  BasePlannerModule
+  ResourcePlannerModule
+  ArmySquadModule
+  DefenseResponseModule
+  SupportAbilityModule
+
+Boundary
+  AI modules cannot mutate gameplay components.
+  AI modules emit validated command intents only.
+```
+
+这与 OpenRA 的本质一致，但要用 Ludots 自己的 ECS/Registry/Pipeline/Mod 设施承载。
+
+## 16 关键源码路径清单
+
+入口与激活：
+
+- `external/reference/OpenRA/OpenRA.Game/Player.cs`
+- `external/reference/OpenRA/OpenRA.Game/Traits/TraitsInterfaces.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/Player/ModularBot.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/Player/DummyBot.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/ServerTraits/SkirmishLogic.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs`
+
+订单与校验：
+
+- `external/reference/OpenRA/OpenRA.Game/World.cs`
+- `external/reference/OpenRA/OpenRA.Game/Network/OrderManager.cs`
+- `external/reference/OpenRA/OpenRA.Game/Network/UnitOrders.cs`
+- `external/reference/OpenRA/OpenRA.Game/Actor.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs`
+
+模块接口与工具：
+
+- `external/reference/OpenRA/OpenRA.Mods.Common/TraitsInterfaces.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/AIUtils.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/ActorIndex.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs`
+
+BotModules：
+
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/ResourceMapBotModule.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/McvExpansionManagerBotModule.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/Squads/Squad.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/Squads/StateMachine.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/Squads/AttackOrFleeFuzzy.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/BuildingRepairBotModule.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/PowerDownBotManager.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/CaptureManagerBotModule.cs`
+- `external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/MinelayerBotModule.cs`
+
+代表配置：
+
+- `external/reference/OpenRA/mods/ra/rules/ai.yaml`
+- `external/reference/OpenRA/mods/cnc/rules/ai.yaml`
+- `external/reference/OpenRA/mods/d2k/rules/ai.yaml`
+- `external/reference/OpenRA/mods/ts/rules/ai.yaml`
+
+## 17 总结
+
+OpenRA AI 的底层系统是一套实用、模块化、命令驱动的 RTS AI 架构：
+
+- Bot 是 player-level trait。
+- AI 类型由 YAML 组合。
+- 逻辑模块通过小接口协作。
+- 决策只发 order。
+- world mutation 仍走正式 order/activity/trait 链路。
+- 性能靠分帧、索引、延迟扫描和限流。
+- 战术层用轻量状态机和局部 fuzzy 判断。
+- 战略层多是启发式和评分，而不是统一 planner。
+
+它最值得 Ludots 学的不是具体算法，而是“AI 作为正式命令管线的外部输入者”这个边界。只要守住这条边界，AI 再复杂也不会跨越玩法系统职责；如果越过这条边界，AI 很快会变成第二套隐藏 gameplay runtime。

--- a/docs/reference/openra_ludots_ai_comparison.html
+++ b/docs/reference/openra_ludots_ai_comparison.html
@@ -1,0 +1,849 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OpenRA AI 与 Ludots 架构对比分析</title>
+  <style>
+    :root {
+      --bg: #ffffff;
+      --ink: #17212b;
+      --muted: #66727f;
+      --line: #d8dee6;
+      --soft: #f5f7fa;
+      --mint: #edf7f4;
+      --teal: #0f766e;
+      --green: #2f855a;
+      --amber: #b45309;
+      --red: #b42318;
+      --blue: #2563eb;
+      --cyan: #0e7490;
+      --shadow: 0 8px 24px rgba(23, 33, 43, 0.07);
+      --radius: 8px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html {
+      scroll-behavior: smooth;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Segoe UI", "Microsoft YaHei", Arial, sans-serif;
+      color: var(--ink);
+      background: var(--bg);
+      line-height: 1.7;
+      letter-spacing: 0;
+    }
+
+    a {
+      color: var(--blue);
+      text-decoration: none;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    code {
+      font-family: Consolas, "Cascadia Mono", "SFMono-Regular", monospace;
+      font-size: 0.92em;
+      background: #eef2f6;
+      border: 1px solid #d8e0e8;
+      border-radius: 6px;
+      padding: 0.08rem 0.32rem;
+      overflow-wrap: anywhere;
+    }
+
+    .hero {
+      background:
+        linear-gradient(115deg, rgba(15, 118, 110, 0.18), transparent 34%),
+        linear-gradient(180deg, #15212d, #10171f);
+      color: #f8fafc;
+      border-bottom: 6px solid var(--cyan);
+    }
+
+    .hero-inner {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: 52px 0 44px;
+      display: grid;
+      grid-template-columns: minmax(0, 1.2fr) minmax(300px, 0.8fr);
+      gap: 28px;
+      align-items: end;
+    }
+
+    .hero h1 {
+      margin: 0 0 16px;
+      font-size: 2.35rem;
+      line-height: 1.16;
+      font-weight: 850;
+      letter-spacing: 0;
+    }
+
+    .hero p {
+      margin: 0;
+      max-width: 820px;
+      color: #dce5ee;
+      font-size: 1.04rem;
+    }
+
+    .hero strong {
+      color: #ffffff;
+    }
+
+    .verdict {
+      display: grid;
+      gap: 12px;
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      border-radius: var(--radius);
+      padding: 18px;
+      box-shadow: var(--shadow);
+    }
+
+    .verdict b {
+      color: #ffffff;
+      font-size: 1.02rem;
+    }
+
+    .verdict span {
+      color: #dce5ee;
+      font-size: 0.92rem;
+    }
+
+    .layout {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: 250px minmax(0, 1fr);
+      gap: 28px;
+      padding: 32px 0 72px;
+    }
+
+    .toc {
+      position: sticky;
+      top: 18px;
+      align-self: start;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 14px;
+      background: #ffffff;
+      box-shadow: var(--shadow);
+    }
+
+    .toc h2 {
+      margin: 0 0 10px;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    .toc a {
+      display: block;
+      padding: 8px;
+      border-radius: 6px;
+      color: #263442;
+      font-size: 0.92rem;
+    }
+
+    .toc a:hover {
+      background: var(--soft);
+      text-decoration: none;
+    }
+
+    main {
+      min-width: 0;
+    }
+
+    section {
+      margin-bottom: 34px;
+      padding: 30px 0;
+      border-top: 1px solid var(--line);
+    }
+
+    section:first-child {
+      border-top: 0;
+      padding-top: 0;
+    }
+
+    h2 {
+      margin: 0 0 16px;
+      font-size: 1.48rem;
+      line-height: 1.25;
+      letter-spacing: 0;
+    }
+
+    h3 {
+      margin: 0 0 10px;
+      font-size: 1.05rem;
+      line-height: 1.35;
+    }
+
+    p {
+      margin: 0 0 13px;
+    }
+
+    ul {
+      margin: 0;
+      padding-left: 1.16rem;
+    }
+
+    li {
+      margin: 6px 0;
+    }
+
+    .label {
+      display: inline-flex;
+      align-items: center;
+      border: 1px solid rgba(15, 118, 110, 0.34);
+      border-radius: 999px;
+      padding: 4px 9px;
+      margin-bottom: 10px;
+      background: var(--mint);
+      color: var(--teal);
+      font-size: 0.8rem;
+      font-weight: 760;
+    }
+
+    .two-col {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      gap: 16px;
+    }
+
+    .card {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #ffffff;
+      padding: 17px;
+      box-shadow: var(--shadow);
+    }
+
+    .card.good {
+      border-top: 4px solid var(--green);
+    }
+
+    .card.gap {
+      border-top: 4px solid var(--red);
+    }
+
+    .card.watch {
+      border-top: 4px solid var(--amber);
+    }
+
+    .card.info {
+      border-top: 4px solid var(--cyan);
+    }
+
+    .card b {
+      display: block;
+      margin-bottom: 6px;
+    }
+
+    .card p {
+      color: var(--muted);
+      font-size: 0.94rem;
+      margin-bottom: 0;
+    }
+
+    .scoreboard {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin-top: 18px;
+    }
+
+    .score {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 15px;
+      background: #ffffff;
+      min-height: 150px;
+    }
+
+    .score span {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 32px;
+      height: 28px;
+      border-radius: 999px;
+      padding: 0 9px;
+      color: #ffffff;
+      font-weight: 820;
+      margin-bottom: 8px;
+      background: var(--teal);
+      font-size: 0.86rem;
+    }
+
+    .score:nth-child(2) span {
+      background: var(--blue);
+    }
+
+    .score:nth-child(3) span {
+      background: var(--amber);
+    }
+
+    .score:nth-child(4) span {
+      background: var(--red);
+    }
+
+    .matrix-wrap {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      overflow: hidden;
+      background: #ffffff;
+      box-shadow: var(--shadow);
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.93rem;
+    }
+
+    th,
+    td {
+      text-align: left;
+      vertical-align: top;
+      padding: 12px 13px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    th {
+      background: #eef2f6;
+      color: #253443;
+      font-weight: 820;
+    }
+
+    tr:last-child td {
+      border-bottom: 0;
+    }
+
+    .pill {
+      display: inline-flex;
+      border-radius: 999px;
+      padding: 3px 8px;
+      font-size: 0.78rem;
+      font-weight: 760;
+      white-space: nowrap;
+      border: 1px solid transparent;
+    }
+
+    .pill.good {
+      background: #ecfdf3;
+      color: #166534;
+      border-color: #bbf7d0;
+    }
+
+    .pill.mid {
+      background: #eff6ff;
+      color: #1d4ed8;
+      border-color: #bfdbfe;
+    }
+
+    .pill.warn {
+      background: #fff7ed;
+      color: #9a3412;
+      border-color: #fed7aa;
+    }
+
+    .pill.gap {
+      background: #fef2f2;
+      color: #991b1b;
+      border-color: #fecaca;
+    }
+
+    .stack {
+      display: grid;
+      gap: 10px;
+    }
+
+    .lane {
+      display: grid;
+      grid-template-columns: 184px minmax(0, 1fr);
+      gap: 12px;
+      align-items: stretch;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #ffffff;
+      overflow: hidden;
+    }
+
+    .lane b {
+      display: flex;
+      align-items: center;
+      padding: 14px;
+      background: var(--soft);
+      border-right: 1px solid var(--line);
+    }
+
+    .lane span {
+      padding: 14px;
+      color: #334155;
+      overflow-wrap: anywhere;
+    }
+
+    .roadmap {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 14px;
+    }
+
+    .step {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 16px;
+      background: #ffffff;
+      min-height: 182px;
+      position: relative;
+    }
+
+    .step strong {
+      display: block;
+      color: var(--teal);
+      margin-bottom: 7px;
+    }
+
+    .step p {
+      color: var(--muted);
+      font-size: 0.94rem;
+      margin-bottom: 0;
+    }
+
+    .callout {
+      border-left: 5px solid var(--teal);
+      background: var(--mint);
+      border-radius: var(--radius);
+      padding: 17px 18px;
+    }
+
+    .callout p:last-child {
+      margin-bottom: 0;
+    }
+
+    .sources {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .source {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 14px;
+      background: #ffffff;
+      min-height: 124px;
+    }
+
+    .source b {
+      display: block;
+      margin-bottom: 8px;
+    }
+
+    .source a,
+    .source span {
+      display: block;
+      font-size: 0.88rem;
+      color: #36536f;
+      overflow-wrap: anywhere;
+      margin-top: 5px;
+    }
+
+    footer {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto 38px;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 980px) {
+      .hero-inner,
+      .layout,
+      .two-col,
+      .sources {
+        grid-template-columns: 1fr;
+      }
+
+      .toc {
+        position: static;
+      }
+
+      .scoreboard,
+      .roadmap {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media (max-width: 620px) {
+      .hero-inner,
+      .layout {
+        width: min(100% - 22px, 1180px);
+      }
+
+      .hero-inner {
+        padding: 34px 0;
+      }
+
+      .hero h1 {
+        font-size: 1.82rem;
+      }
+
+      .layout {
+        padding-top: 18px;
+      }
+
+      .lane {
+        grid-template-columns: 1fr;
+      }
+
+      .lane b {
+        border-right: 0;
+        border-bottom: 1px solid var(--line);
+      }
+
+      .matrix-wrap {
+        overflow-x: auto;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <div class="hero-inner">
+      <div>
+        <h1>OpenRA AI 与 Ludots 架构对比分析</h1>
+        <p>
+          OpenRA 给我们展示的是一套成熟 RTS bot 的工程打法；Ludots 已经有更正式的 ECS、Mod、ConfigPipeline、GAS Order
+          和通用 AI 编译运行时。真正的差距不是“有没有 AI”，而是：<strong>Ludots 还缺一套阵营级 RTS AI 套件，把通用 AI 能力接到经济、基地、分队和调试上。</strong>
+        </p>
+      </div>
+      <aside class="verdict">
+        <b>总判断</b>
+        <span>OpenRA 的强项是可打对局的 RTS bot 模块群。Ludots 的强项是更硬的架构边界和可复用管线。</span>
+        <b>最短路线</b>
+        <span>保留 Ludots 的 Order/GAS 边界，把 OpenRA 的“Player-level bot modules”翻译成 Commander/Faction AI Mod。</span>
+      </aside>
+    </div>
+  </header>
+
+  <div class="layout">
+    <nav class="toc" aria-label="目录">
+      <h2>目录</h2>
+      <a href="#verdict">结论先行</a>
+      <a href="#what-ludots-has">Ludots 已有基础</a>
+      <a href="#matrix">逐项对比</a>
+      <a href="#good">我们做得好的</a>
+      <a href="#missing">我们缺什么</a>
+      <a href="#roadmap">建议路线</a>
+      <a href="#risk">风险边界</a>
+      <a href="#sources">证据索引</a>
+    </nav>
+
+    <main>
+      <section id="verdict">
+        <span class="label">Executive View</span>
+        <h2>结论先行：Ludots 有骨架，OpenRA 有战场肌肉</h2>
+        <p>
+          OpenRA 的 AI 是“玩家级模块群 + Order 出口”。它已经有经济、基地、单位生产、采矿、扩张、分队、支援技能、维修、占领等可用模块，
+          对 RTS skirmish 来说非常完整。Ludots 目前已经有 <code>Gameplay.AI</code> 通用核心：
+          <code>WorldStateProjection</code>、<code>UtilityGoalSelection</code>、<code>GOAP</code>、<code>HTN</code>、
+          <code>AIPlanExecution</code> 和 <code>OrderQueue</code> 提交边界。
+        </p>
+        <p>
+          所以对比后的重点不是重造一个 AI 框架，而是补齐“RTS 领域层”：Commander/Faction host、AI profile schema、
+          资源/威胁地图、经济/建造/采矿/分队模块、AI 调度预算、决策 trace 和可视化。
+        </p>
+        <div class="scoreboard">
+          <article class="score">
+            <span>强</span>
+            <h3>Ludots 架构边界</h3>
+            <p>Order/GAS、ConfigPipeline、Mod、SystemGroup、测试都更正式，AI 不必越权改世界。</p>
+          </article>
+          <article class="score">
+            <span>强</span>
+            <h3>OpenRA RTS 成熟度</h3>
+            <p>已经有可玩的 skirmish bot 模块群，覆盖经营、战术、响应和性能细节。</p>
+          </article>
+          <article class="score">
+            <span>缺</span>
+            <h3>Ludots RTS AI 套件</h3>
+            <p>缺阵营级 AI host、领域 blackboard、基地/经济/分队模块和 profile 组合。</p>
+          </article>
+          <article class="score">
+            <span>忌</span>
+            <h3>照搬 GPL 源码</h3>
+            <p>只能学边界和模式，不能复制 OpenRA 实现。Ludots 要用自己的 ECS 和管线重写。</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="what-ludots-has">
+        <h2>Ludots 已有基础：不是空地，是一座还没装 RTS 指挥塔的城市</h2>
+        <div class="stack">
+          <div class="lane">
+            <b>通用 AI Runtime</b>
+            <span><code>src/Core/Gameplay/AI</code> 已有 256-bit world state、Utility goal selector、GOAP、HTN、plan execution 和 task node 基础。</span>
+          </div>
+          <div class="lane">
+            <b>命令边界</b>
+            <span><code>AIPlanExecutionSystem</code> 通过 <code>PlanExecutor.TrySubmitOrder</code> 把行动提交到 <code>OrderQueue</code>，和 OpenRA “AI 只发 Order”同构。</span>
+          </div>
+          <div class="lane">
+            <b>配置管线</b>
+            <span><code>AiConfigLoader</code> 复用 <code>ConfigPipeline</code> 与 <code>ConfigCatalog</code>，AI atoms、projection、utility、GOAP、HTN 都从 Mod 配置合并。</span>
+          </div>
+          <div class="lane">
+            <b>验证基线</b>
+            <span><code>AiBenchmarkTests</code> 已覆盖 10k agents 的 Utility+GOAP+OrderSubmit 零分配回归；<code>AiConfigLoaderTests</code> 覆盖 VFS/Mod 配置合并。</span>
+          </div>
+          <div class="lane">
+            <b>观察入口</b>
+            <span><code>AIInspectorMod</code> 能打印编译后 AI runtime 规模，<code>AIDemoMod</code> 提供最小配置样例。</span>
+          </div>
+        </div>
+      </section>
+
+      <section id="matrix">
+        <h2>逐项对比</h2>
+        <div class="matrix-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>维度</th>
+                <th>OpenRA</th>
+                <th>Ludots 当前状态</th>
+                <th>判断</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>AI 与世界边界</td>
+                <td>Bot 模块只排队 <code>Order</code>，世界变更走正式 order/activity/trait 链路。</td>
+                <td><code>AIPlanExecutionSystem</code> 提交 <code>OrderQueue</code>，GAS/Order 管线负责后续执行。</td>
+                <td><span class="pill good">Ludots 很好</span></td>
+              </tr>
+              <tr>
+                <td>AI host</td>
+                <td>AI 挂在 <code>SystemActors.Player</code>，天然是玩家/阵营级状态。</td>
+                <td>已有 <code>AIAgent</code> 组件，但缺 RTS 专用 Commander/Faction host 语义和生命周期规范。</td>
+                <td><span class="pill gap">缺领域 host</span></td>
+              </tr>
+              <tr>
+                <td>AI profile 组合</td>
+                <td>YAML 通过 <code>ModularBot@RushAI</code> 和 condition 组合不同性格。</td>
+                <td>AI 配置已进 ConfigPipeline，但缺“RTS bot profile/module enable/预算/参数”的 schema。</td>
+                <td><span class="pill warn">需要补层</span></td>
+              </tr>
+              <tr>
+                <td>规划算法</td>
+                <td>主要是启发式模块、轻状态机和局部 fuzzy，少统一 planner。</td>
+                <td>已有 Utility、GOAP、HTN、world state projection，抽象能力更强。</td>
+                <td><span class="pill good">Ludots 更强</span></td>
+              </tr>
+              <tr>
+                <td>RTS 经营模块</td>
+                <td>BaseBuilder、UnitBuilder、Harvester、MCV、Expansion 都已可用。</td>
+                <td>未看到等价的经济/基地/采矿/扩张 bot module 套件。</td>
+                <td><span class="pill gap">OpenRA 成熟</span></td>
+              </tr>
+              <tr>
+                <td>战术分队</td>
+                <td>SquadManager 组织 assault、air、naval、protection squad，带状态机。</td>
+                <td>有 order/nav/GAS 基础，但缺 RTS squad blackboard、集结、进攻、防守、撤退模块。</td>
+                <td><span class="pill gap">缺 squad 层</span></td>
+              </tr>
+              <tr>
+                <td>移动与命令</td>
+                <td>AI 复用玩家 AttackMove、Harvest、Move 等命令。</td>
+                <td>OrderBuffer、导航目标、NavGoal2D/NavDesiredVelocity2D 分离已经很清楚。</td>
+                <td><span class="pill good">Ludots 基础更规整</span></td>
+              </tr>
+              <tr>
+                <td>技能系统</td>
+                <td>SupportPowerBotModule 按 consideration 扫描目标并发技能 order。</td>
+                <td>GAS Effect Pipeline、AbilityActivation、AttributeSink 更正式，但缺 RTS AI 技能目标评分模块。</td>
+                <td><span class="pill mid">底座强，领域缺</span></td>
+              </tr>
+              <tr>
+                <td>性能预算</td>
+                <td>大量手写 stagger tick、ActorIndex、delayed scan、order throttling。</td>
+                <td>有 10k AI benchmark 和零分配约束，但缺 AI 模块级预算、分帧扫描和输出 cap 规范。</td>
+                <td><span class="pill warn">需要工程化</span></td>
+              </tr>
+              <tr>
+                <td>调试可视化</td>
+                <td>BotDebug 与 RenderDebugState 可显示 squad/目标状态。</td>
+                <td>AIInspector 能打印 runtime 规模，但缺决策 trace、地图 overlay、模块耗时和 order 来源追踪。</td>
+                <td><span class="pill gap">缺可视化闭环</span></td>
+              </tr>
+              <tr>
+                <td>Mod/配置治理</td>
+                <td>YAML 灵活，但 actor names 和 condition 字符串耦合重。</td>
+                <td>ConfigPipeline、catalog merge、launcher graph、Mod loading、Registry 约束更硬。</td>
+                <td><span class="pill good">Ludots 更强</span></td>
+              </tr>
+              <tr>
+                <td>战役脚本</td>
+                <td>skirmish bot 与大量 Lua campaign AI 并存。</td>
+                <td>Trigger pipeline、FunctionRegistry、TriggerDecorators 适合剧情/地图逻辑，但需和 AI runtime 明确边界。</td>
+                <td><span class="pill mid">能力相当，需整合</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="good">
+        <h2>我们做得好的是什么</h2>
+        <div class="two-col">
+          <article class="card good">
+            <b>1. AI 已经走正式命令出口</b>
+            <p>这点非常关键。<code>PlanExecutor</code> 创建 <code>Order</code> 并进入 <code>OrderQueue</code>，没有让 AI 直接改玩法组件。</p>
+          </article>
+          <article class="card good">
+            <b>2. 通用 AI 能力比 OpenRA 更抽象</b>
+            <p>Utility、GOAP、HTN、256-bit world state、compiled runtime 为多类型游戏提供了统一底座。</p>
+          </article>
+          <article class="card good">
+            <b>3. 配置并入 ConfigPipeline</b>
+            <p>AI 配置和其他 gameplay 配置一样通过 VFS、Mod、catalog 和 merge policy 进入系统，治理上更强。</p>
+          </article>
+          <article class="card good">
+            <b>4. SystemGroup 和管线意识更强</b>
+            <p>Ludots 已经明确 SchemaUpdate、InputCollection、AbilityActivation、EffectProcessing 等 phase，AI 可以按职责挂靠。</p>
+          </article>
+          <article class="card good">
+            <b>5. GAS/Order/Nav 的分工清楚</b>
+            <p>命令、技能效果、属性落点、导航目标各自有正式链路，不需要 AI 复制一套执行器。</p>
+          </article>
+          <article class="card good">
+            <b>6. 性能红线已经有测试意识</b>
+            <p>10k agents 零分配 benchmark 是很好的地基，后续 RTS AI 模块也应该继承这个习惯。</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="missing">
+        <h2>我们缺什么</h2>
+        <div class="two-col">
+          <article class="card gap">
+            <b>1. Commander/Faction AI host</b>
+            <p>OpenRA 的 AI 天然挂在 PlayerActor。Ludots 需要明确“阵营/指挥官实体”承载 RTS AI 状态，而不是把战略脑散到单位上。</p>
+          </article>
+          <article class="card gap">
+            <b>2. RTS AI profile schema</b>
+            <p>需要类似 Rush/Normal/Turtle/Naval 的 profile，但用 Ludots 的 ConfigPipeline 表达 module enable、预算、比例、阈值和命令输出。</p>
+          </article>
+          <article class="card gap">
+            <b>3. 资源/威胁/基地 blackboard</b>
+            <p>通用 world state 只有 256-bit 事实层还不够 RTS。还要有空间索引、资源图、威胁图、基地中心、扩张候选。</p>
+          </article>
+          <article class="card gap">
+            <b>4. 经济与基地模块</b>
+            <p>缺 OpenRA 那类 BaseBuilder、UnitBuilder、Harvester、Expansion 的 Ludots 版本。</p>
+          </article>
+          <article class="card gap">
+            <b>5. Squad 战术模块</b>
+            <p>缺分队组织、攻击集结、防守响应、撤退判断、目标选择和支援技能协同。</p>
+          </article>
+          <article class="card gap">
+            <b>6. AI 专用调度预算</b>
+            <p>需要模块级 tick interval、stagger offset、query cache、昂贵扫描配额、每帧 order cap 和耗时统计。</p>
+          </article>
+          <article class="card gap">
+            <b>7. 决策 trace 与地图 overlay</b>
+            <p>AIInspector 的统计打印还不够。需要能看到某个 Commander 为什么造电厂、为什么撤退、为什么没有扩张。</p>
+          </article>
+          <article class="card gap">
+            <b>8. RTS AI 验收地图</b>
+            <p>已有 RTS training showcase，但还需要专门验证 AI 经营闭环：开局、采矿、补产能、组队、进攻、防守、恢复。</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="roadmap">
+        <h2>建议路线：从边界到可玩 bot，不绕路</h2>
+        <div class="roadmap">
+          <article class="step">
+            <strong>阶段 1：定契约</strong>
+            <p>写清楚 AI 只能产生命令，不直接写 gameplay components。明确 AI 运行 phase、输入快照、输出 OrderQueue 的时机。</p>
+          </article>
+          <article class="step">
+            <strong>阶段 2：建 CommanderAiMod</strong>
+            <p>新增阵营级 host entity、AiProfileRef、AiBudget、AiCommandQueue，并用 ConfigPipeline 加载 profile。</p>
+          </article>
+          <article class="step">
+            <strong>阶段 3：做 RTS Blackboard</strong>
+            <p>资源图、威胁图、基地中心、敌方已知建筑、己方产能和单位池都走分帧更新。</p>
+          </article>
+          <article class="step">
+            <strong>阶段 4：最小经营闭环</strong>
+            <p>先实现采矿维护、基础生产和低电/低资源处理，让 AI 能维持经济，不追求聪明进攻。</p>
+          </article>
+          <article class="step">
+            <strong>阶段 5：最小分队闭环</strong>
+            <p>按单位池组建 attack/defense squad，支持集结、AttackMove、防守响应和撤退。</p>
+          </article>
+          <article class="step">
+            <strong>阶段 6：调试与验收</strong>
+            <p>每个模块输出 decision trace、预算计数和 order 来源，showcase 地图验证完整开局到交战。</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="risk">
+        <h2>风险边界</h2>
+        <div class="callout">
+          <p>
+            <strong>不要把 OpenRA 的模块直接搬进来。</strong>
+            OpenRA 是 GPL 项目，这次只能做架构学习。实现时应该沿用 Ludots 的 Arch ECS、Mod、ConfigPipeline、SystemGroup、
+            OrderQueue、GAS 和导航基础，重新设计自己的 Commander/Faction AI。
+          </p>
+          <p>
+            也不要让“通用 GOAP/HTN 框架”吞掉全部 RTS 逻辑。OpenRA 的经验说明，RTS bot 真正难的是资源图、基地布局、寻路预算、
+            分队组织、失败恢复和调试可见性。规划器可以参与，但领域模块不能省。
+          </p>
+        </div>
+      </section>
+
+      <section id="sources">
+        <h2>证据索引</h2>
+        <div class="sources">
+          <article class="source">
+            <b>OpenRA AI 报告</b>
+            <a href="openra_ai_system_analysis.md">docs/reference/openra_ai_system_analysis.md</a>
+            <a href="openra_ai_layered_architecture.html">docs/reference/openra_ai_layered_architecture.html</a>
+          </article>
+          <article class="source">
+            <b>OpenRA 关键源码</b>
+            <a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Player/ModularBot.cs">external/reference/OpenRA/OpenRA.Mods.Common/Traits/Player/ModularBot.cs</a>
+            <a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules">external/reference/OpenRA/OpenRA.Mods.Common/Traits/BotModules</a>
+            <a href="../../external/reference/OpenRA/mods/ra/rules/ai.yaml">external/reference/OpenRA/mods/ra/rules/ai.yaml</a>
+          </article>
+          <article class="source">
+            <b>Ludots AI 核心</b>
+            <a href="../../src/Core/Gameplay/AI/Config/AiConfigLoader.cs">src/Core/Gameplay/AI/Config/AiConfigLoader.cs</a>
+            <a href="../../src/Core/Gameplay/AI/Systems/AIPlanExecutionSystem.cs">src/Core/Gameplay/AI/Systems/AIPlanExecutionSystem.cs</a>
+            <a href="../../src/Core/Gameplay/AI/Planning/PlanExecutor.cs">src/Core/Gameplay/AI/Planning/PlanExecutor.cs</a>
+          </article>
+          <article class="source">
+            <b>Ludots 架构与测试</b>
+            <a href="../../gitbook/architecture/runtime-overview.md">gitbook/architecture/runtime-overview.md</a>
+            <a href="../../docs/architecture/order_navigation_movement.md">docs/architecture/order_navigation_movement.md</a>
+            <a href="../../src/Tests/GasTests/AiBenchmarkTests.cs">src/Tests/GasTests/AiBenchmarkTests.cs</a>
+            <a href="../../mods/AIInspectorMod/Triggers/PrintAiConfigTrigger.cs">mods/AIInspectorMod/Triggers/PrintAiConfigTrigger.cs</a>
+          </article>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <footer>
+    本 HTML 是 Ludots 内部参考分析。它对比架构模式与能力缺口，不代表要复制 OpenRA 源码实现。
+  </footer>
+</body>
+</html>

--- a/docs/reference/openra_targeting_priority_guard_turret_analysis.html
+++ b/docs/reference/openra_targeting_priority_guard_turret_analysis.html
@@ -1,0 +1,806 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OpenRA 索敌优先级、脱战警戒与炮台机制源码剖面</title>
+  <style>
+    :root {
+      --bg: #ffffff;
+      --ink: #17202a;
+      --muted: #66717e;
+      --line: #d9e2ec;
+      --soft: #f5f7fa;
+      --blue-soft: #edf4ff;
+      --green-soft: #edf7f1;
+      --amber-soft: #fff4df;
+      --red-soft: #fff0ee;
+      --blue: #2563eb;
+      --teal: #0f766e;
+      --green: #2f855a;
+      --amber: #b45309;
+      --red: #b42318;
+      --violet: #6d28d9;
+      --radius: 8px;
+      --shadow: 0 8px 24px rgba(23, 32, 42, 0.07);
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+
+    body {
+      margin: 0;
+      font-family: "Segoe UI", "Microsoft YaHei", Arial, sans-serif;
+      color: var(--ink);
+      background: var(--bg);
+      line-height: 1.72;
+      letter-spacing: 0;
+    }
+
+    a { color: var(--blue); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    code {
+      font-family: Consolas, "Cascadia Mono", "SFMono-Regular", monospace;
+      font-size: 0.92em;
+      background: #eef2f6;
+      border: 1px solid #d8e0e8;
+      border-radius: 6px;
+      padding: 0.08rem 0.32rem;
+      overflow-wrap: anywhere;
+    }
+
+    .hero {
+      border-bottom: 6px solid var(--amber);
+      background: #17202a;
+      color: #f8fafc;
+    }
+
+    .hero-inner {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: 48px 0 42px;
+      display: grid;
+      grid-template-columns: minmax(0, 1.18fr) minmax(300px, 0.82fr);
+      gap: 28px;
+      align-items: end;
+    }
+
+    .hero h1 {
+      margin: 0 0 16px;
+      max-width: 880px;
+      font-size: 2.28rem;
+      line-height: 1.16;
+      font-weight: 850;
+      letter-spacing: 0;
+    }
+
+    .hero p {
+      margin: 0;
+      max-width: 860px;
+      color: #dfe7f0;
+      font-size: 1.02rem;
+    }
+
+    .hero code {
+      color: #f8fafc;
+      background: rgba(255, 255, 255, 0.1);
+      border-color: rgba(255, 255, 255, 0.22);
+    }
+
+    .summary {
+      display: grid;
+      gap: 12px;
+      padding: 18px;
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      border-radius: var(--radius);
+      background: rgba(255, 255, 255, 0.08);
+      box-shadow: var(--shadow);
+    }
+
+    .summary b {
+      color: #ffffff;
+      font-size: 1.02rem;
+    }
+
+    .summary span {
+      color: #dfe7f0;
+      font-size: 0.93rem;
+    }
+
+    .layout {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: 260px minmax(0, 1fr);
+      gap: 28px;
+      padding: 32px 0 72px;
+    }
+
+    .toc {
+      position: sticky;
+      top: 18px;
+      align-self: start;
+      padding: 14px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #ffffff;
+      box-shadow: var(--shadow);
+    }
+
+    .toc h2 {
+      margin: 0 0 10px;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    .toc a {
+      display: block;
+      padding: 8px;
+      border-radius: 6px;
+      color: #263442;
+      font-size: 0.91rem;
+    }
+
+    .toc a:hover {
+      background: var(--soft);
+      text-decoration: none;
+    }
+
+    main { min-width: 0; }
+
+    section {
+      margin-bottom: 34px;
+      padding: 30px 0;
+      border-top: 1px solid var(--line);
+    }
+
+    section:first-child {
+      border-top: 0;
+      padding-top: 0;
+    }
+
+    h2 {
+      margin: 0 0 16px;
+      font-size: 1.46rem;
+      line-height: 1.25;
+      letter-spacing: 0;
+    }
+
+    h3 {
+      margin: 0 0 10px;
+      font-size: 1.05rem;
+      line-height: 1.35;
+      letter-spacing: 0;
+    }
+
+    p { margin: 0 0 13px; }
+    ul { margin: 0; padding-left: 1.16rem; }
+    li { margin: 6px 0; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      overflow: hidden;
+      background: #ffffff;
+      font-size: 0.94rem;
+    }
+
+    th, td {
+      padding: 11px 12px;
+      border-bottom: 1px solid var(--line);
+      vertical-align: top;
+      text-align: left;
+    }
+
+    th {
+      background: #f1f5f9;
+      color: #334155;
+      font-weight: 750;
+    }
+
+    tr:last-child td { border-bottom: 0; }
+
+    .table-wrap {
+      width: 100%;
+      overflow-x: auto;
+      margin: 16px 0;
+      border-radius: var(--radius);
+    }
+
+    .label {
+      display: inline-block;
+      margin-bottom: 10px;
+      color: var(--amber);
+      font-size: 0.78rem;
+      font-weight: 800;
+      text-transform: uppercase;
+      letter-spacing: 0;
+    }
+
+    .callout {
+      margin: 16px 0;
+      padding: 16px 18px;
+      border: 1px solid var(--line);
+      border-left: 5px solid var(--blue);
+      border-radius: var(--radius);
+      background: var(--blue-soft);
+    }
+
+    .callout.warn {
+      border-left-color: var(--amber);
+      background: var(--amber-soft);
+    }
+
+    .callout.danger {
+      border-left-color: var(--red);
+      background: var(--red-soft);
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 14px;
+      margin: 16px 0;
+    }
+
+    .tile {
+      min-width: 0;
+      padding: 16px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #ffffff;
+      box-shadow: var(--shadow);
+    }
+
+    .tile.blue { border-top: 4px solid var(--blue); }
+    .tile.green { border-top: 4px solid var(--green); }
+    .tile.amber { border-top: 4px solid var(--amber); }
+    .tile.red { border-top: 4px solid var(--red); }
+    .tile.teal { border-top: 4px solid var(--teal); }
+    .tile.violet { border-top: 4px solid var(--violet); }
+
+    .flow {
+      display: grid;
+      grid-template-columns: repeat(7, minmax(0, 1fr));
+      gap: 10px;
+      margin: 18px 0;
+    }
+
+    .flow-step {
+      min-height: 126px;
+      padding: 13px;
+      border: 1px solid var(--line);
+      border-top: 4px solid var(--blue);
+      border-radius: var(--radius);
+      background: #ffffff;
+      box-shadow: var(--shadow);
+    }
+
+    .flow-step:nth-child(2) { border-top-color: var(--teal); }
+    .flow-step:nth-child(3) { border-top-color: var(--green); }
+    .flow-step:nth-child(4) { border-top-color: var(--amber); }
+    .flow-step:nth-child(5) { border-top-color: var(--violet); }
+    .flow-step:nth-child(6) { border-top-color: var(--red); }
+    .flow-step:nth-child(7) { border-top-color: #475569; }
+
+    .flow-step strong {
+      display: block;
+      margin-bottom: 7px;
+      line-height: 1.3;
+    }
+
+    .flow-step span {
+      color: var(--muted);
+      font-size: 0.89rem;
+    }
+
+    .two-col {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+      margin: 16px 0;
+    }
+
+    .source-list {
+      columns: 2;
+      column-gap: 24px;
+    }
+
+    .source-list li {
+      break-inside: avoid;
+      margin-bottom: 8px;
+    }
+
+    @media (max-width: 980px) {
+      .hero-inner,
+      .layout,
+      .two-col {
+        grid-template-columns: 1fr;
+      }
+
+      .toc {
+        position: static;
+      }
+
+      .grid,
+      .flow {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .source-list {
+        columns: 1;
+      }
+    }
+
+    @media (max-width: 640px) {
+      .hero-inner,
+      .layout {
+        width: min(100% - 24px, 1180px);
+      }
+
+      .hero h1 {
+        font-size: 1.76rem;
+      }
+
+      .grid,
+      .flow {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <div class="hero-inner">
+      <div>
+        <span class="label">OpenRA Source Report</span>
+        <h1>索敌优先级、脱战警戒与炮台机制源码剖面</h1>
+        <p>
+          OpenRA 的基础战斗行为不是一个集中式 AI 子系统，而是单位 trait 与 activity 的组合：
+          <code>AutoTarget</code> 负责发现目标，<code>AttackFollow</code> 负责追击与放弃，
+          <code>Guard</code> 复用 attack-move 跟随保护，<code>Turreted</code> 以 gameplay 状态约束开火。
+        </p>
+      </div>
+      <div class="summary" aria-label="结论摘要">
+        <b>核心结论</b>
+        <span>优先级先于距离；距离只在同优先级目标之间做 tie-break。</span>
+        <span>警戒范围分两层：索敌扫描范围与 Guard 跟随范围不是同一个概念。</span>
+        <span>炮台不是纯动画；炮塔未转到目标方向时，武器不会发射。</span>
+        <span>所谓脱战主要是 activity 结束、目标清理、回到移动或 idle，没有独立 combat-state manager。</span>
+      </div>
+    </div>
+  </header>
+
+  <div class="layout">
+    <nav class="toc" aria-label="目录">
+      <h2>目录</h2>
+      <a href="#scope">1. 范围与源码</a>
+      <a href="#pipeline">2. 运行链路</a>
+      <a href="#user-facing">3. 玩家会看到什么</a>
+      <a href="#stance">4. 姿态与移动门控</a>
+      <a href="#priority">5. 优先级算法</a>
+      <a href="#profiles">6. 数据配置画像</a>
+      <a href="#disengage">7. 脱战与放弃</a>
+      <a href="#guard">8. 警戒与保护</a>
+      <a href="#turret">9. 炮台实现</a>
+      <a href="#takeaways">10. 设计要点</a>
+      <a href="#sources">11. 源码索引</a>
+    </nav>
+
+    <main>
+      <section id="scope">
+        <span class="label">Scope</span>
+        <h2>1. 范围与源码</h2>
+        <p>
+          本报告只分析 OpenRA 基础单位行为中的自动索敌、目标优先级、脱战、警戒范围与炮台开火链路。
+          它不分析 skirmish bot 的战略层，因为这里讨论的是任意单位在收到命令或处于 idle 时如何自行开火。
+        </p>
+        <div class="callout">
+          <p>
+            关键文件包括 <code>AutoTarget.cs</code>、<code>AutoTargetPriority.cs</code>、
+            <code>AttackFollow.cs</code>、<code>AttackMoveActivity.cs</code>、<code>Guard.cs</code>、
+            <code>Turreted.cs</code>、<code>AttackTurreted.cs</code>、<code>Armament.cs</code>，
+            以及 RA mod 的 <code>defaults.yaml</code>、<code>vehicles.yaml</code>、<code>structures.yaml</code>、<code>ships.yaml</code>。
+          </p>
+        </div>
+      </section>
+
+      <section id="pipeline">
+        <span class="label">Runtime Chain</span>
+        <h2>2. 运行链路</h2>
+        <p>
+          OpenRA 的索敌和攻击链路是分层的，但不是以“AI 管理器”命名。单位身上的 trait 在 tick、idle、damage、order resolver
+          等入口被调用，每一层只做自己的事。
+        </p>
+        <div class="flow" aria-label="OpenRA 索敌攻击链路">
+          <div class="flow-step">
+            <strong>Idle / Damage / Order</strong>
+            <span>单位 idle、受到伤害、收到 AttackMove/Guard/Attack 命令时进入战斗链路。</span>
+          </div>
+          <div class="flow-step">
+            <strong>AutoTarget</strong>
+            <span>按姿态、扫描间隔、武器与目标类型选择候选目标。</span>
+          </div>
+          <div class="flow-step">
+            <strong>ChooseTarget</strong>
+            <span>关系、可见性、target type、priority、距离、射界逐层过滤。</span>
+          </div>
+          <div class="flow-step">
+            <strong>AttackBase</strong>
+            <span>把目标包装成 attack activity，并选择可用 armament。</span>
+          </div>
+          <div class="flow-step">
+            <strong>AttackFollow</strong>
+            <span>追击、靠近、记忆最后可见位置、决定何时放弃。</span>
+          </div>
+          <div class="flow-step">
+            <strong>AttackTurreted</strong>
+            <span>如果有炮塔，先让炮塔转向；至少一个炮塔 ready 才允许开火。</span>
+          </div>
+          <div class="flow-step">
+            <strong>Armament</strong>
+            <span>检查 reload、range、min range、turret facing，然后生成弹体。</span>
+          </div>
+        </div>
+      </section>
+
+      <section id="user-facing">
+        <span class="label">Visible Behavior</span>
+        <h2>3. 玩家会看到什么</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>场景</th>
+                <th>屏幕表现</th>
+                <th>源码路径</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>单位原地待命</td>
+                <td>如果姿态允许，单位会按随机间隔扫周围目标；发现目标后攻击。默认人类玩家姿态是 <code>Defend</code>，通常只攻击武器范围内目标。</td>
+                <td><code>INotifyIdle.TickIdle</code> 调 <code>ScanAndAttack</code>。</td>
+              </tr>
+              <tr>
+                <td>单位被攻击</td>
+                <td>姿态至少为 <code>ReturnFire</code> 时，空闲单位会反击攻击者；如果姿态更主动，还会先重新扫描更高优先级目标。</td>
+                <td><code>INotifyDamage.Damaged</code>，随后 <code>Attack(Target.FromActor(Aggressor))</code>。</td>
+              </tr>
+              <tr>
+                <td>Attack Move</td>
+                <td>单位沿目标点移动；途中发现目标会停下攻击；攻击活动结束后继续走原路线。Ctrl 触发的 AssaultMove 会切换 priority profile，通常把建筑也纳入自动攻击。</td>
+                <td><code>AttackMove.ResolveOrder</code> 进入 <code>AttackMoveActivity</code>。</td>
+              </tr>
+              <tr>
+                <td>Guard</td>
+                <td>单位跟随被保护目标，在保护范围内移动；途中发现敌人则和 attack-move 一样插入攻击活动，结束后继续跟随。</td>
+                <td><code>Guard.GuardTarget</code> 创建 <code>AttackMoveActivity</code>，移动子活动是 <code>MoveFollow</code>。</td>
+              </tr>
+              <tr>
+                <td>炮塔单位开火</td>
+                <td>车体或建筑可以不立刻转身，炮塔先转向目标；炮塔没转到位时不出弹。攻击结束后炮塔可按 <code>RealignDelay</code> 回正。</td>
+                <td><code>AttackTurreted.CanAttack</code> 与 <code>Armament.CanFire</code> 双重约束。</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="stance">
+        <span class="label">Stance Gates</span>
+        <h2>4. 姿态与移动门控</h2>
+        <p>
+          <code>UnitStance</code> 有四档：<code>HoldFire</code>、<code>ReturnFire</code>、<code>Defend</code>、<code>AttackAnything</code>。
+          它不只是 UI 下拉框，而是直接改变自动攻击入口和追击权限。
+        </p>
+        <div class="grid">
+          <div class="tile red">
+            <h3>HoldFire</h3>
+            <p>自动索敌基本关闭。强制攻击命令仍由 attack trait 处理，但 idle scan 不会启动。</p>
+          </div>
+          <div class="tile amber">
+            <h3>ReturnFire</h3>
+            <p>不会主动扫描，但受到伤害且空闲时会反击。治疗类负伤害不会触发反击。</p>
+          </div>
+          <div class="tile green">
+            <h3>Defend</h3>
+            <p>空闲时扫描并攻击，但 <code>AllowMove</code> 为 false，通常不会为了自动目标主动追出武器范围。</p>
+          </div>
+          <div class="tile violet">
+            <h3>AttackAnything</h3>
+            <p><code>AllowMove</code> 变为 true，单位可以为了自动目标移动追击；RA 数据也会切到包含 Structure 的优先级 profile。</p>
+          </div>
+          <div class="tile blue">
+            <h3>AI 默认值</h3>
+            <p>bot 或不可玩 owner 默认 <code>InitialStanceAI = AttackAnything</code>，人类默认 <code>InitialStance = Defend</code>。</p>
+          </div>
+          <div class="tile teal">
+            <h3>条件联动</h3>
+            <p>姿态可授予 condition，例如 <code>stance-attackanything</code>，YAML 用它启停不同 <code>AutoTargetPriority</code>。</p>
+          </div>
+        </div>
+        <div class="callout warn">
+          <p>
+            <code>AttackMove</code> 本身不会无条件打开追击。它会在移动途中扫描目标，但是否允许移动追击仍看 <code>autoTarget.AllowMove</code>。
+            RA 的 AssaultMove 主要通过 <code>assault-move</code> condition 切换 priority profile，例如让建筑也成为自动目标。
+          </p>
+        </div>
+      </section>
+
+      <section id="priority">
+        <span class="label">Priority Algorithm</span>
+        <h2>5. 优先级算法</h2>
+        <p>
+          <code>AutoTargetPriorityInfo</code> 的字段很少：<code>ValidTargets</code>、<code>InvalidTargets</code>、
+          <code>ValidRelationships</code>、<code>Priority</code>。真正的行为来自 <code>AutoTarget.ChooseTarget</code> 的过滤顺序。
+        </p>
+        <div class="flow" aria-label="ChooseTarget 过滤顺序">
+          <div class="flow-step">
+            <strong>1. 候选范围</strong>
+            <span><code>ScanRadius</code> 大于 0 时使用它；否则使用 attack trait 的最大武器射程。</span>
+          </div>
+          <div class="flow-step">
+            <strong>2. 空间查询</strong>
+            <span><code>World.FindActorsInCircle</code> 找真实 actor；允许移动或允许冻雾目标时再加入 frozen actor。</span>
+          </div>
+          <div class="flow-step">
+            <strong>3. 基础可打性</strong>
+            <span>跳过友军优化、不可见目标、禁止被自动索敌的目标、失效 frozen actor。</span>
+          </div>
+          <div class="flow-step">
+            <strong>4. Priority Profile</strong>
+            <span>按 <code>Priority</code> 降序缓存；关系与 target type 必须匹配，invalid target type 优先否决。</span>
+          </div>
+          <div class="flow-step">
+            <strong>5. 武器检查</strong>
+            <span><code>ChooseArmamentsForTarget</code> 必须能选出可用武器；不能移动时还要求当前距离可开火。</span>
+          </div>
+          <div class="flow-step">
+            <strong>6. 射界检查</strong>
+            <span>不能转向时必须已在 firing arc 内；能转向时之后交给 attack activity 或炮塔处理。</span>
+          </div>
+          <div class="flow-step">
+            <strong>7. 最终选择</strong>
+            <span>更高 <code>Priority</code> 压过距离；同优先级才选最近。</span>
+          </div>
+        </div>
+        <div class="callout danger">
+          <p>
+            结论很具体：OpenRA 的自动索敌不是“最近敌人优先”。它是“最高有效 priority 优先，同 priority 最近”。
+            如果数据没有显式拉开 <code>Priority</code>，看起来才会像最近目标优先。
+          </p>
+        </div>
+      </section>
+
+      <section id="profiles">
+        <span class="label">YAML Profiles</span>
+        <h2>6. 数据配置画像</h2>
+        <p>
+          RA mod 的默认配置显示，OpenRA 把“什么目标值得自动打”交给 YAML profile，不写死在 C# 里。
+        </p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Profile</th>
+                <th>默认行为</th>
+                <th>切换条件</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>^AutoTargetGround</code></td>
+                <td>默认自动打 Infantry、Vehicle、Ship、Underwater、Defense、Mine；不打 <code>NoAutoTarget</code>。</td>
+                <td><code>stance-attackanything</code> 时切到包含 Structure 的 profile。</td>
+              </tr>
+              <tr>
+                <td><code>^AutoTargetGroundAssaultMove</code></td>
+                <td>继承 ground profile，但 AssaultMove 时也启用 attack-anything profile。</td>
+                <td><code>RequiresCondition: stance-attackanything || assault-move</code>。</td>
+              </tr>
+              <tr>
+                <td><code>^AutoTargetAir</code></td>
+                <td>只自动打 <code>AirborneActor</code>，用于防空炮、SAM 等。</td>
+                <td>无额外 stance condition。</td>
+              </tr>
+              <tr>
+                <td><code>^AutoTargetAll</code></td>
+                <td>默认包含地面、水面、水下、空中与防御类，attack-anything 时包含 Structure。</td>
+                <td>用于能对多域目标开火的单位。</td>
+              </tr>
+              <tr>
+                <td>单位局部覆盖</td>
+                <td>例如 V2RL 设置 <code>AutoTarget.ScanRadius: 10</code>，潜艇重写 target types，巡洋舰配置多炮塔。</td>
+                <td>每个 actor YAML 可覆盖 inherited trait。</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="disengage">
+        <span class="label">Disengage</span>
+        <h2>7. 脱战与放弃</h2>
+        <p>
+          OpenRA 没有一个全局的“脱战系统”。脱战来自 activity 的结束条件、target 失效、姿态变化和 stop order。
+          单位从攻击活动退出来后，要么继续原本的移动/guard 子活动，要么回到 idle，再由 <code>AutoTarget</code> 决定是否下一次扫描。
+        </p>
+        <div class="two-col">
+          <div class="tile red">
+            <h3>攻击活动什么时候结束</h3>
+            <ul>
+              <li>目标死亡、隐藏或失效，且没有可用 last-visible fallback。</li>
+              <li>已经走到最后可见位置或射程附近，但目标仍不可见。</li>
+              <li>没有可用武器，或武器 min/max range 不成立。</li>
+              <li>需要移动进射程，但当前攻击不允许移动。</li>
+              <li>AttackMove 来源下出现补给需求时，不去补给，直接结束这段攻击活动。</li>
+            </ul>
+          </div>
+          <div class="tile amber">
+            <h3>目标什么时候被清理</h3>
+            <ul>
+              <li><code>OnStopOrder</code> 会取消当前 activity，清空 requested/opportunity target。</li>
+              <li>owner 改变会清空目标。</li>
+              <li>姿态变得更保守时，如果当前 opportunity target 不再符合 priority profile，会被丢弃。</li>
+              <li><code>AttackActivity.OnLastRun</code> 调 <code>ClearRequestedTarget</code>；若 <code>PersistentTargeting</code> 为 true，会转成 opportunity target。</li>
+            </ul>
+          </div>
+        </div>
+        <div class="callout">
+          <p>
+            <code>AttackFollow</code> 的 last-visible target 是脱战的关键：它让单位在目标短暂进雾或离开视野时向最后位置靠近，
+            但到达后仍找不到目标就结束。这里没有无限追杀的默认保证。
+          </p>
+        </div>
+      </section>
+
+      <section id="guard">
+        <span class="label">Guard And Alert Range</span>
+        <h2>8. 警戒与保护</h2>
+        <p>
+          OpenRA 至少有三种“范围”，不能混在一起。
+        </p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>范围</th>
+                <th>来源</th>
+                <th>含义</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>索敌扫描范围</td>
+                <td><code>AutoTargetInfo.ScanRadius</code> 或 <code>AttackBase.GetMaximumRange()</code></td>
+                <td>决定自动索敌能看多远。默认不单独配置时，基本等于武器最大射程。</td>
+              </tr>
+              <tr>
+                <td>Guard 跟随范围</td>
+                <td><code>GuardableInfo.Range</code>，默认 2 cells；建筑常见 3 cells。</td>
+                <td>守卫单位与被保护目标保持的最大跟随距离，不等于警戒发现距离。</td>
+              </tr>
+              <tr>
+                <td>攻击进退范围</td>
+                <td>武器 <code>MinRange</code>/<code>MaxRange</code> 与 <code>AttackFollowInfo.RangeMargin</code></td>
+                <td>追击时移动到能开火的距离环；目标移动时用 margin 减少抖动。</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p>
+          <code>Guard</code> 的实现非常短：目标必须是 actor，并且目标 actor 的规则里必须有 <code>GuardableInfo</code>。
+          然后它创建一个 <code>AttackMoveActivity</code>，移动子活动是 <code>move.MoveFollow(self, target, WDist.Zero, range)</code>。
+          所以 Guard 不是单独战斗 AI；它是“跟随目标 + attack-move 插入攻击”的复合活动。
+        </p>
+      </section>
+
+      <section id="turret">
+        <span class="label">Turret</span>
+        <h2>9. 炮台实现</h2>
+        <p>
+          OpenRA 的炮塔由三层协作：<code>Turreted</code> 保存炮塔朝向和偏移，<code>AttackTurreted</code> 在攻击前让炮塔转向，
+          <code>Armament</code> 绑定具体武器到某个 turret，并在开火前再次检查炮塔是否已经就位。
+        </p>
+        <div class="grid">
+          <div class="tile blue">
+            <h3><code>TurretedInfo</code></h3>
+            <p>数据包括 <code>Turret</code> 名称、<code>TurnSpeed</code>、<code>InitialFacing</code>、<code>RealignDelay</code>、<code>Offset</code>。</p>
+          </div>
+          <div class="tile green">
+            <h3><code>AttackTurreted</code></h3>
+            <p><code>CanAttack</code> 遍历所有匹配炮塔，调用 <code>FaceTarget</code>。循环不会提前 break，因为多个炮塔都要转向。</p>
+          </div>
+          <div class="tile amber">
+            <h3><code>Armament</code></h3>
+            <p><code>ArmamentInfo.Turret</code> 指向炮塔名；<code>CanFire</code> 中如果 <code>turret.HasAchievedDesiredFacing</code> 为 false，直接拒绝发射。</p>
+          </div>
+          <div class="tile teal">
+            <h3>表现层</h3>
+            <p><code>WithSpriteTurret</code>、<code>WithSpriteBarrel</code>、<code>WithTurretAttackAnimation</code> 等读取同一 turret/armament 名称做渲染。</p>
+          </div>
+          <div class="tile violet">
+            <h3>多炮塔</h3>
+            <p>巡洋舰等单位可以有 <code>Turreted@PRIMARY</code> 与 <code>Turreted@SECONDARY</code>，<code>AttackTurreted.Turrets</code> 同时列出。</p>
+          </div>
+          <div class="tile red">
+            <h3>回正</h3>
+            <p>不攻击时，<code>Turreted.Tick</code> 根据 <code>RealignDelay</code> 决定是否回到初始角度；<code>-1</code> 关闭回正。</p>
+          </div>
+        </div>
+        <div class="callout danger">
+          <p>
+            炮塔 ready 是 gameplay 条件，不是渲染建议。即使 <code>AttackTurreted.CanAttack</code> 允许攻击，
+            <code>Armament.CanFire</code> 仍会二次拦截未对准炮塔。这个设计避免表现和命中判定脱节。
+          </p>
+        </div>
+      </section>
+
+      <section id="takeaways">
+        <span class="label">Takeaways</span>
+        <h2>10. 设计要点</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>要点</th>
+                <th>具体含义</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>索敌是单位能力，不是 bot 特权</td>
+                <td><code>AutoTarget</code> 挂在 actor trait 上，人类单位、AI 单位、脚本单位都能复用。</td>
+              </tr>
+              <tr>
+                <td>目标优先级必须数据驱动</td>
+                <td>C# 只提供关系、target type、priority、condition 的筛选框架；具体哪些目标自动打由规则数据决定。</td>
+              </tr>
+              <tr>
+                <td>AttackMove 是可恢复 activity</td>
+                <td>它不是“移动 order + 攻击 order”简单排队，而是在一个 activity 内暂停移动、攻击、再恢复移动。</td>
+              </tr>
+              <tr>
+                <td>Guard 是复合移动，不是独立战斗系统</td>
+                <td>它把 follow target 当移动子活动，把战斗插入交给 <code>AttackMoveActivity</code>。</td>
+              </tr>
+              <tr>
+                <td>炮塔需要 gameplay authority</td>
+                <td>炮塔朝向、转速、ready 状态、muzzle 偏移会影响能否开火和弹体生成位置。</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="sources">
+        <span class="label">Source Map</span>
+        <h2>11. 源码索引</h2>
+        <ul class="source-list">
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/AutoTarget.cs">AutoTarget.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/AutoTargetPriority.cs">AutoTargetPriority.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/AttackMove.cs">AttackMove.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs">AttackMoveActivity.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs">AttackBase.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs">AttackFollow.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Activities/Attack.cs">Attack.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Guard.cs">Guard.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Guardable.cs">Guardable.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Turreted.cs">Turreted.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs">AttackTurreted.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Armament.cs">Armament.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Targetable.cs">Targetable.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/mods/ra/rules/defaults.yaml">RA defaults.yaml</a></li>
+          <li><a href="../../external/reference/OpenRA/mods/ra/rules/vehicles.yaml">RA vehicles.yaml</a></li>
+          <li><a href="../../external/reference/OpenRA/mods/ra/rules/structures.yaml">RA structures.yaml</a></li>
+          <li><a href="../../external/reference/OpenRA/mods/ra/rules/ships.yaml">RA ships.yaml</a></li>
+        </ul>
+      </section>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/reference/openra_unit_behavior_attack_move_analysis.html
+++ b/docs/reference/openra_unit_behavior_attack_move_analysis.html
@@ -1,0 +1,1424 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OpenRA 用户输入动作与基础单位指令源码剖面</title>
+  <style>
+    :root {
+      --bg: #ffffff;
+      --ink: #18212a;
+      --muted: #64717f;
+      --line: #d9e1ea;
+      --soft: #f5f7fa;
+      --soft-blue: #edf4ff;
+      --soft-green: #edf7f1;
+      --soft-amber: #fff4df;
+      --soft-red: #fff0ee;
+      --blue: #2563eb;
+      --teal: #0f766e;
+      --green: #2f855a;
+      --amber: #b45309;
+      --red: #b42318;
+      --violet: #6d28d9;
+      --shadow: 0 8px 24px rgba(24, 33, 42, 0.07);
+      --radius: 8px;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html {
+      scroll-behavior: smooth;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Segoe UI", "Microsoft YaHei", Arial, sans-serif;
+      color: var(--ink);
+      background: var(--bg);
+      line-height: 1.7;
+      letter-spacing: 0;
+    }
+
+    a {
+      color: var(--blue);
+      text-decoration: none;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    code {
+      font-family: Consolas, "Cascadia Mono", "SFMono-Regular", monospace;
+      font-size: 0.92em;
+      background: #eef2f6;
+      border: 1px solid #d8e0e8;
+      border-radius: 6px;
+      padding: 0.08rem 0.32rem;
+      overflow-wrap: anywhere;
+    }
+
+    .hero {
+      color: #f8fafc;
+      background:
+        linear-gradient(120deg, rgba(37, 99, 235, 0.22), transparent 34%),
+        linear-gradient(180deg, #16212c, #121820);
+      border-bottom: 6px solid var(--amber);
+    }
+
+    .hero-inner {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: 50px 0 42px;
+      display: grid;
+      grid-template-columns: minmax(0, 1.18fr) minmax(300px, 0.82fr);
+      gap: 28px;
+      align-items: end;
+    }
+
+    .hero h1 {
+      margin: 0 0 16px;
+      max-width: 880px;
+      font-size: 2.32rem;
+      line-height: 1.16;
+      font-weight: 850;
+      letter-spacing: 0;
+    }
+
+    .hero p {
+      margin: 0;
+      max-width: 850px;
+      color: #dfe7f0;
+      font-size: 1.03rem;
+    }
+
+    .hero code {
+      color: #f8fafc;
+      background: rgba(255, 255, 255, 0.1);
+      border-color: rgba(255, 255, 255, 0.2);
+    }
+
+    .summary {
+      display: grid;
+      gap: 12px;
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      border-radius: var(--radius);
+      padding: 18px;
+      box-shadow: var(--shadow);
+    }
+
+    .summary b {
+      color: #ffffff;
+      font-size: 1.02rem;
+    }
+
+    .summary span {
+      color: #dfe7f0;
+      font-size: 0.92rem;
+    }
+
+    .layout {
+      width: min(1180px, calc(100% - 32px));
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: 255px minmax(0, 1fr);
+      gap: 28px;
+      padding: 32px 0 72px;
+    }
+
+    .toc {
+      position: sticky;
+      top: 18px;
+      align-self: start;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 14px;
+      background: #ffffff;
+      box-shadow: var(--shadow);
+    }
+
+    .toc h2 {
+      margin: 0 0 10px;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    .toc a {
+      display: block;
+      padding: 8px;
+      border-radius: 6px;
+      color: #263442;
+      font-size: 0.92rem;
+    }
+
+    .toc a:hover {
+      background: var(--soft);
+      text-decoration: none;
+    }
+
+    main {
+      min-width: 0;
+    }
+
+    section {
+      margin-bottom: 34px;
+      padding: 30px 0;
+      border-top: 1px solid var(--line);
+    }
+
+    section:first-child {
+      border-top: 0;
+      padding-top: 0;
+    }
+
+    h2 {
+      margin: 0 0 16px;
+      font-size: 1.48rem;
+      line-height: 1.25;
+      letter-spacing: 0;
+    }
+
+    h3 {
+      margin: 0 0 10px;
+      font-size: 1.05rem;
+      line-height: 1.35;
+      letter-spacing: 0;
+    }
+
+    p {
+      margin: 0 0 13px;
+    }
+
+    ul {
+      margin: 0;
+      padding-left: 1.16rem;
+    }
+
+    li {
+      margin: 6px 0;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      overflow: hidden;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #ffffff;
+      font-size: 0.95rem;
+    }
+
+    .table-wrap {
+      width: 100%;
+      overflow-x: auto;
+      margin: 16px 0;
+      border-radius: var(--radius);
+    }
+
+    .table-wrap table {
+      min-width: 860px;
+      margin: 0;
+    }
+
+    th,
+    td {
+      padding: 12px 13px;
+      border-bottom: 1px solid var(--line);
+      vertical-align: top;
+      text-align: left;
+    }
+
+    th {
+      background: #f1f5f9;
+      color: #263442;
+      font-weight: 780;
+    }
+
+    tr:last-child td {
+      border-bottom: 0;
+    }
+
+    .label {
+      display: inline-flex;
+      align-items: center;
+      border: 1px solid rgba(37, 99, 235, 0.26);
+      border-radius: 999px;
+      padding: 4px 9px;
+      margin-bottom: 10px;
+      background: var(--soft-blue);
+      color: var(--blue);
+      font-size: 0.8rem;
+      font-weight: 760;
+    }
+
+    .panel {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: #ffffff;
+      padding: 16px;
+      box-shadow: var(--shadow);
+    }
+
+    .panel h3 {
+      color: #1f2a35;
+    }
+
+    .grid-2 {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      gap: 16px;
+    }
+
+    .grid-3 {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 14px;
+    }
+
+    .callout {
+      border-left: 5px solid var(--teal);
+      border-radius: var(--radius);
+      background: var(--soft-green);
+      padding: 14px 16px;
+      margin: 16px 0;
+    }
+
+    .warn {
+      border-left-color: var(--amber);
+      background: var(--soft-amber);
+    }
+
+    .danger {
+      border-left-color: var(--red);
+      background: var(--soft-red);
+    }
+
+    .flow {
+      display: grid;
+      grid-template-columns: repeat(6, minmax(0, 1fr));
+      gap: 10px;
+      margin: 18px 0;
+    }
+
+    .flow-step {
+      min-height: 118px;
+      border: 1px solid var(--line);
+      border-top: 5px solid var(--blue);
+      border-radius: var(--radius);
+      background: #ffffff;
+      padding: 12px;
+      box-shadow: var(--shadow);
+    }
+
+    .flow-step:nth-child(2) {
+      border-top-color: var(--teal);
+    }
+
+    .flow-step:nth-child(3) {
+      border-top-color: var(--green);
+    }
+
+    .flow-step:nth-child(4) {
+      border-top-color: var(--amber);
+    }
+
+    .flow-step:nth-child(5) {
+      border-top-color: var(--violet);
+    }
+
+    .flow-step:nth-child(6) {
+      border-top-color: var(--red);
+    }
+
+    .flow-step strong {
+      display: block;
+      margin-bottom: 7px;
+      color: #1f2a35;
+    }
+
+    .flow-step span {
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    .state-machine {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      gap: 12px;
+      margin: 18px 0;
+    }
+
+    .state-row {
+      display: grid;
+      grid-template-columns: 160px minmax(0, 1fr);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      overflow: hidden;
+      background: #ffffff;
+    }
+
+    .state-name {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 14px;
+      color: #ffffff;
+      background: #1f2a35;
+      font-weight: 790;
+      text-align: center;
+    }
+
+    .state-row:nth-child(2) .state-name {
+      background: var(--teal);
+    }
+
+    .state-row:nth-child(3) .state-name {
+      background: var(--amber);
+    }
+
+    .state-row:nth-child(4) .state-name {
+      background: var(--red);
+    }
+
+    .state-body {
+      padding: 13px 15px;
+    }
+
+    .mini-code {
+      margin: 14px 0 0;
+      border: 1px solid #cfd8e3;
+      border-radius: var(--radius);
+      background: #111827;
+      color: #e5e7eb;
+      overflow-x: auto;
+    }
+
+    .mini-code pre {
+      margin: 0;
+      padding: 14px 16px;
+      font-size: 0.9rem;
+      line-height: 1.55;
+      white-space: pre-wrap;
+    }
+
+    .pill-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin: 12px 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .pill-list li {
+      margin: 0;
+      padding: 6px 9px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: #ffffff;
+      color: #344252;
+      font-size: 0.88rem;
+    }
+
+    .source-list {
+      columns: 2;
+      column-gap: 24px;
+      font-size: 0.93rem;
+    }
+
+    .source-list li {
+      break-inside: avoid;
+      margin-bottom: 8px;
+    }
+
+    @media (max-width: 980px) {
+      .hero-inner,
+      .layout,
+      .grid-2,
+      .grid-3 {
+        grid-template-columns: 1fr;
+      }
+
+      .toc {
+        position: static;
+      }
+
+      .flow {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .source-list {
+        columns: 1;
+      }
+    }
+
+    @media (max-width: 640px) {
+      .hero-inner {
+        width: min(100% - 24px, 1180px);
+        padding: 34px 0 30px;
+      }
+
+      .hero h1 {
+        font-size: 1.74rem;
+      }
+
+      .layout {
+        width: min(100% - 24px, 1180px);
+        padding-top: 22px;
+      }
+
+      .flow {
+        grid-template-columns: 1fr;
+      }
+
+      .state-row {
+        grid-template-columns: 1fr;
+      }
+
+      th,
+      td {
+        padding: 10px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <div class="hero-inner">
+      <div>
+        <h1>OpenRA 用户输入动作与基础单位指令源码剖面</h1>
+        <p>
+          从玩家视角看，OpenRA 的单位控制可以归纳为几类输入动作：默认上下文点击、带修饰键点击、命令栏确认模式、即时命令、姿态切换和特殊多步输入。
+          屏幕上表现为光标变化、按钮高亮、目标线、语音反馈和单位动作；源码里则落到 <code>Order</code>、<code>IResolveOrder</code> 和活动树。
+        </p>
+      </div>
+      <aside class="summary" aria-label="结论摘要">
+        <b>一句话结论</b>
+        <span>用户看到的是“点哪里、按什么键、光标怎么变、单位怎么动”。</span>
+        <span>引擎看到的是“哪个 targeter 接单、生成什么 Order、哪个 trait 排入什么 activity”。</span>
+      </aside>
+    </div>
+  </header>
+
+  <div class="layout">
+    <nav class="toc" aria-label="目录">
+      <h2>目录</h2>
+      <a href="#scope">0. 本报告范围</a>
+      <a href="#input-actions">1. 用户输入动作总览</a>
+      <a href="#screen-feedback">2. 屏幕反馈</a>
+      <a href="#pipeline">3. 输入到活动链路</a>
+      <a href="#basic-orders">4. 基础指令全图</a>
+      <a href="#context-orders">5. 默认上下文点击</a>
+      <a href="#direct-orders">6. 命令栏与姿态</a>
+      <a href="#attack-move">7. AttackMove 状态机</a>
+      <a href="#autotarget">8. AutoTarget 索敌层</a>
+      <a href="#attack">9. 攻击 trait 层</a>
+      <a href="#movement">10. 移动 activity 层</a>
+      <a href="#weapon">11. 武器发射层</a>
+      <a href="#rules">12. RA 配置例子</a>
+      <a href="#ludots">13. 给 Ludots 的启发</a>
+      <a href="#sources">14. 源码索引</a>
+    </nav>
+
+    <main>
+      <section id="scope">
+        <span class="label">Scope</span>
+        <h2>0. 本报告范围</h2>
+        <div class="grid-2">
+          <div class="panel">
+            <h3>分析对象</h3>
+            <p>
+              本报告按玩家实际输入动作组织：选中单位后点击地面、点击敌人、点击友军或建筑、按住 Ctrl/Alt/Shift 点击、点击命令栏按钮、按热键、切换姿态，以及布雷这类多步输入。
+              每类输入都说明用户会看到什么，以及源码里如何变成单位行为。
+            </p>
+          </div>
+          <div class="panel">
+            <h3>源码范围</h3>
+            <p>
+              重点覆盖普通单位常见基础指令：移动、停止、散开、攻击、强攻、攻击移动、守卫、姿态、部署、采集、修理、占领、运输、停靠、布雷、爆破、空军降落与返航。
+              生产队列、建筑摆放、支援技能和全局玩家命令只作为边界参考。
+            </p>
+          </div>
+        </div>
+        <div class="callout warn">
+          <p>
+            注意许可证边界：OpenRA 是 GPL 项目，这里只做架构学习和行为拆解。Ludots 可以学习它的分层思想、数据驱动方式和调度模式，不应直接复制实现代码。
+          </p>
+        </div>
+      </section>
+
+      <section id="input-actions">
+        <span class="label">Input Model</span>
+        <h2>1. 用户输入动作总览</h2>
+        <p>
+          从用户角度，OpenRA 的单位操作可以分成六类。每一类看起来是不同 UI 行为，但都会被规整成 <code>Order</code>，再交给单位 trait 解析。
+        </p>
+
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>输入动作</th>
+                <th>用户会看到什么</th>
+                <th>典型结果</th>
+                <th>源码入口</th>
+                <th>落到的命令</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>默认上下文点击</td>
+                <td>鼠标悬停时光标随目标变化；点击后出现目标线、语音和单位动作。</td>
+                <td>点空地移动，点敌人攻击，点矿采集，点修理厂修理，点运输车上车。</td>
+                <td><code>UnitOrderGenerator</code></td>
+                <td><code>Move</code>、<code>Attack</code>、<code>Harvest</code>、<code>Repair</code>、<code>EnterTransport</code> 等。</td>
+              </tr>
+              <tr>
+                <td>带修饰键点击</td>
+                <td>光标和可执行语义改变；Shift 会把新命令排队，Ctrl/Alt 会改变目标解释。</td>
+                <td>Ctrl 强攻，Alt 强制移动，Shift 队列命令。</td>
+                <td><code>ForceModifiersOrderGenerator</code> / <code>TargetModifiers</code></td>
+                <td><code>ForceAttack</code>、<code>Land</code>、<code>ForceDock</code> 或带 <code>Queued</code> 的普通命令。</td>
+              </tr>
+              <tr>
+                <td>确认模式按钮</td>
+                <td>按钮高亮，鼠标进入专用模式；再次点击目标后退出或继续保持队列模式。</td>
+                <td>Attack Move、Guard、强制攻击、强制移动。</td>
+                <td><code>CommandBarLogic</code> + 专用 <code>OrderGenerator</code></td>
+                <td><code>AttackMove</code>、<code>AssaultMove</code>、<code>Guard</code>、<code>ForceAttack</code>、<code>Move</code>。</td>
+              </tr>
+              <tr>
+                <td>即时按钮/热键</td>
+                <td>按钮短暂高亮；单位立刻响应，不需要再点目标。</td>
+                <td>Stop、Scatter、Deploy、Unload、Return to Base。</td>
+                <td><code>CommandBarLogic</code> / <code>IIssueDeployOrder</code></td>
+                <td><code>Stop</code>、<code>Scatter</code>、<code>DeployTransform</code>、<code>Unload</code>、<code>ReturnToBase</code>。</td>
+              </tr>
+              <tr>
+                <td>姿态切换</td>
+                <td>姿态按钮高亮变化；单位后续自动开火、还击和追击策略改变。</td>
+                <td>Hold Fire、Return Fire、Defend、Attack Anything。</td>
+                <td><code>StanceSelectorLogic</code></td>
+                <td><code>SetUnitStance</code>。</td>
+              </tr>
+              <tr>
+                <td>特殊多步输入</td>
+                <td>进入专用绘制/选择流程，可能需要拖出区域或连续点多个目标。</td>
+                <td>布雷区、建筑放置、信标等；本报告只展开单位布雷。</td>
+                <td><code>MinefieldOrderGenerator</code> 等</td>
+                <td><code>BeginMinefield</code>、<code>PlaceMinefield</code>、<code>PlaceMine</code>。</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="screen-feedback">
+        <span class="label">Feedback</span>
+        <h2>2. 屏幕反馈：玩家看到的行为语言</h2>
+        <p>
+          OpenRA 不只生成命令，还会在命令生成前后给玩家反馈。多数反馈并不改变单位逻辑，但它们决定用户是否能理解“这个点击会做什么”。
+        </p>
+
+        <div class="grid-3">
+          <div class="panel">
+            <h3>光标</h3>
+            <p>
+              targeter 在 <code>CanTarget</code> 中返回 cursor。可移动、不可移动、攻击、强攻、采集、进入、修理、卸载等都会显示不同光标。
+            </p>
+          </div>
+          <div class="panel">
+            <h3>按钮高亮</h3>
+            <p>
+              命令栏按钮通过 <code>IsHighlighted</code> 表示当前模式，例如 attack move、guard、force move、force attack 和 queue orders。
+            </p>
+          </div>
+          <div class="panel">
+            <h3>目标线</h3>
+            <p>
+              resolver 成功排入活动后通常调用 <code>ShowTargetLines</code>。活动的 <code>TargetLineNodes</code> 决定线指向目的地、目标 actor 或子活动目标。
+            </p>
+          </div>
+          <div class="panel">
+            <h3>语音</h3>
+            <p>
+              <code>IOrderVoice</code> 根据命令名和目标有效性返回语音 key。无效命令通常不会播放确认语音。
+            </p>
+          </div>
+          <div class="panel">
+            <h3>单位动作</h3>
+            <p>
+              玩家最终看到的是活动树运行结果：移动、转向、停下、追击、起飞、降落、进入建筑、装载、卸载或发射武器。
+            </p>
+          </div>
+          <div class="panel">
+            <h3>失败反馈</h3>
+            <p>
+              不可部署、不可进入、不可移动会表现为 blocked cursor、通知文本、语音提示或没有订单生成；复杂检查留在 trait 内部。
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section id="pipeline">
+        <span class="label">Order Pipeline</span>
+        <h2>3. 从输入到单位活动树</h2>
+        <p>
+          OpenRA 的关键设计是：玩家 UI、Lua 脚本和 bot 最后都走同一条 <code>Order</code> 通道。bot 没有私有的“瞬移式单位控制权”，它只是像玩家一样提交
+          <code>AttackMove</code>、<code>Move</code>、<code>Attack</code>、<code>Harvest</code>、<code>Dock</code> 等命令。真正的单位行为发生在 actor trait 和 activity 系统里。
+        </p>
+
+        <div class="flow" aria-label="命令链路">
+          <div class="flow-step">
+            <strong>1. 生成命令</strong>
+            <span>UI、bot 或脚本创建 <code>Order</code>，可带分组选中单位或额外数据。</span>
+          </div>
+          <div class="flow-step">
+            <strong>2. 分发订单</strong>
+            <span><code>UnitOrders</code> 校验订单；分组订单会拆成每个 actor 自己的订单。</span>
+          </div>
+          <div class="flow-step">
+            <strong>3. trait 接单</strong>
+            <span><code>Actor.ResolveOrder</code> 遍历所有 <code>IResolveOrder</code> trait。</span>
+          </div>
+          <div class="flow-step">
+            <strong>4. trait 解析</strong>
+            <span>命令名命中哪个 trait，就由哪个 trait 校验目标并队列化 activity。</span>
+          </div>
+          <div class="flow-step">
+            <strong>5. Actor.Tick</strong>
+            <span>每 tick 通过 <code>ActivityUtils.RunActivity</code> 跑当前活动树。</span>
+          </div>
+          <div class="flow-step">
+            <strong>6. 子系统落地</strong>
+            <span>移动、索敌、攻击、武器、弹体分别由自己的 trait/activity 执行。</span>
+          </div>
+        </div>
+
+        <div class="mini-code" aria-label="命令链路伪代码">
+          <pre>伪代码视角：
+Order("Move" / "Attack" / "Harvest" / "AttackMove" / ...)
+  -> UnitOrders 展开分组并做订单校验
+  -> Actor.ResolveOrder(order)
+  -> 所有 IResolveOrder trait 逐个尝试解析
+  -> 命中的 trait 调 Actor.QueueActivity(...)
+  -> Actor.Tick()
+  -> ActivityUtils.RunActivity(CurrentActivity)</pre>
+        </div>
+
+        <div class="callout">
+          <p>
+            这就是 OpenRA 的第一层分离：战略 AI 只负责“下什么命令”，单位 trait 负责“这个命令在每个 tick 怎么执行”。因此基础单位指令
+            同时服务玩家输入、bot 分队和脚本，不会被锁死在某个 AI 模块里。
+          </p>
+        </div>
+      </section>
+
+      <section id="basic-orders">
+        <span class="label">Order Map</span>
+        <h2>4. 基础单位指令全图</h2>
+        <p>
+          同一个点击动作在不同目标上会变成不同指令。表格从玩家可感知的动作出发，列出屏幕反馈、命令名和底层执行者。
+          OpenRA 没有一个“单位基础指令总开关”；每种能力 trait 都能把自己的命令挂到单位身上。
+        </p>
+
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>用户动作</th>
+                <th>屏幕反馈</th>
+                <th>命令名</th>
+                <th>解析 trait</th>
+                <th>核心 activity / 行为</th>
+                <th>要点</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>选中地面单位，点空地</td>
+                <td>移动光标、橙色目标线、移动语音。</td>
+                <td><code>Move</code></td>
+                <td><code>Mobile</code></td>
+                <td><code>Move</code></td>
+                <td>校验迷雾和地形，找最近可移动格，进入路径、阻塞、半格移动系统。</td>
+              </tr>
+              <tr>
+                <td>选中飞机，点空地；Alt 点可降落格</td>
+                <td>飞行/降落光标，目标线指向格子。</td>
+                <td><code>Move</code> / <code>Land</code></td>
+                <td><code>Aircraft</code></td>
+                <td><code>Fly</code> / <code>Land</code></td>
+                <td>Alt force move 可把可降落地形转成 <code>Land</code>；普通点地是飞行移动。</td>
+              </tr>
+              <tr>
+                <td>点 Stop 或 Scatter 按钮/热键</td>
+                <td>按钮短暂高亮，单位停止或小幅避让。</td>
+                <td><code>Stop</code> / <code>Scatter</code></td>
+                <td><code>Mobile</code>、<code>Aircraft</code>、<code>AttackBase</code></td>
+                <td><code>CancelActivity</code> / <code>Nudge</code></td>
+                <td><code>Stop</code> 取消活动，但保留补给等特殊活动；<code>Scatter</code> 排入短距离避让。</td>
+              </tr>
+              <tr>
+                <td>点敌人；Ctrl 点敌人或地面</td>
+                <td>攻击/强攻光标，红色目标线，武器开火。</td>
+                <td><code>Attack</code> / <code>ForceAttack</code></td>
+                <td><code>AttackBase</code> 派生 trait</td>
+                <td><code>Attack</code> / <code>AttackFollow.AttackActivity</code> / <code>SetTarget</code></td>
+                <td>目标过滤、射程、关系、地面强攻都在 targeter 和 <code>ChooseArmamentsForTarget</code> 中完成。</td>
+              </tr>
+              <tr>
+                <td>点 Attack Move 按钮，再点地面；Ctrl 确认变突击移动</td>
+                <td>按钮高亮，attack move 光标，行军中遇敌停下攻击。</td>
+                <td><code>AttackMove</code> / <code>AssaultMove</code></td>
+                <td><code>AttackMove</code></td>
+                <td><code>AttackMoveActivity</code></td>
+                <td>边走边由 <code>AutoTarget</code> 扫描目标，遇敌取消移动并挂攻击活动。</td>
+              </tr>
+              <tr>
+                <td>点 Guard 按钮，再点友军</td>
+                <td>guard 光标，目标线连向友军，单位跟随保护。</td>
+                <td><code>Guard</code></td>
+                <td><code>Guard</code></td>
+                <td><code>AttackMoveActivity</code> + <code>MoveFollow</code></td>
+                <td>守卫本质是跟随友军到范围内，同时复用 attack move 的自动交战逻辑。</td>
+              </tr>
+              <tr>
+                <td>点击姿态按钮</td>
+                <td>对应姿态按钮高亮，单位自动交战规则改变。</td>
+                <td><code>SetUnitStance</code></td>
+                <td><code>AutoTarget</code></td>
+                <td>设置 stance condition，通知当前活动</td>
+                <td>影响 idle 扫描、受击还击、是否允许移动追击，以及当前攻击活动是否继续。</td>
+              </tr>
+              <tr>
+                <td>点击 Deploy 按钮/热键</td>
+                <td>按钮短暂高亮；可部署则变形，不可部署显示阻塞反馈。</td>
+                <td><code>DeployTransform</code></td>
+                <td><code>Transforms</code></td>
+                <td><code>Transform</code> 派生活动</td>
+                <td>MCV 展开、单位部署等走统一 deploy 接口 <code>IIssueDeployOrder</code>。</td>
+              </tr>
+              <tr>
+                <td>选中采集单位，点已探索资源格</td>
+                <td>采集光标，目标线，采集单位开始找矿和回厂。</td>
+                <td><code>Harvest</code></td>
+                <td><code>Harvester</code></td>
+                <td><code>FindAndDeliverResources</code></td>
+                <td>只对已探索资源格暴露命令，活动内部负责找资源、采集、回厂、交付循环。</td>
+              </tr>
+              <tr>
+                <td>受损或缺弹单位点维修/补给建筑</td>
+                <td>进入/修理光标，单位驶向建筑或飞机返航。</td>
+                <td><code>Repair</code> / <code>RepairNear</code> / <code>InstantRepair</code></td>
+                <td><code>Repairable</code>、<code>RepairableNear</code>、<code>InstantlyRepairs</code></td>
+                <td><code>Resupply</code> / <code>InstantRepair</code></td>
+                <td>普通地面单位排 <code>Resupply</code>，空军把 <code>Repair</code> 合流到 <code>ReturnToBase</code>。</td>
+              </tr>
+              <tr>
+                <td>工程/爆破/修桥单位点有效目标</td>
+                <td>进入、capture、C4 或修桥光标，单位靠近目标执行交互。</td>
+                <td><code>CaptureActor</code> / <code>C4</code> / <code>RepairBridge</code></td>
+                <td><code>Captures</code>、<code>Demolition</code>、<code>RepairsBridges</code></td>
+                <td><code>CaptureActor</code> / <code>Demolish</code> / <code>RepairBridge</code></td>
+                <td>这些是“进入目标并执行交互”的命令族，关系、目标类型和是否强攻由 targeter 判定。</td>
+              </tr>
+              <tr>
+                <td>乘客点运输载具；载具点 Unload</td>
+                <td>进入光标、卸载按钮，单位进出载具。</td>
+                <td><code>EnterTransport</code> / <code>Unload</code></td>
+                <td><code>Passenger</code>、<code>Cargo</code></td>
+                <td><code>RideTransport</code> / <code>UnloadCargo</code></td>
+                <td>乘客负责上车，载具负责卸载；载具会预留空间、锁定状态、把乘客放回地图。</td>
+              </tr>
+              <tr>
+                <td>单位点可停靠建筑或隧道入口</td>
+                <td>进入/停靠光标，目标线指向入口或宿主建筑。</td>
+                <td><code>Dock</code> / <code>ForceDock</code> / <code>EnterTunnel</code></td>
+                <td><code>DockClientManager</code>、<code>EntersTunnels</code></td>
+                <td><code>MoveToDock</code> / 连续 <code>MoveTo</code></td>
+                <td>停靠有预约和 host/client 回调；隧道入口直接排入口移动和出口移动两个 activity。</td>
+              </tr>
+              <tr>
+                <td>吊运机点友军单位，或 Alt 点投放地点</td>
+                <td>吊起/投放光标，飞机靠近、吊起、飞到投放点。</td>
+                <td><code>PickupUnit</code> / <code>DeliverUnit</code> / <code>Unload</code></td>
+                <td><code>Carryall</code></td>
+                <td><code>PickupUnit</code> / <code>DeliverUnit</code></td>
+                <td>空中运输与普通 cargo 分开，pickup、drop-off、当前地点卸载都是独立活动。</td>
+              </tr>
+              <tr>
+                <td>布雷单位点布雷按钮或拖出雷区</td>
+                <td>布雷光标/雷区选择流程，单位移动并逐格放雷。</td>
+                <td><code>BeginMinefield</code> / <code>PlaceMinefield</code> / <code>PlaceMine</code></td>
+                <td><code>Minelayer</code></td>
+                <td><code>LayMines</code></td>
+                <td>单点布雷走 deploy，多点雷区会临时切换 order generator 收集矩形雷区。</td>
+              </tr>
+              <tr>
+                <td>携带现金/经验的单位点可接受目标</td>
+                <td>进入光标，单位靠近后完成交付。</td>
+                <td><code>DeliverCash</code> / <code>DeliverExperience</code></td>
+                <td><code>DeliversCash</code>、<code>DeliversExperience</code></td>
+                <td><code>DonateCash</code> / <code>DonateExperience</code></td>
+                <td>用于把载荷或等级交给可接受目标，是“进入交互”模式的轻量变体。</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="callout">
+          <p>
+            这张表背后的统一规律是：指令名只是薄薄的消息，复杂度不在 <code>Order</code> 里，而在 trait 的 targeter、resolver 和 activity 中。OpenRA 因此可以让 bot、玩家、Lua 脚本共用同一套单位行为。
+          </p>
+        </div>
+      </section>
+
+      <section id="context-orders">
+        <span class="label">Context Orders</span>
+        <h2>5. 默认上下文点击怎么选出命令</h2>
+        <p>
+          普通右键不是固定等于移动。<code>UnitOrderGenerator.OrderForUnit</code> 会对当前 target 做两轮判断：先问 actor/frozen actor 上能否交互；如果没有命中，再退回 terrain cell。Ctrl、Shift、Alt 分别转成
+          <code>ForceAttack</code>、<code>ForceQueue</code>、<code>ForceMove</code>，传给每个 targeter 自行解释。
+        </p>
+
+        <div class="flow" aria-label="右键上下文命令选择">
+          <div class="flow-step">
+            <strong>收集 target</strong>
+            <span>鼠标下优先真实 actor，其次 frozen actor，最后 terrain cell。</span>
+          </div>
+          <div class="flow-step">
+            <strong>收集 orders</strong>
+            <span>从单位所有 <code>IIssueOrder</code> trait 取 targeter。</span>
+          </div>
+          <div class="flow-step">
+            <strong>按优先级</strong>
+            <span>高优先级如采集/卸载可压过普通移动。</span>
+          </div>
+          <div class="flow-step">
+            <strong>修饰键</strong>
+            <span>Ctrl 强攻，Alt 强制移动，Shift 队列。</span>
+          </div>
+          <div class="flow-step">
+            <strong>生成 Order</strong>
+            <span>命中的 trait 调 <code>IssueOrder</code> 返回具体命令名。</span>
+          </div>
+          <div class="flow-step">
+            <strong>解析执行</strong>
+            <span>网络订单回到 actor，再由 resolver 排入 activity。</span>
+          </div>
+        </div>
+
+        <div class="grid-2">
+          <div class="panel">
+            <h3>为什么右键矿是采集，右键空地是移动</h3>
+            <p>
+              <code>Harvester</code> 暴露 <code>HarvestOrderTargeter</code>，优先级高于普通移动，只在已探索资源格上返回可用；资源不匹配时它不接单，<code>Mobile</code> 的移动 targeter 才接管。
+            </p>
+          </div>
+          <div class="panel">
+            <h3>为什么 Alt 能强制走过去</h3>
+            <p>
+              多个 targeter 会显式检查 <code>TargetModifiers.ForceMove</code>。攻击、爆破、采集等目标交互通常在 force move 下让位，移动 targeter 则可覆盖选择行为。
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section id="direct-orders">
+        <span class="label">Direct Orders</span>
+        <h2>6. 命令栏、热键与姿态命令</h2>
+        <p>
+          命令栏按钮不会走完整的右键 targeter 竞争，而是直接发特定订单或切换专用 <code>OrderGenerator</code>。例如 <code>AttackMove</code>、<code>Guard</code> 先进入确认模式，
+          <code>Stop</code>、<code>Scatter</code>、<code>Deploy</code> 直接对当前选择发订单。
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>入口</th>
+              <th>源码位置</th>
+              <th>行为</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>命令栏</td>
+              <td><code>CommandBarLogic</code></td>
+              <td>绑定 attack move、force move、force attack、guard、scatter、deploy、stop、queue orders 等按钮。</td>
+            </tr>
+            <tr>
+              <td>部署热键</td>
+              <td><code>IIssueDeployOrder</code></td>
+              <td>各 trait 自己决定 deploy 对应什么：变形、卸载、返航补给、放雷、激活条件都可以挂上来。</td>
+            </tr>
+            <tr>
+              <td>姿态面板</td>
+              <td><code>StanceSelectorLogic</code></td>
+              <td>发 <code>SetUnitStance</code>，由 <code>AutoTarget</code> 设置 <code>HoldFire/ReturnFire/Defend/AttackAnything</code>。</td>
+            </tr>
+            <tr>
+              <td>强制修饰模式</td>
+              <td><code>ForceModifiersOrderGenerator</code></td>
+              <td>临时把 Ctrl/Alt/Shift 注入下一次右键，复用普通 targeter 流程。</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="callout warn">
+          <p>
+            姿态命令虽然不排移动 activity，但它会改变单位后续基础行为：idle 是否扫描、受击是否还击、attack move 是否允许追击、当前攻击活动是否因姿态收紧而取消目标。
+          </p>
+        </div>
+      </section>
+
+      <section id="attack-move">
+        <span class="label">AttackMoveActivity</span>
+        <h2>7. Attack Move 的核心状态机</h2>
+        <p>
+          从玩家角度，attack move 是一个两步确认动作：先点命令栏按钮，按钮进入高亮确认模式；再点地图目的地。普通确认生成 <code>AttackMove</code>，按住 Ctrl 确认生成 <code>AssaultMove</code>。
+          单位会沿目标地点移动，路上发现目标就停下攻击，攻击结束后继续向目的地前进。
+        </p>
+        <p>
+          <code>AttackMove.ResolveOrder</code> 做的事很少：它确认订单是 <code>AttackMove</code> 或 <code>AssaultMove</code>，检查目标有效性和是否允许进入未探索区域，然后把目标 cell 修正成可移动 cell，最后排入
+          <code>AttackMoveActivity</code>。真正的行为循环在 <code>AttackMoveActivity.Tick</code>。
+        </p>
+
+        <div class="state-machine">
+          <div class="state-row">
+            <div class="state-name">初始化</div>
+            <div class="state-body">
+              首次运行时，如果单位缺少 <code>AttackMove</code> 或 <code>AutoTarget</code>，活动退化成普通移动；如果具备条件，则给 actor 临时授予
+              <code>AttackMoveCondition</code> 或 <code>AssaultMoveCondition</code>。
+            </div>
+          </div>
+          <div class="state-row">
+            <div class="state-name">移动阶段</div>
+            <div class="state-body">
+              活动通过传入的 <code>getMove</code> 函数创建移动子活动。普通点地 attack move 里，这个子活动来自 <code>IMove.MoveTo(targetLocation)</code>。
+              关键细节是 <code>ChildHasPriority = false</code>，父活动可以在移动子活动运行期间继续扫描敌人。
+            </div>
+          </div>
+          <div class="state-row">
+            <div class="state-name">索敌阶段</div>
+            <div class="state-body">
+              当当前没有子活动，或正在跑移动子活动时，调用 <code>AutoTarget.ScanForTarget</code>。如果移动还在跑，使用标准扫描间隔；如果刚打完一个目标，则忽略间隔立即重新找目标，避免单位刚开火结束就白走一小段。
+            </div>
+          </div>
+          <div class="state-row">
+            <div class="state-name">攻击阶段</div>
+            <div class="state-body">
+              找到目标后取消移动子活动，然后让每个可用 <code>AttackBase</code> 生成攻击子活动。攻击子活动结束后，<code>AttackMoveActivity</code>
+              不直接结束，而是重新进入索敌/移动循环。只有移动子活动完成并且没有目标时，整个 attack move 才结束。
+            </div>
+          </div>
+        </div>
+
+        <div class="grid-2">
+          <div class="panel">
+            <h3><code>AttackMove</code> 和 <code>AssaultMove</code> 的差别</h3>
+            <p>
+              两者走同一个活动类。区别主要是 <code>AssaultMove</code> 会授予另一个 condition，让规则数据切换自动索敌优先级。例如 RA 规则中，
+              assault move 可以把结构物纳入更激进的自动目标集合。
+            </p>
+          </div>
+          <div class="panel">
+            <h3>UI 层的保护</h3>
+            <p>
+              <code>AttackMoveOrderGenerator</code> 在选中单位没有 <code>AutoTargetInfo</code> 时会退出该输入模式，因为没有自动索敌的单位无法完成“边走边打”的语义。活动层仍有兜底：缺 trait 时只移动。
+            </p>
+          </div>
+        </div>
+
+        <div class="callout warn">
+          <p>
+            一个细节很重要：<code>AttackMove</code> 不天然等于“主动追杀全图敌人”。它把 <code>autoTarget.AllowMove</code> 传给索敌和攻击活动。是否允许为了目标移动追击，取决于自动索敌姿态和单位配置。
+          </p>
+        </div>
+      </section>
+
+      <section id="autotarget">
+        <span class="label">AutoTarget</span>
+        <h2>8. AutoTarget 索敌层：目标选择被数据和姿态约束</h2>
+        <p>
+          <code>AutoTarget</code> 是 attack move 的眼睛。它不是简单地“找最近敌人”，而是带着姿态、扫描间隔、目标类型、关系、武器可用性、视野和射界一起筛选。
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>机制</th>
+              <th>作用</th>
+              <th>对 Attack Move 的影响</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>姿态</td>
+              <td><code>HoldFire</code>、<code>ReturnFire</code>、<code>Defend</code>、<code>AttackAnything</code>。</td>
+              <td>是否允许自动移动追击由 <code>AllowMove</code> 决定，通常只有更激进姿态才会打开。</td>
+            </tr>
+            <tr>
+              <td>扫描间隔</td>
+              <td>默认在一个短随机 tick 区间内节流，减少大量单位同时扫描的性能压力。</td>
+              <td>移动中遵守间隔；刚打完目标后可立即再扫描，保持行为顺滑。</td>
+            </tr>
+            <tr>
+              <td>目标优先级</td>
+              <td><code>AutoTargetPriority</code> 以规则数据定义目标类型、关系和优先级。</td>
+              <td><code>AssaultMoveCondition</code> 可以切换优先级配置，不需要新写一套行为代码。</td>
+            </tr>
+            <tr>
+              <td>武器过滤</td>
+              <td>目标必须至少能被某个 armament 有效攻击，且在不允许移动时还要处在射程内。</td>
+              <td>单位不会为了打不了的目标停下来，也不会在禁止追击时选择太远目标。</td>
+            </tr>
+            <tr>
+              <td>视野和冻结目标</td>
+              <td>可攻击真实 actor，也可按配置考虑迷雾中的 frozen actor。</td>
+              <td>远程炮击、迷雾记忆和 bot 视野限制都收敛在目标选择层。</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="callout">
+          <p>
+            这层最值得 Ludots 借鉴的是：目标选择是数据策略，不是硬编码在 <code>AttackMoveActivity</code> 里的分支。移动行为只问“现在有没有目标”，至于目标是谁，由
+            <code>AutoTarget</code> 和规则配置决定。
+          </p>
+        </div>
+      </section>
+
+      <section id="attack">
+        <span class="label">Attack Traits</span>
+        <h2>9. 攻击 trait 层：同一命令适配不同武器形态</h2>
+        <p>
+          <code>AttackMoveActivity</code> 找到目标后，不自己开火，而是把目标交给 actor 上的 <code>AttackBase</code> 派生 trait。这样同一个 attack move 命令可以驱动坦克炮塔、正面开火单位、全向攻击单位和更多 mod 自定义攻击方式。
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>类型</th>
+              <th>主要职责</th>
+              <th>行为含义</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>AttackBase</code></td>
+              <td>订单入口、武器筛选、射程计算、攻击活动工厂。</td>
+              <td>所有攻击 trait 的共同合同，attack move 只依赖这个抽象。</td>
+            </tr>
+            <tr>
+              <td><code>AttackFollow</code></td>
+              <td>记录请求目标和机会目标，必要时移动到射程内，目标消失时使用最后可见位置。</td>
+              <td>移动单位和炮塔单位的主力攻击活动，能追击、卡距离、保持目标。</td>
+            </tr>
+            <tr>
+              <td><code>AttackTurreted</code></td>
+              <td>继承 <code>AttackFollow</code>，攻击前让炮塔朝向目标。</td>
+              <td>坦克这类单位不用转整个车身也能开火，炮塔准备好后才发射。</td>
+            </tr>
+            <tr>
+              <td><code>AttackFrontal</code></td>
+              <td>要求单位面向目标，生成通用 <code>Activities.Attack</code>。</td>
+              <td>适合必须朝前射击的单位，活动里处理转向和范围。</td>
+            </tr>
+            <tr>
+              <td><code>AttackOmni</code></td>
+              <td>设置目标并持续调用攻击，不承担追击隐藏目标的复杂逻辑。</td>
+              <td>适合全向或更简单的攻击模型。</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="grid-2">
+          <div class="panel">
+            <h3>攻击活动不是只开一枪</h3>
+            <p>
+              <code>AttackFollow.AttackActivity</code> 会持续重算目标。如果目标还可见且在射程内，活动等待 trait tick 去发射；如果目标离开射程且允许移动，则挂
+              <code>MoveWithinRange</code> 子活动追到合适距离。
+            </p>
+          </div>
+          <div class="panel">
+            <h3>AttackMove 有独特限制</h3>
+            <p>
+              当武器耗尽弹药且单位支持补给时，普通攻击可以转去补给；但来源是 <code>AttackSource.AttackMove</code> 时，攻击活动直接结束，不把单位从行军任务里拉去补给。
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section id="movement">
+        <span class="label">Movement</span>
+        <h2>10. 移动 activity 层：路径、阻塞、贴近和卡射程</h2>
+        <p>
+          OpenRA 的移动也不是由 attack move 手写。<code>Mobile</code> 提供 <code>IMove</code>，把不同移动意图转换成 activity：去某个 cell、靠近目标、跟随目标、移动到射程环内。
+        </p>
+
+        <div class="grid-3">
+          <div class="panel">
+            <h3><code>Move</code></h3>
+            <p>
+              寻路到目标 cell，按不同阻塞策略尝试路径。遇到临时阻塞会等待、通知阻塞者、重寻路，必要时后退让路。
+            </p>
+          </div>
+          <div class="panel">
+            <h3><code>MoveAdjacentTo</code></h3>
+            <p>
+              面向移动目标，目标移动后取消旧路径并重新规划。目标隐藏时使用最后可见位置作为退路。
+            </p>
+          </div>
+          <div class="panel">
+            <h3><code>MoveWithinRange</code></h3>
+            <p>
+              在最小射程和最大射程之间找候选格，进入正确距离就停下，是追击和卡射程的关键组件。
+            </p>
+          </div>
+        </div>
+
+        <div class="callout">
+          <p>
+            这层解释了为什么 <code>AttackMoveActivity</code> 可以很薄：它只把“走向目的地”和“进入攻击距离”表达成移动活动，实际寻路、阻塞处理、半格移动插值、actor map 更新都在移动系统内部。
+          </p>
+        </div>
+      </section>
+
+      <section id="weapon">
+        <span class="label">Armament</span>
+        <h2>11. 武器发射层：行为最终落到 projectile</h2>
+        <p>
+          当攻击 trait 判断“可以开火”后，最后一跳是 <code>Armament.CheckFire</code>。它检查装填、暂停、炮塔朝向、最大/最小射程和武器目标类型，然后按 burst、barrel、fire delay 创建 projectile 参数并把 projectile 加进 world。
+        </p>
+
+        <div class="flow" aria-label="武器发射链路">
+          <div class="flow-step">
+            <strong>AttackActivity</strong>
+            <span>确认目标有效，距离和射界满足。</span>
+          </div>
+          <div class="flow-step">
+            <strong>AttackBase</strong>
+            <span>选择可用 armament，调用 <code>DoAttack</code>。</span>
+          </div>
+          <div class="flow-step">
+            <strong>Armament</strong>
+            <span>检查 reload、range、turret、target type。</span>
+          </div>
+          <div class="flow-step">
+            <strong>FireBarrel</strong>
+            <span>计算 muzzle、passive target 和 guided target。</span>
+          </div>
+          <div class="flow-step">
+            <strong>Projectile</strong>
+            <span>根据 weapon projectile 工厂创建弹体。</span>
+          </div>
+          <div class="flow-step">
+            <strong>World.Add</strong>
+            <span>弹体进入 world，之后由弹体/warhead 系统处理命中和伤害。</span>
+          </div>
+        </div>
+
+        <div class="callout danger">
+          <p>
+            所以不要把 <code>AttackMove</code> 理解成“自动扣血”。它只是一段单位行为调度。伤害发生在更后面的 projectile 和 warhead 链路中，这让命令、行为、武器和伤害保持清晰边界。
+          </p>
+        </div>
+      </section>
+
+      <section id="rules">
+        <span class="label">Rules Data</span>
+        <h2>12. RA 规则配置里的真实用法</h2>
+        <p>
+          OpenRA 的 RA mod 把这套行为放进规则继承链中。典型车辆基底包含 <code>Mobile</code> 和 <code>AttackMove</code>，具体单位再组合
+          <code>AutoTarget</code>、<code>Armament</code>、<code>AttackTurreted</code> 或 <code>AttackFrontal</code>。
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>配置对象</th>
+              <th>组合方式</th>
+              <th>行为效果</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>^Vehicle</code></td>
+              <td>基底 traits 中包含 <code>Mobile</code>、<code>AttackMove</code> 等。</td>
+              <td>让车辆天然可移动、可接受 attack move 命令。</td>
+            </tr>
+            <tr>
+              <td><code>^AutoTargetGroundAssaultMove</code></td>
+              <td>继承地面自动索敌，并让 <code>AssaultMoveCondition</code> 打开 assault profile。</td>
+              <td>Ctrl attack move 可以切换更激进的目标优先级。</td>
+            </tr>
+            <tr>
+              <td><code>1TNK</code></td>
+              <td>继承车辆和地面 assault auto target，挂炮塔、武器和 <code>AttackTurreted</code>。</td>
+              <td>典型坦克：边走边扫目标，遇敌停下或追击到合适距离，炮塔对准后开火。</td>
+            </tr>
+            <tr>
+              <td><code>V2RL</code></td>
+              <td>使用远程武器、较大扫描半径和 <code>AttackFrontal</code>。</td>
+              <td>典型正面远程单位：需要朝向和距离，部分配置允许打 frozen actor。</td>
+            </tr>
+            <tr>
+              <td><code>E1</code></td>
+              <td>步兵同样继承 auto target assault move profile。</td>
+              <td>说明这套行为不专属于车辆，而是 trait 组合出的通用单位能力。</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="callout">
+          <p>
+            这个配置方式很漂亮：<code>AttackMove</code> 只是能力入口，<code>AutoTargetPriority</code> 是目标政策，<code>AttackBase</code> 派生 trait 是攻击形态，<code>Armament</code>
+            是武器。一个单位能不能 attack move，不靠继承一个巨型 Unit 类，而靠 traits 组合。
+          </p>
+        </div>
+      </section>
+
+      <section id="ludots">
+        <span class="label">For Ludots</span>
+        <h2>13. 给 Ludots 的单位行为启发</h2>
+        <p>
+          对 Ludots 来说，OpenRA 这块最有价值的不是具体 C# 写法，而是用户输入、命令语义、单位行为调度、目标选择、移动、攻击、武器发射之间的边界。
+          用户看到的是简洁输入动作；系统内部必须把这些动作拆给正确的能力模块。
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>OpenRA 模式</th>
+              <th>Ludots 可映射方向</th>
+              <th>价值</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>能力 trait 暴露自己的 <code>IIssueOrder</code></td>
+              <td>单位基础命令不要集中在单个巨大输入系统里；每个能力模块注册自己的 targeter 和 resolver。</td>
+              <td>新能力可以自然长出新右键语义，例如采集、运输、占领、治疗、建造，不污染移动或攻击系统。</td>
+            </tr>
+            <tr>
+              <td>玩家、bot、脚本共用 <code>Order</code></td>
+              <td>人类输入、AI commander、脚本都提交同一种运行时命令。</td>
+              <td>避免 AI 旁路 Core 行为，也方便 replay、调试和测试。</td>
+            </tr>
+            <tr>
+              <td><code>AttackMoveActivity</code> 是薄编排器</td>
+              <td>在 Ludots 中用 per-entity intent/task/activity 表达组合行为。</td>
+              <td>attack move 不吞掉导航、索敌、武器系统职责。</td>
+            </tr>
+            <tr>
+              <td><code>AutoTargetPriority</code> 数据化</td>
+              <td>用配置定义目标类型、阵营关系、优先级、姿态条件。</td>
+              <td>不同 mod 可以调政策，不必复制行为系统。</td>
+            </tr>
+            <tr>
+              <td><code>AssaultMoveCondition</code> 切目标 profile</td>
+              <td>用 condition/tag 切换 targeting profile，例如普通行军、突击行军、守点。</td>
+              <td>一套行为，多种战术语义。</td>
+            </tr>
+            <tr>
+              <td><code>MoveWithinRange</code> 独立</td>
+              <td>导航层提供“进入射程环”的标准能力，而不是攻击系统自己寻路。</td>
+              <td>远程、近战、施法、采集都能复用同类距离约束。</td>
+            </tr>
+            <tr>
+              <td><code>Armament.CheckFire</code> 独立收口</td>
+              <td>GAS/武器执行层负责冷却、射程、弹体、效果。</td>
+              <td>命令层不会直接造成伤害，战斗规则更可测。</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="grid-2">
+          <div class="panel">
+            <h3>Ludots 已经做得好的方向</h3>
+            <ul>
+              <li>已有 Mod、ConfigPipeline、GAS Effect Pipeline 和 SystemGroup 概念，适合承接数据驱动单位行为。</li>
+              <li>已有导航、输入、GAS、表现层等模块边界，天然适合把 attack move 拆成多个正式管线能力。</li>
+              <li>六边形架构和“一切皆 Mod”的原则，和 OpenRA trait 组合思想相容。</li>
+            </ul>
+          </div>
+          <div class="panel">
+            <h3>仍然需要补的关键能力</h3>
+            <ul>
+              <li>统一的单位命令合同：玩家输入、AI 和脚本共用，不允许 AI 直接改运动或战斗状态。</li>
+              <li>上下文命令 targeter：按优先级决定右键是移动、攻击、采集、修理、装载还是占领。</li>
+              <li>可组合的 per-entity 行为调度：能表达父任务、子任务、取消、排队、完成和继续扫描。</li>
+              <li>数据化自动索敌 profile：目标类型、阵营关系、姿态、扫描间隔、优先级都应配置化。</li>
+              <li>标准“进入能力范围”导航意图：移动系统负责路径和距离环，能力系统只声明需求。</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="callout">
+          <p>
+            最推荐的 Ludots 落地顺序：先统一命令入口，再做右键上下文 targeter，再做轻量单位行为调度，再接数据化自动索敌，最后让 attack move 只组合“移动到目的地”和“有目标时执行攻击能力”。这样不会一上来把所有逻辑塞进一个 RTS AI 系统。
+          </p>
+        </div>
+      </section>
+
+      <section id="sources">
+        <span class="label">Source Map</span>
+        <h2>14. 源码索引</h2>
+        <p>本报告主要参考以下本地 OpenRA 源码文件：</p>
+        <ul class="source-list">
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/AttackMove.cs">AttackMove.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs">AttackMoveActivity.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Orders/UnitOrderGenerator.cs">UnitOrderGenerator.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Orders/UnitOrderTargeter.cs">UnitOrderTargeter.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs">DeployOrderTargeter.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Orders/ForceModifiersOrderGenerator.cs">ForceModifiersOrderGenerator.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Orders/GuardOrderGenerator.cs">GuardOrderGenerator.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs">CommandBarLogic.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Widgets/Logic/Ingame/StanceSelectorLogic.cs">StanceSelectorLogic.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/AutoTarget.cs">AutoTarget.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs">AttackBase.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs">AttackFollow.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs">AttackTurreted.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs">AttackFrontal.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs">AttackOmni.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Mobile.cs">Mobile.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Air/Aircraft.cs">Aircraft.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Guard.cs">Guard.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Harvester.cs">Harvester.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Captures.cs">Captures.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Passenger.cs">Passenger.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Cargo.cs">Cargo.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Carryall.cs">Carryall.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Repairable.cs">Repairable.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/RepairableNear.cs">RepairableNear.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/InstantlyRepairs.cs">InstantlyRepairs.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/DockClientManager.cs">DockClientManager.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/EntersTunnels.cs">EntersTunnels.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Transforms.cs">Transforms.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Minelayer.cs">Minelayer.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Demolition.cs">Demolition.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/RepairsBridges.cs">RepairsBridges.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/DeliversCash.cs">DeliversCash.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/DeliversExperience.cs">DeliversExperience.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Activities/Move/Move.cs">Move.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs">MoveAdjacentTo.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs">MoveWithinRange.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Mods.Common/Traits/Armament.cs">Armament.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Game/Activities/Activity.cs">Activity.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Game/Traits/ActivityUtils.cs">ActivityUtils.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Game/Actor.cs">Actor.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/OpenRA.Game/Network/UnitOrders.cs">UnitOrders.cs</a></li>
+          <li><a href="../../external/reference/OpenRA/mods/ra/rules/defaults.yaml">RA defaults.yaml</a></li>
+          <li><a href="../../external/reference/OpenRA/mods/ra/rules/vehicles.yaml">RA vehicles.yaml</a></li>
+          <li><a href="../../external/reference/OpenRA/mods/ra/rules/infantry.yaml">RA infantry.yaml</a></li>
+        </ul>
+      </section>
+    </main>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add the consolidated SSOT plan `docs/reference/ludots_ai_utility_autocast_ssot_plan.html` that replicates the Uintel utility AI architecture and implements the full OpenRA stance/order set as a behavior pack.
- Core thesis: the basic attack is just an autocast ability; multi-ability arbitration over a shared GCD/mana budget is the entry point where utility AI becomes necessary.
- Land the supporting OpenRA source analyses, the Ludots targeting / Order / GAS gap analysis, the SoA architecture baseline, and the AI status reference map, and index them all in `docs/reference/README.md`.

## Why push separately
The SSOT plan and reference docs are the prerequisite reading for the AI work tracked by epic #224 and sub-issues #225-#234. This branch is docs-only (no code changes) so contributors can open the docs straight from the issues.

## Scope
- Docs only. 10 files added + `docs/reference/README.md` index update.
- No code, no behavior changes.

## Related issues
- Epic: #224
- Sub-issues: #225 #226 #227 #228 #229 #230 #231 #232 #233 #234
