### PR TITLE
fix(ai): enforce fail-fast AI order/ability contract (#225)

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -35,6 +35,7 @@
 
 - [GAS Combat Infrastructure](gas_combat_infrastructure.md)
 - [GAS Layered Architecture](gas_layered_architecture.md)
+- [AI Utility Autocast Contract](../../gitbook/architecture/ai-utility-autocast-contract.md)
 - [Order / Navigation / Movement Architecture](order_navigation_movement.md)
 - [Narrative Quest / Dialogue / Cinematic](narrative_quest_dialogue_cinematic.md)
 - [Narrative Frontend Kit](narrative_frontend_kit.md)

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -24,6 +24,8 @@
   * 选择真相改为 selection container 与 relation membership，并已回写到架构文档
 * [RFC-0059 路网移动 Order、Nav Runtime 与多策略路径演示统一方案](RFC-0059-road-order-nav-runtime-unification.md)
   * 提议把玩家 move order、nav runtime path、move sink 和 timeout/arrival 分层，并用 unified showcase 演示
+* [RFC-0060 AI Utility Autocast 契约收敛](RFC-0060-ai-utility-autocast-contract.md)
+  * 定稿 Intent / Behavior / Deliberation 三层、普攻=autocast、AI Order/GAS 边界与加载期 fail-fast 契约
 
 ## 2 使用规则
 

--- a/docs/rfcs/RFC-0060-ai-utility-autocast-contract.md
+++ b/docs/rfcs/RFC-0060-ai-utility-autocast-contract.md
@@ -1,0 +1,58 @@
+# RFC-0060 AI Utility Autocast 契约收敛
+
+状态：Accepted for issue #225 implementation slice
+
+正式结论：`gitbook/architecture/ai-utility-autocast-contract.md`
+
+## 背景
+
+Epic #224 要把现有 `src/Core/Gameplay/AI` 深化为通用 Utility AI + OpenRA Stance 行为包。#225 先处理契约前提，不实现 scoring、target acquisition、autocast 仲裁、stance/order 行为包或主循环接入。
+
+SSOT 参考材料来自 `docs/ai-utility-autocast-ssot` 分支：
+
+- `docs/reference/ludots_ai_utility_autocast_ssot_plan.html`
+- `docs/reference/ludots_utility_ai_soa_openra_behavior_architecture.html`
+- `docs/reference/ludots_targeting_order_gas_gap_analysis.html`
+
+## 决议
+
+1. AI 三层模型固定为 Intent / Behavior / Deliberation。
+2. AI Core 只产 Order intent，不直接执行 gameplay side effect。
+3. 普攻是一种 autocast ability，不再为攻击建立特例系统。
+4. 多个 autocast 争抢共享 GCD、mana 或施法槽时，仲裁器就是 Utility 决策入口。
+5. `OrderTypeKey` / `OrderTypeId` 必须以 `OrderTypeRegistry` 为 SSOT；未知引用加载期 fail-fast。
+6. `OrderTagId` 不是 AI action 契约字段，必须修正为 `OrderTypeId` 或 `OrderTypeKey`。
+7. GCD = 共享 cooldown tag，复用 `AbilityCooldown.CooldownTagId` 与 `AbilityActivationBlockTags`。
+8. ability 引用若出现在 AI 配置中，必须通过 `AbilityDefinitionRegistry` 校验，未知 id/key 加载期报错。
+
+## 复用清单
+
+- ConfigPipeline / ConfigCatalog：AI 配置继续走正式配置管线。
+- `AiConfigLoader`：现有 AI 配置编译入口，作为 #225 契约收敛点。
+- `OrderTypeRegistry`：Order type key/id 的注册与查询入口。
+- `AbilityDefinitionRegistry`：ability id 到 GAS 执行定义的注册表。
+- `OrderQueue` / `OrderBufferSystem`：AI intent 的正式入口。
+- GAS ability components：cooldown、block tags、activation precondition 继续由 GAS 管理。
+
+## 本轮新增清单
+
+- `AiConfigValidationContext`：把 `OrderTypeRegistry` 和 `AbilityDefinitionRegistry` 显式交给 AI loader 做加载期引用校验。
+- `AiConfigLoader` fail-fast：拒绝未知 order type、未知 ability、未知 atom/op/binding 与旧 `OrderTagId`。
+- `AIDemoMod` GOAP action 配置：`OrderTagId` 修正为 `OrderTypeId`。
+- GitBook 正式契约页：记录 #225 的分层、普攻=autocast、Order/GAS/GCD 边界。
+
+## 非目标
+
+- 不实现 target acquisition、filter、OpenRA target priority。
+- 不实现 Utility scoring、decision-target evaluator、autocast candidate arbitration。
+- 不实现 attackMove、guard、setCombatStance、stance runtime。
+- 不改变 `castAbility` 现有 slot-index 执行语义。
+- 不接入新的 AI systems 到主循环。
+
+## 验收
+
+- 未知 order type id/key 加载期报错。
+- 旧 `OrderTagId` 加载期报错。
+- 未知 ability id/key 加载期报错。
+- 现有 AI loader happy path 正常编译。
+- 现有 AI 相关测试不回归。

--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -14,6 +14,7 @@
   - [Mod 架构](architecture/mod-architecture.md)
   - [GAS 分层架构](architecture/gas-layered-architecture.md)
   - [Exchange Operations](architecture/exchange-operations.md)
+  - [AI Utility Autocast 契约](architecture/ai-utility-autocast-contract.md)
   - [实体仿真分层与车道](architecture/entity-simulation-layering.md)
   - [实体仿真工作流拆分](architecture/entity-simulation-workstreams.md)
   - [实体仿真阶段验收](architecture/entity-simulation-uat.md)

--- a/gitbook/architecture/README.md
+++ b/gitbook/architecture/README.md
@@ -8,6 +8,7 @@
 - [Mod 架构](mod-architecture.md)
 - [GAS 分层架构](gas-layered-architecture.md)
 - [Exchange Operations](exchange-operations.md)
+- [AI Utility Autocast 契约](ai-utility-autocast-contract.md)
 - [实体仿真分层与车道](entity-simulation-layering.md)
 - [实体仿真工作流拆分](entity-simulation-workstreams.md)
 - [实体仿真阶段验收](entity-simulation-uat.md)

--- a/gitbook/architecture/ai-utility-autocast-contract.md
+++ b/gitbook/architecture/ai-utility-autocast-contract.md
@@ -1,0 +1,62 @@
+# AI Utility Autocast 契约
+
+本页记录通用 Utility AI 与 OpenRA Stance 行为包的正式分层契约。长篇方案与证据可放在 `docs/rfcs/` 和 `docs/reference/`，但实现判断以本页为准。
+
+## 三层模型
+
+| 层 | 回答的问题 | Ludots 归属 |
+|----|------------|-------------|
+| Intent / Order | 我被命令做什么 | 玩家、AI、脚本统一提交 `Order`，进入 `OrderQueue` / `OrderBufferSystem` |
+| Behavior / 机制 | 怎么把命令执行出来 | 行为包、Order runtime、GAS、Navigation、Targeting policy |
+| Deliberation / Utility AI | 多个有价值选项此刻选哪个 | AI Core 只产出 intent，不执行 gameplay side effect |
+
+AI Core 只能输出 `DecisionIntent` / Order intent。它不得直接扣血、发布 Effect、生成 Projectile、扣 cost、写 cooldown、写 block tag，也不得绕过 Order 校验。
+
+## 普攻就是 autocast ability
+
+普通攻击不是特殊系统。它是一种带 autocast policy 的 ability：
+
+- 普攻作为显式配置的候选存在，通常优先级最低、前置最宽松、可自动重复。
+- attack-move 的接战阶段等价于“普攻这个 autocast 候选赢得动作槽”。
+- Idle、HoldFire、ReturnFire 等都必须是显式配置的 stance / decision / order state；缺配置时 fail-fast，不允许平台 fallback。
+
+单个或互不冲突的 autocast 可以由机制层触发；多个 autocast 争抢共享 GCD、mana 或施法槽时，仲裁器就是 Utility 决策入口。便宜优先级表和 utility 打分是同一候选流水线的两种选择函数。
+
+## Order 契约
+
+AI 配置中的 Order 引用必须收敛到 `OrderTypeRegistry`：
+
+- Authoring 优先写 `OrderTypeKey`，加载期解析为 `OrderTypeId`。
+- 已编译或测试配置可以写 `OrderTypeId`，但加载期必须确认该 id 已注册。
+- 同时写 `OrderTypeKey` 与 `OrderTypeId` 时，两者必须指向同一个注册 order type。
+- `OrderTagId` 不是 AI Order 契约字段，加载期必须报错。
+- 缺失、未知或非正数 order type 不允许 fallback 到 `0`。
+
+AI action 可以引用 ability id / key 作为执行意图的契约数据，但现阶段不改变 `castAbility` Order 的 slot-index 执行语义。存在 ability 引用时，加载期必须通过 `AbilityDefinitionRegistry` 校验；未知 ability id/key 直接 fail-fast。
+
+## GAS 与 GCD 契约
+
+能力执行仍归 GAS：
+
+- cost、cooldown、activation precondition、block tag、damage、effect、projectile 都由 GAS 负责。
+- GCD 表达为共享 cooldown tag，复用 `AbilityCooldown.CooldownTagId` 与 `AbilityActivationBlockTags`。
+- AI / 行为包只能读取 readiness / gate 状态并提交 Order，不能写 GAS 执行状态。
+
+## 分层边界
+
+AI Core 只保留跨题材通用词：
+
+- `ActuatorReadiness`
+- `AimGate`
+- `TargetFilter`
+- `DecisionIntent`
+- `ExecutionPrecondition`
+
+Stance、AttackMove、Guard、Patrol、AutoTarget profile 属于 behavior pack；炮台、采集器、建造者、蓄力施法等业务名词属于对应 gameplay ability / actuator adapter，不进入 AI Core。
+
+## 代码锚点
+
+- `src/Core/Gameplay/AI/Config/AiConfigLoader.cs`：AI 配置加载与引用 fail-fast。
+- `src/Core/Gameplay/GAS/Orders/OrderTypeRegistry.cs`：Order type key/id SSOT。
+- `src/Core/Gameplay/GAS/AbilityDefinitionRegistry.cs`：ability id 到执行定义的注册表。
+- `src/Core/Gameplay/GAS/Components/AbilityCooldown.cs` 与 `AbilityActivationBlockTags.cs`：GCD 共享 cooldown tag 的 GAS 原语。

--- a/mods/AIDemoMod/assets/Configs/AI/goap_actions.json
+++ b/mods/AIDemoMod/assets/Configs/AI/goap_actions.json
@@ -4,7 +4,7 @@
     "Cost": 1,
     "Pre": { "Mask": [], "Values": [] },
     "Post": { "Mask": [], "Values": [] },
-    "Order": { "OrderTagId": 1234, "SubmitMode": 0, "PlayerId": 0 },
+    "Order": { "OrderTypeKey": "attackTarget", "SubmitMode": 0, "PlayerId": 0 },
     "Bindings": []
   }
 ]

--- a/src/Core/Engine/GameEngine.cs
+++ b/src/Core/Engine/GameEngine.cs
@@ -399,7 +399,6 @@ namespace Ludots.Core.Engine
 
             ConfigCatalog = Ludots.Core.Config.ConfigCatalogLoader.Load(ConfigPipeline);
             ConfigConflictReport = new Ludots.Core.Config.ConfigConflictReport();
-            RebuildAiRuntime();
 
             // Apply log config from merged game.json
             LogConfigApplier.Apply(MergedConfig.Logging);
@@ -464,7 +463,15 @@ namespace Ludots.Core.Engine
             }
 
             var atoms = new Ludots.Core.Gameplay.AI.WorldState.AtomRegistry(capacity: 256);
-            var loader = new Ludots.Core.Gameplay.AI.Config.AiConfigLoader(ConfigPipeline, atoms);
+            Ludots.Core.Gameplay.AI.Config.AiConfigValidationContext? validation = null;
+            if (TryGetService(CoreServiceKeys.OrderTypeRegistry, out OrderTypeRegistry orderTypes) && orderTypes != null)
+            {
+                validation = new Ludots.Core.Gameplay.AI.Config.AiConfigValidationContext(
+                    orderTypes,
+                    GetService(CoreServiceKeys.AbilityDefinitionRegistry));
+            }
+
+            var loader = new Ludots.Core.Gameplay.AI.Config.AiConfigLoader(ConfigPipeline, atoms, validation);
             var catalog = ConfigCatalog ?? Ludots.Core.Gameplay.AI.Config.AiConfigCatalog.CreateDefault();
             AiRuntime = loader.LoadAndCompile(catalog, ConfigConflictReport);
         }
@@ -1030,6 +1037,8 @@ namespace Ludots.Core.Engine
             SetService(CoreServiceKeys.OrderQueue, orderQueue);
             SetService(CoreServiceKeys.OrderTypeRegistry, orderTypeRegistry);
             SetService(CoreServiceKeys.OrderRuleRegistry, orderRuleRegistry);
+            RebuildAiRuntime();
+            SetService(CoreServiceKeys.AiRuntime, AiRuntime);
             SetService(CoreServiceKeys.OrderBufferSystem, orderBufferSystem);
             SetService(CoreServiceKeys.OrderRequestQueue, orderRequestQueue);
             SetService(CoreServiceKeys.ResponseChainTelemetryBuffer, responseChainTelemetry);

--- a/src/Core/Gameplay/AI/Config/AiConfigLoader.cs
+++ b/src/Core/Gameplay/AI/Config/AiConfigLoader.cs
@@ -6,6 +6,7 @@ using Ludots.Core.Config;
 using Ludots.Core.Gameplay.AI.Planning;
 using Ludots.Core.Gameplay.AI.Utility;
 using Ludots.Core.Gameplay.AI.WorldState;
+using Ludots.Core.Gameplay.GAS.Registry;
 using Ludots.Core.Gameplay.GAS.Orders;
 
 namespace Ludots.Core.Gameplay.AI.Config
@@ -14,11 +15,13 @@ namespace Ludots.Core.Gameplay.AI.Config
     {
         private readonly ConfigPipeline _pipeline;
         private readonly AtomRegistry _atoms;
+        private readonly AiConfigValidationContext? _validation;
 
-        public AiConfigLoader(ConfigPipeline pipeline, AtomRegistry atoms)
+        public AiConfigLoader(ConfigPipeline pipeline, AtomRegistry atoms, AiConfigValidationContext? validation = null)
         {
-            _pipeline = pipeline;
-            _atoms = atoms;
+            _pipeline = pipeline ?? throw new ArgumentNullException(nameof(pipeline));
+            _atoms = atoms ?? throw new ArgumentNullException(nameof(atoms));
+            _validation = validation;
         }
 
         public AiCompiledRuntime LoadAndCompile(ConfigCatalog catalog, ConfigConflictReport? report = null)
@@ -29,8 +32,13 @@ namespace Ludots.Core.Gameplay.AI.Config
             {
                 for (int i = 0; i < atomsArr.Count; i++)
                 {
-                    if (atomsArr[i] is not JsonObject obj) continue;
-                    if (!TryReadString(obj, "id", out string id)) continue;
+                    string path = $"AI/atoms.json[{i}]";
+                    if (atomsArr[i] is not JsonObject obj)
+                    {
+                        throw Fail(path, "Expected an object.");
+                    }
+
+                    string id = RequireString(obj, "id", path);
                     _atoms.GetOrAdd(id);
                 }
             }
@@ -43,11 +51,19 @@ namespace Ludots.Core.Gameplay.AI.Config
                 var tmp = new List<WorldStateProjectionRule>(projArr.Count);
                 for (int i = 0; i < projArr.Count; i++)
                 {
-                    if (projArr[i] is not JsonObject obj) continue;
-                    if (!TryReadString(obj, "Atom", out string atomName)) continue;
-                    int atomId = _atoms.GetOrAdd(atomName);
-                    if (!TryReadString(obj, "Op", out string op)) continue;
-                    if (!TryParseProjectionOp(op, out var pOp)) continue;
+                    string path = $"AI/projection.json[{i}]";
+                    if (projArr[i] is not JsonObject obj)
+                    {
+                        throw Fail(path, "Expected an object.");
+                    }
+
+                    string id = ReadRecordId(obj, path);
+                    int atomId = RequireAtomId(RequireString(obj, "Atom", path), $"AI/projection.json:{id}.Atom");
+                    string op = RequireString(obj, "Op", path);
+                    if (!TryParseProjectionOp(op, out var pOp))
+                    {
+                        throw Fail($"AI/projection.json:{id}.Op", $"Unsupported projection op '{op}'.");
+                    }
 
                     int intKey = TryReadInt(obj, "IntKey", out int ik) ? ik : -1;
                     int intValue = TryReadInt(obj, "IntValue", out int iv) ? iv : 0;
@@ -68,10 +84,15 @@ namespace Ludots.Core.Gameplay.AI.Config
                 var tmp = new List<UtilityGoalPresetDefinition>(goalsArr.Count);
                 for (int i = 0; i < goalsArr.Count; i++)
                 {
-                    if (goalsArr[i] is not JsonObject obj) continue;
+                    string path = $"AI/utility.json[{i}]";
+                    if (goalsArr[i] is not JsonObject obj)
+                    {
+                        throw Fail(path, "Expected an object.");
+                    }
 
-                    int goalPresetId = TryReadInt(obj, "GoalPresetId", out int gpid) ? gpid : 0;
-                    int planningStrategyId = TryReadInt(obj, "PlanningStrategyId", out int psid) ? psid : 0;
+                    string id = ReadRecordId(obj, path);
+                    int goalPresetId = RequirePositiveInt(obj, "GoalPresetId", path);
+                    int planningStrategyId = RequirePlanningStrategyId(obj, "PlanningStrategyId", path);
                     float weight = TryReadFloat(obj, "Weight", out float w) ? w : 1f;
 
                     var boolCons = Array.Empty<UtilityConsiderationBool256>();
@@ -80,9 +101,13 @@ namespace Ludots.Core.Gameplay.AI.Config
                         var bc = new List<UtilityConsiderationBool256>(boolArr.Count);
                         for (int c = 0; c < boolArr.Count; c++)
                         {
-                            if (boolArr[c] is not JsonObject bObj) continue;
-                            if (!TryReadString(bObj, "Atom", out string atomName)) continue;
-                            int atomId = _atoms.GetOrAdd(atomName);
+                            string considerationPath = $"AI/utility.json:{id}.Bool[{c}]";
+                            if (boolArr[c] is not JsonObject bObj)
+                            {
+                                throw Fail(considerationPath, "Expected an object.");
+                            }
+
+                            int atomId = RequireAtomId(RequireString(bObj, "Atom", considerationPath), $"{considerationPath}.Atom");
                             float ts = TryReadFloat(bObj, "TrueScore", out float tsv) ? tsv : 1f;
                             float fs = TryReadFloat(bObj, "FalseScore", out float fsv) ? fsv : 1f;
                             bc.Add(new UtilityConsiderationBool256(atomId, ts, fs));
@@ -105,20 +130,27 @@ namespace Ludots.Core.Gameplay.AI.Config
                 var tmp = new List<ActionOpDefinition256>(actArr.Count);
                 for (int i = 0; i < actArr.Count; i++)
                 {
-                    if (actArr[i] is not JsonObject obj) continue;
+                    string path = $"AI/goap_actions.json[{i}]";
+                    if (actArr[i] is not JsonObject obj)
+                    {
+                        throw Fail(path, "Expected an object.");
+                    }
+
+                    string id = ReadRecordId(obj, path);
                     int cost = TryReadInt(obj, "Cost", out int c) ? c : 1;
 
-                    var pre = ReadCondition(obj, "Pre", _atoms);
-                    var post = ReadCondition(obj, "Post", _atoms);
+                    var pre = ReadCondition(obj, "Pre", _atoms, $"AI/goap_actions.json:{id}.Pre");
+                    var post = ReadCondition(obj, "Post", _atoms, $"AI/goap_actions.json:{id}.Post");
 
                     var orderSpec = default(ActionOrderSpec);
                     var execKind = ActionExecutorKind.SubmitOrder;
                     if (obj.TryGetPropertyValue("Order", out var orderNode) && orderNode is JsonObject orderObj)
                     {
-                        int orderTypeId = TryReadInt(orderObj, "OrderTypeId", out int ot) ? ot : 0;
-                        byte submitModeByte = TryReadByte(orderObj, "SubmitMode", out byte sm) ? sm : (byte)OrderSubmitMode.Immediate;
-                        int playerId = TryReadInt(orderObj, "PlayerId", out int pid) ? pid : 0;
-                        orderSpec = new ActionOrderSpec(orderTypeId, (OrderSubmitMode)submitModeByte, playerId);
+                        orderSpec = ReadOrderSpec(orderObj, $"AI/goap_actions.json:{id}.Order");
+                    }
+                    else
+                    {
+                        throw Fail($"AI/goap_actions.json:{id}.Order", "SubmitOrder action must declare an Order object.");
                     }
 
                     var bindings = Array.Empty<ActionBinding>();
@@ -127,10 +159,19 @@ namespace Ludots.Core.Gameplay.AI.Config
                         var btmp = new List<ActionBinding>(bindArr.Count);
                         for (int b = 0; b < bindArr.Count; b++)
                         {
-                            if (bindArr[b] is not JsonObject bObj) continue;
-                            if (!TryReadString(bObj, "Op", out string op)) continue;
-                            if (!TryParseBindingOp(op, out var bop)) continue;
-                            if (!TryReadInt(bObj, "SourceKey", out int sk)) continue;
+                            string bindingPath = $"AI/goap_actions.json:{id}.Bindings[{b}]";
+                            if (bindArr[b] is not JsonObject bObj)
+                            {
+                                throw Fail(bindingPath, "Expected an object.");
+                            }
+
+                            string op = RequireString(bObj, "Op", bindingPath);
+                            if (!TryParseBindingOp(op, out var bop))
+                            {
+                                throw Fail($"{bindingPath}.Op", $"Unsupported binding op '{op}'.");
+                            }
+
+                            int sk = RequireInt(bObj, "SourceKey", bindingPath);
                             btmp.Add(new ActionBinding(bop, sk));
                         }
                         bindings = btmp.ToArray();
@@ -159,10 +200,16 @@ namespace Ludots.Core.Gameplay.AI.Config
                 var tmp = new List<GoapGoalPreset256>(gArr.Count);
                 for (int i = 0; i < gArr.Count; i++)
                 {
-                    if (gArr[i] is not JsonObject obj) continue;
-                    int goalPresetId = TryReadInt(obj, "GoalPresetId", out int gpid) ? gpid : 0;
+                    string path = $"AI/goap_goals.json[{i}]";
+                    if (gArr[i] is not JsonObject obj)
+                    {
+                        throw Fail(path, "Expected an object.");
+                    }
+
+                    string id = ReadRecordId(obj, path);
+                    int goalPresetId = RequirePositiveInt(obj, "GoalPresetId", path);
                     int hw = TryReadInt(obj, "HeuristicWeight", out int hwi) ? hwi : 1;
-                    var cond = ReadCondition(obj, "Goal", _atoms);
+                    var cond = ReadCondition(obj, "Goal", _atoms, $"AI/goap_goals.json:{id}.Goal");
                     var goalCond = new WorldStateCondition256(in cond.Mask, in cond.Values);
                     tmp.Add(new GoapGoalPreset256(goalPresetId, in goalCond, hw));
                 }
@@ -185,35 +232,94 @@ namespace Ludots.Core.Gameplay.AI.Config
                     var tasks = new HtnCompoundTask[tArr.Count];
                     for (int i = 0; i < tArr.Count; i++)
                     {
-                        if (tArr[i] is not JsonObject o) continue;
-                        if (!TryReadInt(o, "TaskId", out int tid)) continue;
+                        string path = $"AI/htn_domain.json.Tasks[{i}]";
+                        if (tArr[i] is not JsonObject o)
+                        {
+                            throw Fail(path, "Expected an object.");
+                        }
+
+                        int tid = RequireInt(o, "TaskId", path);
                         int fm = TryReadInt(o, "FirstMethod", out int x) ? x : 0;
                         int mc = TryReadInt(o, "MethodCount", out int y) ? y : 0;
-                        if ((uint)tid < (uint)tasks.Length) tasks[tid] = new HtnCompoundTask(fm, mc);
+                        if ((uint)tid >= (uint)tasks.Length)
+                        {
+                            throw Fail($"{path}.TaskId", $"Task id {tid} is outside task table length {tasks.Length}.");
+                        }
+
+                        tasks[tid] = new HtnCompoundTask(fm, mc);
                     }
 
                     var methods = new HtnMethod256[mArr.Count];
                     for (int i = 0; i < mArr.Count; i++)
                     {
-                        if (mArr[i] is not JsonObject o) continue;
-                        if (!TryReadInt(o, "MethodId", out int mid)) continue;
+                        string path = $"AI/htn_domain.json.Methods[{i}]";
+                        if (mArr[i] is not JsonObject o)
+                        {
+                            throw Fail(path, "Expected an object.");
+                        }
+
+                        int mid = RequireInt(o, "MethodId", path);
                         int cost = TryReadInt(o, "Cost", out int cc) ? cc : 0;
                         int off = TryReadInt(o, "SubtaskOffset", out int so) ? so : 0;
                         int cnt = TryReadInt(o, "SubtaskCount", out int sc) ? sc : 0;
-                        var cond = ReadCondition(o, "Condition", _atoms);
+                        var cond = ReadCondition(o, "Condition", _atoms, $"{path}.Condition");
                         var cnd = new WorldStateCondition256(in cond.Mask, in cond.Values);
-                        if ((uint)mid < (uint)methods.Length) methods[mid] = new HtnMethod256(in cnd, off, cnt, cost);
+                        if ((uint)mid >= (uint)methods.Length)
+                        {
+                            throw Fail($"{path}.MethodId", $"Method id {mid} is outside method table length {methods.Length}.");
+                        }
+
+                        if (off < 0 || cnt < 0 || off + cnt > sArr.Count)
+                        {
+                            throw Fail(path, $"Method {mid} subtask range [{off}, {off + cnt}) exceeds subtask table length {sArr.Count}.");
+                        }
+
+                        methods[mid] = new HtnMethod256(in cnd, off, cnt, cost);
                     }
 
                     var subtasks = new HtnSubtask[sArr.Count];
                     for (int i = 0; i < sArr.Count; i++)
                     {
-                        if (sArr[i] is not JsonObject o) continue;
-                        if (!TryReadInt(o, "Index", out int idx)) continue;
-                        if (!TryReadString(o, "Kind", out string kind)) continue;
-                        if (!TryReadInt(o, "RefId", out int rid)) continue;
-                        var k = string.Equals(kind, "Compound", StringComparison.OrdinalIgnoreCase) ? HtnSubtaskKind.Compound : HtnSubtaskKind.Action;
-                        if ((uint)idx < (uint)subtasks.Length) subtasks[idx] = new HtnSubtask(k, rid);
+                        string path = $"AI/htn_domain.json.Subtasks[{i}]";
+                        if (sArr[i] is not JsonObject o)
+                        {
+                            throw Fail(path, "Expected an object.");
+                        }
+
+                        int idx = RequireInt(o, "Index", path);
+                        string kind = RequireString(o, "Kind", path);
+                        int rid = RequireInt(o, "RefId", path);
+                        var k = string.Equals(kind, "Compound", StringComparison.OrdinalIgnoreCase)
+                            ? HtnSubtaskKind.Compound
+                            : string.Equals(kind, "Action", StringComparison.OrdinalIgnoreCase)
+                                ? HtnSubtaskKind.Action
+                                : throw Fail($"{path}.Kind", $"Unsupported subtask kind '{kind}'.");
+
+                        if ((uint)idx >= (uint)subtasks.Length)
+                        {
+                            throw Fail($"{path}.Index", $"Subtask index {idx} is outside subtask table length {subtasks.Length}.");
+                        }
+
+                        if (k == HtnSubtaskKind.Compound && (uint)rid >= (uint)tasks.Length)
+                        {
+                            throw Fail($"{path}.RefId", $"Subtask references unknown compound task id {rid}.");
+                        }
+
+                        if (k == HtnSubtaskKind.Action && (uint)rid >= (uint)goapActions.Length)
+                        {
+                            throw Fail($"{path}.RefId", $"Subtask references unknown action id {rid}.");
+                        }
+
+                        subtasks[idx] = new HtnSubtask(k, rid);
+                    }
+
+                    for (int i = 0; i < tasks.Length; i++)
+                    {
+                        ref readonly var task = ref tasks[i];
+                        if (task.FirstMethod < 0 || task.MethodCount < 0 || task.FirstMethod + task.MethodCount > methods.Length)
+                        {
+                            throw Fail($"AI/htn_domain.json.Tasks[{i}]", $"Task method range [{task.FirstMethod}, {task.FirstMethod + task.MethodCount}) exceeds method table length {methods.Length}.");
+                        }
                     }
 
                     htnDomain = new HtnDomainCompiled256(tasks, methods, subtasks);
@@ -225,9 +331,19 @@ namespace Ludots.Core.Gameplay.AI.Config
                     int count = 0;
                     for (int i = 0; i < rArr.Count; i++)
                     {
-                        if (rArr[i] is not JsonObject o) continue;
-                        if (!TryReadInt(o, "GoalPresetId", out int gpid)) continue;
-                        if (!TryReadInt(o, "RootTaskId", out int rid)) continue;
+                        string path = $"AI/htn_domain.json.Roots[{i}]";
+                        if (rArr[i] is not JsonObject o)
+                        {
+                            throw Fail(path, "Expected an object.");
+                        }
+
+                        int gpid = RequirePositiveInt(o, "GoalPresetId", path);
+                        int rid = RequireInt(o, "RootTaskId", path);
+                        if (htnDomain.Tasks.Length > 0 && (uint)rid >= (uint)htnDomain.Tasks.Length)
+                        {
+                            throw Fail($"{path}.RootTaskId", $"Root references unknown task id {rid}.");
+                        }
+
                         roots[count++] = (gpid, rid);
                     }
                     if (count != roots.Length) Array.Resize(ref roots, count);
@@ -236,6 +352,112 @@ namespace Ludots.Core.Gameplay.AI.Config
             }
 
             return new AiCompiledRuntime(_atoms, projectionTable, goalSelector, actionLibrary, goapGoalTable, htnDomain, htnRoots);
+        }
+
+        private ActionOrderSpec ReadOrderSpec(JsonObject orderObj, string path)
+        {
+            if (orderObj.ContainsKey("OrderTagId"))
+            {
+                throw Fail($"{path}.OrderTagId", "OrderTagId is not a supported AI order contract field. Use OrderTypeKey or OrderTypeId.");
+            }
+
+            if (_validation == null)
+            {
+                throw Fail(path, "AI Order references require AiConfigValidationContext with OrderTypeRegistry.");
+            }
+
+            int orderTypeId = 0;
+            if (TryReadString(orderObj, "OrderTypeKey", out string orderTypeKey))
+            {
+                if (!_validation.OrderTypes.TryGetId(orderTypeKey, out orderTypeId) ||
+                    orderTypeId <= 0 ||
+                    !_validation.OrderTypes.IsRegistered(orderTypeId))
+                {
+                    throw Fail($"{path}.OrderTypeKey", $"References unknown order type key '{orderTypeKey}'.");
+                }
+            }
+
+            if (TryReadInt(orderObj, "OrderTypeId", out int authoredOrderTypeId))
+            {
+                if (authoredOrderTypeId <= 0)
+                {
+                    throw Fail($"{path}.OrderTypeId", "OrderTypeId must be positive.");
+                }
+
+                if (_validation != null && !_validation.OrderTypes.IsRegistered(authoredOrderTypeId))
+                {
+                    throw Fail($"{path}.OrderTypeId", $"References unknown order type id {authoredOrderTypeId}.");
+                }
+
+                if (orderTypeId > 0 && orderTypeId != authoredOrderTypeId)
+                {
+                    throw Fail(path, $"OrderTypeKey resolved to {orderTypeId}, but OrderTypeId is {authoredOrderTypeId}.");
+                }
+
+                orderTypeId = authoredOrderTypeId;
+            }
+
+            if (orderTypeId <= 0)
+            {
+                throw Fail(path, "Order must declare OrderTypeKey or OrderTypeId.");
+            }
+
+            byte submitModeByte = TryReadByte(orderObj, "SubmitMode", out byte sm)
+                ? sm
+                : (byte)OrderSubmitMode.Immediate;
+            if (!Enum.IsDefined(typeof(OrderSubmitMode), submitModeByte))
+            {
+                throw Fail($"{path}.SubmitMode", $"Unsupported submit mode value {submitModeByte}.");
+            }
+
+            int playerId = TryReadInt(orderObj, "PlayerId", out int pid) ? pid : 0;
+            int abilityId = ResolveAbilityId(orderObj, path);
+            return new ActionOrderSpec(orderTypeId, (OrderSubmitMode)submitModeByte, playerId, abilityId);
+        }
+
+        private int ResolveAbilityId(JsonObject orderObj, string path)
+        {
+            int abilityId = 0;
+            if (TryReadString(orderObj, "AbilityKey", out string abilityKey))
+            {
+                if (_validation == null || _validation.Abilities == null)
+                {
+                    throw Fail($"{path}.AbilityKey", "AbilityKey requires AiConfigValidationContext with AbilityDefinitionRegistry.");
+                }
+
+                abilityId = AbilityIdRegistry.GetId(abilityKey);
+                if (abilityId <= 0 || !_validation.Abilities.TryGet(abilityId, out _))
+                {
+                    throw Fail($"{path}.AbilityKey", $"References unknown ability key '{abilityKey}'.");
+                }
+            }
+
+            if (TryReadInt(orderObj, "AbilityId", out int authoredAbilityId))
+            {
+                if (authoredAbilityId <= 0)
+                {
+                    throw Fail($"{path}.AbilityId", "AbilityId must be positive.");
+                }
+
+                if (_validation == null || _validation.Abilities == null)
+                {
+                    throw Fail($"{path}.AbilityId", "AbilityId requires AiConfigValidationContext with AbilityDefinitionRegistry.");
+                }
+
+                if (!_validation.Abilities.TryGet(authoredAbilityId, out _))
+                {
+                    throw Fail($"{path}.AbilityId", $"References unknown ability id {authoredAbilityId}.");
+                }
+
+                if (abilityId > 0 && abilityId != authoredAbilityId)
+                {
+                    throw Fail(path, $"AbilityKey resolved to {abilityId}, but AbilityId is {authoredAbilityId}.");
+                }
+
+                abilityId = authoredAbilityId;
+            }
+
+            return abilityId;
         }
 
         private JsonNode? Merge(in ConfigCatalogEntry entry, ConfigConflictReport? report)
@@ -250,7 +472,7 @@ namespace Ludots.Core.Gameplay.AI.Config
             return new ConfigCatalogEntry(relativePath, policy, idField);
         }
 
-        private static (WorldStateBits256 Mask, WorldStateBits256 Values) ReadCondition(JsonObject obj, string propertyName, AtomRegistry atoms)
+        private static (WorldStateBits256 Mask, WorldStateBits256 Values) ReadCondition(JsonObject obj, string propertyName, AtomRegistry atoms, string path)
         {
             var mask = new WorldStateBits256();
             var values = new WorldStateBits256();
@@ -261,8 +483,12 @@ namespace Ludots.Core.Gameplay.AI.Config
             {
                 for (int i = 0; i < maskArr.Count; i++)
                 {
-                    if (maskArr[i] == null) continue;
-                    int id = atoms.GetOrAdd(maskArr[i]!.ToString());
+                    if (maskArr[i] == null)
+                    {
+                        throw Fail($"{path}.Mask[{i}]", "Atom id is required.");
+                    }
+
+                    int id = RequireAtomId(atoms, maskArr[i]!.ToString(), $"{path}.Mask[{i}]");
                     mask.SetBit(id, true);
                 }
             }
@@ -271,13 +497,87 @@ namespace Ludots.Core.Gameplay.AI.Config
             {
                 for (int i = 0; i < valArr.Count; i++)
                 {
-                    if (valArr[i] == null) continue;
-                    int id = atoms.GetOrAdd(valArr[i]!.ToString());
+                    if (valArr[i] == null)
+                    {
+                        throw Fail($"{path}.Values[{i}]", "Atom id is required.");
+                    }
+
+                    int id = RequireAtomId(atoms, valArr[i]!.ToString(), $"{path}.Values[{i}]");
                     values.SetBit(id, true);
                 }
             }
 
             return (mask, values);
+        }
+
+        private int RequireAtomId(string atomName, string path)
+        {
+            return RequireAtomId(_atoms, atomName, path);
+        }
+
+        private static int RequireAtomId(AtomRegistry atoms, string atomName, string path)
+        {
+            if (string.IsNullOrWhiteSpace(atomName) || !atoms.TryGetId(atomName, out int atomId))
+            {
+                throw Fail(path, $"References unknown AI atom '{atomName}'. Declare it in AI/atoms.json.");
+            }
+
+            return atomId;
+        }
+
+        private static string ReadRecordId(JsonObject obj, string path)
+        {
+            return TryReadString(obj, "id", out string id) ? id : path;
+        }
+
+        private static int RequirePlanningStrategyId(JsonObject obj, string key, string path)
+        {
+            int value = RequireInt(obj, key, path);
+            if (value != AIPlanningStrategyIds.None &&
+                value != AIPlanningStrategyIds.Goap &&
+                value != AIPlanningStrategyIds.Htn &&
+                value != AIPlanningStrategyIds.DirectTask)
+            {
+                throw Fail($"{path}.{key}", $"Unknown planning strategy id {value}.");
+            }
+
+            return value;
+        }
+
+        private static int RequirePositiveInt(JsonObject obj, string key, string path)
+        {
+            int value = RequireInt(obj, key, path);
+            if (value <= 0)
+            {
+                throw Fail($"{path}.{key}", "Value must be positive.");
+            }
+
+            return value;
+        }
+
+        private static int RequireInt(JsonObject obj, string key, string path)
+        {
+            if (!TryReadInt(obj, key, out int value))
+            {
+                throw Fail($"{path}.{key}", "Integer value is required.");
+            }
+
+            return value;
+        }
+
+        private static string RequireString(JsonObject obj, string key, string path)
+        {
+            if (!TryReadString(obj, key, out string value))
+            {
+                throw Fail($"{path}.{key}", "Non-empty string value is required.");
+            }
+
+            return value;
+        }
+
+        private static InvalidOperationException Fail(string path, string message)
+        {
+            return new InvalidOperationException($"[AiConfigLoader] {path}: {message}");
         }
 
         private static bool TryParseProjectionOp(string op, out WorldStateProjectionOp result)

--- a/src/Core/Gameplay/AI/Config/AiConfigModels.cs
+++ b/src/Core/Gameplay/AI/Config/AiConfigModels.cs
@@ -120,7 +120,10 @@ namespace Ludots.Core.Gameplay.AI.Config
 
     public sealed class AiOrderExecConfig
     {
+        public string OrderTypeKey { get; set; } = string.Empty;
         public int OrderTypeId { get; set; }
+        public string AbilityKey { get; set; } = string.Empty;
+        public int AbilityId { get; set; }
         public byte SubmitMode { get; set; }
         public int PlayerId { get; set; }
     }

--- a/src/Core/Gameplay/AI/Config/AiConfigValidationContext.cs
+++ b/src/Core/Gameplay/AI/Config/AiConfigValidationContext.cs
@@ -1,0 +1,21 @@
+using System;
+using Ludots.Core.Gameplay.GAS;
+using Ludots.Core.Gameplay.GAS.Orders;
+
+namespace Ludots.Core.Gameplay.AI.Config
+{
+    public sealed class AiConfigValidationContext
+    {
+        public AiConfigValidationContext(
+            OrderTypeRegistry orderTypes,
+            AbilityDefinitionRegistry? abilities = null)
+        {
+            OrderTypes = orderTypes ?? throw new ArgumentNullException(nameof(orderTypes));
+            Abilities = abilities;
+        }
+
+        public OrderTypeRegistry OrderTypes { get; }
+
+        public AbilityDefinitionRegistry? Abilities { get; }
+    }
+}

--- a/src/Core/Gameplay/AI/Planning/ActionOrderSpec.cs
+++ b/src/Core/Gameplay/AI/Planning/ActionOrderSpec.cs
@@ -7,12 +7,14 @@ namespace Ludots.Core.Gameplay.AI.Planning
         public readonly int OrderTypeId;
         public readonly OrderSubmitMode SubmitMode;
         public readonly int PlayerId;
+        public readonly int AbilityId;
 
-        public ActionOrderSpec(int orderTypeId, OrderSubmitMode submitMode, int playerId = 0)
+        public ActionOrderSpec(int orderTypeId, OrderSubmitMode submitMode, int playerId = 0, int abilityId = 0)
         {
             OrderTypeId = orderTypeId;
             SubmitMode = submitMode;
             PlayerId = playerId;
+            AbilityId = abilityId;
         }
     }
 }

--- a/src/Tests/GasTests/AiConfigLoaderTests.cs
+++ b/src/Tests/GasTests/AiConfigLoaderTests.cs
@@ -2,8 +2,10 @@ using System;
 using System.IO;
 using Ludots.Core.Config;
 using Ludots.Core.Gameplay.AI.Config;
-using Ludots.Core.Gameplay.AI.Planning;
 using Ludots.Core.Gameplay.AI.WorldState;
+using Ludots.Core.Gameplay.GAS;
+using Ludots.Core.Gameplay.GAS.Orders;
+using Ludots.Core.Gameplay.GAS.Registry;
 using Ludots.Core.Modding;
 using NUnit.Framework;
 
@@ -12,44 +14,150 @@ namespace Ludots.Tests.GAS
     [TestFixture]
     public class AiConfigLoaderTests
     {
+        private const int AttackOrderTypeId = 102;
+
         [Test]
         public void AiConfigLoader_LoadsAndCompilesFromVfs()
         {
-            string root = Path.Combine(Path.GetTempPath(), "Ludots_AiConfigLoaderTests", Guid.NewGuid().ToString("N"));
-            Directory.CreateDirectory(root);
+            using var fixture = AiConfigFixture.Create();
 
-            string core = Path.Combine(root, "Core");
-            string mod = Path.Combine(root, "ModA");
-            Directory.CreateDirectory(Path.Combine(core, "Configs", "AI"));
-            Directory.CreateDirectory(Path.Combine(mod, "assets", "Configs", "AI"));
-
-            File.WriteAllText(Path.Combine(core, "Configs", "AI", "atoms.json"), "[ { \"id\": \"HasEnemy\" } ]");
-            File.WriteAllText(Path.Combine(core, "Configs", "AI", "projection.json"), "[ { \"id\": \"R0\", \"Atom\": \"HasEnemy\", \"Op\": \"EntityIsNonNull\", \"EntityKey\": 1 } ]");
-            File.WriteAllText(Path.Combine(core, "Configs", "AI", "utility.json"), "[ { \"id\": \"G0\", \"GoalPresetId\": 1, \"PlanningStrategyId\": 1, \"Weight\": 1, \"Bool\": [ { \"Atom\": \"HasEnemy\", \"TrueScore\": 1, \"FalseScore\": 0 } ] } ]");
-            File.WriteAllText(Path.Combine(core, "Configs", "AI", "goap_actions.json"), "[ { \"id\": \"A0\", \"Cost\": 1, \"Pre\": {\"Mask\":[],\"Values\":[]}, \"Post\": {\"Mask\":[],\"Values\":[]}, \"Order\": { \"OrderTypeId\": 1234, \"SubmitMode\": 0, \"PlayerId\": 0 }, \"Bindings\": [] } ]");
-            File.WriteAllText(Path.Combine(core, "Configs", "AI", "goap_goals.json"), "[ { \"id\": \"GG0\", \"GoalPresetId\": 1, \"HeuristicWeight\": 1, \"Goal\": { \"Mask\": [\"HasEnemy\"], \"Values\": [\"HasEnemy\"] } } ]");
-            File.WriteAllText(Path.Combine(core, "Configs", "AI", "htn_domain.json"), "{ \"Tasks\": [], \"Methods\": [], \"Subtasks\": [], \"Roots\": [] }");
-
-            File.WriteAllText(Path.Combine(mod, "assets", "Configs", "AI", "atoms.json"), "[ { \"id\": \"HasCover\" } ]");
-
-            var vfs = new VirtualFileSystem();
-            vfs.Mount("Core", core);
-            vfs.Mount("ModA", mod);
-            var modLoader = new ModLoader(vfs, new Ludots.Core.Scripting.FunctionRegistry(), new Ludots.Core.Scripting.TriggerManager());
-            modLoader.LoadedModIds.Add("ModA");
-            var pipeline = new ConfigPipeline(vfs, modLoader);
-
-            var atoms = new AtomRegistry(capacity: 256);
-            var loader = new AiConfigLoader(pipeline, atoms);
-            var runtime = loader.LoadAndCompile(AiConfigCatalog.CreateDefault());
+            var runtime = fixture.Load();
 
             Assert.That(runtime.Atoms.Count, Is.EqualTo(2));
             Assert.That(runtime.ProjectionTable.Rules.Length, Is.EqualTo(1));
             Assert.That(runtime.GoalSelector.Count, Is.EqualTo(1));
             Assert.That(runtime.ActionLibrary.Count, Is.EqualTo(1));
+            Assert.That(runtime.ActionLibrary.OrderSpec[0].OrderTypeId, Is.EqualTo(AttackOrderTypeId));
             Assert.That(runtime.GoapGoals.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void AiConfigLoader_RejectsLegacyOrderTagId()
+        {
+            using var fixture = AiConfigFixture.Create(orderJson: "{ \"OrderTagId\": 1234, \"SubmitMode\": 0, \"PlayerId\": 0 }");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => fixture.Load());
+
+            Assert.That(ex!.Message, Does.Contain("OrderTagId"));
+            Assert.That(ex.Message, Does.Contain("OrderTypeKey or OrderTypeId"));
+        }
+
+        [Test]
+        public void AiConfigLoader_RejectsUnknownOrderTypeId()
+        {
+            using var fixture = AiConfigFixture.Create(orderJson: "{ \"OrderTypeId\": 1234, \"SubmitMode\": 0, \"PlayerId\": 0 }");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => fixture.Load());
+
+            Assert.That(ex!.Message, Does.Contain("unknown order type id 1234"));
+        }
+
+        [Test]
+        public void AiConfigLoader_RejectsUnknownOrderTypeKey()
+        {
+            using var fixture = AiConfigFixture.Create(orderJson: "{ \"OrderTypeKey\": \"missingOrder\", \"SubmitMode\": 0, \"PlayerId\": 0 }");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => fixture.Load());
+
+            Assert.That(ex!.Message, Does.Contain("unknown order type key 'missingOrder'"));
+        }
+
+        [Test]
+        public void AiConfigLoader_RejectsUnknownAbilityId()
+        {
+            using var fixture = AiConfigFixture.Create(orderJson: "{ \"OrderTypeKey\": \"attackTarget\", \"AbilityId\": 9090, \"SubmitMode\": 0, \"PlayerId\": 0 }");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => fixture.Load());
+
+            Assert.That(ex!.Message, Does.Contain("unknown ability id 9090"));
+        }
+
+        [Test]
+        public void AiConfigLoader_RejectsUnknownAbilityKey()
+        {
+            using var fixture = AiConfigFixture.Create(orderJson: "{ \"OrderTypeKey\": \"attackTarget\", \"AbilityKey\": \"Ability.Missing\", \"SubmitMode\": 0, \"PlayerId\": 0 }");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => fixture.Load());
+
+            Assert.That(ex!.Message, Does.Contain("unknown ability key 'Ability.Missing'"));
+        }
+
+        private sealed class AiConfigFixture : IDisposable
+        {
+            private readonly string _root;
+            private readonly ConfigPipeline _pipeline;
+            private readonly AiConfigValidationContext _validation;
+
+            private AiConfigFixture(string root, ConfigPipeline pipeline, AiConfigValidationContext validation)
+            {
+                _root = root;
+                _pipeline = pipeline;
+                _validation = validation;
+            }
+
+            public static AiConfigFixture Create(string? orderJson = null)
+            {
+                string root = Path.Combine(Path.GetTempPath(), "Ludots_AiConfigLoaderTests", Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(root);
+
+                string core = Path.Combine(root, "Core");
+                string mod = Path.Combine(root, "ModA");
+                Directory.CreateDirectory(Path.Combine(core, "Configs", "AI"));
+                Directory.CreateDirectory(Path.Combine(mod, "assets", "Configs", "AI"));
+
+                orderJson ??= "{ \"OrderTypeKey\": \"attackTarget\", \"SubmitMode\": 0, \"PlayerId\": 0 }";
+
+                File.WriteAllText(Path.Combine(core, "Configs", "AI", "atoms.json"), "[ { \"id\": \"HasEnemy\" } ]");
+                File.WriteAllText(Path.Combine(core, "Configs", "AI", "projection.json"), "[ { \"id\": \"R0\", \"Atom\": \"HasEnemy\", \"Op\": \"EntityIsNonNull\", \"EntityKey\": 1 } ]");
+                File.WriteAllText(Path.Combine(core, "Configs", "AI", "utility.json"), "[ { \"id\": \"G0\", \"GoalPresetId\": 1, \"PlanningStrategyId\": 1, \"Weight\": 1, \"Bool\": [ { \"Atom\": \"HasEnemy\", \"TrueScore\": 1, \"FalseScore\": 0 } ] } ]");
+                File.WriteAllText(Path.Combine(core, "Configs", "AI", "goap_actions.json"), $"[ {{ \"id\": \"A0\", \"Cost\": 1, \"Pre\": {{\"Mask\":[],\"Values\":[]}}, \"Post\": {{\"Mask\":[],\"Values\":[]}}, \"Order\": {orderJson}, \"Bindings\": [] }} ]");
+                File.WriteAllText(Path.Combine(core, "Configs", "AI", "goap_goals.json"), "[ { \"id\": \"GG0\", \"GoalPresetId\": 1, \"HeuristicWeight\": 1, \"Goal\": { \"Mask\": [\"HasEnemy\"], \"Values\": [\"HasEnemy\"] } } ]");
+                File.WriteAllText(Path.Combine(core, "Configs", "AI", "htn_domain.json"), "{ \"Tasks\": [], \"Methods\": [], \"Subtasks\": [], \"Roots\": [] }");
+
+                File.WriteAllText(Path.Combine(mod, "assets", "Configs", "AI", "atoms.json"), "[ { \"id\": \"HasCover\" } ]");
+
+                var vfs = new VirtualFileSystem();
+                vfs.Mount("Core", core);
+                vfs.Mount("ModA", mod);
+                var modLoader = new ModLoader(vfs, new Ludots.Core.Scripting.FunctionRegistry(), new Ludots.Core.Scripting.TriggerManager());
+                modLoader.LoadedModIds.Add("ModA");
+                var pipeline = new ConfigPipeline(vfs, modLoader);
+
+                var orderTypes = new OrderTypeRegistry();
+                orderTypes.Register(new OrderTypeConfig
+                {
+                    Key = "attackTarget",
+                    OrderTypeId = AttackOrderTypeId
+                });
+
+                AbilityIdRegistry.Clear();
+                int abilityId = AbilityIdRegistry.Register("Ability.Test.Attack");
+                var abilities = new AbilityDefinitionRegistry();
+                abilities.Register(abilityId, new AbilityDefinition());
+
+                return new AiConfigFixture(root, pipeline, new AiConfigValidationContext(orderTypes, abilities));
+            }
+
+            public AiCompiledRuntime Load()
+            {
+                var atoms = new AtomRegistry(capacity: 256);
+                var loader = new AiConfigLoader(_pipeline, atoms, _validation);
+                return loader.LoadAndCompile(AiConfigCatalog.CreateDefault());
+            }
+
+            public void Dispose()
+            {
+                try
+                {
+                    Directory.Delete(_root, recursive: true);
+                }
+                catch (IOException)
+                {
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
+            }
         }
     }
 }
-
-


### PR DESCRIPTION
## Summary
- Isolated the #225 AI order/ability contract work onto a branch based directly on `origin/main`.
- Added RFC-0060 / GitBook architecture docs for the Utility AI + autocast contract: Intent / Behavior / Deliberation, ordinary attacks as autocast abilities, and GCD as shared GAS cooldown tags.
- Rejected legacy `OrderTagId` in AI GOAP action config and resolved `OrderTypeKey` / `OrderTypeId` through `OrderTypeRegistry` at load time.
- Added `AiConfigValidationContext` so `AiConfigLoader` fails fast on unknown order types, abilities, atoms, planning strategies, and invalid HTN references.
- Moved `GameEngine.RebuildAiRuntime()` after order / ability registries are available so AI config validation can use the real runtime registries.

## OrderTagId handling
- `mods/AIDemoMod/assets/Configs/AI/goap_actions.json` now authors `OrderTypeKey: attackTarget` instead of the rejected `OrderTagId` field.
- `AiConfigLoader` explicitly throws on `OrderTagId` with guidance to use `OrderTypeKey` or `OrderTypeId`.

## Atom contract scan
- Scanned all AI config directories under `assets/Configs/AI` for atom references in `projection.json`, `utility.json`, `goap_actions.json`, `goap_goals.json`, and `htn_*.json`.
- Found one AI config mod: `mods/AIDemoMod/assets/Configs/AI`.
- Referenced atoms: `HasEnemy`; declared atoms: `HasEnemy`.
- No missing atom declarations were found, so no separate atom data-fix commit was needed.

## Validation
- `dotnet build src/Tests/GasTests/GasTests.csproj -clp:ErrorsOnly` passed with 0 errors.
- `dotnet test src/Tests/GasTests/GasTests.csproj --filter FullyQualifiedName~AiConfigLoader --logger console;verbosity=minimal` passed: 6/6.

Closes #225