### PR TITLE
fix(save): harden restore follow-ups

### DIFF
--- a/gitbook/architecture/save-system.md
+++ b/gitbook/architecture/save-system.md
@@ -37,6 +37,7 @@ SaveSlotStore.ReadSlot / SaveContainerCodec.Decode
   -> SaveContextValidator.Validate
   -> LudotsBinaryWorldSerializer.Deserialize
   -> GameEngine.RestoreWorldSnapshot
+  -> LudotsWorldStateImporter.ImportOwnedSnapshotInto
   -> SaveParticipantRegistry.RestoreDomains
 ```
 
@@ -47,14 +48,17 @@ SaveSlotStore.ReadSlot / SaveContainerCodec.Decode
 Arch.Persistence 的 contractless 反射不能正确覆盖 Ludots 的 fixed buffer 组件，所以 Core 显式注册 formatter：
 
 - unmanaged 组件使用 `UnmanagedComponentFormatter<T>` 做整结构 raw-bytes 序列化。
-- managed 组件必须显式 formatter，目前 `Name` 使用 `NameFormatter`。
-- 新组件如果需要进入存档，必须加入 `LudotsCorePersistenceFormatters.CreateFormatters()`，并补覆盖 fixed buffer、entity-ref 和读回保真度的测试。
+- managed 组件必须显式 formatter，目前 `Name` 使用 `NameFormatter`，`MapEntity` 使用 `MapEntityFormatter`。
+- formatter 和组件类型集由 `LudotsCorePersistenceFormatters` 静态缓存，`ArchBinarySerializer` 以线程级缓存复用；一次进程内反射发现只应构建一次。
+- 新 unmanaged 组件由 formatter 自动发现覆盖；新 managed 组件必须加入 `LudotsCorePersistenceFormatters`，并补覆盖 fixed buffer、entity-ref 和读回保真度的测试。
 
 `LudotsBinaryWorldSerializer` 在写入前后执行：
 
 - `SaveEntityReferenceValidator.Validate`：拒绝引用缺失实体或被排除实体。
 - `SaveEntityWorldIdNormalizer.Normalize`：读回后把已知 entity-ref buffer 的 WorldId 对齐到当前 World。
 - `SaveEntityInclusionPolicy.Default`：排除 `SaveExcludedTag`、`GameplayEvent`、`SimulationBudgetFuseEvent`、`PresentationDestroyPending`。
+
+恢复导入使用消费式 world 转移：`WorldRestoreService` 反序列化得到的 world 由 `LudotsWorldStateImporter.ImportOwnedSnapshotInto` 直接导入目标 world，并在导入后从源 world 解绑已转移的 Arch 内部存储。这样 restore 不再额外执行整世界 serialize/deserialize，也不依赖源 world 后续 `Dispose()` 的内部清理细节。
 
 ## 非 ECS 域
 
@@ -118,7 +122,7 @@ Core Save/Load 的验收必须覆盖：
 - 实体纳入/排除策略与 clean tick boundary。
 - Entity Id / WorldId / Version 稳定性和 entity-ref 有效性。
 - Core participant capture / restore。
-- restore 后确定性续跑 trace。
+- restore 后确定性续跑 trace，必须比较 tick、fixed frame 和稳定 world 状态哈希。
 - `.ldsave` section hash、header-only listing、原子写入、autosave retention。
 - 既有 showcase UAT：`rts_cnc_training` 存档、变更、读档、续跑一致。
 

--- a/src/Core/Engine/GameEngine.SaveRestore.cs
+++ b/src/Core/Engine/GameEngine.SaveRestore.cs
@@ -19,7 +19,7 @@ namespace Ludots.Core.Engine
                 throw new SaveContextException("Save participant registry is not available.");
             }
 
-            LudotsWorldStateImporter.ImportInto(restoredWorld, World);
+            LudotsWorldStateImporter.ImportOwnedSnapshotInto(restoredWorld, World);
             SetService(CoreServiceKeys.World, World);
             registry.RestoreDomains(domains);
             _cooperativeSimulation?.Reset();

--- a/src/Core/Persistence/LudotsBinaryWorldSerializer.cs
+++ b/src/Core/Persistence/LudotsBinaryWorldSerializer.cs
@@ -14,7 +14,7 @@ namespace Ludots.Core.Persistence
 
             EnsureWorldComponentFormatters(world);
             ArchBinarySerializer serializer = LudotsCorePersistenceFormatters.CreateBinarySerializer();
-            using World filteredWorld = CreateFilteredWorld(world);
+            using World filteredWorld = CloneIncludedWorld(world);
             EnsureWorldComponentFormatters(filteredWorld);
             return serializer.Serialize(filteredWorld);
         }
@@ -28,6 +28,36 @@ namespace Ludots.Core.Persistence
             SaveEntityWorldIdNormalizer.Normalize(world);
             SaveEntityReferenceValidator.Validate(world, SaveEntityInclusionPolicy.Default);
             return world;
+        }
+
+        internal World CloneIncludedWorld(World source)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+
+            ArchBinarySerializer serializer = LudotsCorePersistenceFormatters.CreateBinarySerializer();
+            World filtered = serializer.Deserialize(serializer.Serialize(source));
+            SaveEntityWorldIdNormalizer.Normalize(filtered);
+
+            var excluded = new List<Entity>();
+            var policy = SaveEntityInclusionPolicy.Default;
+            filtered.Query(in QueryDescription.Null, entity =>
+            {
+                if (!policy.ShouldInclude(filtered, entity))
+                {
+                    excluded.Add(entity);
+                }
+            });
+
+            for (int i = 0; i < excluded.Count; i++)
+            {
+                if (filtered.IsAlive(excluded[i]))
+                {
+                    filtered.Destroy(excluded[i]);
+                }
+            }
+
+            SaveEntityReferenceValidator.Validate(filtered, policy);
+            return filtered;
         }
 
         public static void EnsureWorldComponentFormatters(World world)
@@ -68,32 +98,5 @@ namespace Ludots.Core.Persistence
             }
         }
 
-        private World CreateFilteredWorld(World source)
-        {
-            ArchBinarySerializer serializer = LudotsCorePersistenceFormatters.CreateBinarySerializer();
-            World filtered = serializer.Deserialize(serializer.Serialize(source));
-            SaveEntityWorldIdNormalizer.Normalize(filtered);
-
-            var excluded = new List<Entity>();
-            var policy = SaveEntityInclusionPolicy.Default;
-            filtered.Query(in QueryDescription.Null, entity =>
-            {
-                if (!policy.ShouldInclude(filtered, entity))
-                {
-                    excluded.Add(entity);
-                }
-            });
-
-            for (int i = 0; i < excluded.Count; i++)
-            {
-                if (filtered.IsAlive(excluded[i]))
-                {
-                    filtered.Destroy(excluded[i]);
-                }
-            }
-
-            SaveEntityReferenceValidator.Validate(filtered, policy);
-            return filtered;
-        }
     }
 }

--- a/src/Core/Persistence/LudotsCorePersistenceFormatters.cs
+++ b/src/Core/Persistence/LudotsCorePersistenceFormatters.cs
@@ -5,31 +5,63 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace Ludots.Core.Persistence
 {
     public static class LudotsCorePersistenceFormatters
     {
+        private static Lazy<FormatterCache> s_cache = CreateLazyCache();
+        private static int s_cacheBuildCount;
+
         public static ArchBinarySerializer CreateBinarySerializer()
         {
-            return new ArchBinarySerializer(CreateFormatters());
+            return s_cache.Value.Serializer;
         }
 
         public static IMessagePackFormatter[] CreateFormatters()
+        {
+            return s_cache.Value.Formatters.ToArray();
+        }
+
+        public static IReadOnlySet<Type> GetFormatterComponentTypes()
+        {
+            return s_cache.Value.ComponentTypes;
+        }
+
+        internal static int FormatterCacheBuildCountForTests => s_cacheBuildCount;
+
+        internal static void ResetCacheForTests()
+        {
+            s_cache = CreateLazyCache();
+            Interlocked.Exchange(ref s_cacheBuildCount, 0);
+        }
+
+        private static Lazy<FormatterCache> CreateLazyCache()
+        {
+            return new Lazy<FormatterCache>(BuildCache, isThreadSafe: true);
+        }
+
+        private static FormatterCache BuildCache()
+        {
+            Interlocked.Increment(ref s_cacheBuildCount);
+            IMessagePackFormatter[] formatters = BuildFormatters();
+            IReadOnlySet<Type> componentTypes = formatters
+                .OfType<ILudotsPersistenceComponentFormatter>()
+                .Select(formatter => formatter.ComponentType)
+                .ToHashSet();
+            return new FormatterCache(
+                formatters,
+                componentTypes);
+        }
+
+        private static IMessagePackFormatter[] BuildFormatters()
         {
             var formatters = new Dictionary<Type, IMessagePackFormatter>();
             AddComponentFormatter(formatters, new NameFormatter());
             AddComponentFormatter(formatters, new MapEntityFormatter());
             AddAutoDiscoveredUnmanagedFormatters(formatters);
             return formatters.Values.ToArray();
-        }
-
-        public static IReadOnlySet<Type> GetFormatterComponentTypes()
-        {
-            return CreateFormatters()
-                .OfType<ILudotsPersistenceComponentFormatter>()
-                .Select(formatter => formatter.ComponentType)
-                .ToHashSet();
         }
 
         private static void AddComponentFormatter(
@@ -142,6 +174,16 @@ namespace Ludots.Core.Persistence
         private static bool ContainsReferencesGeneric<T>()
         {
             return RuntimeHelpers.IsReferenceOrContainsReferences<T>();
+        }
+
+        private sealed record FormatterCache(
+            IMessagePackFormatter[] Formatters,
+            IReadOnlySet<Type> ComponentTypes)
+        {
+            private readonly ThreadLocal<ArchBinarySerializer> _serializer =
+                new(() => new ArchBinarySerializer(Formatters), trackAllValues: false);
+
+            public ArchBinarySerializer Serializer => _serializer.Value!;
         }
     }
 }

--- a/src/Core/Persistence/LudotsWorldStateImporter.cs
+++ b/src/Core/Persistence/LudotsWorldStateImporter.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using Arch.Core;
 using Arch.Core.Extensions.Dangerous;
+using Arch.LowLevel.Jagged;
 using Ludots.Core.Gameplay.GAS;
 
 namespace Ludots.Core.Persistence
@@ -12,21 +14,70 @@ namespace Ludots.Core.Persistence
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (target == null) throw new ArgumentNullException(nameof(target));
 
-            target.Clear();
-            byte[] bytes = new LudotsBinaryWorldSerializer().Serialize(source);
-            using World normalizedSource = new LudotsBinaryWorldSerializer().Deserialize(bytes);
+            using World normalizedSource = new LudotsBinaryWorldSerializer().CloneIncludedWorld(source);
+            ImportOwnedSnapshotInto(normalizedSource, target);
+        }
 
-            target.SetEntityDataArray(normalizedSource.GetEntityDataArray());
-            target.SetRecycledEntityIds(normalizedSource.GetRecycledEntityIds());
-            target.EnsureCapacity(normalizedSource.GetEntityDataArray().Capacity);
-            foreach (Archetype archetype in normalizedSource)
+        internal static void ImportOwnedSnapshotInto(World source, World target)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (target == null) throw new ArgumentNullException(nameof(target));
+            if (ReferenceEquals(source, target))
             {
-                target.SetArchetypes(new System.Collections.Generic.List<Archetype> { archetype });
+                throw new ArgumentException("Save world import requires distinct source and target worlds.", nameof(target));
             }
 
+            PrepareIncludedSource(source);
+            target.Clear();
+            SaveEntityWorldIdNormalizer.Normalize(source);
+            SaveEntityReferenceValidator.Validate(source, SaveEntityInclusionPolicy.Default);
+
+            var entityData = source.GetEntityDataArray();
+            target.SetEntityDataArray(entityData);
+            target.SetRecycledEntityIds(source.GetRecycledEntityIds());
+            target.EnsureCapacity(entityData.Capacity);
+            var archetypes = new List<Archetype>();
+            foreach (Archetype archetype in source)
+            {
+                archetypes.Add(archetype);
+            }
+
+            // Arch's SetArchetypes appends; target.Clear above establishes replacement semantics.
+            target.SetArchetypes(archetypes);
+            DetachTransferredStorage(source);
             NormalizeChunkEntityWorldIds(target);
             SaveEntityWorldIdNormalizer.Normalize(target);
             SaveEntityReferenceValidator.Validate(target, SaveEntityInclusionPolicy.Default);
+        }
+
+        private static void PrepareIncludedSource(World source)
+        {
+            var excluded = new List<Entity>();
+            SaveEntityInclusionPolicy policy = SaveEntityInclusionPolicy.Default;
+            source.Query(in QueryDescription.Null, entity =>
+            {
+                if (!policy.ShouldInclude(source, entity))
+                {
+                    excluded.Add(entity);
+                }
+            });
+
+            for (int i = 0; i < excluded.Count; i++)
+            {
+                if (source.IsAlive(excluded[i]))
+                {
+                    source.Destroy(excluded[i]);
+                }
+            }
+        }
+
+        private static void DetachTransferredStorage(World source)
+        {
+            source.SetEntityDataArray(new JaggedArray<EntityData>(
+                source.BaseChunkSize / System.Runtime.CompilerServices.Unsafe.SizeOf<EntityData>(),
+                new EntityData(null!, new Slot(-1, -1), 0),
+                0));
+            source.Clear();
         }
 
         private static void NormalizeChunkEntityWorldIds(World world)

--- a/src/Core/Properties/AssemblyInfo.cs
+++ b/src/Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("PersistenceTests")]

--- a/src/Tests/PersistenceTests/ArchPersistenceCharacterizationTests.cs
+++ b/src/Tests/PersistenceTests/ArchPersistenceCharacterizationTests.cs
@@ -277,6 +277,20 @@ public sealed class ArchPersistenceCharacterizationTests
         Assert.That(error.Message, Does.Contain("without Ludots persistence formatters"));
     }
 
+    [Test]
+    public void CorePersistenceFormattersAreScannedOnceForRepeatedSerializes()
+    {
+        LudotsCorePersistenceFormatters.ResetCacheForTests();
+        using World world = World.Create();
+        world.Create(new Name { Value = "scan-once" }, WorldPositionCm.FromCm(1, 2));
+        var serializer = new LudotsBinaryWorldSerializer();
+
+        serializer.Serialize(world);
+        serializer.Serialize(world);
+
+        Assert.That(LudotsCorePersistenceFormatters.FormatterCacheBuildCountForTests, Is.EqualTo(1));
+    }
+
     private static World RoundTrip(World world)
     {
         var serializer = new ArchBinarySerializer();

--- a/src/Tests/PersistenceTests/EntityIdentityPersistenceTests.cs
+++ b/src/Tests/PersistenceTests/EntityIdentityPersistenceTests.cs
@@ -165,6 +165,49 @@ public sealed class EntityIdentityPersistenceTests
         AssertAliveName(restored, restoredTeam, "team");
     }
 
+    [Test]
+    public void ImportIntoKeepsTargetStableAfterImportedSourceIsDisposedAndWorldsAllocate()
+    {
+        using World source = World.Create();
+        Entity childA = source.Create(new Name { Value = "child-a" });
+        Entity childB = source.Create(new Name { Value = "child-b" });
+        var children = new ChildrenBuffer();
+        Assert.That(children.Add(childA), Is.True);
+        Assert.That(children.Add(childB), Is.True);
+        source.Create(new Name { Value = "parent" }, children, WorldPositionCm.FromCm(25, 75));
+        source.Create(new Name { Value = "excluded" }, new SaveExcludedTag());
+
+        using World target = World.Create();
+        using (World normalized = new LudotsBinaryWorldSerializer().CloneIncludedWorld(source))
+        {
+            LudotsWorldStateImporter.ImportOwnedSnapshotInto(normalized, target);
+        }
+
+        for (int i = 0; i < 128; i++)
+        {
+            source.Create(new Name { Value = $"source-noise-{i}" }, WorldPositionCm.FromCm(i, -i));
+        }
+
+        for (int i = 0; i < 128; i++)
+        {
+            using World pressure = World.Create();
+            pressure.Create(new Name { Value = $"pressure-{i}" }, WorldPositionCm.FromCm(i * 2, i * 3));
+        }
+
+        Entity restoredParent = FindSingle<ChildrenBuffer>(target);
+        ref readonly ChildrenBuffer restoredChildren = ref target.Get<ChildrenBuffer>(restoredParent);
+        Entity restoredChildA = restoredChildren.Get(0);
+        Entity restoredChildB = restoredChildren.Get(1);
+
+        Assert.Multiple(() =>
+        {
+            AssertAliveName(target, restoredChildA, "child-a");
+            AssertAliveName(target, restoredChildB, "child-b");
+            Assert.That(FindByName(target, "excluded"), Is.EqualTo(Entity.Null));
+            Assert.That(target.Get<WorldPositionCm>(restoredParent).ToWorldCmInt2(), Is.EqualTo(new Ludots.Core.Mathematics.WorldCmInt2(25, 75)));
+        });
+    }
+
     private static World CoreRoundTrip(World world)
     {
         var serializer = new LudotsBinaryWorldSerializer();
@@ -192,6 +235,25 @@ public sealed class EntityIdentityPersistenceTests
         });
 
         Assert.That(matches, Is.EqualTo(1));
+        return found;
+    }
+
+    private static Entity FindByName(World world, string name)
+    {
+        var query = new QueryDescription().WithAll<Name>();
+        Entity found = Entity.Null;
+        int matches = 0;
+
+        world.Query(in query, (Entity entity, ref Name entityName) =>
+        {
+            if (string.Equals(entityName.Value, name, StringComparison.Ordinal))
+            {
+                found = entity;
+                matches++;
+            }
+        });
+
+        Assert.That(matches, Is.LessThanOrEqualTo(1));
         return found;
     }
 }

--- a/src/Tests/PersistenceTests/SaveContinuationTrace.cs
+++ b/src/Tests/PersistenceTests/SaveContinuationTrace.cs
@@ -1,0 +1,77 @@
+using System.Security.Cryptography;
+using System.Text;
+using Arch.Core;
+using Ludots.Core.Engine;
+using Ludots.Core.Engine.Pacemaker;
+using Ludots.Core.Persistence;
+using Ludots.Core.Scripting;
+using MessagePack;
+using MessagePack.Formatters;
+using MessagePack.Resolvers;
+
+namespace Ludots.Tests.Persistence;
+
+internal static class SaveContinuationTrace
+{
+    public static string[] RunFixedSteps(GameEngine engine, int count, float deltaTime)
+    {
+        var trace = new string[count];
+        var pacemaker = (TurnBasedPacemaker)engine.Pacemaker;
+        IClock clock = engine.GetService(CoreServiceKeys.Clock);
+        for (int i = 0; i < count; i++)
+        {
+            pacemaker.Step();
+            engine.Tick(deltaTime);
+            trace[i] = $"tick={engine.GameSession.CurrentTick};fixedFrame={clock.Now(ClockDomainId.FixedFrame)};worldHash={ComputeWorldStateHash(engine.World)}";
+        }
+
+        return trace;
+    }
+
+    private static string ComputeWorldStateHash(World world)
+    {
+        MessagePackSerializerOptions options = CreateComponentSerializerOptions();
+        var rows = new List<string>();
+        world.Query(in QueryDescription.Null, entity =>
+        {
+            Signature signature = world.GetSignature(entity);
+            var componentRows = new List<string>(signature.Components.Length);
+            foreach (ComponentType componentType in signature.Components)
+            {
+                Type type = componentType.Type;
+                object? component = world.Get(entity, componentType);
+                if (component == null)
+                {
+                    componentRows.Add($"{type.FullName ?? type.Name}=<null>");
+                    continue;
+                }
+
+                componentRows.Add($"{type.FullName ?? type.Name}={Convert.ToHexString(SerializeComponent(type, component, options))}");
+            }
+
+            componentRows.Sort(StringComparer.Ordinal);
+            rows.Add($"{entity.Id}:{entity.Version}|{string.Join("|", componentRows)}");
+        });
+
+        rows.Sort(StringComparer.Ordinal);
+        byte[] bytes = Encoding.UTF8.GetBytes(string.Join("\n", rows));
+        return Convert.ToHexString(SHA256.HashData(bytes));
+    }
+
+    private static MessagePackSerializerOptions CreateComponentSerializerOptions()
+    {
+        return MessagePackSerializerOptions.Standard.WithResolver(
+            CompositeResolver.Create(
+                LudotsCorePersistenceFormatters.CreateFormatters(),
+                new IFormatterResolver[]
+                {
+                    BuiltinResolver.Instance,
+                    ContractlessStandardResolverAllowPrivate.Instance
+                }));
+    }
+
+    private static byte[] SerializeComponent(Type type, object component, MessagePackSerializerOptions options)
+    {
+        return MessagePackSerializer.Serialize(type, component, options);
+    }
+}

--- a/src/Tests/PersistenceTests/SaveSystemUatTests.cs
+++ b/src/Tests/PersistenceTests/SaveSystemUatTests.cs
@@ -126,17 +126,7 @@ public sealed class SaveSystemUatTests
 
     private static string[] RunFixedSteps(GameEngine engine, int count)
     {
-        var trace = new string[count];
-        var pacemaker = (TurnBasedPacemaker)engine.Pacemaker;
-        IClock clock = engine.GetService(CoreServiceKeys.Clock);
-        for (int i = 0; i < count; i++)
-        {
-            pacemaker.Step();
-            engine.Tick(1f / 60f);
-            trace[i] = $"tick={engine.GameSession.CurrentTick};fixedFrame={clock.Now(ClockDomainId.FixedFrame)}";
-        }
-
-        return trace;
+        return SaveContinuationTrace.RunFixedSteps(engine, count, 1f / 60f);
     }
 
     private static SavePointTrace CaptureTrace(

--- a/src/Tests/PersistenceTests/WorldSnapshotOrchestrationTests.cs
+++ b/src/Tests/PersistenceTests/WorldSnapshotOrchestrationTests.cs
@@ -165,17 +165,7 @@ public sealed class WorldSnapshotOrchestrationTests
 
     private static string[] RunFixedSteps(GameEngine engine, int count)
     {
-        var trace = new string[count];
-        var pacemaker = (TurnBasedPacemaker)engine.Pacemaker;
-        IClock clock = engine.GetService(CoreServiceKeys.Clock);
-        for (int i = 0; i < count; i++)
-        {
-            pacemaker.Step();
-            engine.Tick(1f);
-            trace[i] = $"tick={engine.GameSession.CurrentTick};fixedFrame={clock.Now(ClockDomainId.FixedFrame)}";
-        }
-
-        return trace;
+        return SaveContinuationTrace.RunFixedSteps(engine, count, 1f);
     }
 
     private static string FindRepoRoot()


### PR DESCRIPTION
## Summary
- Fixes #317 by importing owned restored worlds directly, detaching transferred Arch storage from the source world, and covering source-dispose/allocation pressure.
- Fixes #318 by caching formatter discovery/component sets and using thread-local Arch serializers while removing the extra restore serialize/deserialize pass.
- Fixes #319 by comparing deterministic continuation traces with tick, fixed frame, and a stable persisted-world hash in orchestration and RTS UAT coverage.
- Updates the formal save-system architecture page to describe cached formatters, owned restore import, and the stronger trace requirement.

## Validation
- dotnet test src\\Tests\\PersistenceTests\\PersistenceTests.csproj (54 passed)
- git diff --check
- .\\scripts\\validate-docs.ps1

Fixes #317
Fixes #318
Fixes #319