### PR TITLE
Harden Order and Ability config fail-fast contracts

### DIFF
--- a/mods/AIDemoMod/assets/Configs/AI/projection.json
+++ b/mods/AIDemoMod/assets/Configs/AI/projection.json
@@ -3,7 +3,7 @@
     "id": "HasEnemy.FromTarget",
     "Atom": "HasEnemy",
     "Op": "EntityIsNonNull",
-    "EntityKey": 1000
+    "EntityKey": "Attack.TargetEntity"
   }
 ]
 

--- a/mods/ArpgDemoMod/assets/GAS/effects.json
+++ b/mods/ArpgDemoMod/assets/GAS/effects.json
@@ -22,7 +22,8 @@
       "limit": 3,
       "policy": "RefreshDuration",
       "overflowPolicy": "RejectNew"
-    }
+    },
+    "participatesInResponse": false
   },
   {
     "id": "Effect.Arpg.HealPotion",
@@ -37,7 +38,8 @@
         "op": "Add",
         "value": 25
       }
-    ]
+    ],
+    "participatesInResponse": false
   },
   {
     "id": "Effect.Arpg.FireArrow",
@@ -51,7 +53,8 @@
       "range": 2000,
       "arcHeight": 0,
       "impactEffect": "Effect.Arpg.Poison",
-      "collisionRelationFilter": "All"
+      "travelMode": "Legacy",
+      "impactPolicy": "Legacy"
     },
     "configParams": {
       "damage_base": {
@@ -62,7 +65,8 @@
         "type": "Int",
         "value": 1
       }
-    }
+    },
+    "participatesInResponse": false
   },
   {
     "id": "Effect.Arpg.SummonWolf",
@@ -75,8 +79,10 @@
       "unitType": "Unit.Wolf",
       "count": 1,
       "offsetRadius": 120,
-      "onSpawnEffect": "Effect.Arpg.WolfSpawnBuff"
-    }
+      "onSpawnEffect": "Effect.Arpg.WolfSpawnBuff",
+      "placementPattern": "Scatter"
+    },
+    "participatesInResponse": false
   },
   {
     "id": "Effect.Arpg.WolfSpawnBuff",
@@ -96,7 +102,8 @@
         "op": "Add",
         "value": 5
       }
-    ]
+    ],
+    "participatesInResponse": false
   },
   {
     "id": "Effect.Arpg.Bleed",

--- a/mods/CoreInputMod/Systems/LocalOrderSourceHelper.cs
+++ b/mods/CoreInputMod/Systems/LocalOrderSourceHelper.cs
@@ -101,7 +101,13 @@ namespace CoreInputMod.Systems
                     return registryOrderTypeId;
                 }
 
-                return _orderTypeIds.TryGetValue(key, out int configOrderTypeId) ? configOrderTypeId : 0;
+                if (_orderTypeIds.TryGetValue(key, out int configOrderTypeId) && configOrderTypeId > 0)
+                {
+                    return configOrderTypeId;
+                }
+
+                throw new InvalidOperationException(
+                    $"[{ctx.ModId}] input_order_mappings.json references unknown orderTypeKey '{key}'.");
             });
             mapping.SetGroundPositionProvider((out Vector3 worldCm) =>
             {

--- a/mods/EntityCommandPanelMod/Runtime/GasEntityCommandPanelSource.cs
+++ b/mods/EntityCommandPanelMod/Runtime/GasEntityCommandPanelSource.cs
@@ -1007,9 +1007,12 @@ namespace EntityCommandPanelMod.Runtime
             return string.Empty;
         }
 
-        private static string ResolveOrderActionDetail(in Order order)
+        private string ResolveOrderActionDetail(in Order order)
         {
-            return order.OrderTypeId == 100 && order.Args.I0 >= 0
+            return _orderTypes != null &&
+                   _orderTypes.TryGet(order.OrderTypeId, out var config) &&
+                   string.Equals(config.Key, "castAbility", StringComparison.OrdinalIgnoreCase) &&
+                   order.Args.I0 >= 0
                 ? $"slot {order.Args.I0}"
                 : string.Empty;
         }

--- a/mods/FourXDemoMod/assets/GAS/effects.json
+++ b/mods/FourXDemoMod/assets/GAS/effects.json
@@ -10,13 +10,9 @@
     "unitCreation": {
       "unitType": "Unit.Outpost",
       "placementPattern": "Scatter",
-      "facingPattern": "PreserveTemplate",
       "count": 1,
       "offsetRadius": 80,
-      "placementRadiusCm": 80,
-      "placementStartAngleDeg": 0,
       "copySourcePlayerOwner": true,
-      "linkSourceAsParent": false,
       "onSpawnEffect": "Effect.4X.OutpostComplete"
     }
   },
@@ -65,8 +61,7 @@
       {
         "tag": "Status.Researching",
         "formula": "Fixed",
-        "amount": 1,
-        "base": 0
+        "amount": 1
       }
     ]
   },
@@ -78,17 +73,11 @@
     "presetType": "Buff",
     "lifetime": "Infinite",
     "participatesInResponse": false,
-    "duration": {
-      "durationTicks": 0,
-      "periodTicks": 0,
-      "clockId": "FixedFrame"
-    },
     "grantedTags": [
       {
         "tag": "Progression.Agriculture",
         "formula": "Fixed",
-        "amount": 1,
-        "base": 0
+        "amount": 1
       }
     ],
     "modifiers": [
@@ -107,17 +96,11 @@
     "presetType": "Buff",
     "lifetime": "Infinite",
     "participatesInResponse": false,
-    "duration": {
-      "durationTicks": 0,
-      "periodTicks": 0,
-      "clockId": "FixedFrame"
-    },
     "grantedTags": [
       {
         "tag": "Status.Allied",
         "formula": "Fixed",
-        "amount": 1,
-        "base": 0
+        "amount": 1
       }
     ]
   },

--- a/mods/MobaDemoMod/Systems/MobaLocalOrderSourceSystem.cs
+++ b/mods/MobaDemoMod/Systems/MobaLocalOrderSourceSystem.cs
@@ -94,7 +94,8 @@ namespace MobaDemoMod.Systems
             {
                 "castAbility" => _castAbilityOrderTypeId,
                 "stop" => _stopOrderTypeId,
-                _ => 0
+                _ => throw new InvalidOperationException(
+                    $"[{_ctx.ModId}] input_order_mappings.json references unknown orderTypeKey '{key}'.")
             });
             
             // Ground position provider

--- a/mods/MobaDemoMod/assets/GAS/effects.json
+++ b/mods/MobaDemoMod/assets/GAS/effects.json
@@ -51,12 +51,7 @@
       "maxTargets": 8
     },
     "targetDispatch": {
-      "payloadEffect": "Effect.Moba.Cone.E.Hit",
-      "contextMapping": {
-        "payloadSource": "OriginalSource",
-        "payloadTarget": "ResolvedEntity",
-        "payloadTargetContext": "OriginalTarget"
-      }
+      "payloadEffect": "Effect.Moba.Cone.E.Hit"
     }
   },
   {
@@ -216,7 +211,9 @@
       "range": 2000,
       "arcHeight": 0,
       "impactEffect": "Effect.Moba.Damage.R",
-      "collisionRelationFilter": "All"
+      "presentationEffect": "Effect.Moba.Damage.R",
+      "travelMode": "Legacy",
+      "impactPolicy": "Legacy"
     }
   },
   {
@@ -229,8 +226,10 @@
     "participatesInResponse": false,
     "unitCreation": {
       "unitType": "Unit.Skeleton",
+      "placementPattern": "Scatter",
       "count": 1,
-      "offsetRadius": 200
+      "offsetRadius": 200,
+      "copySourcePlayerOwner": true
     }
   },
   {
@@ -256,9 +255,9 @@
     "phaseListeners": [
       {
         "listenTag": "Effect.Moba.Damage",
-        "phase": "onHit",
-        "scope": "target",
-        "action": "graph",
+        "phase": "OnHit",
+        "scope": "Target",
+        "action": "Graph",
         "graphProgram": "Graph.Shield.Absorb",
         "priority": 100
       }
@@ -393,7 +392,6 @@
     "participatesInResponse": true,
     "displacement": {
       "directionMode": "AwayFromSource",
-      "fixedDirectionDeg": 0,
       "totalDistanceCm": 350,
       "totalDurationTicks": 12,
       "overrideNavigation": true

--- a/mods/RtsDemoMod/assets/GAS/abilities.json
+++ b/mods/RtsDemoMod/assets/GAS/abilities.json
@@ -34,7 +34,8 @@
     "indicator": {
       "shape": "Single",
       "range": 1200,
-      "showRangeCircle": true
+      "showRangeCircle": true,
+      "rangeCircleColor": "#3366FF55"
     },
     "presentation": {
       "displayName": "进驻",
@@ -78,6 +79,7 @@
       "range": 1600,
       "radius": 240,
       "showRangeCircle": true,
+      "rangeCircleColor": "#3366FF55",
       "preview": {
         "performerId": "core_input_preview_build_site",
         "scaleY": 1.1,
@@ -110,6 +112,7 @@
       "range": 1500,
       "radius": 220,
       "showRangeCircle": true,
+      "rangeCircleColor": "#3366FF55",
       "preview": {
         "performerId": "core_input_preview_build_site",
         "scaleY": 1.45,
@@ -159,6 +162,7 @@
       "range": 2200,
       "radius": 280,
       "showRangeCircle": true,
+      "rangeCircleColor": "#3366FF55",
       "preview": {
         "performerId": "core_input_preview_build_site",
         "scaleY": 0.82,
@@ -187,6 +191,7 @@
       "range": 2200,
       "radius": 300,
       "showRangeCircle": true,
+      "rangeCircleColor": "#3366FF55",
       "preview": {
         "performerId": "core_input_preview_build_site",
         "scaleY": 1.25,
@@ -290,6 +295,7 @@
       "range": 2600,
       "radius": 180,
       "showRangeCircle": true,
+      "rangeCircleColor": "#3366FF55",
       "preview": {
         "performerId": "core_input_preview_warp_site",
         "scaleY": 2.4,
@@ -322,6 +328,7 @@
       "range": 1500,
       "radius": 260,
       "showRangeCircle": true,
+      "rangeCircleColor": "#3366FF55",
       "preview": {
         "performerId": "core_input_preview_morph_site",
         "scaleY": 1.8,

--- a/mods/RtsDemoMod/assets/GAS/effects.json
+++ b/mods/RtsDemoMod/assets/GAS/effects.json
@@ -171,14 +171,9 @@
     "unitCreation": {
       "templateId": "rts_war3_lumber_mill_site",
       "placementPattern": "Scatter",
-      "facingPattern": "PreserveTemplate",
       "count": 1,
-      "offsetRadius": 0,
-      "placementRadiusCm": 0,
-      "placementStartAngleDeg": 0,
-      "copySourcePlayerOwner": true,
-      "linkSourceAsParent": false,
-      "onSpawnEffect": "Effect.Rts.Shared.Construction.War3"
+      "onSpawnEffect": "Effect.Rts.Shared.Construction.War3",
+      "copySourcePlayerOwner": true
     }
   },
   {
@@ -192,14 +187,9 @@
     "unitCreation": {
       "templateId": "rts_war3_guard_tower_site",
       "placementPattern": "Scatter",
-      "facingPattern": "PreserveTemplate",
       "count": 1,
-      "offsetRadius": 0,
-      "placementRadiusCm": 0,
-      "placementStartAngleDeg": 0,
-      "copySourcePlayerOwner": true,
-      "linkSourceAsParent": false,
-      "onSpawnEffect": "Effect.Rts.Shared.Construction.War3"
+      "onSpawnEffect": "Effect.Rts.Shared.Construction.War3",
+      "copySourcePlayerOwner": true
     }
   },
   {
@@ -213,13 +203,9 @@
     "unitCreation": {
       "templateId": "rts_war3_footman",
       "placementPattern": "Scatter",
-      "facingPattern": "PreserveTemplate",
       "count": 1,
       "offsetRadius": 280,
-      "placementRadiusCm": 280,
-      "placementStartAngleDeg": 0,
-      "copySourcePlayerOwner": true,
-      "linkSourceAsParent": false
+      "copySourcePlayerOwner": true
     }
   },
   {
@@ -297,14 +283,9 @@
     "unitCreation": {
       "templateId": "rts_ra2_power_plant",
       "placementPattern": "Scatter",
-      "facingPattern": "PreserveTemplate",
       "count": 1,
-      "offsetRadius": 0,
-      "placementRadiusCm": 0,
-      "placementStartAngleDeg": 0,
-      "copySourcePlayerOwner": true,
-      "linkSourceAsParent": false,
-      "onSpawnEffect": "Effect.Rts.Shared.Construction.Cnc"
+      "onSpawnEffect": "Effect.Rts.Shared.Construction.Cnc",
+      "copySourcePlayerOwner": true
     }
   },
   {
@@ -318,14 +299,9 @@
     "unitCreation": {
       "templateId": "rts_ra2_refinery",
       "placementPattern": "Scatter",
-      "facingPattern": "PreserveTemplate",
       "count": 1,
-      "offsetRadius": 0,
-      "placementRadiusCm": 0,
-      "placementStartAngleDeg": 0,
-      "copySourcePlayerOwner": true,
-      "linkSourceAsParent": false,
-      "onSpawnEffect": "Effect.Rts.Shared.Construction.Cnc"
+      "onSpawnEffect": "Effect.Rts.Shared.Construction.Cnc",
+      "copySourcePlayerOwner": true
     }
   },
   {
@@ -339,13 +315,9 @@
     "unitCreation": {
       "templateId": "rts_ra2_rhino",
       "placementPattern": "Scatter",
-      "facingPattern": "PreserveTemplate",
       "count": 1,
       "offsetRadius": 340,
-      "placementRadiusCm": 340,
-      "placementStartAngleDeg": 0,
-      "copySourcePlayerOwner": true,
-      "linkSourceAsParent": false
+      "copySourcePlayerOwner": true
     }
   },
   {
@@ -412,13 +384,9 @@
     "unitCreation": {
       "templateId": "rts_sc2_zealot",
       "placementPattern": "Scatter",
-      "facingPattern": "PreserveTemplate",
       "count": 1,
       "offsetRadius": 260,
-      "placementRadiusCm": 260,
-      "placementStartAngleDeg": 0,
-      "copySourcePlayerOwner": true,
-      "linkSourceAsParent": false
+      "copySourcePlayerOwner": true
     }
   },
   {
@@ -454,14 +422,9 @@
     "unitCreation": {
       "templateId": "rts_sc2_zealot",
       "placementPattern": "Scatter",
-      "facingPattern": "PreserveTemplate",
       "count": 1,
-      "offsetRadius": 0,
-      "placementRadiusCm": 0,
-      "placementStartAngleDeg": 0,
-      "copySourcePlayerOwner": true,
-      "linkSourceAsParent": false,
-      "onSpawnEffect": "Effect.Rts.Shared.WarpIn"
+      "onSpawnEffect": "Effect.Rts.Shared.WarpIn",
+      "copySourcePlayerOwner": true
     }
   },
   {
@@ -491,14 +454,9 @@
     "unitCreation": {
       "templateId": "rts_zerg_spawning_pool",
       "placementPattern": "Scatter",
-      "facingPattern": "PreserveTemplate",
       "count": 1,
-      "offsetRadius": 0,
-      "placementRadiusCm": 0,
-      "placementStartAngleDeg": 0,
-      "copySourcePlayerOwner": true,
-      "linkSourceAsParent": false,
-      "onSpawnEffect": "Effect.Rts.Shared.Construction.Zerg"
+      "onSpawnEffect": "Effect.Rts.Shared.Construction.Zerg",
+      "copySourcePlayerOwner": true
     }
   }
 ]

--- a/mods/TcgDemoMod/assets/GAS/effects.json
+++ b/mods/TcgDemoMod/assets/GAS/effects.json
@@ -12,7 +12,8 @@
         "op": "Add",
         "value": -30
       }
-    ]
+    ],
+    "participatesInResponse": false
   },
   {
     "id": "Effect.Tcg.CounterBlast",
@@ -27,7 +28,8 @@
         "op": "Add",
         "value": -15
       }
-    ]
+    ],
+    "participatesInResponse": false
   },
   {
     "id": "Effect.Tcg.PoisonCounter",

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxRuntime.cs
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/Runtime/ChampionSkillSandboxRuntime.cs
@@ -450,10 +450,11 @@ namespace ChampionSkillSandboxMod.Runtime
                 return;
             }
 
+            engine.GlobalContext[ChampionSkillSandboxIds.CameraFollowModeKey] = ChampionSkillSandboxIds.FreeCameraToolbarButtonId;
             engine.GameSession.Camera.ActivateVirtualCamera(
                 virtualCameraId,
                 blendDurationSeconds: 0f,
-                followTarget: CameraFollowTargetFactory.Build(engine.World, engine.GlobalContext, definition.FollowTargetKind),
+                followTarget: null,
                 snapToFollowTargetWhenAvailable: definition.SnapToFollowTargetWhenAvailable,
                 resetRuntimeState: true);
 
@@ -473,6 +474,7 @@ namespace ChampionSkillSandboxMod.Runtime
                 DistanceCm = cameraConfig.DistanceCm,
                 FovYDeg = cameraConfig.FovYDeg,
             });
+            engine.GameSession.Camera.SynchronizeActiveVirtualCameraBoundsAndHeight();
         }
 
         private static void SyncCameraFollow(GameEngine engine)

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/abilities.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/abilities.json
@@ -10,7 +10,7 @@
         { "kind": "End", "tick": 5 }
       ]
     },
-    "indicator": { "shape": "Circle", "range": 440, "radius": 120, "showRangeCircle": true, "validColor": "#4FD7F077", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Circle", "range": 440, "radius": 120, "showRangeCircle": true, "validColor": "#4FD7F077", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Ezreal.E"] },
     "input": {
       "autoTargetPolicy": "NearestEnemyInRange",
@@ -37,7 +37,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Line", "range": 760, "radius": 85, "showRangeCircle": true, "validColor": "#F0C35A77", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Line", "range": 760, "radius": 85, "showRangeCircle": true, "validColor": "#F0C35A77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Ezreal.W"] },
     "presentation": {
       "displayName": "Essence Flux",
@@ -60,7 +60,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Line", "range": 840, "radius": 70, "showRangeCircle": true, "validColor": "#61C3FF77", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Line", "range": 840, "radius": 70, "showRangeCircle": true, "validColor": "#61C3FF77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Ezreal.Q"] },
     "presentation": {
       "displayName": "Mystic Shot",
@@ -83,7 +83,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Line", "range": 2200, "radius": 120, "showRangeCircle": true, "validColor": "#9BE0FF77", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Line", "range": 2200, "radius": 120, "showRangeCircle": true, "validColor": "#9BE0FF77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Ezreal.R"] },
     "presentation": {
       "displayName": "Trueshot Barrage",
@@ -115,7 +115,7 @@
         ]
       }
     },
-    "indicator": { "shape": "Circle", "range": 0, "radius": 220, "showRangeCircle": false, "validColor": "#C9E98766", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Circle", "radius": 220, "showRangeCircle": false, "validColor": "#C9E98766", "invalidColor": "#E2575788" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Garen.W"] },
     "presentation": {
       "displayName": "Courage",
@@ -138,7 +138,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Circle", "range": 320, "radius": 100, "showRangeCircle": true, "validColor": "#F6D37A77", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Circle", "range": 320, "radius": 100, "showRangeCircle": true, "validColor": "#F6D37A77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Garen.Q"] },
     "presentation": {
       "displayName": "Decisive Strike",
@@ -161,7 +161,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Circle", "range": 520, "radius": 150, "showRangeCircle": true, "validColor": "#FF8B76AA", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Circle", "range": 520, "radius": 150, "showRangeCircle": true, "validColor": "#FF8B76AA", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Garen.R"] },
     "presentation": {
       "displayName": "Demacian Justice",
@@ -184,7 +184,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Circle", "range": 0, "radius": 260, "showRangeCircle": false, "validColor": "#E5A95A77", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Circle", "radius": 260, "showRangeCircle": false, "validColor": "#E5A95A77", "invalidColor": "#E2575788" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Garen.E"] },
     "presentation": {
       "displayName": "Judgment",
@@ -207,7 +207,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Circle", "range": 720, "radius": 110, "showRangeCircle": true, "validColor": "#86E2A977", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Circle", "range": 720, "radius": 110, "showRangeCircle": true, "validColor": "#86E2A977", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Geomancer.Q"] },
     "presentation": {
       "displayName": "Runic Beacon",
@@ -230,7 +230,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Circle", "range": 720, "radius": 220, "showRangeCircle": true, "validColor": "#D7F08B77", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Circle", "range": 720, "radius": 220, "showRangeCircle": true, "validColor": "#D7F08B77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Geomancer.W"] },
     "presentation": {
       "displayName": "Rune Field",
@@ -253,7 +253,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Circle", "range": 720, "radius": 140, "showRangeCircle": true, "validColor": "#F0B36C77", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Circle", "range": 720, "radius": 140, "showRangeCircle": true, "validColor": "#F0B36C77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Geomancer.E"] },
     "presentation": {
       "displayName": "Stone Pillar",
@@ -276,7 +276,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Line", "range": 920, "radius": 80, "showRangeCircle": true, "validColor": "#78E2FF77", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Line", "range": 920, "radius": 80, "showRangeCircle": true, "validColor": "#78E2FF77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Geomancer.R"] },
     "presentation": {
       "displayName": "Prismatic Beam",
@@ -299,7 +299,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Rectangle", "range": 640, "radius": 220, "showRangeCircle": true, "validColor": "#8ED9A977", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Rectangle", "range": 640, "radius": 220, "showRangeCircle": true, "validColor": "#8ED9A977", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Jayce.E"] },
     "presentation": {
       "displayName": "Acceleration Gate",
@@ -322,7 +322,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Circle", "range": 0, "radius": 220, "showRangeCircle": false, "validColor": "#B4F0C277", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Circle", "radius": 220, "showRangeCircle": false, "validColor": "#B4F0C277", "invalidColor": "#E2575788" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Jayce.W"] },
     "presentation": {
       "displayName": "Hyper Charge",
@@ -345,7 +345,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Line", "range": 880, "radius": 90, "showRangeCircle": true, "validColor": "#67D4FF77", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Line", "range": 880, "radius": 90, "showRangeCircle": true, "validColor": "#67D4FF77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Jayce.Q"] },
     "presentation": {
       "displayName": "Shock Blast",
@@ -368,7 +368,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Ring", "range": 0, "radius": 280, "innerRadius": 90, "showRangeCircle": false, "validColor": "#FFD27B77", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Ring", "radius": 280, "innerRadius": 90, "showRangeCircle": false, "validColor": "#FFD27B77", "invalidColor": "#E2575788" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Jayce.W"] },
     "presentation": {
       "displayName": "Lightning Field",
@@ -391,7 +391,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Cone", "range": 300, "radius": 300, "angleDeg": 40, "showRangeCircle": true, "validColor": "#FFA76777", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Cone", "range": 300, "radius": 300, "angleDeg": 40, "showRangeCircle": true, "validColor": "#FFA76777", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Jayce.E"] },
     "presentation": {
       "displayName": "Thundering Blow",
@@ -414,7 +414,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Circle", "range": 520, "radius": 170, "showRangeCircle": true, "validColor": "#FFB85B77", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Circle", "range": 520, "radius": 170, "showRangeCircle": true, "validColor": "#FFB85B77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Jayce.Q"] },
     "presentation": {
       "displayName": "To The Skies!",
@@ -445,7 +445,7 @@
         ]
       }
     },
-    "indicator": { "shape": "Circle", "range": 0, "radius": 200, "showRangeCircle": false, "validColor": "#8AA8FF66", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Circle", "radius": 200, "showRangeCircle": false, "validColor": "#8AA8FF66", "invalidColor": "#E2575788" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Jayce.R"] },
     "presentation": {
       "displayName": "Mercury Cannon",
@@ -476,7 +476,7 @@
         ]
       }
     },
-    "indicator": { "shape": "Circle", "range": 0, "radius": 200, "showRangeCircle": false, "validColor": "#FFB55C66", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Circle", "radius": 200, "showRangeCircle": false, "validColor": "#FFB55C66", "invalidColor": "#E2575788" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.Jayce.R"] },
     "presentation": {
       "displayName": "Mercury Hammer",
@@ -499,7 +499,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Circle", "range": 180, "radius": 180, "showRangeCircle": true, "validColor": "#F1A45E77", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Circle", "range": 180, "radius": 180, "showRangeCircle": true, "validColor": "#F1A45E77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.ChampionStress.Warrior.Q"] },
     "presentation": {
       "displayName": "Cleave",
@@ -522,7 +522,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Circle", "range": 1200, "radius": 180, "showRangeCircle": true, "validColor": "#FF8B5F77", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Circle", "range": 1200, "radius": 180, "showRangeCircle": true, "validColor": "#FF8B5F77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.ChampionStress.FireMage.Q"] },
     "presentation": {
       "displayName": "Fireball",
@@ -545,7 +545,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Line", "range": 1400, "radius": 80, "showRangeCircle": true, "validColor": "#63D8FF77", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Line", "range": 1400, "radius": 80, "showRangeCircle": true, "validColor": "#63D8FF77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.ChampionStress.LaserMage.Q"] },
     "presentation": {
       "displayName": "Laser Bolt",
@@ -568,7 +568,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Circle", "range": 900, "radius": 140, "showRangeCircle": true, "validColor": "#83E7A177", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Circle", "range": 900, "radius": 140, "showRangeCircle": true, "validColor": "#83E7A177", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.ChampionStress.Priest.Q"] },
     "presentation": {
       "displayName": "Renew",
@@ -591,7 +591,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Circle", "range": 760, "radius": 110, "showRangeCircle": true, "validColor": "#73E1FF77", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Circle", "range": 760, "radius": 110, "showRangeCircle": true, "validColor": "#73E1FF77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.SpellEngineer.Q"] },
     "presentation": {
       "displayName": "Spell Beacon",
@@ -614,7 +614,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Circle", "range": 760, "radius": 240, "showRangeCircle": true, "validColor": "#78AFFF77", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Circle", "range": 760, "radius": 240, "showRangeCircle": true, "validColor": "#78AFFF77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.SpellEngineer.W"] },
     "presentation": {
       "displayName": "Gravity Well",
@@ -638,7 +638,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Circle", "range": 700, "radius": 300, "showRangeCircle": true, "validColor": "#FF9D6F77", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Circle", "range": 700, "radius": 300, "showRangeCircle": true, "validColor": "#FF9D6F77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.SpellEngineer.E"] },
     "presentation": {
       "displayName": "Cataclysm Ring",
@@ -662,7 +662,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": { "shape": "Line", "range": 1050, "radius": 75, "showRangeCircle": true, "validColor": "#B07CFF77", "invalidColor": "#E2575788" },
+    "indicator": { "shape": "Line", "range": 1050, "radius": 75, "showRangeCircle": true, "validColor": "#B07CFF77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Champion.SpellEngineer.R"] },
     "input": {
       "trigger": "Held",

--- a/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/effects.json
+++ b/mods/showcases/champion_skill_sandbox/ChampionSkillSandboxMod/assets/GAS/effects.json
@@ -103,21 +103,21 @@
       {
         "phase": "OnApply",
         "scope": "Target",
-        "action": "graph",
+        "action": "Graph",
         "listenEffectId": "Effect.Champion.Ezreal.MysticShotHit",
         "graphProgram": "Graph.Champion.Ezreal.PopEssenceFlux"
       },
       {
         "phase": "OnApply",
         "scope": "Target",
-        "action": "graph",
+        "action": "Graph",
         "listenEffectId": "Effect.Champion.Ezreal.ArcaneShiftBoltHit",
         "graphProgram": "Graph.Champion.Ezreal.PopEssenceFlux"
       },
       {
         "phase": "OnApply",
         "scope": "Target",
-        "action": "graph",
+        "action": "Graph",
         "listenEffectId": "Effect.Champion.Ezreal.TrueshotBarrageHit",
         "graphProgram": "Graph.Champion.Ezreal.PopEssenceFlux"
       }
@@ -237,7 +237,8 @@
     ],
     "expireCondition": {
       "kind": "TagPresent",
-      "tag": "State.Champion.Garen.Courage"
+      "tag": "State.Champion.Garen.Courage",
+      "sense": "Raw"
     }
   },
   {
@@ -350,7 +351,8 @@
       "templateId": "champion_skill_sandbox_runic_beacon",
       "count": 1,
       "copySourcePlayerOwner": true,
-      "linkSourceAsParent": true
+      "linkSourceAsParent": true,
+      "placementPattern": "Scatter"
     }
   },
   {
@@ -367,7 +369,8 @@
       "count": 1,
       "onSpawnEffect": "Effect.Champion.Geomancer.RuneFieldPersistent",
       "copySourcePlayerOwner": true,
-      "linkSourceAsParent": true
+      "linkSourceAsParent": true,
+      "placementPattern": "Scatter"
     }
   },
   {
@@ -426,7 +429,8 @@
       "templateId": "champion_skill_sandbox_stone_pillar",
       "count": 1,
       "copySourcePlayerOwner": true,
-      "linkSourceAsParent": true
+      "linkSourceAsParent": true,
+      "placementPattern": "Scatter"
     }
   },
   {
@@ -524,7 +528,9 @@
       "range": 880,
       "arcHeight": 0,
       "impactEffect": "Effect.Champion.Jayce.Cannon.ShockBlastResolve",
-      "collisionRelationFilter": "All"
+      "presentationEffect": "Effect.Champion.Jayce.Cannon.ShockBlastResolve",
+      "travelMode": "Legacy",
+      "impactPolicy": "Legacy"
     }
   },
   {
@@ -733,7 +739,9 @@
       "range": 1400,
       "arcHeight": 0,
       "impactEffect": "Effect.ChampionStress.FireMage.FireballResolve",
-      "collisionRelationFilter": "All"
+      "presentationEffect": "Effect.ChampionStress.FireMage.FireballResolve",
+      "travelMode": "Legacy",
+      "impactPolicy": "Legacy"
     }
   },
   {
@@ -787,7 +795,9 @@
       "range": 1500,
       "arcHeight": 0,
       "impactEffect": "Effect.ChampionStress.LaserMage.LaserResolve",
-      "collisionRelationFilter": "All"
+      "presentationEffect": "Effect.ChampionStress.LaserMage.LaserResolve",
+      "travelMode": "Legacy",
+      "impactPolicy": "Legacy"
     }
   },
   {
@@ -857,7 +867,8 @@
       "templateId": "champion_skill_sandbox_spell_beacon",
       "count": 1,
       "copySourcePlayerOwner": true,
-      "linkSourceAsParent": true
+      "linkSourceAsParent": true,
+      "placementPattern": "Scatter"
     }
   },
   {
@@ -874,7 +885,8 @@
       "count": 1,
       "onSpawnEffect": "Effect.Champion.SpellEngineer.GravityWellPersistent",
       "copySourcePlayerOwner": true,
-      "linkSourceAsParent": true
+      "linkSourceAsParent": true,
+      "placementPattern": "Scatter"
     }
   },
   {
@@ -954,7 +966,8 @@
       "count": 1,
       "onSpawnEffect": "Effect.Champion.SpellEngineer.GuidedLaserPersistent",
       "copySourcePlayerOwner": true,
-      "linkSourceAsParent": true
+      "linkSourceAsParent": true,
+      "placementPattern": "Scatter"
     }
   },
   {

--- a/mods/showcases/interaction/InteractionShowcaseMod/assets/GAS/abilities.json
+++ b/mods/showcases/interaction/InteractionShowcaseMod/assets/GAS/abilities.json
@@ -63,14 +63,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": {
-      "shape": "Circle",
-      "range": 0,
-      "radius": 280,
-      "showRangeCircle": false,
-      "validColor": "#D76BFF77",
-      "invalidColor": "#E2575788"
-    },
+    "indicator": { "shape": "Circle", "radius": 280, "showRangeCircle": false, "validColor": "#D76BFF77", "invalidColor": "#E2575788" },
     "blockTags": { "blockedAny": ["Cooldown.Arcweaver.R"] }
   },
   {
@@ -83,14 +76,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": {
-      "shape": "Line",
-      "range": 360,
-      "showRangeCircle": true,
-      "validColor": "#6BE1C988",
-      "invalidColor": "#E2575788",
-      "rangeCircleColor": "#3372D16A"
-    },
+    "indicator": { "shape": "Line", "range": 360, "radius": 55, "showRangeCircle": true, "validColor": "#6BE1C988", "invalidColor": "#E2575788", "rangeCircleColor": "#3372D16A" },
     "blockTags": { "blockedAny": ["Cooldown.Arcweaver.Z"] }
   },
   {
@@ -167,14 +153,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": {
-      "shape": "Circle",
-      "range": 440,
-      "radius": 120,
-      "showRangeCircle": true,
-      "validColor": "#F0C36B77",
-      "invalidColor": "#E2575788"
-    },
+    "indicator": { "shape": "Circle", "range": 440, "radius": 120, "showRangeCircle": true, "validColor": "#F0C36B77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Vanguard.W"] }
   },
   {
@@ -187,15 +166,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": {
-      "shape": "Cone",
-      "range": 360,
-      "radius": 360,
-      "angleDeg": 42,
-      "showRangeCircle": true,
-      "validColor": "#D2A55C77",
-      "invalidColor": "#E2575788"
-    },
+    "indicator": { "shape": "Cone", "range": 360, "radius": 360, "angleDeg": 42, "showRangeCircle": true, "validColor": "#D2A55C77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Vanguard.E"] }
   },
   {
@@ -208,15 +179,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": {
-      "shape": "Ring",
-      "range": 0,
-      "radius": 320,
-      "innerRadius": 140,
-      "showRangeCircle": false,
-      "validColor": "#E9A34A77",
-      "invalidColor": "#E2575788"
-    },
+    "indicator": { "shape": "Ring", "radius": 320, "innerRadius": 140, "showRangeCircle": false, "validColor": "#E9A34A77", "invalidColor": "#E2575788" },
     "blockTags": { "blockedAny": ["Cooldown.Vanguard.R"] }
   },
   {
@@ -229,13 +192,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": {
-      "shape": "Line",
-      "range": 300,
-      "showRangeCircle": true,
-      "validColor": "#F06B5E77",
-      "invalidColor": "#E2575788"
-    },
+    "indicator": { "shape": "Line", "range": 300, "radius": 55, "showRangeCircle": true, "validColor": "#F06B5E77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Vanguard.Z"] }
   },
   {
@@ -278,14 +235,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": {
-      "shape": "Rectangle",
-      "range": 520,
-      "radius": 130,
-      "showRangeCircle": true,
-      "validColor": "#F0936F77",
-      "invalidColor": "#E2575788"
-    },
+    "indicator": { "shape": "Rectangle", "range": 520, "radius": 130, "showRangeCircle": true, "validColor": "#F0936F77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Vanguard.Rune"] }
   },
   {
@@ -310,14 +260,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": {
-      "shape": "Circle",
-      "range": 560,
-      "radius": 100,
-      "showRangeCircle": true,
-      "validColor": "#5ED5BB77",
-      "invalidColor": "#E2575788"
-    },
+    "indicator": { "shape": "Circle", "range": 560, "radius": 100, "showRangeCircle": true, "validColor": "#5ED5BB77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Commander.W"] }
   },
   {
@@ -330,14 +273,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": {
-      "shape": "Line",
-      "range": 720,
-      "radius": 90,
-      "showRangeCircle": true,
-      "validColor": "#7CC4E877",
-      "invalidColor": "#E2575788"
-    },
+    "indicator": { "shape": "Line", "range": 720, "radius": 90, "showRangeCircle": true, "validColor": "#7CC4E877", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Commander.E"] }
   },
   {
@@ -362,13 +298,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": {
-      "shape": "Line",
-      "range": 320,
-      "showRangeCircle": true,
-      "validColor": "#7BD89A77",
-      "invalidColor": "#E2575788"
-    },
+    "indicator": { "shape": "Line", "range": 320, "radius": 55, "showRangeCircle": true, "validColor": "#7BD89A77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Commander.Z"] }
   },
   {
@@ -411,14 +341,7 @@
         { "kind": "End", "tick": 0 }
       ]
     },
-    "indicator": {
-      "shape": "Line",
-      "range": 820,
-      "radius": 120,
-      "showRangeCircle": true,
-      "validColor": "#86B9FF77",
-      "invalidColor": "#E2575788"
-    },
+    "indicator": { "shape": "Line", "range": 820, "radius": 120, "showRangeCircle": true, "validColor": "#86B9FF77", "invalidColor": "#E2575788", "rangeCircleColor": "#3366FF55" },
     "blockTags": { "blockedAny": ["Cooldown.Commander.Rune"] }
   },
   {

--- a/mods/showcases/interaction/InteractionShowcaseMod/assets/GAS/effects.json
+++ b/mods/showcases/interaction/InteractionShowcaseMod/assets/GAS/effects.json
@@ -144,7 +144,8 @@
     ],
     "expireCondition": {
       "kind": "TagPresent",
-      "tag": "State.Arcweaver.Guarding"
+      "tag": "State.Arcweaver.Guarding",
+      "sense": "Raw"
     }
   },
   {
@@ -348,7 +349,8 @@
     ],
     "expireCondition": {
       "kind": "TagPresent",
-      "tag": "State.Vanguard.IronWall"
+      "tag": "State.Vanguard.IronWall",
+      "sense": "Raw"
     }
   },
   {
@@ -363,7 +365,8 @@
       "kind": "BuiltinSpatial",
       "shape": "Rectangle",
       "halfWidth": 130,
-      "halfHeight": 260
+      "halfHeight": 260,
+      "rotation": 0
     },
     "targetFilter": {
       "relationFilter": "Hostile",
@@ -518,7 +521,8 @@
     ],
     "expireCondition": {
       "kind": "TagPresent",
-      "tag": "State.Commander.ShieldNet"
+      "tag": "State.Commander.ShieldNet",
+      "sense": "Raw"
     }
   },
   {
@@ -578,7 +582,8 @@
       "range": 5200,
       "arcHeight": 0,
       "impactEffect": "Effect.Interaction.Stress.FireballHit",
-      "collisionRelationFilter": "All"
+      "travelMode": "Legacy",
+      "impactPolicy": "Legacy"
     }
   },
   {

--- a/mods/showcases/item_system/ItemSystemShowcaseMod/assets/GAS/effects.json
+++ b/mods/showcases/item_system/ItemSystemShowcaseMod/assets/GAS/effects.json
@@ -36,7 +36,6 @@
     "tags": ["Effect.ItemShowcase.Passive"],
     "presetType": "Buff",
     "lifetime": "Infinite",
-    "duration": { "durationTicks": 0, "periodTicks": 0, "clockId": "FixedFrame" },
     "participatesInResponse": false,
     "modifiers": [
       { "attribute": "MoveSpeed", "op": "Add", "value": 18.0 }
@@ -47,7 +46,6 @@
     "tags": ["Effect.ItemShowcase.Passive"],
     "presetType": "Buff",
     "lifetime": "Infinite",
-    "duration": { "durationTicks": 0, "periodTicks": 0, "clockId": "FixedFrame" },
     "participatesInResponse": false,
     "modifiers": [
       { "attribute": "AttackDamage", "op": "Add", "value": 12.0 },
@@ -59,7 +57,6 @@
     "tags": ["Effect.ItemShowcase.Passive"],
     "presetType": "Buff",
     "lifetime": "Infinite",
-    "duration": { "durationTicks": 0, "periodTicks": 0, "clockId": "FixedFrame" },
     "participatesInResponse": false,
     "modifiers": [
       { "attribute": "Shield", "op": "Add", "value": 10.0 },
@@ -71,7 +68,6 @@
     "tags": ["Effect.ItemShowcase.Passive"],
     "presetType": "Buff",
     "lifetime": "Infinite",
-    "duration": { "durationTicks": 0, "periodTicks": 0, "clockId": "FixedFrame" },
     "participatesInResponse": false,
     "modifiers": [
       { "attribute": "Health", "op": "Add", "value": 8.0 },
@@ -83,7 +79,6 @@
     "tags": ["Effect.ItemShowcase.Passive"],
     "presetType": "Buff",
     "lifetime": "Infinite",
-    "duration": { "durationTicks": 0, "periodTicks": 0, "clockId": "FixedFrame" },
     "participatesInResponse": false,
     "modifiers": [
       { "attribute": "AttackDamage", "op": "Add", "value": 7.0 },
@@ -95,7 +90,6 @@
     "tags": ["Effect.ItemShowcase.Passive"],
     "presetType": "Buff",
     "lifetime": "Infinite",
-    "duration": { "durationTicks": 0, "periodTicks": 0, "clockId": "FixedFrame" },
     "participatesInResponse": false,
     "modifiers": [
       { "attribute": "Shield", "op": "Add", "value": 20.0 }
@@ -106,7 +100,6 @@
     "tags": ["Effect.ItemShowcase.Passive"],
     "presetType": "Buff",
     "lifetime": "Infinite",
-    "duration": { "durationTicks": 0, "periodTicks": 0, "clockId": "FixedFrame" },
     "participatesInResponse": false,
     "modifiers": [
       { "attribute": "AttackDamage", "op": "Add", "value": 9.0 }
@@ -117,7 +110,6 @@
     "tags": ["Effect.ItemShowcase.Passive"],
     "presetType": "Buff",
     "lifetime": "Infinite",
-    "duration": { "durationTicks": 0, "periodTicks": 0, "clockId": "FixedFrame" },
     "participatesInResponse": false,
     "modifiers": [
       { "attribute": "AttackDamage", "op": "Add", "value": 3.0 }
@@ -128,13 +120,12 @@
     "tags": ["Effect.ItemShowcase.Passive"],
     "presetType": "Buff",
     "lifetime": "Infinite",
-    "duration": { "durationTicks": 0, "periodTicks": 0, "clockId": "FixedFrame" },
     "participatesInResponse": false,
     "modifiers": [
       { "attribute": "Armor", "op": "Add", "value": 2.0 }
     ],
     "grantedTags": [
-      { "tag": "Weapon.State.Suppressed", "formula": "Fixed", "amount": 1, "base": 0 }
+      { "tag": "Weapon.State.Suppressed", "formula": "Fixed", "amount": 1 }
     ]
   },
   {
@@ -142,7 +133,6 @@
     "tags": ["Effect.ItemShowcase.Passive"],
     "presetType": "Buff",
     "lifetime": "Infinite",
-    "duration": { "durationTicks": 0, "periodTicks": 0, "clockId": "FixedFrame" },
     "participatesInResponse": false,
     "modifiers": [
       { "attribute": "Armor", "op": "Add", "value": 3.0 }
@@ -153,7 +143,6 @@
     "tags": ["Effect.ItemShowcase.Passive"],
     "presetType": "Buff",
     "lifetime": "Infinite",
-    "duration": { "durationTicks": 0, "periodTicks": 0, "clockId": "FixedFrame" },
     "participatesInResponse": false,
     "modifiers": [
       { "attribute": "AttackDamage", "op": "Add", "value": 6.0 }
@@ -164,7 +153,6 @@
     "tags": ["Effect.ItemShowcase.Passive"],
     "presetType": "Buff",
     "lifetime": "Infinite",
-    "duration": { "durationTicks": 0, "periodTicks": 0, "clockId": "FixedFrame" },
     "participatesInResponse": false,
     "modifiers": [
       { "attribute": "Shield", "op": "Add", "value": 14.0 },

--- a/src/Core/Config/ConfigMerger.cs
+++ b/src/Core/Config/ConfigMerger.cs
@@ -39,7 +39,7 @@ namespace Ludots.Core.Config
 
             if (entry.MergePolicy == ConfigMergePolicy.ArrayById)
             {
-                var entries = MergeArrayByIdToEntriesReported(fragments, in entry, report);
+                var entries = MergeArrayByIdToEntriesCore(fragments, in entry, report);
                 var result = new JsonArray();
                 for (int i = 0; i < entries.Count; i++) result.Add(entries[i].Node);
                 return result;
@@ -82,7 +82,14 @@ namespace Ludots.Core.Config
 
         private static JsonNode MergeArrayById(IReadOnlyList<JsonNode> fragments, string idField, string[] arrayAppendFields)
         {
-            var entries = MergeArrayByIdToEntriesCore(fragments, idField, arrayAppendFields, report: null, relativePath: null);
+            var wrapped = new ConfigFragment[fragments.Count];
+            for (int i = 0; i < fragments.Count; i++)
+            {
+                wrapped[i] = new ConfigFragment(fragments[i], "<unknown>");
+            }
+
+            var entry = new ConfigCatalogEntry("<unknown>", ConfigMergePolicy.ArrayById, idField, arrayAppendFields);
+            var entries = MergeArrayByIdToEntriesCore(wrapped, in entry, report: null);
             var result = new JsonArray();
             for (int i = 0; i < entries.Count; i++) result.Add(entries[i].Node);
             return result;
@@ -99,66 +106,10 @@ namespace Ludots.Core.Config
                     report.RecordFragment(entry.RelativePath, fragments[i].SourceUri);
             }
 
-            var nodes = new JsonNode[fragments.Count];
-            for (int i = 0; i < fragments.Count; i++) nodes[i] = fragments[i].Node;
-
-            if (report == null)
-                return MergeArrayByIdToEntriesCore(nodes, entry.IdField, entry.ArrayAppendFields, report: null, relativePath: null);
-
-            return MergeArrayByIdToEntriesReported(fragments, in entry, report);
+            return MergeArrayByIdToEntriesCore(fragments, in entry, report);
         }
 
         private static List<MergedConfigEntry> MergeArrayByIdToEntriesCore(
-            IReadOnlyList<JsonNode> fragments, string idField, string[] arrayAppendFields,
-            ConfigConflictReport report, string relativePath)
-        {
-            var orderedIds = new List<string>(capacity: 256);
-            var mergedNodes = new Dictionary<string, JsonNode>(StringComparer.Ordinal);
-
-            for (int i = 0; i < fragments.Count; i++)
-            {
-                if (fragments[i] is not JsonArray arr) continue;
-
-                foreach (var node in arr)
-                {
-                    if (node is not JsonObject obj) continue;
-                    if (!TryReadId(obj, idField, out string id)) continue;
-
-                    if (IsDeleted(obj))
-                    {
-                        mergedNodes.Remove(id);
-                        for (int oi = orderedIds.Count - 1; oi >= 0; oi--)
-                        {
-                            if (string.Equals(orderedIds[oi], id, StringComparison.Ordinal))
-                            {
-                                orderedIds.RemoveAt(oi);
-                                break;
-                            }
-                        }
-                        continue;
-                    }
-
-                    if (!mergedNodes.TryGetValue(id, out var existing))
-                    {
-                        mergedNodes[id] = obj.DeepClone();
-                        orderedIds.Add(id);
-                        continue;
-                    }
-
-                    MergeObject(existing, obj, arrayAppendFields);
-                }
-            }
-
-            var result = new List<MergedConfigEntry>(orderedIds.Count);
-            for (int i = 0; i < orderedIds.Count; i++)
-            {
-                if (mergedNodes.TryGetValue(orderedIds[i], out var n) && n is JsonObject jObj)
-                    result.Add(new MergedConfigEntry(orderedIds[i], jObj));
-            }
-            return result;
-        }
-
-        private static List<MergedConfigEntry> MergeArrayByIdToEntriesReported(
             IReadOnlyList<ConfigFragment> fragments,
             in ConfigCatalogEntry entry,
             ConfigConflictReport report)
@@ -168,18 +119,32 @@ namespace Ludots.Core.Config
 
             for (int i = 0; i < fragments.Count; i++)
             {
-                if (fragments[i].Node is not JsonArray arr) continue;
-                string src = fragments[i].SourceUri;
-
-                foreach (var node in arr)
+                if (fragments[i].Node is not JsonArray arr)
                 {
-                    if (node is not JsonObject obj) continue;
-                    if (!TryReadId(obj, entry.IdField, out string id)) continue;
+                    throw new InvalidOperationException(
+                        $"Config '{entry.RelativePath}' fragment '{fragments[i].SourceUri}' must be a JSON array for ArrayById merge.");
+                }
+
+                string src = fragments[i].SourceUri;
+                for (int itemIndex = 0; itemIndex < arr.Count; itemIndex++)
+                {
+                    JsonNode? node = arr[itemIndex];
+                    if (node is not JsonObject obj)
+                    {
+                        throw new InvalidOperationException(
+                            $"Config '{entry.RelativePath}' fragment '{src}' item[{itemIndex}] must be a JSON object.");
+                    }
+
+                    if (!TryReadId(obj, entry.IdField, out string id))
+                    {
+                        throw new InvalidOperationException(
+                            $"Config '{entry.RelativePath}' fragment '{src}' item[{itemIndex}] must define non-empty string field '{entry.IdField}'.");
+                    }
 
                     if (IsDeleted(obj))
                     {
                         mergedNodes.Remove(id);
-                        report.RecordDeleted(entry.RelativePath, id, src);
+                        report?.RecordDeleted(entry.RelativePath, id, src);
                         for (int oi = orderedIds.Count - 1; oi >= 0; oi--)
                         {
                             if (string.Equals(orderedIds[oi], id, StringComparison.Ordinal))
@@ -195,12 +160,12 @@ namespace Ludots.Core.Config
                     {
                         mergedNodes[id] = obj.DeepClone();
                         orderedIds.Add(id);
-                        report.RecordWinner(entry.RelativePath, id, src);
+                        report?.RecordWinner(entry.RelativePath, id, src);
                         continue;
                     }
 
                     MergeObject(existing, obj, entry.ArrayAppendFields);
-                    report.RecordWinner(entry.RelativePath, id, src);
+                    report?.RecordWinner(entry.RelativePath, id, src);
                 }
             }
 

--- a/src/Core/Config/ConfigPipeline.cs
+++ b/src/Core/Config/ConfigPipeline.cs
@@ -44,7 +44,8 @@ namespace Ludots.Core.Config
             options.Converters.Add(new JsonStringEnumConverter());
             
             var jsonString = merged.ToJsonString();
-            var config = JsonSerializer.Deserialize<GameConfig>(jsonString, options) ?? new GameConfig();
+            var config = JsonSerializer.Deserialize<GameConfig>(jsonString, options)
+                ?? throw new InvalidOperationException("Merged game.json deserialized to null GameConfig.");
             
             return config;
         }
@@ -107,19 +108,10 @@ namespace Ludots.Core.Config
             var fragments = new List<ConfigFragment>();
             LoadFromAllSources(relativePath, (stream, sourceUri) =>
             {
-                try
-                {
-                    var node = JsonNode.Parse(stream);
-                    if (node != null)
-                    {
-                        fragments.Add(new ConfigFragment(node, sourceUri));
-                        Log.Info(in LogChannels.Config, $"Merged fragment from: {sourceUri}");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(in LogChannels.Config, $"Error parsing JSON from {sourceUri}: {ex.Message}");
-                }
+                var node = JsonNode.Parse(stream)
+                    ?? throw new JsonException($"JSON root in {sourceUri} is null.");
+                fragments.Add(new ConfigFragment(node, sourceUri));
+                Log.Info(in LogChannels.Config, $"Merged fragment from: {sourceUri}");
             });
             return fragments;
         }
@@ -156,7 +148,14 @@ namespace Ludots.Core.Config
             var result = report != null
                 ? MergeFromCatalog(in deepEntry, report)
                 : MergeFromCatalog(in deepEntry);
-            return result as JsonObject;
+            if (result == null)
+            {
+                return null;
+            }
+
+            return result as JsonObject
+                ?? throw new InvalidOperationException(
+                    $"Config '{entry.RelativePath}' must merge to a JSON object for DeepObject policy.");
         }
 
         public static ConfigCatalogEntry RequireEntry(
@@ -204,9 +203,13 @@ namespace Ludots.Core.Config
             {
                 // Ignore missing files
             }
-            catch (Exception ex)
+            catch (InvalidDataException ex)
             {
-                Log.Error(in LogChannels.Config, $"Error loading {uri}: {ex.Message}");
+                throw new InvalidOperationException($"Error loading {uri}: {ex.Message}", ex);
+            }
+            catch (JsonException ex)
+            {
+                throw new JsonException($"Error parsing JSON from {uri}: {ex.Message}", ex);
             }
         }
     }

--- a/src/Core/Gameplay/AI/Config/AiConfigLoader.cs
+++ b/src/Core/Gameplay/AI/Config/AiConfigLoader.cs
@@ -69,9 +69,27 @@ namespace Ludots.Core.Gameplay.AI.Config
                         throw Fail($"AI/projection.json:{id}.Op", $"Unsupported projection op '{op}'.");
                     }
 
-                    int intKey = TryReadInt(obj, "IntKey", out int ik) ? ik : -1;
-                    int intValue = TryReadInt(obj, "IntValue", out int iv) ? iv : 0;
-                    int entityKey = TryReadInt(obj, "EntityKey", out int ek) ? ek : -1;
+                    int intKey = -1;
+                    int intValue = 0;
+                    int entityKey = -1;
+                    switch (pOp)
+                    {
+                        case WorldStateProjectionOp.IntEquals:
+                        case WorldStateProjectionOp.IntGreaterOrEqual:
+                        case WorldStateProjectionOp.IntLessOrEqual:
+                            intKey = RequireOrderBlackboardKey(obj, "IntKey", $"AI/projection.json:{id}.IntKey");
+                            intValue = RequireInt(obj, "IntValue", $"AI/projection.json:{id}");
+                            RejectProjectionField(obj, "EntityKey", $"AI/projection.json:{id}.EntityKey", op);
+                            break;
+                        case WorldStateProjectionOp.EntityIsNonNull:
+                        case WorldStateProjectionOp.EntityIsNull:
+                            entityKey = RequireOrderBlackboardKey(obj, "EntityKey", $"AI/projection.json:{id}.EntityKey");
+                            RejectProjectionField(obj, "IntKey", $"AI/projection.json:{id}.IntKey", op);
+                            RejectProjectionField(obj, "IntValue", $"AI/projection.json:{id}.IntValue", op);
+                            break;
+                        default:
+                            throw Fail($"AI/projection.json:{id}.Op", $"Unsupported projection op '{op}'.");
+                    }
 
                     tmp.Add(new WorldStateProjectionRule(atomId, pOp, intKey, intValue, entityKey));
                 }
@@ -1481,6 +1499,47 @@ namespace Ludots.Core.Gameplay.AI.Config
             }
 
             return value;
+        }
+
+        private static int RequireOrderBlackboardKey(JsonObject obj, string key, string path)
+        {
+            if (!obj.TryGetPropertyValue(key, out JsonNode? node) || node == null)
+            {
+                throw Fail(path, "Order blackboard key is required.");
+            }
+
+            if (node is JsonValue value)
+            {
+                if (value.TryGetValue<int>(out int numericId))
+                {
+                    throw Fail(path, $"Order blackboard key must be a semantic string, not numeric id {numericId}.");
+                }
+
+                if (value.TryGetValue<string>(out string? text) && !string.IsNullOrWhiteSpace(text))
+                {
+                    if (!string.Equals(text, text.Trim(), StringComparison.Ordinal))
+                    {
+                        throw Fail(path, "Order blackboard key must not contain leading or trailing whitespace.");
+                    }
+
+                    if (OrderBlackboardKeyRegistry.TryGetId(text, out int keyId))
+                    {
+                        return keyId;
+                    }
+
+                    throw Fail(path, $"References unknown order blackboard key '{text}'. Declare it in GAS/order_types.json orderBlackboardKeys or use a built-in key.");
+                }
+            }
+
+            throw Fail(path, "Order blackboard key must be a non-empty semantic string.");
+        }
+
+        private static void RejectProjectionField(JsonObject obj, string key, string path, string op)
+        {
+            if (obj.ContainsKey(key))
+            {
+                throw Fail(path, $"Field is not valid for projection op '{op}'.");
+            }
         }
 
         private static int RequireInt(JsonObject obj, string key, string path)

--- a/src/Core/Gameplay/AI/Planning/PlanExecutor.cs
+++ b/src/Core/Gameplay/AI/Planning/PlanExecutor.cs
@@ -14,8 +14,21 @@ namespace Ludots.Core.Gameplay.AI.Planning
             ref BlackboardIntBuffer ints,
             ref BlackboardEntityBuffer entities,
             int submitStep,
-            OrderQueue queue)
+            OrderQueue queue,
+            OrderTypeRegistry? orderTypeRegistry = null)
         {
+            if (spec.OrderTypeId <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"AI plan attempted to submit invalid order type id {spec.OrderTypeId}.");
+            }
+
+            if (orderTypeRegistry != null && !orderTypeRegistry.IsRegistered(spec.OrderTypeId))
+            {
+                throw new InvalidOperationException(
+                    $"AI plan attempted to submit unregistered order type id {spec.OrderTypeId}.");
+            }
+
             var order = new Order
             {
                 OrderTypeId = spec.OrderTypeId,

--- a/src/Core/Gameplay/AI/Systems/AIPlanExecutionSystem.cs
+++ b/src/Core/Gameplay/AI/Systems/AIPlanExecutionSystem.cs
@@ -14,22 +14,29 @@ namespace Ludots.Core.Gameplay.AI.Systems
         private readonly IClock _clock;
         private readonly ActionLibraryCompiled256 _library;
         private readonly OrderQueue _orders;
+        private readonly OrderTypeRegistry? _orderTypeRegistry;
 
         private static readonly QueryDescription _query = new QueryDescription()
             .WithAll<AIAgent, AIPlan32, OrderBuffer, BlackboardIntBuffer, BlackboardEntityBuffer>();
 
-        public AIPlanExecutionSystem(World world, IClock clock, ActionLibraryCompiled256 library, OrderQueue orders)
+        public AIPlanExecutionSystem(
+            World world,
+            IClock clock,
+            ActionLibraryCompiled256 library,
+            OrderQueue orders,
+            OrderTypeRegistry? orderTypeRegistry = null)
             : base(world)
         {
             _clock = clock;
             _library = library;
             _orders = orders;
+            _orderTypeRegistry = orderTypeRegistry;
         }
 
         public override void Update(in float dt)
         {
             int step = _clock.Now(ClockDomainId.Step);
-            var job = new ExecuteJob(_library, _orders, step);
+            var job = new ExecuteJob(_library, _orders, _orderTypeRegistry, step);
             World.InlineEntityQuery<ExecuteJob, AIAgent, AIPlan32, OrderBuffer, BlackboardIntBuffer, BlackboardEntityBuffer>(in _query, ref job);
         }
 
@@ -37,12 +44,14 @@ namespace Ludots.Core.Gameplay.AI.Systems
         {
             private readonly ActionLibraryCompiled256 _library;
             private readonly OrderQueue _orders;
+            private readonly OrderTypeRegistry? _orderTypeRegistry;
             private readonly int _step;
 
-            public ExecuteJob(ActionLibraryCompiled256 library, OrderQueue orders, int step)
+            public ExecuteJob(ActionLibraryCompiled256 library, OrderQueue orders, OrderTypeRegistry? orderTypeRegistry, int step)
             {
                 _library = library;
                 _orders = orders;
+                _orderTypeRegistry = orderTypeRegistry;
                 _step = step;
             }
 
@@ -77,7 +86,8 @@ namespace Ludots.Core.Gameplay.AI.Systems
                     ref ints,
                     ref entities,
                     _step,
-                    _orders);
+                    _orders,
+                    _orderTypeRegistry);
 
                 if (ok) plan.Advance();
             }

--- a/src/Core/Gameplay/GAS/Config/AbilityExecLoader.cs
+++ b/src/Core/Gameplay/GAS/Config/AbilityExecLoader.cs
@@ -21,6 +21,7 @@ namespace Ludots.Core.Gameplay.GAS.Config
     {
         private readonly ConfigPipeline _pipeline;
         private readonly AbilityDefinitionRegistry _registry;
+        private const int MaxToggleActiveEffects = 4;
 
         public AbilityExecLoader(ConfigPipeline pipeline, AbilityDefinitionRegistry registry)
         {
@@ -89,24 +90,39 @@ namespace Ludots.Core.Gameplay.GAS.Config
             var def = new AbilityDefinition();
 
             // ── exec block ──
-            if (obj["exec"] is JsonObject execObj)
+            if (obj["exec"] is not JsonObject execObj)
             {
-                def.ExecSpec = CompileExecSpec(execObj, id, path);
-                CompileCallerParamsPool(execObj, id, path, out var pool, out bool hasPool);
-                def.ExecCallerParamsPool = pool;
-                def.HasExecCallerParamsPool = hasPool;
+                throw new InvalidOperationException(
+                    $"Ability '{id}' field 'exec' is required in '{path}'.");
             }
+
+            def.ExecSpec = CompileExecSpec(execObj, id, path);
+            CompileCallerParamsPool(execObj, id, path, out var pool, out bool hasPool);
+            def.ExecCallerParamsPool = pool;
+            def.HasExecCallerParamsPool = hasPool;
 
             // ── onActivateEffects ──
             if (obj["onActivateEffects"] is JsonArray effectArr)
             {
                 var onActivate = default(AbilityOnActivateEffects);
-                foreach (var item in effectArr)
+                for (int effectIndex = 0; effectIndex < effectArr.Count; effectIndex++)
                 {
+                    var item = effectArr[effectIndex];
                     string effectName = item?.GetValue<string>();
-                    if (string.IsNullOrWhiteSpace(effectName)) continue;
+                    if (string.IsNullOrWhiteSpace(effectName))
+                    {
+                        throw new InvalidOperationException(
+                            $"Ability '{id}' field 'onActivateEffects[{effectIndex}]' in '{path}' must be a non-empty effect template key.");
+                    }
+
                     int tid = EffectTemplateIdRegistry.GetId(effectName);
-                    if (tid > 0) onActivate.Add(tid);
+                    if (tid <= 0)
+                    {
+                        throw new InvalidOperationException(
+                            $"Ability '{id}' field 'onActivateEffects[{effectIndex}]' in '{path}' references unknown effect template '{effectName}'.");
+                    }
+
+                    onActivate.Add(tid);
                 }
                 def.HasOnActivateEffects = onActivate.Count > 0;
                 def.OnActivateEffects = onActivate;
@@ -124,18 +140,18 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 var blockTags = default(AbilityActivationBlockTags);
                 if (blockObj["requiredAll"] is JsonArray reqArr)
                 {
-                    foreach (var t in reqArr)
+                    for (int tagIndex = 0; tagIndex < reqArr.Count; tagIndex++)
                     {
-                        string tag = t?.GetValue<string>();
-                        if (!string.IsNullOrWhiteSpace(tag)) blockTags.RequiredAll.AddTag(TagRegistry.Register(tag));
+                        string tag = RequireString(reqArr[tagIndex], id, path, $"blockTags.requiredAll[{tagIndex}]");
+                        blockTags.RequiredAll.AddTag(TagRegistry.Register(tag));
                     }
                 }
                 if (blockObj["blockedAny"] is JsonArray blkArr)
                 {
-                    foreach (var t in blkArr)
+                    for (int tagIndex = 0; tagIndex < blkArr.Count; tagIndex++)
                     {
-                        string tag = t?.GetValue<string>();
-                        if (!string.IsNullOrWhiteSpace(tag)) blockTags.BlockedAny.AddTag(TagRegistry.Register(tag));
+                        string tag = RequireString(blkArr[tagIndex], id, path, $"blockTags.blockedAny[{tagIndex}]");
+                        blockTags.BlockedAny.AddTag(TagRegistry.Register(tag));
                     }
                 }
                 def.HasActivationBlockTags = true;
@@ -164,7 +180,7 @@ namespace Ludots.Core.Gameplay.GAS.Config
 
             if (obj["presentation"] is JsonObject presentationObj)
             {
-                def.Presentation = CompilePresentation(presentationObj);
+                def.Presentation = CompilePresentation(presentationObj, id, path);
                 def.HasPresentation = def.Presentation != null;
             }
 
@@ -207,28 +223,38 @@ namespace Ludots.Core.Gameplay.GAS.Config
             var spec = default(AbilityExecSpec);
 
             // clockId
-            string clockStr = execObj["clockId"]?.GetValue<string>() ?? "Step";
+            string clockStr = RequireString(execObj, "clockId", id, path, "exec.clockId");
             spec.ClockId = ParseClockId(clockStr);
 
             // interruptAny
             if (execObj["interruptAny"] is JsonArray intArr)
             {
-                foreach (var t in intArr)
+                for (int tagIndex = 0; tagIndex < intArr.Count; tagIndex++)
                 {
-                    string tag = t?.GetValue<string>();
-                    if (!string.IsNullOrWhiteSpace(tag)) spec.InterruptAny.AddTag(TagRegistry.Register(tag));
+                    string tag = RequireString(intArr[tagIndex], id, path, $"exec.interruptAny[{tagIndex}]");
+                    spec.InterruptAny.AddTag(TagRegistry.Register(tag));
                 }
             }
 
             // items
             if (execObj["items"] is JsonArray itemsArr)
             {
-                int idx = 0;
-                foreach (var itemNode in itemsArr)
+                if (itemsArr.Count > AbilityExecSpec.MAX_ITEMS)
                 {
-                    if (idx >= AbilityExecSpec.MAX_ITEMS) break;
-                    if (itemNode is not JsonObject itemObj) continue;
-                    CompileItem(itemObj, ref spec, idx, id, path);
+                    throw new InvalidOperationException(
+                        $"Ability '{id}' field 'exec.items' in '{path}' contains {itemsArr.Count} items, max {AbilityExecSpec.MAX_ITEMS}.");
+                }
+
+                int idx = 0;
+                for (int sourceIndex = 0; sourceIndex < itemsArr.Count; sourceIndex++)
+                {
+                    if (itemsArr[sourceIndex] is not JsonObject itemObj)
+                    {
+                        throw new InvalidOperationException(
+                            $"Ability '{id}' field 'exec.items[{sourceIndex}]' in '{path}' must be an object.");
+                    }
+
+                    CompileItem(itemObj, ref spec, idx, sourceIndex, id, path);
                     idx++;
                 }
             }
@@ -294,12 +320,13 @@ namespace Ludots.Core.Gameplay.GAS.Config
             return cooldown;
         }
 
-        private static void CompileItem(JsonObject itemObj, ref AbilityExecSpec spec, int idx, string id, string path)
+        private static void CompileItem(JsonObject itemObj, ref AbilityExecSpec spec, int idx, int sourceIndex, string id, string path)
         {
-            string kindStr = itemObj["kind"]?.GetValue<string>() ?? "None";
+            string itemPath = $"exec.items[{sourceIndex}]";
+            string kindStr = RequireString(itemObj, "kind", id, path, $"{itemPath}.kind");
             var kind = ParseItemKind(kindStr);
-            int tick = itemObj["tick"]?.GetValue<int>() ?? 0;
-            int durationTicks = itemObj["duration"]?.GetValue<int>() ?? 0;
+            int tick = RequireInt(itemObj, "tick", id, path, $"{itemPath}.tick");
+            int durationTicks = TryGetInt(itemObj, "duration", out int durationValue) ? durationValue : 0;
 
             GasClockId clockId = default;
             string clockStr = itemObj["clock"]?.GetValue<string>();
@@ -327,7 +354,8 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 callerParamsIdx = (byte)cpNode.GetValue<int>();
             }
 
-            int payloadA = itemObj["payloadA"]?.GetValue<int>() ?? 0;
+            int payloadA = TryGetInt(itemObj, "payloadA", out int payloadValue) ? payloadValue : 0;
+            bool hasPayloadA = itemObj["payloadA"] is JsonNode;
 
             if ((kind == ExecItemKind.EffectClip || kind == ExecItemKind.EffectSignal) &&
                 itemObj["dispatchTarget"] is JsonValue dispatchTargetNode)
@@ -339,14 +367,73 @@ namespace Ludots.Core.Gameplay.GAS.Config
             // For GraphSignal, "graph" field maps to payloadA via GraphIdRegistry
             if (kind == ExecItemKind.GraphSignal)
             {
-                string graphName = itemObj["graph"]?.GetValue<string>();
-                if (!string.IsNullOrWhiteSpace(graphName))
+                string graphName = RequireString(itemObj, "graph", id, path, $"{itemPath}.graph");
+                payloadA = GraphIdRegistry.GetId(graphName);
+                if (payloadA <= 0)
                 {
-                    payloadA = Ludots.Core.NodeLibraries.GASGraph.Host.GraphIdRegistry.Register(graphName);
+                    throw new InvalidOperationException(
+                        $"Ability '{id}' field '{itemPath}.graph' in '{path}' references unknown graph '{graphName}'.");
                 }
             }
 
+            ValidateItemFields(kind, templateId, tagId, durationTicks, hasPayloadA, id, path, itemPath);
+
             spec.SetItem(idx, kind, tick, durationTicks, clockId, tagId, templateId, callerParamsIdx, payloadA);
+        }
+
+        private static void ValidateItemFields(
+            ExecItemKind kind,
+            int templateId,
+            int tagId,
+            int durationTicks,
+            bool hasPayloadA,
+            string id,
+            string path,
+            string itemPath)
+        {
+            switch (kind)
+            {
+                case ExecItemKind.EffectClip:
+                    if (templateId <= 0) throw RequiredItemField(id, path, itemPath, "template", kind);
+                    if (durationTicks <= 0) throw RequiredItemField(id, path, itemPath, "duration", kind);
+                    break;
+                case ExecItemKind.TagClip:
+                case ExecItemKind.TagClipTarget:
+                    if (tagId <= 0) throw RequiredItemField(id, path, itemPath, "tag", kind);
+                    if (durationTicks <= 0) throw RequiredItemField(id, path, itemPath, "duration", kind);
+                    break;
+                case ExecItemKind.EffectSignal:
+                    if (templateId <= 0) throw RequiredItemField(id, path, itemPath, "template", kind);
+                    break;
+                case ExecItemKind.EventSignal:
+                case ExecItemKind.TagSignal:
+                case ExecItemKind.TagSignalTarget:
+                    if (tagId <= 0) throw RequiredItemField(id, path, itemPath, "tag", kind);
+                    break;
+                case ExecItemKind.InputGate:
+                case ExecItemKind.SelectionGate:
+                    if (tagId <= 0) throw RequiredItemField(id, path, itemPath, "tag", kind);
+                    if (!hasPayloadA) throw RequiredItemField(id, path, itemPath, "payloadA", kind);
+                    break;
+                case ExecItemKind.EventGate:
+                    if (tagId <= 0 && !hasPayloadA)
+                    {
+                        throw new InvalidOperationException(
+                            $"Ability '{id}' field '{itemPath}' in '{path}' requires either 'tag' or 'payloadA' for item kind '{kind}'.");
+                    }
+                    break;
+            }
+        }
+
+        private static InvalidOperationException RequiredItemField(
+            string id,
+            string path,
+            string itemPath,
+            string fieldName,
+            ExecItemKind kind)
+        {
+            return new InvalidOperationException(
+                $"Ability '{id}' field '{itemPath}.{fieldName}' in '{path}' is required for item kind '{kind}'.");
         }
 
         private static ExecEffectDispatchTarget ParseExecEffectDispatchTarget(string rawValue, string abilityId, int itemIndex, string path)
@@ -371,28 +458,49 @@ namespace Ludots.Core.Gameplay.GAS.Config
 
             if (execObj["callerParams"] is not JsonArray paramsArr) return;
 
-            foreach (var setNode in paramsArr)
+            for (int setIndex = 0; setIndex < paramsArr.Count; setIndex++)
             {
-                if (setNode is not JsonObject setObj) continue;
+                if (paramsArr[setIndex] is not JsonObject setObj)
+                {
+                    throw new InvalidOperationException(
+                        $"Ability '{id}' field 'exec.callerParams[{setIndex}]' in '{path}' must be an object.");
+                }
+
                 var cp = default(EffectConfigParams);
 
-                if (setObj["entries"] is JsonArray entriesArr)
+                if (setObj["entries"] is not JsonArray entriesArr)
                 {
-                    foreach (var entryNode in entriesArr)
-                    {
-                        if (entryNode is not JsonObject entryObj) continue;
-                        string key = entryObj["key"]?.GetValue<string>();
-                        if (string.IsNullOrWhiteSpace(key)) continue;
-                        int keyId = ConfigKeyRegistry.Register(key);
+                    throw new InvalidOperationException(
+                        $"Ability '{id}' field 'exec.callerParams[{setIndex}].entries' in '{path}' must be a non-empty array.");
+                }
 
-                        if (entryObj["value"] is JsonNode valNode)
-                        {
-                            float val = valNode.GetValue<JsonElement>().ValueKind == JsonValueKind.Number
-                                ? valNode.GetValue<float>()
-                                : float.Parse(valNode.GetValue<string>(), CultureInfo.InvariantCulture);
-                            cp.TryAddFloat(keyId, val);
-                        }
+                if (entriesArr.Count == 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Ability '{id}' field 'exec.callerParams[{setIndex}].entries' in '{path}' must be a non-empty array.");
+                }
+
+                for (int entryIndex = 0; entryIndex < entriesArr.Count; entryIndex++)
+                {
+                    if (entriesArr[entryIndex] is not JsonObject entryObj)
+                    {
+                        throw new InvalidOperationException(
+                            $"Ability '{id}' field 'exec.callerParams[{setIndex}].entries[{entryIndex}]' in '{path}' must be an object.");
                     }
+
+                    string key = RequireString(entryObj, "key", id, path, $"exec.callerParams[{setIndex}].entries[{entryIndex}].key");
+                    int keyId = ConfigKeyRegistry.Register(key);
+
+                    if (entryObj["value"] is not JsonNode valNode)
+                    {
+                        throw new InvalidOperationException(
+                            $"Ability '{id}' field 'exec.callerParams[{setIndex}].entries[{entryIndex}].value' is required in '{path}'.");
+                    }
+
+                    float val = valNode.GetValue<JsonElement>().ValueKind == JsonValueKind.Number
+                        ? valNode.GetValue<float>()
+                        : float.Parse(valNode.GetValue<string>(), CultureInfo.InvariantCulture);
+                    cp.TryAddFloat(keyId, val);
                 }
 
                 if (!pool.TryAdd(in cp))
@@ -423,19 +531,16 @@ namespace Ludots.Core.Gameplay.GAS.Config
 
             if (toggleObj["activeEffects"] is JsonArray activeEffects)
             {
-                int activeCount = 0;
-                foreach (var effectNode in activeEffects)
+                if (activeEffects.Count > MaxToggleActiveEffects)
                 {
-                    if (activeCount >= 4)
-                    {
-                        break;
-                    }
+                    throw new InvalidOperationException(
+                        $"Ability '{id}' field 'toggleSpec.activeEffects' in '{path}' contains {activeEffects.Count} effects, max {MaxToggleActiveEffects}.");
+                }
 
-                    string effectId = effectNode?.GetValue<string>() ?? string.Empty;
-                    if (string.IsNullOrWhiteSpace(effectId))
-                    {
-                        continue;
-                    }
+                int activeCount = 0;
+                for (int effectIndex = 0; effectIndex < activeEffects.Count; effectIndex++)
+                {
+                    string effectId = RequireString(activeEffects[effectIndex], id, path, $"toggleSpec.activeEffects[{effectIndex}]");
 
                     int templateId = EffectTemplateIdRegistry.GetId(effectId);
                     if (templateId <= 0)
@@ -465,18 +570,46 @@ namespace Ludots.Core.Gameplay.GAS.Config
 
         private static AbilityIndicatorConfig CompileIndicator(JsonObject indicatorObj, string id, string path)
         {
-            string shapeValue = indicatorObj["shape"]?.GetValue<string>() ?? "Circle";
+            string shapeValue = RequireString(indicatorObj, "shape", id, path, "indicator.shape");
+            TargetShape shape = ParseTargetShape(shapeValue, id, path);
+            bool showRangeCircle = RequireBool(indicatorObj, "showRangeCircle", id, path, "indicator.showRangeCircle");
+            if (!showRangeCircle)
+            {
+                RequireAbsent(indicatorObj, "rangeCircleColor", id, path, "indicator.rangeCircleColor");
+            }
+
+            bool requiresRange = showRangeCircle || ShapeRequiresRange(shape);
+            bool requiresRadius = ShapeRequiresRadius(shape);
+            float range = requiresRange
+                ? RequirePositiveFloat(indicatorObj, "range", id, path, "indicator.range")
+                : ReadOptionalPositiveFloat(indicatorObj, "range", id, path, "indicator.range");
+            float radius = requiresRadius
+                ? RequirePositiveFloat(indicatorObj, "radius", id, path, "indicator.radius")
+                : ReadOptionalPositiveFloat(indicatorObj, "radius", id, path, "indicator.radius");
+            float innerRadius = TryGetFloat(indicatorObj, "innerRadius", out float innerRadiusValue) ? innerRadiusValue : 0f;
+            float angle = TryGetFloat(indicatorObj, "angle", out float angleValue) ? angleValue : 0f;
+
             var indicator = new AbilityIndicatorConfig
             {
-                Shape = ParseTargetShape(shapeValue, id, path),
-                Range = indicatorObj["range"]?.GetValue<float>() ?? 0f,
-                Radius = indicatorObj["radius"]?.GetValue<float>() ?? 0f,
-                InnerRadius = indicatorObj["innerRadius"]?.GetValue<float>() ?? 0f,
-                Angle = indicatorObj["angle"]?.GetValue<float>() ?? 0f,
-                ValidColor = ParseColor(indicatorObj["validColor"], new System.Numerics.Vector4(0.20f, 0.85f, 0.45f, 0.35f)),
-                InvalidColor = ParseColor(indicatorObj["invalidColor"], new System.Numerics.Vector4(0.95f, 0.30f, 0.25f, 0.35f)),
-                RangeCircleColor = ParseColor(indicatorObj["rangeCircleColor"], new System.Numerics.Vector4(0.25f, 0.55f, 0.95f, 0.18f)),
-                ShowRangeCircle = indicatorObj["showRangeCircle"]?.GetValue<bool>() ?? false
+                Shape = shape,
+                Range = range,
+                Radius = radius,
+                InnerRadius = innerRadius,
+                Angle = angle,
+                ValidColor = ParseColor(
+                    indicatorObj["validColor"],
+                    new System.Numerics.Vector4(0.20f, 0.85f, 0.45f, 0.35f),
+                    id,
+                    path,
+                    "indicator.validColor"),
+                InvalidColor = ParseColor(
+                    indicatorObj["invalidColor"],
+                    new System.Numerics.Vector4(0.95f, 0.30f, 0.25f, 0.35f),
+                    id,
+                    path,
+                    "indicator.invalidColor"),
+                RangeCircleColor = showRangeCircle ? ParseColor(indicatorObj["rangeCircleColor"], id, path, "indicator.rangeCircleColor") : default,
+                ShowRangeCircle = showRangeCircle
             };
 
             if (indicatorObj["preview"] is JsonObject previewObj)
@@ -496,10 +629,54 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 indicator.Angle = MathF.PI * angleDegNode.GetValue<float>() / 180f;
             }
 
+            ValidateIndicatorShapeSemantics(indicator, id, path);
             return indicator;
         }
 
-        private static AbilityPresentationConfig? CompilePresentation(JsonObject presentationObj)
+        private static void ValidateIndicatorShapeSemantics(AbilityIndicatorConfig indicator, string id, string path)
+        {
+            if (indicator.Shape == TargetShape.Single && indicator.Radius > 0f)
+            {
+                throw new InvalidOperationException(
+                    $"Ability '{id}' field 'indicator.radius' in '{path}' is not valid for shape 'Single'.");
+            }
+
+            if (indicator.InnerRadius < 0f)
+            {
+                throw new InvalidOperationException(
+                    $"Ability '{id}' field 'indicator.innerRadius' in '{path}' must be non-negative.");
+            }
+
+            if (indicator.Shape == TargetShape.Ring && indicator.InnerRadius <= 0f)
+            {
+                throw new InvalidOperationException(
+                    $"Ability '{id}' field 'indicator.innerRadius' in '{path}' is required and must be > 0 for shape 'Ring'.");
+            }
+
+            if (indicator.Shape == TargetShape.Ring && indicator.InnerRadius >= indicator.Radius)
+            {
+                throw new InvalidOperationException(
+                    $"Ability '{id}' field 'indicator.innerRadius' in '{path}' must be less than indicator.radius for shape 'Ring'.");
+            }
+
+            if (indicator.Shape == TargetShape.Cone && indicator.Angle <= 0f)
+            {
+                throw new InvalidOperationException(
+                    $"Ability '{id}' field 'indicator.angleDeg' in '{path}' is required for shape 'Cone'.");
+            }
+        }
+
+        private static bool ShapeRequiresRange(TargetShape shape)
+        {
+            return shape is TargetShape.Cone or TargetShape.Line or TargetShape.Rectangle;
+        }
+
+        private static bool ShapeRequiresRadius(TargetShape shape)
+        {
+            return shape is TargetShape.Circle or TargetShape.Cone or TargetShape.Line or TargetShape.Ring or TargetShape.Rectangle;
+        }
+
+        private static AbilityPresentationConfig? CompilePresentation(JsonObject presentationObj, string id, string path)
         {
             var displayName = presentationObj["displayName"]?.GetValue<string>() ?? string.Empty;
             var iconGlyph = presentationObj["iconGlyph"]?.GetValue<string>() ?? string.Empty;
@@ -528,16 +705,9 @@ namespace Ludots.Core.Gameplay.GAS.Config
             {
                 foreach ((string? modeKey, JsonNode? valueNode) in modeIconGlyphs)
                 {
-                    if (string.IsNullOrWhiteSpace(modeKey) || valueNode == null)
-                    {
-                        continue;
-                    }
-
-                    string glyph = valueNode.GetValue<string>();
-                    if (!string.IsNullOrWhiteSpace(glyph))
-                    {
-                        config.ModeIconGlyphOverrides[modeKey] = glyph;
-                    }
+                    string canonicalModeKey = RequireInteractionModeKey(modeKey, id, path, "presentation.modeIconGlyphs");
+                    string glyph = RequireString(valueNode, id, path, $"presentation.modeIconGlyphs.{canonicalModeKey}");
+                    config.ModeIconGlyphOverrides[canonicalModeKey] = glyph;
                 }
             }
 
@@ -545,16 +715,9 @@ namespace Ludots.Core.Gameplay.GAS.Config
             {
                 foreach ((string? modeKey, JsonNode? valueNode) in modeHints)
                 {
-                    if (string.IsNullOrWhiteSpace(modeKey) || valueNode == null)
-                    {
-                        continue;
-                    }
-
-                    string hint = valueNode.GetValue<string>();
-                    if (!string.IsNullOrWhiteSpace(hint))
-                    {
-                        config.ModeHintOverrides[modeKey] = hint;
-                    }
+                    string canonicalModeKey = RequireInteractionModeKey(modeKey, id, path, "presentation.modeHints");
+                    string hint = RequireString(valueNode, id, path, $"presentation.modeHints.{canonicalModeKey}");
+                    config.ModeHintOverrides[canonicalModeKey] = hint;
                 }
             }
 
@@ -653,21 +816,39 @@ namespace Ludots.Core.Gameplay.GAS.Config
             };
         }
 
-        private static System.Numerics.Vector4 ParseColor(JsonNode? node, System.Numerics.Vector4 fallback)
+        private static System.Numerics.Vector4 ParseColor(
+            JsonNode? node,
+            System.Numerics.Vector4 defaultValue,
+            string id,
+            string path,
+            string fieldPath)
+        {
+            return node is null
+                ? defaultValue
+                : ParseColor(node, id, path, fieldPath);
+        }
+
+        private static System.Numerics.Vector4 ParseColor(JsonNode? node, string id, string path, string fieldPath)
         {
             if (node is JsonArray arr)
             {
-                float r = arr.Count > 0 ? arr[0]?.GetValue<float>() ?? fallback.X : fallback.X;
-                float g = arr.Count > 1 ? arr[1]?.GetValue<float>() ?? fallback.Y : fallback.Y;
-                float b = arr.Count > 2 ? arr[2]?.GetValue<float>() ?? fallback.Z : fallback.Z;
-                float a = arr.Count > 3 ? arr[3]?.GetValue<float>() ?? fallback.W : fallback.W;
+                if (arr.Count != 4)
+                {
+                    throw new InvalidOperationException(
+                        $"Ability '{id}' field '{fieldPath}' in '{path}' must contain exactly four numeric components.");
+                }
+
+                float r = arr[0]?.GetValue<float>() ?? throw RequiredField(id, path, $"{fieldPath}[0]");
+                float g = arr[1]?.GetValue<float>() ?? throw RequiredField(id, path, $"{fieldPath}[1]");
+                float b = arr[2]?.GetValue<float>() ?? throw RequiredField(id, path, $"{fieldPath}[2]");
+                float a = arr[3]?.GetValue<float>() ?? throw RequiredField(id, path, $"{fieldPath}[3]");
                 return new System.Numerics.Vector4(r, g, b, a);
             }
 
             string? hex = node?.GetValue<string>();
             if (string.IsNullOrWhiteSpace(hex))
             {
-                return fallback;
+                throw RequiredField(id, path, fieldPath);
             }
 
             hex = hex.Trim();
@@ -678,15 +859,20 @@ namespace Ludots.Core.Gameplay.GAS.Config
 
             if (hex.Length != 6 && hex.Length != 8)
             {
-                return fallback;
+                throw new InvalidOperationException(
+                    $"Ability '{id}' field '{fieldPath}' in '{path}' must be #RRGGBB or #RRGGBBAA.");
             }
 
-            byte rByte = byte.Parse(hex.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-            byte gByte = byte.Parse(hex.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-            byte bByte = byte.Parse(hex.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-            byte aByte = hex.Length == 8
-                ? byte.Parse(hex.Substring(6, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture)
-                : (byte)255;
+            if (!byte.TryParse(hex.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte rByte) ||
+                !byte.TryParse(hex.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte gByte) ||
+                !byte.TryParse(hex.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte bByte) ||
+                (hex.Length == 8 && !byte.TryParse(hex.Substring(6, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out _)))
+            {
+                throw new InvalidOperationException(
+                    $"Ability '{id}' field '{fieldPath}' in '{path}' contains invalid hex color '{node.GetValue<string>()}'.");
+            }
+
+            byte aByte = hex.Length == 8 ? byte.Parse(hex.Substring(6, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture) : (byte)255;
 
             return new System.Numerics.Vector4(
                 rByte / 255f,
@@ -727,6 +913,167 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 _ => throw new InvalidOperationException($"Unknown ExecItemKind '{str}'. Valid values: EffectClip, TagClip, TagClipTarget, EffectSignal, EventSignal, GraphSignal, TagSignal, TagSignalTarget, InputGate, EventGate, SelectionGate, End."),
             };
         }
+
+        private static string RequireString(JsonObject obj, string propertyName, string abilityId, string path, string fieldPath)
+        {
+            if (obj[propertyName] is not JsonNode node)
+            {
+                throw RequiredField(abilityId, path, fieldPath);
+            }
+
+            string value = node.GetValue<string>();
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw RequiredField(abilityId, path, fieldPath);
+            }
+
+            return value;
+        }
+
+        private static string RequireString(JsonNode? node, string abilityId, string path, string fieldPath)
+        {
+            if (node is not JsonValue valueNode ||
+                !valueNode.TryGetValue<string>(out string? value) ||
+                string.IsNullOrWhiteSpace(value))
+            {
+                throw new InvalidOperationException(
+                    $"Ability '{abilityId}' field '{fieldPath}' in '{path}' must be a non-empty string.");
+            }
+
+            return value;
+        }
+
+        private static string RequireInteractionModeKey(string? modeKey, string abilityId, string path, string fieldPath)
+        {
+            if (string.IsNullOrWhiteSpace(modeKey))
+            {
+                throw new InvalidOperationException(
+                    $"Ability '{abilityId}' field '{fieldPath}' in '{path}' must use non-empty interaction mode keys.");
+            }
+
+            if (!string.Equals(modeKey, modeKey.Trim(), StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Ability '{abilityId}' field '{fieldPath}.{modeKey}' in '{path}' must not contain leading or trailing whitespace.");
+            }
+
+            if (!Enum.TryParse(modeKey, ignoreCase: true, out InteractionModeType mode) ||
+                !Enum.IsDefined(typeof(InteractionModeType), mode))
+            {
+                throw new InvalidOperationException(
+                    $"Ability '{abilityId}' field '{fieldPath}.{modeKey}' in '{path}' references unknown interaction mode '{modeKey}'.");
+            }
+
+            return mode.ToString();
+        }
+
+        private static int RequireInt(JsonObject obj, string propertyName, string abilityId, string path, string fieldPath)
+        {
+            if (!TryGetInt(obj, propertyName, out int value))
+            {
+                throw RequiredField(abilityId, path, fieldPath);
+            }
+
+            return value;
+        }
+
+        private static bool TryGetInt(JsonObject obj, string propertyName, out int value)
+        {
+            value = 0;
+            if (obj[propertyName] is not JsonNode node)
+            {
+                return false;
+            }
+
+            value = node.GetValue<int>();
+            return true;
+        }
+
+        private static float RequireFloat(JsonObject obj, string propertyName, string abilityId, string path, string fieldPath)
+        {
+            if (!TryGetFloat(obj, propertyName, out float value))
+            {
+                throw RequiredField(abilityId, path, fieldPath);
+            }
+
+            return value;
+        }
+
+        private static float RequirePositiveFloat(JsonObject obj, string propertyName, string abilityId, string path, string fieldPath)
+        {
+            float value = RequireFloat(obj, propertyName, abilityId, path, fieldPath);
+            if (value <= 0f)
+            {
+                throw new InvalidOperationException(
+                    $"Ability '{abilityId}' field '{fieldPath}' in '{path}' must be > 0.");
+            }
+
+            return value;
+        }
+
+        private static float ReadOptionalPositiveFloat(JsonObject obj, string propertyName, string abilityId, string path, string fieldPath)
+        {
+            if (!TryGetFloat(obj, propertyName, out float value))
+            {
+                return 0f;
+            }
+
+            if (value <= 0f)
+            {
+                throw new InvalidOperationException(
+                    $"Ability '{abilityId}' field '{fieldPath}' in '{path}' must be omitted or > 0.");
+            }
+
+            return value;
+        }
+
+        private static bool TryGetFloat(JsonObject obj, string propertyName, out float value)
+        {
+            value = 0f;
+            if (obj[propertyName] is not JsonNode node)
+            {
+                return false;
+            }
+
+            value = node.GetValue<float>();
+            return true;
+        }
+
+        private static bool RequireBool(JsonObject obj, string propertyName, string abilityId, string path, string fieldPath)
+        {
+            if (obj[propertyName] is not JsonNode node)
+            {
+                throw RequiredField(abilityId, path, fieldPath);
+            }
+
+            return node.GetValue<bool>();
+        }
+
+        private static bool TryGetBool(JsonObject obj, string propertyName, out bool value)
+        {
+            value = false;
+            if (obj[propertyName] is not JsonNode node)
+            {
+                return false;
+            }
+
+            value = node.GetValue<bool>();
+            return true;
+        }
+
+        private static void RequireAbsent(JsonObject obj, string propertyName, string abilityId, string path, string fieldPath)
+        {
+            if (obj[propertyName] is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Ability '{abilityId}' field '{fieldPath}' in '{path}' is only valid when indicator.showRangeCircle is true.");
+            }
+        }
+
+        private static InvalidOperationException RequiredField(string abilityId, string path, string fieldPath)
+        {
+            return new InvalidOperationException(
+                $"Ability '{abilityId}' field '{fieldPath}' is required in '{path}'.");
+        }
     }
 }
-

--- a/src/Core/Gameplay/GAS/Config/AbilityFormSetConfigLoader.cs
+++ b/src/Core/Gameplay/GAS/Config/AbilityFormSetConfigLoader.cs
@@ -48,12 +48,12 @@ namespace Ludots.Core.Gameplay.GAS.Config
             {
                 if (routesNode[routeIndex] is not JsonObject routeNode)
                 {
-                    continue;
+                    throw new InvalidOperationException($"Ability form set '{formSetName}' route[{routeIndex}] must be an object.");
                 }
 
-                var requiredAll = CompileTagMask(routeNode["requiredAll"] as JsonArray);
-                var blockedAny = CompileTagMask(routeNode["blockedAny"] as JsonArray);
-                int priority = routeNode["priority"]?.GetValue<int>() ?? 0;
+                var requiredAll = CompileTagMask(routeNode["requiredAll"] as JsonArray, formSetName, routeIndex, "requiredAll");
+                var blockedAny = CompileTagMask(routeNode["blockedAny"] as JsonArray, formSetName, routeIndex, "blockedAny");
+                int priority = RequireInt(routeNode, "priority", formSetName, routeIndex);
 
                 if (routeNode["slotOverrides"] is not JsonArray slotOverridesNode || slotOverridesNode.Count == 0)
                 {
@@ -68,7 +68,7 @@ namespace Ludots.Core.Gameplay.GAS.Config
             return new AbilityFormSetDefinition(routes.ToArray());
         }
 
-        private static GameplayTagContainer CompileTagMask(JsonArray? tagsNode)
+        private static GameplayTagContainer CompileTagMask(JsonArray? tagsNode, string formSetName, int routeIndex, string fieldName)
         {
             var tags = default(GameplayTagContainer);
             if (tagsNode == null)
@@ -81,13 +81,24 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 string? tagName = tagsNode[i]?.GetValue<string>();
                 if (string.IsNullOrWhiteSpace(tagName))
                 {
-                    continue;
+                    throw new InvalidOperationException(
+                        $"Ability form set '{formSetName}' route[{routeIndex}] {fieldName}[{i}] must be a non-empty tag string.");
                 }
 
                 tags.AddTag(TagRegistry.Register(tagName));
             }
 
             return tags;
+        }
+
+        private static int RequireInt(JsonObject obj, string fieldName, string formSetName, int routeIndex)
+        {
+            if (obj[fieldName] is not JsonNode node)
+            {
+                throw new InvalidOperationException($"Ability form set '{formSetName}' route[{routeIndex}] requires {fieldName}.");
+            }
+
+            return node.GetValue<int>();
         }
 
         private static AbilityFormSlotOverride[] CompileSlotOverrides(JsonArray slotOverridesNode, string formSetName, int routeIndex)
@@ -99,7 +110,8 @@ namespace Ludots.Core.Gameplay.GAS.Config
             {
                 if (slotOverridesNode[slotOverrideIndex] is not JsonObject slotOverrideNode)
                 {
-                    continue;
+                    throw new InvalidOperationException(
+                        $"Ability form set '{formSetName}' route[{routeIndex}] slotOverrides[{slotOverrideIndex}] must be an object.");
                 }
 
                 if (slotOverrideNode["slotIndex"] is not JsonNode slotIndexNode)

--- a/src/Core/Gameplay/GAS/Config/AttributeConstraintsLoader.cs
+++ b/src/Core/Gameplay/GAS/Config/AttributeConstraintsLoader.cs
@@ -12,7 +12,7 @@ namespace Ludots.Core.Gameplay.GAS.Config
 
         public AttributeConstraintsLoader(ConfigPipeline pipeline)
         {
-            _pipeline = pipeline;
+            _pipeline = pipeline ?? throw new ArgumentNullException(nameof(pipeline));
         }
 
         public void Load(
@@ -20,17 +20,26 @@ namespace Ludots.Core.Gameplay.GAS.Config
             ConfigConflictReport report = null,
             string relativePath = "GAS/attribute_constraints.json")
         {
-            if (_pipeline == null) return;
-
             var entry = ConfigPipeline.RequireEntry(catalog, relativePath, ConfigMergePolicy.DeepObject);
             var mergedObject = _pipeline.MergeDeepObjectFromCatalog(in entry, report);
-            if (mergedObject == null) return;
+            if (mergedObject == null)
+            {
+                throw new InvalidOperationException($"Missing required config '{relativePath}'.");
+            }
 
             foreach (var kvp in mergedObject)
             {
-                if (string.IsNullOrWhiteSpace(kvp.Key) || kvp.Value is not JsonObject obj) continue;
+                if (string.IsNullOrWhiteSpace(kvp.Key))
+                {
+                    throw new InvalidOperationException($"Config '{relativePath}' contains an empty attribute constraint key.");
+                }
 
-                bool clampToBase = GetBool(obj, "clampToBase", defaultValue: false);
+                if (kvp.Value is not JsonObject obj)
+                {
+                    throw new InvalidOperationException($"Config '{relativePath}' attribute constraint '{kvp.Key}' must be an object.");
+                }
+
+                bool clampToBase = GetBool(obj, "clampToBase", attributeName: kvp.Key, relativePath);
                 bool hasMin = TryGetFloat(obj, "min", out var min);
                 bool hasMax = TryGetFloat(obj, "max", out var max);
 
@@ -46,37 +55,31 @@ namespace Ludots.Core.Gameplay.GAS.Config
             }
         }
 
-        private static bool GetBool(JsonObject obj, string key, bool defaultValue)
+        private static bool GetBool(JsonObject obj, string key, string attributeName, string relativePath)
         {
-            if (!obj.TryGetPropertyValue(key, out var node) || node == null) return defaultValue;
-            try
-            {
-                return node.GetValue<bool>();
-            }
-            catch
-            {
-                return defaultValue;
-            }
+            if (!obj.TryGetPropertyValue(key, out var node) || node == null) return false;
+            return node.GetValue<bool>();
         }
 
         private static bool TryGetFloat(JsonObject obj, string key, out float value)
         {
             value = 0f;
             if (!obj.TryGetPropertyValue(key, out var node) || node == null) return false;
-            try
+            if (node is JsonValue v)
             {
-                value = node.GetValue<float>();
-                return true;
-            }
-            catch
-            {
-                if (node is JsonValue v && v.TryGetValue<string>(out var s) && float.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var f))
+                if (v.TryGetValue<float>(out value))
+                {
+                    return true;
+                }
+
+                if (v.TryGetValue<string>(out var s) && float.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var f))
                 {
                     value = f;
                     return true;
                 }
-                return false;
             }
+
+            throw new InvalidOperationException($"Attribute constraint field '{key}' must be a number.");
         }
     }
 }

--- a/src/Core/Gameplay/GAS/Config/ContextGroupConfigLoader.cs
+++ b/src/Core/Gameplay/GAS/Config/ContextGroupConfigLoader.cs
@@ -60,19 +60,39 @@ namespace Ludots.Core.Gameplay.GAS.Config
             {
                 if (candidatesNode[i] is not JsonObject candidateNode)
                 {
-                    continue;
+                    throw new InvalidOperationException($"Context group '{groupName}' candidates[{i}] must be an object.");
                 }
 
                 int abilityId = ResolveAbilityId(candidateNode["abilityId"]?.GetValue<string>(), groupName, $"candidates[{i}].abilityId");
                 int preconditionGraphId = ResolveGraphId(candidateNode["preconditionGraph"]?.GetValue<string>());
                 int scoreGraphId = ResolveGraphId(candidateNode["scoreGraph"]?.GetValue<string>());
-                float basePriority = candidateNode["basePriority"]?.GetValue<float>() ?? 0f;
-                int maxDistanceCm = candidateNode["maxDistanceCm"]?.GetValue<int>() ?? 0;
-                float distanceWeight = candidateNode["distanceWeight"]?.GetValue<float>() ?? 0f;
-                int maxAngleDeg = candidateNode["maxAngleDeg"]?.GetValue<int>() ?? 0;
-                float angleWeight = candidateNode["angleWeight"]?.GetValue<float>() ?? 0f;
-                float hoveredBiasScore = candidateNode["hoveredBiasScore"]?.GetValue<float>() ?? 0f;
                 bool requiresTarget = candidateNode["requiresTarget"]?.GetValue<bool>() ?? true;
+                float basePriority = RequireFloat(candidateNode, "basePriority", groupName, i);
+                int maxDistanceCm = requiresTarget
+                    ? RequireInt(candidateNode, "maxDistanceCm", groupName, i)
+                    : ReadOptionalNonNegativeInt(candidateNode, "maxDistanceCm", groupName, i);
+                float distanceWeight = requiresTarget
+                    ? RequireFloat(candidateNode, "distanceWeight", groupName, i)
+                    : ReadOptionalFloat(candidateNode, "distanceWeight", groupName, i);
+                int maxAngleDeg = requiresTarget
+                    ? RequireInt(candidateNode, "maxAngleDeg", groupName, i)
+                    : ReadOptionalNonNegativeInt(candidateNode, "maxAngleDeg", groupName, i);
+                float angleWeight = requiresTarget
+                    ? RequireFloat(candidateNode, "angleWeight", groupName, i)
+                    : ReadOptionalFloat(candidateNode, "angleWeight", groupName, i);
+                float hoveredBiasScore = requiresTarget
+                    ? RequireFloat(candidateNode, "hoveredBiasScore", groupName, i)
+                    : ReadOptionalFloat(candidateNode, "hoveredBiasScore", groupName, i);
+
+                if (maxDistanceCm < 0)
+                {
+                    throw new InvalidOperationException($"Context group '{groupName}' candidates[{i}].maxDistanceCm must be non-negative.");
+                }
+
+                if (maxAngleDeg < 0)
+                {
+                    throw new InvalidOperationException($"Context group '{groupName}' candidates[{i}].maxAngleDeg must be non-negative.");
+                }
 
                 candidates.Add(new ContextGroupCandidate(
                     abilityId,
@@ -120,6 +140,52 @@ namespace Ludots.Core.Gameplay.GAS.Config
             }
 
             return graphId;
+        }
+
+        private static float RequireFloat(JsonObject obj, string fieldName, string groupName, int candidateIndex)
+        {
+            if (obj[fieldName] is not JsonNode node)
+            {
+                throw new InvalidOperationException($"Context group '{groupName}' requires candidates[{candidateIndex}].{fieldName}.");
+            }
+
+            return node.GetValue<float>();
+        }
+
+        private static int RequireInt(JsonObject obj, string fieldName, string groupName, int candidateIndex)
+        {
+            if (obj[fieldName] is not JsonNode node)
+            {
+                throw new InvalidOperationException($"Context group '{groupName}' requires candidates[{candidateIndex}].{fieldName}.");
+            }
+
+            return node.GetValue<int>();
+        }
+
+        private static float ReadOptionalFloat(JsonObject obj, string fieldName, string groupName, int candidateIndex)
+        {
+            if (obj[fieldName] is not JsonNode node)
+            {
+                return 0f;
+            }
+
+            return node.GetValue<float>();
+        }
+
+        private static int ReadOptionalNonNegativeInt(JsonObject obj, string fieldName, string groupName, int candidateIndex)
+        {
+            if (obj[fieldName] is not JsonNode node)
+            {
+                return 0;
+            }
+
+            int value = node.GetValue<int>();
+            if (value < 0)
+            {
+                throw new InvalidOperationException($"Context group '{groupName}' candidates[{candidateIndex}].{fieldName} must be non-negative.");
+            }
+
+            return value;
         }
     }
 }

--- a/src/Core/Gameplay/GAS/Config/EffectTemplateLoader.cs
+++ b/src/Core/Gameplay/GAS/Config/EffectTemplateLoader.cs
@@ -142,14 +142,29 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 durationTicks = RequireInt(cfg.Duration.DurationTicks, cfg.Id, relativePath, "duration.durationTicks");
                 periodTicks = RequireInt(cfg.Duration.PeriodTicks, cfg.Id, relativePath, "duration.periodTicks");
                 clockId = ParseClockId(RequireString(cfg.Duration.ClockId, cfg.Id, relativePath, "duration.clockId"));
+                if (lifetimeKind == EffectLifetimeKind.After && durationTicks <= 0)
+                {
+                    throw new InvalidOperationException($"Effect template '{cfg.Id}' in {relativePath}: lifetime '{lifetimeKind}' requires duration.durationTicks > 0.");
+                }
+                if (lifetimeKind == EffectLifetimeKind.Instant)
+                {
+                    throw new InvalidOperationException($"Effect template '{cfg.Id}' in {relativePath}: lifetime '{lifetimeKind}' must omit the duration block.");
+                }
+
+                if (lifetimeKind == EffectLifetimeKind.Infinite &&
+                    durationTicks == 0 &&
+                    periodTicks == 0 &&
+                    clockId == GasClockId.FixedFrame)
+                {
+                    throw new InvalidOperationException($"Effect template '{cfg.Id}' in {relativePath}: lifetime '{lifetimeKind}' must omit the default zero duration block.");
+                }
+            }
+            else if (lifetimeKind == EffectLifetimeKind.After)
+            {
+                throw new InvalidOperationException($"Effect template '{cfg.Id}' in {relativePath}: lifetime '{lifetimeKind}' requires an explicit duration block.");
             }
             else
             {
-                if (lifetimeKind != EffectLifetimeKind.Instant)
-                {
-                    throw new InvalidOperationException($"Effect template '{cfg.Id}' in {relativePath}: lifetime '{lifetimeKind}' requires an explicit duration block.");
-                }
-
                 durationTicks = 0;
                 periodTicks = 0;
             }
@@ -446,7 +461,13 @@ namespace Ludots.Core.Gameplay.GAS.Config
 
             int totalDistanceCm = RequireInt(cfg.TotalDistanceCm, ownerId, relativePath, "displacement.totalDistanceCm");
             int totalDurationTicks = RequireInt(cfg.TotalDurationTicks, ownerId, relativePath, "displacement.totalDurationTicks");
-            int fixedDirectionDeg = RequireInt(cfg.FixedDirectionDeg, ownerId, relativePath, "displacement.fixedDirectionDeg");
+            int fixedDirectionDeg = directionMode == DisplacementDirectionMode.Fixed
+                ? RequireInt(cfg.FixedDirectionDeg, ownerId, relativePath, "displacement.fixedDirectionDeg")
+                : cfg.FixedDirectionDeg ?? 0;
+            if (directionMode != DisplacementDirectionMode.Fixed)
+            {
+                RequireAbsent(cfg.FixedDirectionDeg, ownerId, relativePath, "displacement.fixedDirectionDeg", $"directionMode={directionMode}");
+            }
             bool overrideNavigation = RequireBool(cfg.OverrideNavigation, ownerId, relativePath, "displacement.overrideNavigation");
 
             if (totalDistanceCm <= 0)
@@ -522,42 +543,30 @@ namespace Ludots.Core.Gameplay.GAS.Config
         {
             if (cfg == null) return default;
 
-            int impactId = 0;
-            string impactEffect = RequireString(cfg.ImpactEffect, ownerId, relativePath, "projectile.impactEffect");
-            if (!string.IsNullOrWhiteSpace(impactEffect))
-            {
-                impactId = EffectTemplateIdRegistry.GetId(impactEffect);
-                if (impactId <= 0)
-                {
-                    throw new InvalidOperationException($"Effect template '{ownerId}' in {relativePath}: projectile.impactEffect references unknown effect template '{impactEffect}'.");
-                }
-            }
-
-            int hitId = 0;
-            string hitEffect = RequireString(cfg.HitEffect, ownerId, relativePath, "projectile.hitEffect");
-            if (!string.IsNullOrWhiteSpace(hitEffect))
-            {
-                hitId = EffectTemplateIdRegistry.GetId(hitEffect);
-                if (hitId <= 0)
-                {
-                    throw new InvalidOperationException($"Effect template '{ownerId}' in {relativePath}: projectile.hitEffect references unknown effect template '{hitEffect}'.");
-                }
-            }
-
-            int presentationId = 0;
-            string presentationEffect = RequireString(cfg.PresentationEffect, ownerId, relativePath, "projectile.presentationEffect");
-            if (!string.IsNullOrWhiteSpace(presentationEffect))
-            {
-                presentationId = EffectTemplateIdRegistry.GetId(presentationEffect);
-                if (presentationId <= 0)
-                {
-                    throw new InvalidOperationException($"Effect template '{ownerId}' in {relativePath}: projectile.presentationEffect references unknown effect template '{presentationEffect}'.");
-                }
-            }
-
             ProjectileTravelMode travelMode = ParseProjectileTravelMode(cfg.TravelMode);
             ProjectileImpactPolicy impactPolicy = ParseProjectileImpactPolicy(cfg.ImpactPolicy);
-            int collisionHalfWidth = RequireInt(cfg.CollisionHalfWidth, ownerId, relativePath, "projectile.collisionHalfWidth");
+            bool isLegacyTravel = travelMode == ProjectileTravelMode.Legacy;
+            bool isLegacyImpact = impactPolicy == ProjectileImpactPolicy.Legacy;
+            if (isLegacyTravel != isLegacyImpact)
+            {
+                throw new InvalidOperationException(
+                    $"Effect template '{ownerId}' in {relativePath}: projectile.travelMode and projectile.impactPolicy must both be Legacy or both be non-Legacy.");
+            }
+
+            int impactId = ResolveOptionalEffectTemplateId(cfg.ImpactEffect, ownerId, relativePath, "projectile.impactEffect");
+            int hitId = ResolveOptionalEffectTemplateId(cfg.HitEffect, ownerId, relativePath, "projectile.hitEffect");
+            int presentationId = ResolveOptionalEffectTemplateId(cfg.PresentationEffect, ownerId, relativePath, "projectile.presentationEffect");
+            int collisionHalfWidth = cfg.CollisionHalfWidth ?? 0;
+            RelationshipFilter collisionRelationFilter = RelationshipFilter.All;
+            if (isLegacyImpact)
+            {
+                RequireAbsent(cfg.HitEffect, ownerId, relativePath, "projectile.hitEffect", "impactPolicy=Legacy");
+                RequireAbsent(cfg.CollisionRelationFilter, ownerId, relativePath, "projectile.collisionRelationFilter", "impactPolicy=Legacy");
+                RequireAbsent(cfg.CollisionHalfWidth, ownerId, relativePath, "projectile.collisionHalfWidth", "impactPolicy=Legacy");
+                RequireAbsent(cfg.CollisionExcludeSource, ownerId, relativePath, "projectile.collisionExcludeSource", "impactPolicy=Legacy");
+                RequireAbsent(cfg.MaxHitCount, ownerId, relativePath, "projectile.maxHitCount", "impactPolicy=Legacy");
+            }
+
             if (impactPolicy != ProjectileImpactPolicy.Legacy)
             {
                 if (hitId <= 0)
@@ -569,6 +578,22 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 {
                     throw new InvalidOperationException($"Effect template '{ownerId}' in {relativePath}: projectile.impactPolicy '{impactPolicy}' requires projectile.collisionHalfWidth > 0.");
                 }
+
+                collisionRelationFilter = ParseRequiredRelationshipFilter(
+                    cfg.CollisionRelationFilter,
+                    ownerId,
+                    "projectile.collisionRelationFilter",
+                    relativePath);
+            }
+            else if (!string.IsNullOrWhiteSpace(cfg.CollisionRelationFilter))
+            {
+                collisionRelationFilter = RelationshipFilterUtil.Parse(cfg.CollisionRelationFilter);
+            }
+
+            RejectOptionalFalse(cfg.CollisionExcludeSource, ownerId, relativePath, "projectile.collisionExcludeSource");
+            if (cfg.MaxHitCount is < 0)
+            {
+                throw new InvalidOperationException($"Effect template '{ownerId}' in {relativePath}: projectile.maxHitCount must be non-negative.");
             }
 
             return new ProjectileDescriptor
@@ -582,14 +607,31 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 TravelMode = travelMode,
                 ImpactPolicy = impactPolicy,
                 CollisionHalfWidthCm = collisionHalfWidth,
-                CollisionRelationFilter = ParseRequiredRelationshipFilter(
-                    cfg.CollisionRelationFilter,
-                    ownerId,
-                    "projectile.collisionRelationFilter",
-                    relativePath),
-                CollisionExcludeSource = RequireBool(cfg.CollisionExcludeSource, ownerId, relativePath, "projectile.collisionExcludeSource"),
-                MaxHitCount = RequireInt(cfg.MaxHitCount, ownerId, relativePath, "projectile.maxHitCount")
+                CollisionRelationFilter = collisionRelationFilter,
+                CollisionExcludeSource = cfg.CollisionExcludeSource ?? false,
+                MaxHitCount = cfg.MaxHitCount ?? 0
             };
+        }
+
+        private static int ResolveOptionalEffectTemplateId(string? raw, string effectId, string path, string fieldPath)
+        {
+            if (raw == null)
+            {
+                return 0;
+            }
+
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                throw new InvalidOperationException($"Effect template '{effectId}' in {path}: {fieldPath} must be omitted or a semantic key.");
+            }
+
+            int templateId = EffectTemplateIdRegistry.GetId(raw);
+            if (templateId <= 0)
+            {
+                throw new InvalidOperationException($"Effect template '{effectId}' in {path}: {fieldPath} references unknown effect template '{raw}'.");
+            }
+
+            return templateId;
         }
 
         private static ProjectileTravelMode ParseProjectileTravelMode(string? raw)
@@ -657,20 +699,53 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 }
             }
 
+            UnitCreationPlacementPattern placementPattern = ParseUnitCreationPlacementPattern(cfg.PlacementPattern);
+            UnitCreationFacingPattern facingPattern = string.IsNullOrWhiteSpace(cfg.FacingPattern)
+                ? UnitCreationFacingPattern.PreserveTemplate
+                : ParseUnitCreationFacingPattern(cfg.FacingPattern);
+            int offsetRadius = cfg.OffsetRadius ?? 0;
+            int placementRadiusCm = cfg.PlacementRadiusCm ?? 0;
+            int placementStartAngleDeg = cfg.PlacementStartAngleDeg ?? 0;
+
+            if (placementPattern == UnitCreationPlacementPattern.Scatter)
+            {
+                RequireAbsent(cfg.FacingPattern, ownerId, relativePath, "unitCreation.facingPattern", "placementPattern=Scatter");
+                RequireAbsent(cfg.PlacementRadiusCm, ownerId, relativePath, "unitCreation.placementRadiusCm", "placementPattern=Scatter");
+                RequireAbsent(cfg.PlacementStartAngleDeg, ownerId, relativePath, "unitCreation.placementStartAngleDeg", "placementPattern=Scatter");
+                offsetRadius = cfg.OffsetRadius ?? 0;
+                if (offsetRadius < 0)
+                {
+                    throw new InvalidOperationException($"Effect template '{ownerId}' in {relativePath}: unitCreation.offsetRadius must be non-negative.");
+                }
+            }
+            else if (placementPattern == UnitCreationPlacementPattern.Circle)
+            {
+                RequireAbsent(cfg.OffsetRadius, ownerId, relativePath, "unitCreation.offsetRadius", "placementPattern=Circle");
+                placementRadiusCm = RequireInt(cfg.PlacementRadiusCm, ownerId, relativePath, "unitCreation.placementRadiusCm");
+                placementStartAngleDeg = RequireInt(cfg.PlacementStartAngleDeg, ownerId, relativePath, "unitCreation.placementStartAngleDeg");
+                if (placementRadiusCm <= 0)
+                {
+                    throw new InvalidOperationException($"Effect template '{ownerId}' in {relativePath}: unitCreation.placementRadiusCm must be > 0 when placementPattern=Circle.");
+                }
+            }
+
+            RejectOptionalFalse(cfg.CopySourcePlayerOwner, ownerId, relativePath, "unitCreation.copySourcePlayerOwner");
+            RejectOptionalFalse(cfg.LinkSourceAsParent, ownerId, relativePath, "unitCreation.linkSourceAsParent");
+
             return new UnitCreationDescriptor
             {
-                PlacementPattern = ParseUnitCreationPlacementPattern(cfg.PlacementPattern),
-                FacingPattern = ParseUnitCreationFacingPattern(cfg.FacingPattern),
+                PlacementPattern = placementPattern,
+                FacingPattern = facingPattern,
                 UnitTypeId = unitTypeId,
                 TemplateId = hasTemplateId ? cfg.TemplateId : string.Empty,
                 UseTemplateSpawn = hasTemplateId,
                 Count = RequireInt(cfg.Count, ownerId, relativePath, "unitCreation.count"),
-                OffsetRadius = RequireInt(cfg.OffsetRadius, ownerId, relativePath, "unitCreation.offsetRadius"),
-                PlacementRadiusCm = RequireInt(cfg.PlacementRadiusCm, ownerId, relativePath, "unitCreation.placementRadiusCm"),
-                PlacementStartAngleDeg = RequireInt(cfg.PlacementStartAngleDeg, ownerId, relativePath, "unitCreation.placementStartAngleDeg"),
+                OffsetRadius = offsetRadius,
+                PlacementRadiusCm = placementRadiusCm,
+                PlacementStartAngleDeg = placementStartAngleDeg,
                 OnSpawnEffectTemplateId = onSpawnId,
-                CopySourcePlayerOwner = RequireBool(cfg.CopySourcePlayerOwner, ownerId, relativePath, "unitCreation.copySourcePlayerOwner"),
-                LinkSourceAsParent = RequireBool(cfg.LinkSourceAsParent, ownerId, relativePath, "unitCreation.linkSourceAsParent"),
+                CopySourcePlayerOwner = cfg.CopySourcePlayerOwner ?? false,
+                LinkSourceAsParent = cfg.LinkSourceAsParent ?? false,
             };
         }
 
@@ -1014,7 +1089,7 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 if ((flags & PhaseListenerActionFlags.PublishEvent) != 0 && !string.IsNullOrWhiteSpace(lc.EventTag))
                     eventTagId = TagRegistry.Register(lc.EventTag);
 
-                int priority = RequireInt(lc.Priority, ownerId, relativePath, $"phaseListeners[{i}].priority");
+                int priority = lc.Priority ?? 0;
                 if (!result.TryAddTemplate(listenTagId, listenEffectId, phaseId, scope, flags, graphProgramId, eventTagId, priority))
                 {
                     throw new InvalidOperationException($"Effect template '{ownerId}' in {relativePath}: phaseListeners exceeded capacity ({EffectPhaseListenerBuffer.CAPACITY}).");
@@ -1121,17 +1196,88 @@ namespace Ludots.Core.Gameplay.GAS.Config
 
             if (desc.Kind == TargetResolverKind.BuiltinSpatial)
             {
-                desc.Spatial.Shape = ParseSpatialShape(RequireString(cfg.Shape, effectId, path, "targetQuery.shape"), effectId, path);
-                desc.Spatial.RadiusCm = RequireInt(cfg.Radius, effectId, path, "targetQuery.radius");
-                desc.Spatial.InnerRadiusCm = RequireInt(cfg.InnerRadius, effectId, path, "targetQuery.innerRadius");
-                desc.Spatial.HalfAngleDeg = RequireInt(cfg.HalfAngle, effectId, path, "targetQuery.halfAngle");
-                desc.Spatial.HalfWidthCm = RequireInt(cfg.HalfWidth, effectId, path, "targetQuery.halfWidth");
-                desc.Spatial.HalfHeightCm = RequireInt(cfg.HalfHeight, effectId, path, "targetQuery.halfHeight");
-                desc.Spatial.RotationDeg = RequireInt(cfg.Rotation, effectId, path, "targetQuery.rotation");
-                desc.Spatial.LengthCm = RequireInt(cfg.Length, effectId, path, "targetQuery.length");
+                RequireAbsent(cfg.GraphProgramId, effectId, path, "targetQuery.graphProgramId", "kind=BuiltinSpatial");
+                desc.Spatial = CompileBuiltinSpatialQuery(cfg, effectId, path);
             }
-            desc.GraphProgramId = RequireInt(cfg.GraphProgramId, effectId, path, "targetQuery.graphProgramId");
+            else
+            {
+                RequireAbsent(cfg.Shape, effectId, path, "targetQuery.shape", "kind=GraphProgram");
+                RequireAbsent(cfg.Radius, effectId, path, "targetQuery.radius", "kind=GraphProgram");
+                RequireAbsent(cfg.InnerRadius, effectId, path, "targetQuery.innerRadius", "kind=GraphProgram");
+                RequireAbsent(cfg.HalfAngle, effectId, path, "targetQuery.halfAngle", "kind=GraphProgram");
+                RequireAbsent(cfg.HalfWidth, effectId, path, "targetQuery.halfWidth", "kind=GraphProgram");
+                RequireAbsent(cfg.HalfHeight, effectId, path, "targetQuery.halfHeight", "kind=GraphProgram");
+                RequireAbsent(cfg.Rotation, effectId, path, "targetQuery.rotation", "kind=GraphProgram");
+                RequireAbsent(cfg.Length, effectId, path, "targetQuery.length", "kind=GraphProgram");
+                desc.GraphProgramId = RequireInt(cfg.GraphProgramId, effectId, path, "targetQuery.graphProgramId");
+                if (desc.GraphProgramId <= 0)
+                {
+                    throw new InvalidOperationException($"Effect template '{effectId}' in {path}: targetQuery.graphProgramId must be > 0 when kind=GraphProgram.");
+                }
+            }
+
             return desc;
+        }
+
+        private static BuiltinSpatialDescriptor CompileBuiltinSpatialQuery(TargetQueryConfig cfg, string effectId, string path)
+        {
+            var spatial = default(BuiltinSpatialDescriptor);
+            spatial.Shape = ParseSpatialShape(RequireString(cfg.Shape, effectId, path, "targetQuery.shape"), effectId, path);
+
+            switch (spatial.Shape)
+            {
+                case SpatialShape.Circle:
+                    RequireAbsent(cfg.InnerRadius, effectId, path, "targetQuery.innerRadius", "shape=Circle");
+                    RequireAbsent(cfg.HalfAngle, effectId, path, "targetQuery.halfAngle", "shape=Circle");
+                    RequireAbsent(cfg.HalfWidth, effectId, path, "targetQuery.halfWidth", "shape=Circle");
+                    RequireAbsent(cfg.HalfHeight, effectId, path, "targetQuery.halfHeight", "shape=Circle");
+                    RequireAbsent(cfg.Rotation, effectId, path, "targetQuery.rotation", "shape=Circle");
+                    RequireAbsent(cfg.Length, effectId, path, "targetQuery.length", "shape=Circle");
+                    spatial.RadiusCm = RequirePositiveInt(cfg.Radius, effectId, path, "targetQuery.radius");
+                    break;
+                case SpatialShape.Ring:
+                    RequireAbsent(cfg.HalfAngle, effectId, path, "targetQuery.halfAngle", "shape=Ring");
+                    RequireAbsent(cfg.HalfWidth, effectId, path, "targetQuery.halfWidth", "shape=Ring");
+                    RequireAbsent(cfg.HalfHeight, effectId, path, "targetQuery.halfHeight", "shape=Ring");
+                    RequireAbsent(cfg.Rotation, effectId, path, "targetQuery.rotation", "shape=Ring");
+                    RequireAbsent(cfg.Length, effectId, path, "targetQuery.length", "shape=Ring");
+                    spatial.RadiusCm = RequirePositiveInt(cfg.Radius, effectId, path, "targetQuery.radius");
+                    spatial.InnerRadiusCm = RequireInt(cfg.InnerRadius, effectId, path, "targetQuery.innerRadius");
+                    if (spatial.InnerRadiusCm < 0 || spatial.InnerRadiusCm >= spatial.RadiusCm)
+                    {
+                        throw new InvalidOperationException($"Effect template '{effectId}' in {path}: targetQuery.innerRadius must be >= 0 and < targetQuery.radius for shape=Ring.");
+                    }
+                    break;
+                case SpatialShape.Cone:
+                    RequireAbsent(cfg.InnerRadius, effectId, path, "targetQuery.innerRadius", "shape=Cone");
+                    RequireAbsent(cfg.HalfWidth, effectId, path, "targetQuery.halfWidth", "shape=Cone");
+                    RequireAbsent(cfg.HalfHeight, effectId, path, "targetQuery.halfHeight", "shape=Cone");
+                    RequireAbsent(cfg.Rotation, effectId, path, "targetQuery.rotation", "shape=Cone");
+                    RequireAbsent(cfg.Length, effectId, path, "targetQuery.length", "shape=Cone");
+                    spatial.RadiusCm = RequirePositiveInt(cfg.Radius, effectId, path, "targetQuery.radius");
+                    spatial.HalfAngleDeg = RequirePositiveInt(cfg.HalfAngle, effectId, path, "targetQuery.halfAngle");
+                    break;
+                case SpatialShape.Line:
+                    RequireAbsent(cfg.Radius, effectId, path, "targetQuery.radius", "shape=Line");
+                    RequireAbsent(cfg.InnerRadius, effectId, path, "targetQuery.innerRadius", "shape=Line");
+                    RequireAbsent(cfg.HalfAngle, effectId, path, "targetQuery.halfAngle", "shape=Line");
+                    RequireAbsent(cfg.HalfHeight, effectId, path, "targetQuery.halfHeight", "shape=Line");
+                    RequireAbsent(cfg.Rotation, effectId, path, "targetQuery.rotation", "shape=Line");
+                    spatial.LengthCm = RequirePositiveInt(cfg.Length, effectId, path, "targetQuery.length");
+                    spatial.HalfWidthCm = RequirePositiveInt(cfg.HalfWidth, effectId, path, "targetQuery.halfWidth");
+                    break;
+                case SpatialShape.Rectangle:
+                    RequireAbsent(cfg.Radius, effectId, path, "targetQuery.radius", "shape=Rectangle");
+                    RequireAbsent(cfg.InnerRadius, effectId, path, "targetQuery.innerRadius", "shape=Rectangle");
+                    RequireAbsent(cfg.HalfAngle, effectId, path, "targetQuery.halfAngle", "shape=Rectangle");
+                    RequireAbsent(cfg.Length, effectId, path, "targetQuery.length", "shape=Rectangle");
+                    spatial.HalfWidthCm = RequirePositiveInt(cfg.HalfWidth, effectId, path, "targetQuery.halfWidth");
+                    spatial.HalfHeightCm = RequirePositiveInt(cfg.HalfHeight, effectId, path, "targetQuery.halfHeight");
+                    spatial.RotationDeg = cfg.Rotation ?? 0;
+                    break;
+            }
+
+            return spatial;
         }
 
         private static TargetFilterDescriptor CompileTargetFilter(TargetFilterConfig cfg, string effectId, string path)
@@ -1183,6 +1329,57 @@ namespace Ludots.Core.Gameplay.GAS.Config
             return value.Value;
         }
 
+        private static int RequirePositiveInt(int? value, string effectId, string path, string fieldPath)
+        {
+            int result = RequireInt(value, effectId, path, fieldPath);
+            if (result <= 0)
+            {
+                throw new InvalidOperationException($"Effect template '{effectId}' in {path}: {fieldPath} must be > 0.");
+            }
+
+            return result;
+        }
+
+        private static void RequireAbsent(int? value, string effectId, string path, string fieldPath, string when)
+        {
+            if (value.HasValue)
+            {
+                throw new InvalidOperationException($"Effect template '{effectId}' in {path}: {fieldPath} is not valid when {when}.");
+            }
+        }
+
+        private static void RequireAbsent(bool? value, string effectId, string path, string fieldPath, string when)
+        {
+            if (value.HasValue)
+            {
+                throw new InvalidOperationException($"Effect template '{effectId}' in {path}: {fieldPath} is not valid when {when}.");
+            }
+        }
+
+        private static void RequireAbsent(string? value, string effectId, string path, string fieldPath, string when)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                throw new InvalidOperationException($"Effect template '{effectId}' in {path}: {fieldPath} is not valid when {when}.");
+            }
+        }
+
+        private static void RejectOptionalFalse(bool? value, string effectId, string path, string fieldPath)
+        {
+            if (value.HasValue && !value.Value)
+            {
+                throw new InvalidOperationException($"Effect template '{effectId}' in {path}: {fieldPath}=false must be omitted.");
+            }
+        }
+
+        private static void RejectOptionalZero(int? value, string effectId, string path, string fieldPath)
+        {
+            if (value.HasValue && value.Value == 0)
+            {
+                throw new InvalidOperationException($"Effect template '{effectId}' in {path}: {fieldPath}=0 must be omitted.");
+            }
+        }
+
         private static float RequireFloat(float? value, string effectId, string path, string fieldPath)
         {
             if (!value.HasValue)
@@ -1206,6 +1403,9 @@ namespace Ludots.Core.Gameplay.GAS.Config
         private TargetDispatchDescriptor CompileTargetDispatch(TargetDispatchConfig cfg, string effectId, string path)
         {
             var desc = default(TargetDispatchDescriptor);
+            bool hasPreset = !string.IsNullOrWhiteSpace(cfg.Preset);
+            bool hasContextMapping = cfg.ContextMapping != null;
+
             if (!string.IsNullOrWhiteSpace(cfg.PayloadEffect))
             {
                 desc.PayloadEffectTemplateId = EffectTemplateIdRegistry.GetId(cfg.PayloadEffect);
@@ -1213,7 +1413,13 @@ namespace Ludots.Core.Gameplay.GAS.Config
                     throw new InvalidOperationException($"Effect template '{effectId}' in {path}: targetDispatch.payloadEffect '{cfg.PayloadEffect}' not found.");
             }
 
-            if (!string.IsNullOrWhiteSpace(cfg.Preset))
+            if (hasPreset && hasContextMapping)
+            {
+                throw new InvalidOperationException(
+                    $"Effect template '{effectId}' in {path}: targetDispatch must define either preset or contextMapping, not both.");
+            }
+
+            if (hasPreset)
             {
                 if (_targetDispatchPresets == null)
                 {
@@ -1226,7 +1432,7 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 return desc;
             }
 
-            if (cfg.ContextMapping != null)
+            if (hasContextMapping)
             {
                 desc.ContextMapping = new TargetResolverContextMapping
                 {
@@ -1249,8 +1455,7 @@ namespace Ludots.Core.Gameplay.GAS.Config
             }
             else
             {
-                throw new InvalidOperationException(
-                    $"Effect template '{effectId}' in {path}: targetDispatch must define either preset or contextMapping.");
+                desc.ContextMapping = TargetResolverContextMapping.Default;
             }
             return desc;
         }
@@ -1318,15 +1523,45 @@ namespace Ludots.Core.Gameplay.GAS.Config
                     _ => throw new InvalidOperationException($"Effect template '{effectId}' in {path}: grantedTags[{i}] unknown formula '{formulaValue}'."),
                 };
 
-                int amount = RequireInt(cfg.Amount, effectId, path, $"grantedTags[{i}].amount");
-                int baseValue = RequireInt(cfg.Base, effectId, path, $"grantedTags[{i}].base");
+                int amount = formula == Components.TagContributionFormula.GraphProgram
+                    ? cfg.Amount ?? 0
+                    : RequireInt(cfg.Amount, effectId, path, $"grantedTags[{i}].amount");
+                int baseValue = formula == Components.TagContributionFormula.LinearPlusBase
+                    ? RequireInt(cfg.Base, effectId, path, $"grantedTags[{i}].base")
+                    : cfg.Base ?? 0;
+                int graphProgramId = 0;
+                switch (formula)
+                {
+                    case Components.TagContributionFormula.Fixed:
+                    case Components.TagContributionFormula.Linear:
+                        RequireAbsent(cfg.Base, effectId, path, $"grantedTags[{i}].base", $"formula={formula}");
+                        RequireAbsent(cfg.GraphProgram, effectId, path, $"grantedTags[{i}].graphProgram", $"formula={formula}");
+                        break;
+                    case Components.TagContributionFormula.LinearPlusBase:
+                        RequireAbsent(cfg.GraphProgram, effectId, path, $"grantedTags[{i}].graphProgram", "formula=LinearPlusBase");
+                        break;
+                    case Components.TagContributionFormula.GraphProgram:
+                        RequireAbsent(cfg.Amount, effectId, path, $"grantedTags[{i}].amount", "formula=GraphProgram");
+                        RequireAbsent(cfg.Base, effectId, path, $"grantedTags[{i}].base", "formula=GraphProgram");
+                        break;
+                }
+
+                if (formula == Components.TagContributionFormula.GraphProgram)
+                {
+                    graphProgramId = ResolveGraphProgram(
+                        RequireString(cfg.GraphProgram, effectId, path, $"grantedTags[{i}].graphProgram"),
+                        effectId,
+                        $"grantedTags[{i}].graphProgram",
+                        path);
+                }
+
                 result.Add(new Components.TagContribution
                 {
                     TagId = tagId,
                     Formula = formula,
                     Amount = (ushort)System.Math.Clamp(amount, 0, ushort.MaxValue),
                     Base = (ushort)System.Math.Clamp(baseValue, 0, ushort.MaxValue),
-                    GraphProgramId = 0, // Resolved later if needed
+                    GraphProgramId = graphProgramId,
                 });
             }
             return result;

--- a/src/Core/Gameplay/GAS/Config/PresetTypeLoader.cs
+++ b/src/Core/Gameplay/GAS/Config/PresetTypeLoader.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json.Nodes;
 using Ludots.Core.Config;
+using Ludots.Core.NodeLibraries.GASGraph.Host;
 
 namespace Ludots.Core.Gameplay.GAS.Config
 {
@@ -121,12 +122,13 @@ namespace Ludots.Core.Gameplay.GAS.Config
 
             if (type == "graph")
             {
-                if (int.TryParse(id, out int graphId) && graphId > 0)
+                int graphId = GraphIdRegistry.GetId(id);
+                if (graphId > 0)
                 {
                     return PhaseHandler.Graph(graphId);
                 }
 
-                throw new InvalidOperationException($"Preset type '{presetTypeId}' handler '{phaseName}' graph id '{id}' must be a positive numeric graph id.");
+                throw new InvalidOperationException($"Preset type '{presetTypeId}' handler '{phaseName}' references unknown graph '{id}'.");
             }
 
             throw new InvalidOperationException($"Preset type '{presetTypeId}' handler '{phaseName}' has unsupported type '{type}'. Supported: builtin, graph.");

--- a/src/Core/Gameplay/GAS/Orders/OrderQueue.cs
+++ b/src/Core/Gameplay/GAS/Orders/OrderQueue.cs
@@ -47,6 +47,7 @@ namespace Ludots.Core.Gameplay.GAS.Orders
 
         public bool TryEnqueueAssigned(ref Order order)
         {
+            ValidateOrderTypeId(order.OrderTypeId);
             if (_count >= _items.Length) return false;
             EnsureOrderId(ref order);
 
@@ -61,6 +62,15 @@ namespace Ludots.Core.Gameplay.GAS.Orders
             if (order.OrderId == 0)
             {
                 order.OrderId = _nextOrderId++;
+            }
+        }
+
+        private static void ValidateOrderTypeId(int orderTypeId)
+        {
+            if (orderTypeId <= 0 || orderTypeId >= OrderTypeRegistry.MaxOrderTypes)
+            {
+                throw new System.InvalidOperationException(
+                    $"OrderQueue requires a positive order type id below {OrderTypeRegistry.MaxOrderTypes}; got {orderTypeId}.");
             }
         }
 

--- a/src/Core/Gameplay/GAS/Systems/EffectProposalProcessingSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/EffectProposalProcessingSystem.cs
@@ -22,13 +22,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
         public int ChainPass;
         public int ChainNegate;
         public int ChainActivateEffect;
-        
-        public static ResponseChainOrderTypes Default => new ResponseChainOrderTypes
-        {
-            ChainPass = 1,
-            ChainNegate = 2,
-            ChainActivateEffect = 3
-        };
     }
 
     public sealed class EffectProposalProcessingSystem : BaseSystem<World, float>, ITimeSlicedSystem
@@ -245,7 +238,13 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             _chainOrders = chainOrders;
             _telemetry = telemetry;
             _orderRequests = orderRequests;
-            _responseChainOrderTypes = responseChainOrderTypes ?? ResponseChainOrderTypes.Default;
+            if ((chainOrders != null || orderRequests != null) && responseChainOrderTypes == null)
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(EffectProposalProcessingSystem)} requires configured response-chain order type ids when response-chain queues are enabled.");
+            }
+
+            _responseChainOrderTypes = responseChainOrderTypes ?? default;
             _presentationEvents = presentationEvents;
             _tagOps = tagOps ?? new TagOps();
             _phaseExecutor = phaseExecutor;

--- a/src/Core/Input/Orders/InputOrderMappingLoader.cs
+++ b/src/Core/Input/Orders/InputOrderMappingLoader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Ludots.Core.Config;
@@ -36,10 +37,14 @@ namespace Ludots.Core.Input.Orders
             var mergedObject = _pipeline.MergeDeepObjectFromCatalog(in entry, report);
 
             if (mergedObject == null)
-                return CreateDefaultMobaConfig();
+            {
+                throw new InvalidOperationException($"Missing required config '{relativePath}'.");
+            }
 
             var config = mergedObject.Deserialize<InputOrderMappingConfig>(JsonOptions);
-            return config ?? CreateDefaultMobaConfig();
+            config = config ?? throw new InvalidOperationException($"Failed to deserialize '{relativePath}'.");
+            Validate(config, relativePath);
+            return config;
         }
 
         /// <summary>
@@ -52,7 +57,9 @@ namespace Ludots.Core.Input.Orders
 
             var content = System.IO.File.ReadAllText(filePath);
             var config = JsonSerializer.Deserialize<InputOrderMappingConfig>(content, JsonOptions);
-            return config ?? new InputOrderMappingConfig();
+            config ??= new InputOrderMappingConfig();
+            Validate(config, filePath);
+            return config;
         }
 
         /// <summary>
@@ -62,7 +69,9 @@ namespace Ludots.Core.Input.Orders
         {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
             var config = JsonSerializer.Deserialize<InputOrderMappingConfig>(stream, JsonOptions);
-            return config ?? throw new InvalidOperationException("Deserialized null from input_order_mappings stream.");
+            config = config ?? throw new InvalidOperationException("Deserialized null from input_order_mappings stream.");
+            Validate(config, "input_order_mappings stream");
+            return config;
         }
 
         /// <summary>
@@ -92,74 +101,67 @@ namespace Ludots.Core.Input.Orders
             System.IO.File.WriteAllText(filePath, json);
         }
 
-        /// <summary>
-        /// Create default mappings for MOBA-style gameplay.
-        /// </summary>
-        public static InputOrderMappingConfig CreateDefaultMobaConfig()
+        public static void Validate(InputOrderMappingConfig config, string source)
         {
-            return new InputOrderMappingConfig
+            if (config == null) throw new ArgumentNullException(nameof(config));
+            if (config.Mappings == null)
             {
-                InteractionMode = InteractionModeType.TargetFirst,
-                Mappings = new()
+                throw new InvalidOperationException($"Input order mapping config '{source}' must explicitly define mappings.");
+            }
+
+            var actionIds = new HashSet<string>(StringComparer.Ordinal);
+            for (int i = 0; i < config.Mappings.Count; i++)
+            {
+                InputOrderMapping mapping = config.Mappings[i] ??
+                    throw new InvalidOperationException($"Input order mapping '{source}' mappings[{i}] must be an object.");
+
+                string path = $"{source}.mappings[{i}]";
+                if (string.IsNullOrWhiteSpace(mapping.ActionId))
                 {
-                    new InputOrderMapping
-                    {
-                        ActionId = "SkillQ",
-                        Trigger = InputTriggerType.PressedThisFrame,
-                        OrderTypeKey = "castAbility",
-                        ArgsTemplate = new OrderArgsTemplate { I0 = 0 },
-                        RequireSelection = false,
-                        SelectionType = OrderSelectionType.Entity,
-                        IsSkillMapping = true
-                    },
-                    new InputOrderMapping
-                    {
-                        ActionId = "SkillW",
-                        Trigger = InputTriggerType.PressedThisFrame,
-                        OrderTypeKey = "castAbility",
-                        ArgsTemplate = new OrderArgsTemplate { I0 = 1 },
-                        RequireSelection = false,
-                        SelectionType = OrderSelectionType.None,
-                        IsSkillMapping = true
-                    },
-                    new InputOrderMapping
-                    {
-                        ActionId = "SkillE",
-                        Trigger = InputTriggerType.PressedThisFrame,
-                        OrderTypeKey = "castAbility",
-                        ArgsTemplate = new OrderArgsTemplate { I0 = 2 },
-                        RequireSelection = false,
-                        SelectionType = OrderSelectionType.Entity,
-                        IsSkillMapping = true
-                    },
-                    new InputOrderMapping
-                    {
-                        ActionId = "SkillR",
-                        Trigger = InputTriggerType.PressedThisFrame,
-                        OrderTypeKey = "castAbility",
-                        ArgsTemplate = new OrderArgsTemplate { I0 = 3 },
-                        RequireSelection = false,
-                        SelectionType = OrderSelectionType.Entity,
-                        IsSkillMapping = true
-                    },
-                    new InputOrderMapping
-                    {
-                        ActionId = "Command",
-                        Trigger = InputTriggerType.PressedThisFrame,
-                        OrderTypeKey = "castAbility",
-                        ArgsTemplate = new OrderArgsTemplate { I0 = 4 },
-                        RequireSelection = true,
-                        SelectionType = OrderSelectionType.Ground,
-                        IsSkillMapping = false
-                    }
-                },
-                UserOverrides = new UserOverrideSettings
-                {
-                    Enabled = true,
-                    PersistPath = "user://input_preferences.json"
+                    throw new InvalidOperationException($"{path}.actionId must be a non-empty string.");
                 }
-            };
+
+                if (!string.Equals(mapping.ActionId, mapping.ActionId.Trim(), StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException($"{path}.actionId must not contain leading or trailing whitespace.");
+                }
+
+                if (!actionIds.Add(mapping.ActionId))
+                {
+                    throw new InvalidOperationException(
+                        $"{path}.actionId duplicates input action '{mapping.ActionId}'.");
+                }
+
+                if (string.IsNullOrWhiteSpace(mapping.OrderTypeKey))
+                {
+                    throw new InvalidOperationException($"{path}.orderTypeKey must be a non-empty string.");
+                }
+
+                if (!string.Equals(mapping.OrderTypeKey, mapping.OrderTypeKey.Trim(), StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException($"{path}.orderTypeKey must not contain leading or trailing whitespace.");
+                }
+
+                if (mapping.HeldPolicy == HeldPolicy.StartEnd && mapping.Trigger != InputTriggerType.Held)
+                {
+                    throw new InvalidOperationException(
+                        $"{path}.heldPolicy StartEnd requires trigger Held.");
+                }
+
+                if (mapping.AutoTargetPolicy != AutoTargetPolicy.None && mapping.AutoTargetRangeCm <= 0)
+                {
+                    throw new InvalidOperationException(
+                        $"{path}.autoTargetRangeCm must be positive when autoTargetPolicy is {mapping.AutoTargetPolicy}.");
+                }
+
+                if (mapping.CursorTargetPolicy != AutoTargetPolicy.None && mapping.CursorTargetRangeCm <= 0)
+                {
+                    throw new InvalidOperationException(
+                        $"{path}.cursorTargetRangeCm must be positive when cursorTargetPolicy is {mapping.CursorTargetPolicy}.");
+                }
+            }
         }
+
     }
 }
 

--- a/src/Core/Input/Orders/InputOrderMappingSystem.cs
+++ b/src/Core/Input/Orders/InputOrderMappingSystem.cs
@@ -243,6 +243,7 @@ namespace Ludots.Core.Input.Orders
         {
             _input = input ?? throw new ArgumentNullException(nameof(input));
             _config = config ?? throw new ArgumentNullException(nameof(config));
+            InputOrderMappingLoader.Validate(_config, "InputOrderMappingSystem config");
             
             _mappingsByActionId = new Dictionary<string, InputOrderMapping>();
             _userOverrides = new Dictionary<string, InputOrderMapping>();
@@ -250,16 +251,17 @@ namespace Ludots.Core.Input.Orders
             // Index mappings by action ID
             foreach (var mapping in config.Mappings)
             {
-                if (!string.IsNullOrEmpty(mapping.ActionId))
-                {
-                    _mappingsByActionId[mapping.ActionId] = mapping;
-                }
+                _mappingsByActionId.Add(mapping.ActionId, mapping);
             }
         }
         
         // Callback setters (unchanged API + new ones)
 
-        public void SetOrderTypeKeyResolver(OrderTypeKeyResolver resolver) => _orderTypeKeyResolver = resolver;
+        public void SetOrderTypeKeyResolver(OrderTypeKeyResolver resolver)
+        {
+            _orderTypeKeyResolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+            ValidateAllOrderTypeKeys();
+        }
         public void SetGroundPositionProvider(GroundPositionProvider provider) => _groundPositionProvider = provider;
         public void SetActorProvider(ActorProvider provider) => _actorProvider = provider;
         public void SetSelectedEntityProvider(SelectedEntityProvider provider) => _selectedEntityProvider = provider;
@@ -738,8 +740,7 @@ namespace Ludots.Core.Input.Orders
         {
             order = default;
             if (!HasExplicitLocalPlayer()) return false;
-            int orderTypeId = _orderTypeKeyResolver!(mapping.OrderTypeKey + orderTypeSuffix);
-            if (orderTypeId <= 0) return false;
+            int orderTypeId = RequireOrderTypeId(mapping, orderTypeSuffix);
             var args = new OrderArgs();
             ApplyArgsTemplate(ref args, mapping.ArgsTemplate);
 
@@ -797,6 +798,25 @@ namespace Ludots.Core.Input.Orders
             return true;
         }
 
+        private int RequireOrderTypeId(InputOrderMapping mapping, string orderTypeSuffix = "")
+        {
+            string orderTypeKey = mapping.OrderTypeKey + orderTypeSuffix;
+            if (string.IsNullOrWhiteSpace(orderTypeKey))
+            {
+                throw new InvalidOperationException(
+                    $"Input mapping '{mapping.ActionId}' must define non-empty orderTypeKey.");
+            }
+
+            int orderTypeId = _orderTypeKeyResolver!(orderTypeKey);
+            if (orderTypeId <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"Input mapping '{mapping.ActionId}' orderTypeKey '{orderTypeKey}' is not registered.");
+            }
+
+            return orderTypeId;
+        }
+
         private InputOrderMapping ResolveEffectiveMapping(string actionId, InputOrderMapping mapping, out Entity resolvedActor)
         {
             var effectiveMapping = _userOverrides.TryGetValue(actionId, out var overrideMapping)
@@ -843,11 +863,7 @@ namespace Ludots.Core.Input.Orders
             order = default;
             if (!HasExplicitLocalPlayer()) return false;
 
-            int orderTypeId = _orderTypeKeyResolver!(mapping.OrderTypeKey);
-            if (orderTypeId <= 0)
-            {
-                return false;
-            }
+            int orderTypeId = RequireOrderTypeId(mapping);
 
             Entity actor = ResolvePrimaryActor(mapping);
             if (!_contextScoredProvider!(actor, mapping, hoveredEntity, out var resolution))
@@ -877,8 +893,7 @@ namespace Ludots.Core.Input.Orders
             order = default;
             if (!HasExplicitLocalPlayer()) return false;
 
-            int orderTypeId = _orderTypeKeyResolver!(mapping.OrderTypeKey);
-            if (orderTypeId <= 0) return false;
+            int orderTypeId = RequireOrderTypeId(mapping);
 
             Entity actor = ResolvePrimaryActor(mapping);
             var args = new OrderArgs();
@@ -991,8 +1006,7 @@ namespace Ludots.Core.Input.Orders
             order = default;
             if (!HasExplicitLocalPlayer()) return false;
             
-            int orderTypeId = _orderTypeKeyResolver!(mapping.OrderTypeKey);
-            if (orderTypeId <= 0) return false;
+            int orderTypeId = RequireOrderTypeId(mapping);
             
             Entity actor = ResolvePrimaryActor(mapping);
             var args = new OrderArgs();
@@ -1021,8 +1035,7 @@ namespace Ludots.Core.Input.Orders
             order = default;
             if (!HasExplicitLocalPlayer()) return false;
             
-            int orderTypeId = _orderTypeKeyResolver!(mapping.OrderTypeKey);
-            if (orderTypeId <= 0) return false;
+            int orderTypeId = RequireOrderTypeId(mapping);
             
             Entity actor = ResolvePrimaryActor(mapping);
             
@@ -1250,7 +1263,11 @@ namespace Ludots.Core.Input.Orders
                 CursorTargetPolicy = original.CursorTargetPolicy,
                 CursorTargetRangeCm = original.CursorTargetRangeCm
             };
-            
+
+            InputOrderMappingLoader.Validate(
+                new InputOrderMappingConfig { Mappings = new List<InputOrderMapping> { newMapping } },
+                $"input mapping override '{actionId}'");
+            ValidateOrderTypeKeys(newMapping);
             _userOverrides[actionId] = newMapping;
         }
         
@@ -1418,8 +1435,43 @@ namespace Ludots.Core.Input.Orders
             {
                 if (!string.IsNullOrEmpty(mapping.ActionId))
                 {
+                    if (!_mappingsByActionId.ContainsKey(mapping.ActionId))
+                    {
+                        throw new InvalidOperationException(
+                            $"Input mapping override references unknown actionId '{mapping.ActionId}'.");
+                    }
+
+                    ValidateOrderTypeKeys(mapping);
                     _userOverrides[mapping.ActionId] = mapping;
                 }
+            }
+        }
+
+        private void ValidateAllOrderTypeKeys()
+        {
+            foreach (var mapping in _mappingsByActionId.Values)
+            {
+                ValidateOrderTypeKeys(mapping);
+            }
+
+            foreach (var mapping in _userOverrides.Values)
+            {
+                ValidateOrderTypeKeys(mapping);
+            }
+        }
+
+        private void ValidateOrderTypeKeys(InputOrderMapping mapping)
+        {
+            if (_orderTypeKeyResolver == null)
+            {
+                return;
+            }
+
+            RequireOrderTypeId(mapping);
+            if (mapping.Trigger == InputTriggerType.Held && mapping.HeldPolicy == HeldPolicy.StartEnd)
+            {
+                RequireOrderTypeId(mapping, ".Start");
+                RequireOrderTypeId(mapping, ".End");
             }
         }
 

--- a/src/Core/Presentation/Systems/ResponseChainHumanOrderSourceSystem.cs
+++ b/src/Core/Presentation/Systems/ResponseChainHumanOrderSourceSystem.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System;
 using Arch.System;
 using Ludots.Core.Config;
 using Ludots.Core.Gameplay.GAS.Orders;
@@ -22,19 +23,18 @@ namespace Ludots.Core.Presentation.Systems
             _ui = ui;
             _chainOrders = chainOrders;
 
-            if (_globals.TryGetValue(CoreServiceKeys.GameConfig.Name, out var configObj) && configObj is GameConfig config)
+            if (!_globals.TryGetValue(CoreServiceKeys.GameConfig.Name, out var configObj) || configObj is not GameConfig config)
             {
-                _responseChainOrderTypes = new ResponseChainOrderTypes
-                {
-                    ChainPass = config.Constants.ResponseChainOrderTypeIds.GetValueOrDefault("chainPass", 1),
-                    ChainNegate = config.Constants.ResponseChainOrderTypeIds.GetValueOrDefault("chainNegate", 2),
-                    ChainActivateEffect = config.Constants.ResponseChainOrderTypeIds.GetValueOrDefault("chainActivateEffect", 3)
-                };
+                throw new InvalidOperationException(
+                    $"{nameof(ResponseChainHumanOrderSourceSystem)} requires GameConfig constants.responseChainOrderTypeIds (chainPass, chainNegate, chainActivateEffect).");
             }
-            else
+
+            _responseChainOrderTypes = new ResponseChainOrderTypes
             {
-                _responseChainOrderTypes = ResponseChainOrderTypes.Default;
-            }
+                ChainPass = RequireResponseChainOrderTypeId(config, "chainPass"),
+                ChainNegate = RequireResponseChainOrderTypeId(config, "chainNegate"),
+                ChainActivateEffect = RequireResponseChainOrderTypeId(config, "chainActivateEffect")
+            };
         }
 
         public void Initialize() { }
@@ -91,6 +91,20 @@ namespace Ludots.Core.Presentation.Systems
         private InteractionActionBindings ResolveBindings()
         {
             return InteractionActionBindingsResolver.Require(_globals, nameof(ResponseChainHumanOrderSourceSystem));
+        }
+
+        private static int RequireResponseChainOrderTypeId(GameConfig config, string key)
+        {
+            if (config.Constants == null ||
+                config.Constants.ResponseChainOrderTypeIds == null ||
+                !config.Constants.ResponseChainOrderTypeIds.TryGetValue(key, out int orderTypeId) ||
+                orderTypeId <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(ResponseChainHumanOrderSourceSystem)} requires GameConfig constants.responseChainOrderTypeIds.{key} to be a positive registered order type id.");
+            }
+
+            return orderTypeId;
         }
 
         public void BeforeUpdate(in float dt) { }

--- a/src/Tests/GasTests/AbilityExecLoaderFailFastTests.cs
+++ b/src/Tests/GasTests/AbilityExecLoaderFailFastTests.cs
@@ -1,0 +1,670 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json.Nodes;
+using Ludots.Core.Config;
+using Ludots.Core.Gameplay.GAS;
+using Ludots.Core.Gameplay.GAS.Config;
+using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.Modding;
+using Ludots.Core.NodeLibraries.GASGraph.Host;
+using Ludots.Core.Scripting;
+using NUnit.Framework;
+using static NUnit.Framework.Assert;
+
+namespace Ludots.Tests.GAS
+{
+    [TestFixture]
+    public sealed class AbilityExecLoaderFailFastTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            AbilityIdRegistry.Clear();
+            EffectTemplateIdRegistry.Clear();
+            GraphIdRegistry.Clear();
+        }
+
+        [Test]
+        public void Load_MissingExecBlock_IsRejected()
+        {
+            string root = CreateTempRoot();
+            try
+            {
+                WriteAbilities(root,
+                    """
+                    [
+                      {
+                        "id": "Ability.Test.MissingExec"
+                      }
+                    ]
+                    """);
+
+                var loader = CreateLoader(root, out _);
+
+                var ex = Throws<AggregateException>(() => loader.Load(CreateAbilitiesCatalog(), relativePath: "GAS/abilities.json"));
+
+                That(ex!.Flatten().InnerExceptions[0].Message, Does.Contain("exec"));
+                That(ex.Flatten().InnerExceptions[0].Message, Does.Contain("GAS/abilities.json"));
+            }
+            finally
+            {
+                TryDeleteDirectory(root);
+            }
+        }
+
+        [Test]
+        public void Load_UnknownOnActivateEffect_IsRejected()
+        {
+            string root = CreateTempRoot();
+            try
+            {
+                WriteAbilities(root,
+                    """
+                    [
+                      {
+                        "id": "Ability.Test.UnknownEffect",
+                        "onActivateEffects": ["Effect.Test.Missing"],
+                        "exec": {
+                          "clockId": "FixedFrame",
+                          "items": [
+                            { "kind": "End", "tick": 0 }
+                          ]
+                        }
+                      }
+                    ]
+                    """);
+
+                var loader = CreateLoader(root, out _);
+
+                var ex = Throws<AggregateException>(() => loader.Load(CreateAbilitiesCatalog(), relativePath: "GAS/abilities.json"));
+
+                That(ex!.Flatten().InnerExceptions[0].Message, Does.Contain("onActivateEffects"));
+                That(ex.Flatten().InnerExceptions[0].Message, Does.Contain("Effect.Test.Missing"));
+            }
+            finally
+            {
+                TryDeleteDirectory(root);
+            }
+        }
+
+        [Test]
+        public void CompileAbility_MissingClockId_IsRejected()
+        {
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    """
+                    {
+                      "exec": {
+                        "items": [
+                          { "kind": "End", "tick": 0 }
+                        ]
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("exec.clockId"));
+        }
+
+        [Test]
+        public void CompileAbility_NonObjectTimelineItem_IsRejected()
+        {
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    """
+                    {
+                      "exec": {
+                        "clockId": "FixedFrame",
+                        "items": [42]
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("exec.items[0]"));
+            That(ex.Message, Does.Contain("object"));
+        }
+
+        [Test]
+        public void CompileAbility_TooManyTimelineItems_IsRejected()
+        {
+            string items = string.Join(",\n", Enumerable.Range(0, 17).Select(i => $@"{{ ""kind"": ""End"", ""tick"": {i} }}"));
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    $$"""
+                    {
+                      "exec": {
+                        "clockId": "FixedFrame",
+                        "items": [
+                          {{items}}
+                        ]
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("exec.items"));
+            That(ex.Message, Does.Contain("max 16"));
+        }
+
+        [Test]
+        public void CompileAbility_BlankBlockTag_IsRejected()
+        {
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    """
+                    {
+                      "exec": {
+                        "clockId": "FixedFrame",
+                        "items": [
+                          { "kind": "End", "tick": 0 }
+                        ]
+                      },
+                      "blockTags": {
+                        "requiredAll": [""]
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("blockTags.requiredAll[0]"));
+            That(ex.Message, Does.Contain("non-empty"));
+        }
+
+        [Test]
+        public void CompileAbility_BlankInterruptTag_IsRejected()
+        {
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    """
+                    {
+                      "exec": {
+                        "clockId": "FixedFrame",
+                        "interruptAny": [""],
+                        "items": [
+                          { "kind": "End", "tick": 0 }
+                        ]
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("exec.interruptAny[0]"));
+            That(ex.Message, Does.Contain("non-empty"));
+        }
+
+        [Test]
+        public void CompileAbility_TimelineItemMissingTick_IsRejected()
+        {
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    """
+                    {
+                      "exec": {
+                        "clockId": "FixedFrame",
+                        "items": [
+                          { "kind": "End" }
+                        ]
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("exec.items[0].tick"));
+        }
+
+        [Test]
+        public void CompileAbility_InputGateMissingPayload_IsRejected()
+        {
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    """
+                    {
+                      "exec": {
+                        "clockId": "FixedFrame",
+                        "items": [
+                          { "kind": "InputGate", "tick": 0, "tag": "Input.Confirm" }
+                        ]
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("payloadA"));
+            That(ex.Message, Does.Contain("InputGate"));
+        }
+
+        [Test]
+        public void CompileAbility_EventGateWithTimeoutPayload_IsAccepted()
+        {
+            var ability = Compile(
+                """
+                {
+                  "exec": {
+                    "clockId": "FixedFrame",
+                    "items": [
+                      { "kind": "EventGate", "tick": 0, "payloadA": 180 }
+                    ]
+                  }
+                }
+                """);
+
+            That(ability.ExecSpec.GetPayloadA(0), Is.EqualTo(180));
+        }
+
+        [Test]
+        public void CompileAbility_CallerParamsEntryMustBeObject()
+        {
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    """
+                    {
+                      "exec": {
+                        "clockId": "FixedFrame",
+                        "callerParams": [
+                          { "entries": [12] }
+                        ],
+                        "items": [
+                          { "kind": "End", "tick": 0 }
+                        ]
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("exec.callerParams[0].entries[0]"));
+            That(ex.Message, Does.Contain("object"));
+        }
+
+        [Test]
+        public void CompileAbility_GraphSignalUnknownGraph_IsRejected()
+        {
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    """
+                    {
+                      "exec": {
+                        "clockId": "FixedFrame",
+                        "items": [
+                          { "kind": "GraphSignal", "tick": 0, "graph": "Graph.Missing" }
+                        ]
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("Graph.Missing"));
+        }
+
+        [Test]
+        public void CompileAbility_InvalidIndicatorColor_IsRejected()
+        {
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    """
+                    {
+                      "exec": {
+                        "clockId": "FixedFrame",
+                        "items": [
+                          { "kind": "End", "tick": 0 }
+                        ]
+                      },
+                      "indicator": {
+                        "shape": "Circle",
+                        "range": 500,
+                        "radius": 120,
+                        "showRangeCircle": true,
+                        "validColor": "#XXCC66",
+                        "invalidColor": "#FF3333",
+                        "rangeCircleColor": "#3366FF"
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("indicator.validColor"));
+            That(ex.Message, Does.Contain("invalid hex"));
+        }
+
+        [Test]
+        public void CompileAbility_CircleIndicatorWithoutRangeCircle_DoesNotRequireRangeOrRangeCircleColor()
+        {
+            var ability = Compile(
+                """
+                {
+                  "exec": {
+                    "clockId": "FixedFrame",
+                    "items": [
+                      { "kind": "End", "tick": 0 }
+                    ]
+                  },
+                  "indicator": {
+                    "shape": "Circle",
+                    "radius": 120,
+                    "showRangeCircle": false,
+                    "validColor": "#33CC66",
+                    "invalidColor": "#FF3333"
+                  }
+                }
+                """);
+
+            That(ability.Indicator.Range, Is.EqualTo(0f));
+            That(ability.Indicator.Radius, Is.EqualTo(120f));
+            That(ability.Indicator.ShowRangeCircle, Is.False);
+        }
+
+        [Test]
+        public void CompileAbility_IndicatorStateColorsAreOptionalDefaults()
+        {
+            var ability = Compile(
+                """
+                {
+                  "exec": {
+                    "clockId": "FixedFrame",
+                    "items": [
+                      { "kind": "End", "tick": 0 }
+                    ]
+                  },
+                  "indicator": {
+                    "shape": "Single",
+                    "range": 500,
+                    "showRangeCircle": true,
+                    "rangeCircleColor": "#3366FF"
+                  }
+                }
+                """);
+
+            That(ability.Indicator.Range, Is.EqualTo(500f));
+            That(ability.Indicator.Radius, Is.EqualTo(0f));
+            That(ability.Indicator.ShowRangeCircle, Is.True);
+        }
+
+        [Test]
+        public void CompileAbility_OptionalIndicatorRangeZero_IsRejected()
+        {
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    """
+                    {
+                      "exec": {
+                        "clockId": "FixedFrame",
+                        "items": [
+                          { "kind": "End", "tick": 0 }
+                        ]
+                      },
+                      "indicator": {
+                        "shape": "Circle",
+                        "range": 0,
+                        "radius": 120,
+                        "showRangeCircle": false,
+                        "validColor": "#33CC66",
+                        "invalidColor": "#FF3333"
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("indicator.range"));
+            That(ex.Message, Does.Contain("omitted or > 0"));
+        }
+
+        [Test]
+        public void CompileAbility_SingleIndicatorRadius_IsRejected()
+        {
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    """
+                    {
+                      "exec": {
+                        "clockId": "FixedFrame",
+                        "items": [
+                          { "kind": "End", "tick": 0 }
+                        ]
+                      },
+                      "indicator": {
+                        "shape": "Single",
+                        "range": 500,
+                        "radius": 80,
+                        "showRangeCircle": true,
+                        "validColor": "#33CC66",
+                        "invalidColor": "#FF3333",
+                        "rangeCircleColor": "#3366FF"
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("indicator.radius"));
+            That(ex.Message, Does.Contain("Single"));
+        }
+
+        [Test]
+        public void CompileAbility_RangeCircleRequiresColor()
+        {
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    """
+                    {
+                      "exec": {
+                        "clockId": "FixedFrame",
+                        "items": [
+                          { "kind": "End", "tick": 0 }
+                        ]
+                      },
+                      "indicator": {
+                        "shape": "Circle",
+                        "range": 500,
+                        "radius": 120,
+                        "showRangeCircle": true,
+                        "validColor": "#33CC66",
+                        "invalidColor": "#FF3333"
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("indicator.rangeCircleColor"));
+        }
+
+        [Test]
+        public void CompileAbility_LineIndicatorRequiresPositiveRadiusAsWidth()
+        {
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    """
+                    {
+                      "exec": {
+                        "clockId": "FixedFrame",
+                        "items": [
+                          { "kind": "End", "tick": 0 }
+                        ]
+                      },
+                      "indicator": {
+                        "shape": "Line",
+                        "range": 500,
+                        "radius": 0,
+                        "showRangeCircle": false,
+                        "validColor": "#33CC66",
+                        "invalidColor": "#FF3333"
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("indicator.radius"));
+            That(ex.Message, Does.Contain("> 0"));
+        }
+
+        [Test]
+        public void CompileAbility_RangeCircleColorWithoutRangeCircle_IsRejected()
+        {
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    """
+                    {
+                      "exec": {
+                        "clockId": "FixedFrame",
+                        "items": [
+                          { "kind": "End", "tick": 0 }
+                        ]
+                      },
+                      "indicator": {
+                        "shape": "Circle",
+                        "radius": 120,
+                        "showRangeCircle": false,
+                        "validColor": "#33CC66",
+                        "invalidColor": "#FF3333",
+                        "rangeCircleColor": "#3366FF"
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("indicator.rangeCircleColor"));
+            That(ex.Message, Does.Contain("showRangeCircle"));
+        }
+
+        [Test]
+        public void CompileAbility_TooManyToggleActiveEffects_IsRejected()
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                EffectTemplateIdRegistry.Register($"Effect.Toggle.{i}");
+            }
+
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    """
+                    {
+                      "exec": {
+                        "clockId": "FixedFrame",
+                        "items": [
+                          { "kind": "End", "tick": 0 }
+                        ]
+                      },
+                      "toggleSpec": {
+                        "toggleTag": "State.Toggle",
+                        "activeEffects": [
+                          "Effect.Toggle.0",
+                          "Effect.Toggle.1",
+                          "Effect.Toggle.2",
+                          "Effect.Toggle.3",
+                          "Effect.Toggle.4"
+                        ]
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("toggleSpec.activeEffects"));
+            That(ex.Message, Does.Contain("max 4"));
+        }
+
+        [Test]
+        public void CompileAbility_BlankToggleActiveEffect_IsRejected()
+        {
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    """
+                    {
+                      "exec": {
+                        "clockId": "FixedFrame",
+                        "items": [
+                          { "kind": "End", "tick": 0 }
+                        ]
+                      },
+                      "toggleSpec": {
+                        "toggleTag": "State.Toggle",
+                        "activeEffects": [""]
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("toggleSpec.activeEffects[0]"));
+            That(ex.Message, Does.Contain("non-empty"));
+        }
+
+        [Test]
+        public void CompileAbility_UnknownPresentationModeHint_IsRejected()
+        {
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    """
+                    {
+                      "exec": {
+                        "clockId": "FixedFrame",
+                        "items": [
+                          { "kind": "End", "tick": 0 }
+                        ]
+                      },
+                      "presentation": {
+                        "modeHints": {
+                          "SmartCastTypo": "bad mode"
+                        }
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("presentation.modeHints.SmartCastTypo"));
+            That(ex.Message, Does.Contain("unknown interaction mode"));
+        }
+
+        [Test]
+        public void CompileAbility_BlankPresentationModeGlyph_IsRejected()
+        {
+            var ex = Throws<InvalidOperationException>(() =>
+                Compile(
+                    """
+                    {
+                      "exec": {
+                        "clockId": "FixedFrame",
+                        "items": [
+                          { "kind": "End", "tick": 0 }
+                        ]
+                      },
+                      "presentation": {
+                        "modeIconGlyphs": {
+                          "SmartCast": ""
+                        }
+                      }
+                    }
+                    """));
+
+            That(ex!.Message, Does.Contain("presentation.modeIconGlyphs.SmartCast"));
+            That(ex.Message, Does.Contain("non-empty string"));
+        }
+
+        private static AbilityExecLoader CreateLoader(string root, out AbilityDefinitionRegistry registry)
+        {
+            var vfs = new VirtualFileSystem();
+            vfs.Mount("Core", root);
+            var modLoader = new ModLoader(vfs, new FunctionRegistry(), new TriggerManager());
+            var pipeline = new ConfigPipeline(vfs, modLoader);
+
+            registry = new AbilityDefinitionRegistry();
+            return new AbilityExecLoader(pipeline, registry);
+        }
+
+        private static ConfigCatalog CreateAbilitiesCatalog()
+        {
+            var catalog = new ConfigCatalog();
+            catalog.Add(new ConfigCatalogEntry("GAS/abilities.json", ConfigMergePolicy.ArrayById, "id"));
+            return catalog;
+        }
+
+        private static AbilityDefinition Compile(string json)
+        {
+            var obj = JsonNode.Parse(json)!.AsObject();
+            return AbilityExecLoader.CompileAbility(obj, "Ability.Test.Strict", "GAS/abilities.json");
+        }
+
+        private static void WriteAbilities(string root, string json)
+        {
+            Directory.CreateDirectory(Path.Combine(root, "Configs", "GAS"));
+            File.WriteAllText(Path.Combine(root, "Configs", "GAS", "abilities.json"), json);
+        }
+
+        private static string CreateTempRoot()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "Ludots_AbilityExecLoaderFailFastTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(root);
+            return root;
+        }
+
+        private static void TryDeleteDirectory(string path)
+        {
+            try
+            {
+                if (Directory.Exists(path)) Directory.Delete(path, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/src/Tests/GasTests/AiBenchmarkTests.cs
+++ b/src/Tests/GasTests/AiBenchmarkTests.cs
@@ -55,7 +55,7 @@ namespace Ludots.Tests.GAS
                     postValues: in postValues,
                     cost: 1,
                     executorKind: ActionExecutorKind.SubmitOrder,
-                    orderSpec: new ActionOrderSpec(orderTypeId: 1234, submitMode: OrderSubmitMode.Immediate, playerId: 0),
+                    orderSpec: new ActionOrderSpec(orderTypeId: 123, submitMode: OrderSubmitMode.Immediate, playerId: 0),
                     bindings: Array.Empty<ActionBinding>())
             });
 
@@ -137,7 +137,7 @@ namespace Ludots.Tests.GAS
                     postValues: default,
                     cost: 1,
                     executorKind: ActionExecutorKind.SubmitOrder,
-                    orderSpec: new ActionOrderSpec(orderTypeId: 5678, submitMode: OrderSubmitMode.Immediate, playerId: 0),
+                    orderSpec: new ActionOrderSpec(orderTypeId: 123, submitMode: OrderSubmitMode.Immediate, playerId: 0),
                     bindings: Array.Empty<ActionBinding>())
             });
 

--- a/src/Tests/GasTests/AiConfigLoaderTests.cs
+++ b/src/Tests/GasTests/AiConfigLoaderTests.cs
@@ -186,6 +186,41 @@ namespace Ludots.Tests.GAS
             Assert.That(ex!.Message, Does.Contain("unknown gameplay tag 'Cooldown.Missing'"));
         }
 
+        [Test]
+        public void AiConfigLoader_RejectsNumericProjectionEntityKey()
+        {
+            using var fixture = AiConfigFixture.Create(
+                projectionJson: "[ { \"id\": \"R0\", \"Atom\": \"HasEnemy\", \"Op\": \"EntityIsNonNull\", \"EntityKey\": 1 } ]");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => fixture.Load());
+
+            Assert.That(ex!.Message, Does.Contain("EntityKey"));
+            Assert.That(ex.Message, Does.Contain("semantic string"));
+        }
+
+        [Test]
+        public void AiConfigLoader_RejectsMissingProjectionIntValue()
+        {
+            using var fixture = AiConfigFixture.Create(
+                projectionJson: "[ { \"id\": \"R0\", \"Atom\": \"HasEnemy\", \"Op\": \"IntEquals\", \"IntKey\": \"Generic.IntParam\" } ]");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => fixture.Load());
+
+            Assert.That(ex!.Message, Does.Contain("IntValue"));
+        }
+
+        [Test]
+        public void AiConfigLoader_RejectsWrongProjectionFieldForOp()
+        {
+            using var fixture = AiConfigFixture.Create(
+                projectionJson: "[ { \"id\": \"R0\", \"Atom\": \"HasEnemy\", \"Op\": \"EntityIsNonNull\", \"EntityKey\": \"Attack.TargetEntity\", \"IntValue\": 0 } ]");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => fixture.Load());
+
+            Assert.That(ex!.Message, Does.Contain("IntValue"));
+            Assert.That(ex.Message, Does.Contain("EntityIsNonNull"));
+        }
+
         private sealed class AiConfigFixture : IDisposable
         {
             private readonly string _root;
@@ -220,7 +255,7 @@ namespace Ludots.Tests.GAS
 
             public int ScoreGraphId { get; }
 
-            public static AiConfigFixture Create(string? orderJson = null)
+            public static AiConfigFixture Create(string? orderJson = null, string? projectionJson = null)
             {
                 string root = Path.Combine(Path.GetTempPath(), "Ludots_AiConfigLoaderTests", Guid.NewGuid().ToString("N"));
                 Directory.CreateDirectory(root);
@@ -231,9 +266,10 @@ namespace Ludots.Tests.GAS
                 Directory.CreateDirectory(Path.Combine(mod, "assets", "Configs", "AI"));
 
                 orderJson ??= "{ \"OrderTypeKey\": \"attackTarget\", \"SubmitMode\": 0, \"PlayerId\": 0 }";
+                projectionJson ??= "[ { \"id\": \"R0\", \"Atom\": \"HasEnemy\", \"Op\": \"EntityIsNonNull\", \"EntityKey\": \"Attack.TargetEntity\" } ]";
 
                 File.WriteAllText(Path.Combine(core, "Configs", "AI", "atoms.json"), "[ { \"id\": \"HasEnemy\" } ]");
-                File.WriteAllText(Path.Combine(core, "Configs", "AI", "projection.json"), "[ { \"id\": \"R0\", \"Atom\": \"HasEnemy\", \"Op\": \"EntityIsNonNull\", \"EntityKey\": 1 } ]");
+                File.WriteAllText(Path.Combine(core, "Configs", "AI", "projection.json"), projectionJson);
                 File.WriteAllText(Path.Combine(core, "Configs", "AI", "utility.json"), "[ { \"id\": \"G0\", \"GoalPresetId\": 1, \"PlanningStrategyId\": 1, \"Weight\": 1, \"Bool\": [ { \"Atom\": \"HasEnemy\", \"TrueScore\": 1, \"FalseScore\": 0 } ] } ]");
                 File.WriteAllText(Path.Combine(core, "Configs", "AI", "goap_actions.json"), $"[ {{ \"id\": \"A0\", \"Cost\": 1, \"Pre\": {{\"Mask\":[],\"Values\":[]}}, \"Post\": {{\"Mask\":[],\"Values\":[]}}, \"Order\": {orderJson}, \"Bindings\": [] }} ]");
                 File.WriteAllText(Path.Combine(core, "Configs", "AI", "goap_goals.json"), "[ { \"id\": \"GG0\", \"GoalPresetId\": 1, \"HeuristicWeight\": 1, \"Goal\": { \"Mask\": [\"HasEnemy\"], \"Values\": [\"HasEnemy\"] } } ]");

--- a/src/Tests/GasTests/AllocationTests.cs
+++ b/src/Tests/GasTests/AllocationTests.cs
@@ -127,7 +127,14 @@ namespace Ludots.Tests.GAS
 
             var requests = new EffectRequestQueue();
             var chainOrders = new Ludots.Core.Gameplay.GAS.Orders.OrderQueue();
-            var proposal = new EffectProposalProcessingSystem(world, requests, budget: null, templates: templates, inputRequests: null, chainOrders: chainOrders);
+            var proposal = new EffectProposalProcessingSystem(
+                world,
+                requests,
+                budget: null,
+                templates: templates,
+                inputRequests: null,
+                chainOrders: chainOrders,
+                responseChainOrderTypes: TestResponseChainOrderTypeIds.Types);
 
             var sinks = new Ludots.Core.Gameplay.GAS.Bindings.AttributeSinkRegistry();
             Ludots.Core.Gameplay.GAS.Bindings.GasAttributeSinks.RegisterBuiltins(sinks);

--- a/src/Tests/GasTests/ApplyForceEndToEndTests.cs
+++ b/src/Tests/GasTests/ApplyForceEndToEndTests.cs
@@ -146,7 +146,14 @@ namespace Ludots.Tests.GAS
                 chainOrders.TryEnqueue(new Order { OrderTypeId = TestResponseChainOrderTypeIds.ChainPass });
                 chainOrders.TryEnqueue(new Order { OrderTypeId = TestResponseChainOrderTypeIds.ChainPass });
 
-                var proposal = new Ludots.Core.Gameplay.GAS.Systems.EffectProposalProcessingSystem(world, requests, budget: null, templates: templates, inputRequests: null, chainOrders: chainOrders);
+                var proposal = new Ludots.Core.Gameplay.GAS.Systems.EffectProposalProcessingSystem(
+                    world,
+                    requests,
+                    budget: null,
+                    templates: templates,
+                    inputRequests: null,
+                    chainOrders: chainOrders,
+                    responseChainOrderTypes: TestResponseChainOrderTypeIds.Types);
                 proposal.Update(0.016f);
 
                 ref var attr = ref world.Get<AttributeBuffer>(target);

--- a/src/Tests/GasTests/CallerParamsE2ETests.cs
+++ b/src/Tests/GasTests/CallerParamsE2ETests.cs
@@ -89,7 +89,8 @@ namespace Ludots.Tests.GAS
 
                 var proposalSys = new Ludots.Core.Gameplay.GAS.Systems.EffectProposalProcessingSystem(
                     world, requests, budget: null, templates: templates,
-                    inputRequests: null, chainOrders: chainOrders);
+                    inputRequests: null, chainOrders: chainOrders,
+                    responseChainOrderTypes: TestResponseChainOrderTypeIds.Types);
                 proposalSys.Update(0.016f);
 
                 ref var attr = ref world.Get<AttributeBuffer>(target);
@@ -147,7 +148,8 @@ namespace Ludots.Tests.GAS
 
                 var proposalSys = new Ludots.Core.Gameplay.GAS.Systems.EffectProposalProcessingSystem(
                     world, requests, budget: null, templates: templates,
-                    inputRequests: null, chainOrders: chainOrders);
+                    inputRequests: null, chainOrders: chainOrders,
+                    responseChainOrderTypes: TestResponseChainOrderTypeIds.Types);
                 proposalSys.Update(0.016f);
 
                 // Without CallerParams, force values should be 0 (template doesn't define them in configParams)

--- a/src/Tests/GasTests/ConfigCatalogTests.cs
+++ b/src/Tests/GasTests/ConfigCatalogTests.cs
@@ -274,5 +274,34 @@ namespace Ludots.Tests.GAS
                 }
             }
         }
+
+        [Test]
+        public void ConfigPipeline_InvalidJsonFragment_IsRejected()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "Ludots_ConfigCatalogTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(root);
+            try
+            {
+                string core = Path.Combine(root, "Core");
+                Directory.CreateDirectory(Path.Combine(core, "Configs"));
+                File.WriteAllText(Path.Combine(core, "Configs", "game.json"), "{ \"startupMapId\": ");
+
+                var vfs = new VirtualFileSystem();
+                vfs.Mount("Core", core);
+                var modLoader = new ModLoader(vfs, new Ludots.Core.Scripting.FunctionRegistry(), new Ludots.Core.Scripting.TriggerManager());
+                var pipeline = new ConfigPipeline(vfs, modLoader);
+
+                JsonException ex = Assert.Throws<JsonException>(() => pipeline.CollectFragmentsWithSources("game.json"))!;
+
+                Assert.That(ex.Message, Does.Contain("Core:Configs/game.json"));
+            }
+            finally
+            {
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, recursive: true);
+                }
+            }
+        }
     }
 }

--- a/src/Tests/GasTests/ConfigMergerEntriesTests.cs
+++ b/src/Tests/GasTests/ConfigMergerEntriesTests.cs
@@ -118,6 +118,22 @@ namespace Ludots.Tests.GAS
         }
 
         [Test]
+        public void MergeArrayByIdToEntries_MissingId_IsRejectedWithSource()
+        {
+            var frags = new List<ConfigFragment>
+            {
+                MakeFrag(@"[{""id"":""A"",""v"":1}, {""v"":2}]", "ModA:test.json")
+            };
+            var entry = new ConfigCatalogEntry("GAS/abilities.json", ConfigMergePolicy.ArrayById, "id");
+
+            var ex = Throws<InvalidOperationException>(() => ConfigMerger.MergeArrayByIdToEntries(frags, in entry));
+
+            That(ex!.Message, Does.Contain("GAS/abilities.json"));
+            That(ex.Message, Does.Contain("ModA:test.json"));
+            That(ex.Message, Does.Contain("id"));
+        }
+
+        [Test]
         public void MergeArrayByIdToEntries_EmptyFragments_ReturnsEmpty()
         {
             var frags = new List<ConfigFragment>();
@@ -144,30 +160,33 @@ namespace Ludots.Tests.GAS
         }
 
         [Test]
-        public void MergeArrayByIdToEntries_NonObjectNodes_Skipped()
+        public void MergeArrayByIdToEntries_NonObjectNodes_AreRejected()
         {
             var frags = new List<ConfigFragment>
             {
                 MakeFrag(@"[{""id"":""A"",""v"":1}, 42, ""str"", null]")
             };
             var entry = new ConfigCatalogEntry("test.json", ConfigMergePolicy.ArrayById, "id");
-            var result = ConfigMerger.MergeArrayByIdToEntries(frags, in entry);
 
-            That(result.Count, Is.EqualTo(1));
-            That(result[0].Id, Is.EqualTo("A"));
+            var ex = Throws<InvalidOperationException>(() => ConfigMerger.MergeArrayByIdToEntries(frags, in entry));
+
+            That(ex!.Message, Does.Contain("test.json"));
+            That(ex.Message, Does.Contain("JSON object"));
         }
 
         [Test]
-        public void MergeArrayByIdToEntries_NonArrayFragment_Skipped()
+        public void MergeArrayByIdToEntries_NonArrayFragment_IsRejected()
         {
             var frags = new List<ConfigFragment>
             {
                 MakeFrag(@"{""id"":""A"",""v"":1}")
             };
             var entry = new ConfigCatalogEntry("test.json", ConfigMergePolicy.ArrayById, "id");
-            var result = ConfigMerger.MergeArrayByIdToEntries(frags, in entry);
 
-            That(result.Count, Is.EqualTo(0), "Non-array fragments are skipped");
+            var ex = Throws<InvalidOperationException>(() => ConfigMerger.MergeArrayByIdToEntries(frags, in entry));
+
+            That(ex!.Message, Does.Contain("test.json"));
+            That(ex.Message, Does.Contain("JSON array"));
         }
     }
 }

--- a/src/Tests/GasTests/EffectPresetInteractionModeTests.cs
+++ b/src/Tests/GasTests/EffectPresetInteractionModeTests.cs
@@ -146,6 +146,12 @@ namespace Ludots.Tests.GAS
             var obj = JsonNode.Parse(
                 """
                 {
+                  "exec": {
+                    "clockId": "FixedFrame",
+                    "items": [
+                      { "kind": "End", "tick": 0 }
+                    ]
+                  },
                   "presentation": {
                     "displayName": "Mystic Shot",
                     "iconGlyph": "Q",

--- a/src/Tests/GasTests/EffectTemplateLoaderTests.cs
+++ b/src/Tests/GasTests/EffectTemplateLoaderTests.cs
@@ -6,6 +6,7 @@ using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Config;
 using Ludots.Core.Gameplay.GAS.Registry;
 using Ludots.Core.Modding;
+using Ludots.Core.NodeLibraries.GASGraph.Host;
 using Ludots.Core.Scripting;
 using NUnit.Framework;
 using static NUnit.Framework.Assert;
@@ -179,9 +180,9 @@ namespace Ludots.Tests.GAS
                           "impactEffect": "Effect_Hit",
                           "hitEffect": "Effect_Hit",
                           "presentationEffect": "Effect_Hit",
-                          "travelMode": "Legacy",
-                          "impactPolicy": "Legacy",
-                          "collisionHalfWidth": 0,
+                          "travelMode": "Direction",
+                          "impactPolicy": "DestroyOnFirstHit",
+                          "collisionHalfWidth": 24,
                           "collisionExcludeSource": true,
                           "maxHitCount": 0
                         }
@@ -199,6 +200,422 @@ namespace Ludots.Tests.GAS
                 var loader = CreateLoader(root, out _);
 
                 Throws<InvalidOperationException>(() => loader.Load(CreateEffectsCatalog(), relativePath: "GAS/effects.json"));
+            }
+            finally
+            {
+                TryDeleteDirectory(root);
+            }
+        }
+
+        [Test]
+        public void Load_LegacyProjectileOmittedOptionalRefs_AreAccepted()
+        {
+            string root = CreateTempRoot();
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(root, "Configs", "GAS"));
+                File.WriteAllText(Path.Combine(root, "Configs", "GAS", "effects.json"),
+                    """
+                    [
+                      {
+                        "id": "Effect_Projectile",
+                        "tags": ["Event.Projectile"],
+                        "presetType": "LaunchProjectile",
+                        "lifetime": "Instant",
+                        "participatesInResponse": true,
+                        "projectile": {
+                          "speed": 1000,
+                          "range": 1200,
+                          "arcHeight": 0,
+                          "travelMode": "Legacy",
+                          "impactPolicy": "Legacy"
+                        }
+                      }
+                    ]
+                    """);
+
+                var loader = CreateLoader(root, out var registry);
+                loader.Load(CreateEffectsCatalog(), relativePath: "GAS/effects.json");
+
+                int templateId = EffectTemplateIdRegistry.GetId("Effect_Projectile");
+                That(registry.TryGet(templateId, out var tpl), Is.True);
+                That(tpl.Projectile.ImpactEffectTemplateId, Is.EqualTo(0));
+                That(tpl.Projectile.HitEffectTemplateId, Is.EqualTo(0));
+                That(tpl.Projectile.PresentationEffectTemplateId, Is.EqualTo(0));
+                That(tpl.Projectile.CollisionHalfWidthCm, Is.EqualTo(0));
+                That(tpl.Projectile.CollisionExcludeSource, Is.False);
+                That(tpl.Projectile.MaxHitCount, Is.EqualTo(0));
+            }
+            finally
+            {
+                TryDeleteDirectory(root);
+            }
+        }
+
+        [Test]
+        public void Load_ProjectileBlankOptionalEffectRef_IsRejected()
+        {
+            string root = CreateTempRoot();
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(root, "Configs", "GAS"));
+                File.WriteAllText(Path.Combine(root, "Configs", "GAS", "effects.json"),
+                    """
+                    [
+                      {
+                        "id": "Effect_Projectile",
+                        "tags": ["Event.Projectile"],
+                        "presetType": "LaunchProjectile",
+                        "lifetime": "Instant",
+                        "participatesInResponse": true,
+                        "projectile": {
+                          "speed": 1000,
+                          "range": 1200,
+                          "arcHeight": 0,
+                          "impactEffect": "",
+                          "travelMode": "Legacy",
+                          "impactPolicy": "Legacy"
+                        }
+                      }
+                    ]
+                    """);
+
+                var loader = CreateLoader(root, out _);
+
+                var ex = Throws<InvalidOperationException>(() => loader.Load(CreateEffectsCatalog(), relativePath: "GAS/effects.json"));
+
+                That(ex!.Message, Does.Contain("projectile.impactEffect"));
+                That(ex.Message, Does.Contain("omitted or a semantic key"));
+            }
+            finally
+            {
+                TryDeleteDirectory(root);
+            }
+        }
+
+        [Test]
+        public void Load_NonLegacyProjectileMissingHitEffect_IsRejected()
+        {
+            string root = CreateTempRoot();
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(root, "Configs", "GAS"));
+                File.WriteAllText(Path.Combine(root, "Configs", "GAS", "effects.json"),
+                    """
+                    [
+                      {
+                        "id": "Effect_Projectile",
+                        "tags": ["Event.Projectile"],
+                        "presetType": "LaunchProjectile",
+                        "lifetime": "Instant",
+                        "participatesInResponse": true,
+                        "projectile": {
+                          "speed": 1000,
+                          "range": 1200,
+                          "arcHeight": 0,
+                          "travelMode": "Direction",
+                          "impactPolicy": "DestroyOnFirstHit",
+                          "collisionHalfWidth": 24,
+                          "collisionRelationFilter": "All"
+                        }
+                      }
+                    ]
+                    """);
+
+                var loader = CreateLoader(root, out _);
+
+                var ex = Throws<InvalidOperationException>(() => loader.Load(CreateEffectsCatalog(), relativePath: "GAS/effects.json"));
+
+                That(ex!.Message, Does.Contain("projectile.hitEffect"));
+                That(ex.Message, Does.Contain("DestroyOnFirstHit"));
+            }
+            finally
+            {
+                TryDeleteDirectory(root);
+            }
+        }
+
+        [Test]
+        public void Load_InfiniteLifetimeCanOmitDurationBlock()
+        {
+            string root = CreateTempRoot();
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(root, "Configs", "GAS"));
+                File.WriteAllText(Path.Combine(root, "Configs", "GAS", "effects.json"),
+                    """
+                    [
+                      {
+                        "id": "Effect_Aura",
+                        "tags": ["Event.Aura"],
+                        "presetType": "None",
+                        "lifetime": "Infinite",
+                        "participatesInResponse": true
+                      }
+                    ]
+                    """);
+
+                var loader = CreateLoader(root, out var registry);
+                loader.Load(CreateEffectsCatalog(), relativePath: "GAS/effects.json");
+
+                int templateId = EffectTemplateIdRegistry.GetId("Effect_Aura");
+                That(registry.TryGet(templateId, out var tpl), Is.True);
+                That(tpl.LifetimeKind, Is.EqualTo(EffectLifetimeKind.Infinite));
+                That(tpl.DurationTicks, Is.EqualTo(0));
+                That(tpl.PeriodTicks, Is.EqualTo(0));
+            }
+            finally
+            {
+                TryDeleteDirectory(root);
+            }
+        }
+
+        [Test]
+        public void Load_InfiniteLifetimeDefaultZeroDurationBlock_IsRejected()
+        {
+            string root = CreateTempRoot();
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(root, "Configs", "GAS"));
+                File.WriteAllText(Path.Combine(root, "Configs", "GAS", "effects.json"),
+                    """
+                    [
+                      {
+                        "id": "Effect_Aura",
+                        "tags": ["Event.Aura"],
+                        "presetType": "None",
+                        "lifetime": "Infinite",
+                        "duration": { "durationTicks": 0, "periodTicks": 0, "clockId": "FixedFrame" },
+                        "participatesInResponse": true
+                      }
+                    ]
+                    """);
+
+                var loader = CreateLoader(root, out _);
+
+                var ex = Throws<InvalidOperationException>(() => loader.Load(CreateEffectsCatalog(), relativePath: "GAS/effects.json"));
+
+                That(ex!.Message, Does.Contain("duration"));
+                That(ex.Message, Does.Contain("omit"));
+            }
+            finally
+            {
+                TryDeleteDirectory(root);
+            }
+        }
+
+        [Test]
+        public void Load_TargetDispatchPayloadEffectWithoutContextMapping_UsesDefaultMapping()
+        {
+            string root = CreateTempRoot();
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(root, "Configs", "GAS"));
+                File.WriteAllText(Path.Combine(root, "Configs", "GAS", "effects.json"),
+                    """
+                    [
+                      {
+                        "id": "Effect_Search",
+                        "tags": ["Event.Search"],
+                        "presetType": "Search",
+                        "lifetime": "Instant",
+                        "participatesInResponse": true,
+                        "targetQuery": {
+                          "kind": "BuiltinSpatial",
+                          "shape": "Circle",
+                          "radius": 100
+                        },
+                        "targetFilter": { "excludeSource": true, "maxTargets": 4, "relationFilter": "All" },
+                        "targetDispatch": { "payloadEffect": "Effect_Hit" }
+                      },
+                      {
+                        "id": "Effect_Hit",
+                        "tags": ["Event.Hit"],
+                        "presetType": "InstantDamage",
+                        "lifetime": "Instant",
+                        "participatesInResponse": true
+                      }
+                    ]
+                    """);
+
+                var loader = CreateLoader(root, out var registry);
+                loader.Load(CreateEffectsCatalog(), relativePath: "GAS/effects.json");
+
+                int templateId = EffectTemplateIdRegistry.GetId("Effect_Search");
+                int hitId = EffectTemplateIdRegistry.GetId("Effect_Hit");
+                That(registry.TryGet(templateId, out var tpl), Is.True);
+                That(tpl.TargetDispatch.PayloadEffectTemplateId, Is.EqualTo(hitId));
+                That(tpl.TargetDispatch.ContextMapping.PayloadSource, Is.EqualTo(ContextSlot.OriginalSource));
+                That(tpl.TargetDispatch.ContextMapping.PayloadTarget, Is.EqualTo(ContextSlot.ResolvedEntity));
+                That(tpl.TargetDispatch.ContextMapping.PayloadTargetContext, Is.EqualTo(ContextSlot.OriginalTarget));
+            }
+            finally
+            {
+                TryDeleteDirectory(root);
+            }
+        }
+
+        [Test]
+        public void Load_PhaseListenerOmittedPriority_DefaultsToZero()
+        {
+            GraphIdRegistry.Clear();
+            GraphIdRegistry.Register("Graph.Test.OnHit");
+
+            string root = CreateTempRoot();
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(root, "Configs", "GAS"));
+                File.WriteAllText(Path.Combine(root, "Configs", "GAS", "effects.json"),
+                    """
+                    [
+                      {
+                        "id": "Effect_Reactive",
+                        "tags": ["Event.Reactive"],
+                        "presetType": "None",
+                        "lifetime": "Infinite",
+                        "participatesInResponse": true,
+                        "phaseListeners": [
+                          {
+                            "phase": "OnHit",
+                            "scope": "Target",
+                            "action": "Graph",
+                            "graphProgram": "Graph.Test.OnHit"
+                          }
+                        ]
+                      }
+                    ]
+                    """);
+
+                var loader = CreateLoader(root, out var registry);
+                loader.Load(CreateEffectsCatalog(), relativePath: "GAS/effects.json");
+
+                int templateId = EffectTemplateIdRegistry.GetId("Effect_Reactive");
+                That(registry.TryGet(templateId, out var tpl), Is.True);
+                That(tpl.ListenerSetup.Count, Is.EqualTo(1));
+                unsafe
+                {
+                    That(tpl.ListenerSetup.Priorities[0], Is.EqualTo(0));
+                }
+            }
+            finally
+            {
+                GraphIdRegistry.Clear();
+                TryDeleteDirectory(root);
+            }
+        }
+
+        [Test]
+        public void Load_ScatterUnitCreationOmittedOffsetRadius_IsAcceptedAsZero()
+        {
+            string root = CreateTempRoot();
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(root, "Configs", "GAS"));
+                File.WriteAllText(Path.Combine(root, "Configs", "GAS", "effects.json"),
+                    """
+                    [
+                      {
+                        "id": "Effect_CreateUnit",
+                        "tags": ["Event.CreateUnit"],
+                        "presetType": "CreateUnit",
+                        "lifetime": "Instant",
+                        "participatesInResponse": true,
+                        "unitCreation": {
+                          "unitType": "Unit.Test.Wolf",
+                          "count": 1,
+                          "placementPattern": "Scatter"
+                        }
+                      }
+                    ]
+                    """);
+
+                var loader = CreateLoader(root, out var registry);
+                loader.Load(CreateEffectsCatalog(), relativePath: "GAS/effects.json");
+
+                int templateId = EffectTemplateIdRegistry.GetId("Effect_CreateUnit");
+                That(registry.TryGet(templateId, out var tpl), Is.True);
+                That(tpl.UnitCreation.PlacementPattern, Is.EqualTo(UnitCreationPlacementPattern.Scatter));
+                That(tpl.UnitCreation.OffsetRadius, Is.EqualTo(0));
+            }
+            finally
+            {
+                TryDeleteDirectory(root);
+            }
+        }
+
+        [Test]
+        public void Load_ScatterUnitCreationNegativeOffsetRadius_IsRejected()
+        {
+            string root = CreateTempRoot();
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(root, "Configs", "GAS"));
+                File.WriteAllText(Path.Combine(root, "Configs", "GAS", "effects.json"),
+                    """
+                    [
+                      {
+                        "id": "Effect_CreateUnit",
+                        "tags": ["Event.CreateUnit"],
+                        "presetType": "CreateUnit",
+                        "lifetime": "Instant",
+                        "participatesInResponse": true,
+                        "unitCreation": {
+                          "unitType": "Unit.Test.Wolf",
+                          "count": 1,
+                          "placementPattern": "Scatter",
+                          "offsetRadius": -1
+                        }
+                      }
+                    ]
+                    """);
+
+                var loader = CreateLoader(root, out _);
+
+                var ex = Throws<InvalidOperationException>(() => loader.Load(CreateEffectsCatalog(), relativePath: "GAS/effects.json"));
+
+                That(ex!.Message, Does.Contain("unitCreation.offsetRadius"));
+                That(ex.Message, Does.Contain("non-negative"));
+            }
+            finally
+            {
+                TryDeleteDirectory(root);
+            }
+        }
+
+        [Test]
+        public void Load_CircleUnitCreationOffsetRadius_IsRejected()
+        {
+            string root = CreateTempRoot();
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(root, "Configs", "GAS"));
+                File.WriteAllText(Path.Combine(root, "Configs", "GAS", "effects.json"),
+                    """
+                    [
+                      {
+                        "id": "Effect_CreateUnit",
+                        "tags": ["Event.CreateUnit"],
+                        "presetType": "CreateUnit",
+                        "lifetime": "Instant",
+                        "participatesInResponse": true,
+                        "unitCreation": {
+                          "unitType": "Unit.Test.Wolf",
+                          "count": 3,
+                          "placementPattern": "Circle",
+                          "offsetRadius": 80,
+                          "placementRadiusCm": 160,
+                          "placementStartAngleDeg": 0
+                        }
+                      }
+                    ]
+                    """);
+
+                var loader = CreateLoader(root, out _);
+
+                var ex = Throws<InvalidOperationException>(() => loader.Load(CreateEffectsCatalog(), relativePath: "GAS/effects.json"));
+
+                That(ex!.Message, Does.Contain("unitCreation.offsetRadius"));
+                That(ex.Message, Does.Contain("placementPattern=Circle"));
             }
             finally
             {

--- a/src/Tests/GasTests/GasConfigLoaderFailFastTests.cs
+++ b/src/Tests/GasTests/GasConfigLoaderFailFastTests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.IO;
+using Ludots.Core.Config;
+using Ludots.Core.Gameplay.GAS;
+using Ludots.Core.Gameplay.GAS.Config;
+using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.Modding;
+using Ludots.Core.Scripting;
+using NUnit.Framework;
+using static NUnit.Framework.Assert;
+
+namespace Ludots.Tests.GAS
+{
+    [TestFixture]
+    public sealed class GasConfigLoaderFailFastTests
+    {
+        private string _root = string.Empty;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "Ludots_GasConfigLoaderFailFastTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+            AbilityIdRegistry.Clear();
+            ContextGroupIdRegistry.Clear();
+            AbilityFormSetIdRegistry.Clear();
+            AttributeRegistry.Clear();
+            TagRegistry.Clear();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            try
+            {
+                if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+
+        [Test]
+        public void AttributeConstraintsLoader_InvalidBool_IsRejected()
+        {
+            WriteConfig("config_catalog.json",
+                @"[{ ""Path"": ""GAS/attribute_constraints.json"", ""Policy"": ""DeepObject"" }]");
+            WriteConfig("GAS/attribute_constraints.json",
+                @"{ ""Health"": { ""clampToBase"": ""sometimes"", ""min"": 0 } }");
+
+            var (pipeline, catalog) = BuildPipeline();
+            var loader = new AttributeConstraintsLoader(pipeline);
+
+            Throws<InvalidOperationException>(() => loader.Load(catalog));
+        }
+
+        [Test]
+        public void AttributeConstraintsLoader_NonObjectEntry_IsRejected()
+        {
+            WriteConfig("config_catalog.json",
+                @"[{ ""Path"": ""GAS/attribute_constraints.json"", ""Policy"": ""DeepObject"" }]");
+            WriteConfig("GAS/attribute_constraints.json",
+                @"{ ""Health"": 12 }");
+
+            var (pipeline, catalog) = BuildPipeline();
+            var loader = new AttributeConstraintsLoader(pipeline);
+
+            var ex = Throws<InvalidOperationException>(() => loader.Load(catalog));
+
+            That(ex!.Message, Does.Contain("Health"));
+            That(ex.Message, Does.Contain("object"));
+        }
+
+        [Test]
+        public void ContextGroupConfigLoader_NonObjectCandidate_IsRejected()
+        {
+            WriteConfig("config_catalog.json",
+                @"[{ ""Path"": ""GAS/context_groups.json"", ""Policy"": ""ArrayById"", ""IdField"": ""id"" }]");
+            WriteConfig("GAS/context_groups.json",
+                """
+                [
+                  {
+                    "id": "strict_context",
+                    "rootAbilityId": "Ability.Root",
+                    "searchRadiusCm": 500,
+                    "candidates": [12]
+                  }
+                ]
+                """);
+
+            AbilityIdRegistry.Register("Ability.Root");
+            var (pipeline, catalog) = BuildPipeline();
+            var loader = new ContextGroupConfigLoader(pipeline, new ContextGroupRegistry());
+
+            var ex = Throws<InvalidOperationException>(() => loader.Load(catalog));
+
+            That(ex!.Message, Does.Contain("candidates[0]"));
+            That(ex.Message, Does.Contain("object"));
+        }
+
+        [Test]
+        public void ContextGroupConfigLoader_TargetedCandidateRequiresScoringFields()
+        {
+            WriteConfig("config_catalog.json",
+                @"[{ ""Path"": ""GAS/context_groups.json"", ""Policy"": ""ArrayById"", ""IdField"": ""id"" }]");
+            WriteConfig("GAS/context_groups.json",
+                """
+                [
+                  {
+                    "id": "strict_context",
+                    "rootAbilityId": "Ability.Root",
+                    "searchRadiusCm": 500,
+                    "candidates": [
+                      {
+                        "abilityId": "Ability.Candidate",
+                        "basePriority": 10,
+                        "requiresTarget": true
+                      }
+                    ]
+                  }
+                ]
+                """);
+
+            AbilityIdRegistry.Register("Ability.Root");
+            AbilityIdRegistry.Register("Ability.Candidate");
+            var (pipeline, catalog) = BuildPipeline();
+            var loader = new ContextGroupConfigLoader(pipeline, new ContextGroupRegistry());
+
+            var ex = Throws<InvalidOperationException>(() => loader.Load(catalog));
+
+            That(ex!.Message, Does.Contain("maxDistanceCm"));
+        }
+
+        [Test]
+        public void AbilityFormSetConfigLoader_RoutePriorityIsRequired()
+        {
+            WriteConfig("config_catalog.json",
+                @"[{ ""Path"": ""GAS/ability_form_sets.json"", ""Policy"": ""ArrayById"", ""IdField"": ""id"" }]");
+            WriteConfig("GAS/ability_form_sets.json",
+                """
+                [
+                  {
+                    "id": "strict_forms",
+                    "routes": [
+                      {
+                        "slotOverrides": [
+                          { "slotIndex": 0, "abilityId": "Ability.Slot" }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+                """);
+
+            AbilityIdRegistry.Register("Ability.Slot");
+            var (pipeline, catalog) = BuildPipeline();
+            var loader = new AbilityFormSetConfigLoader(pipeline, new AbilityFormSetRegistry());
+
+            var ex = Throws<InvalidOperationException>(() => loader.Load(catalog));
+
+            That(ex!.Message, Does.Contain("priority"));
+        }
+
+        [Test]
+        public void AbilityFormSetConfigLoader_EmptyTagString_IsRejected()
+        {
+            WriteConfig("config_catalog.json",
+                @"[{ ""Path"": ""GAS/ability_form_sets.json"", ""Policy"": ""ArrayById"", ""IdField"": ""id"" }]");
+            WriteConfig("GAS/ability_form_sets.json",
+                """
+                [
+                  {
+                    "id": "strict_forms",
+                    "routes": [
+                      {
+                        "requiredAll": [""],
+                        "priority": 10,
+                        "slotOverrides": [
+                          { "slotIndex": 0, "abilityId": "Ability.Slot" }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+                """);
+
+            AbilityIdRegistry.Register("Ability.Slot");
+            var (pipeline, catalog) = BuildPipeline();
+            var loader = new AbilityFormSetConfigLoader(pipeline, new AbilityFormSetRegistry());
+
+            var ex = Throws<InvalidOperationException>(() => loader.Load(catalog));
+
+            That(ex!.Message, Does.Contain("requiredAll[0]"));
+        }
+
+        private (ConfigPipeline Pipeline, ConfigCatalog Catalog) BuildPipeline()
+        {
+            var vfs = new VirtualFileSystem();
+            vfs.Mount("Core", Path.Combine(_root, "Core"));
+            var modLoader = new ModLoader(vfs, new FunctionRegistry(), new TriggerManager());
+            var pipeline = new ConfigPipeline(vfs, modLoader);
+            return (pipeline, ConfigCatalogLoader.Load(pipeline));
+        }
+
+        private void WriteConfig(string relativePath, string json)
+        {
+            string fullPath = Path.Combine(_root, "Core", "Configs", relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+            File.WriteAllText(fullPath, json);
+        }
+    }
+}

--- a/src/Tests/GasTests/InputOrderAbilityAuditTests.cs
+++ b/src/Tests/GasTests/InputOrderAbilityAuditTests.cs
@@ -335,7 +335,8 @@ namespace Ludots.Tests.GAS
                     "angleDeg": 45,
                     "showRangeCircle": true,
                     "validColor": "#33CC66AA",
-                    "invalidColor": [1.0, 0.2, 0.2, 0.5]
+                    "invalidColor": [1.0, 0.2, 0.2, 0.5],
+                    "rangeCircleColor": "#3366FF44"
                   }
                 }
                 """)!.AsObject();

--- a/src/Tests/GasTests/InputOrderAbilityAuditTests.cs
+++ b/src/Tests/GasTests/InputOrderAbilityAuditTests.cs
@@ -13,6 +13,7 @@ using Ludots.Core.Gameplay.GAS.Orders;
 using Ludots.Core.Gameplay.GAS.Systems;
 using Ludots.Core.Gameplay.GAS.Presentation;
 using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.Gameplay.AI.Planning;
 using Ludots.Core.GraphRuntime;
 using Ludots.Core.Mathematics;
 using Ludots.Core.NodeLibraries.GASGraph;
@@ -146,6 +147,41 @@ namespace Ludots.Tests.GAS
             var ex = Throws<KeyNotFoundException>(() => registry.Get(999));
 
             That(ex!.Message, Does.Contain("999"));
+        }
+
+        [Test]
+        public void OrderQueue_InvalidOrderTypeId_Throws()
+        {
+            var queue = new OrderQueue();
+            var order = new Order { OrderTypeId = 0 };
+
+            var ex = Throws<InvalidOperationException>(() => queue.TryEnqueue(in order));
+
+            That(ex!.Message, Does.Contain("OrderQueue"));
+            That(ex.Message, Does.Contain("0"));
+        }
+
+        [Test]
+        public void PlanExecutor_UnregisteredOrderTypeId_Throws()
+        {
+            var queue = new OrderQueue();
+            var orderTypes = new OrderTypeRegistry();
+            var spec = new ActionOrderSpec(orderTypeId: 42, submitMode: OrderSubmitMode.Immediate);
+            var ints = new BlackboardIntBuffer();
+            var entities = new BlackboardEntityBuffer();
+
+            var ex = Throws<InvalidOperationException>(() =>
+                PlanExecutor.TrySubmitOrder(
+                    in spec,
+                    ReadOnlySpan<ActionBinding>.Empty,
+                    Entity.Null,
+                    ref ints,
+                    ref entities,
+                    submitStep: 0,
+                    queue,
+                    orderTypes));
+
+            That(ex!.Message, Does.Contain("unregistered order type id 42"));
         }
 
         [Test]

--- a/src/Tests/GasTests/InputOrderContractTests.cs
+++ b/src/Tests/GasTests/InputOrderContractTests.cs
@@ -6,9 +6,12 @@ using System.Numerics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Arch.Core;
+using Ludots.Core.Config;
 using Ludots.Core.Input.Config;
 using Ludots.Core.Input.Orders;
 using Ludots.Core.Input.Runtime;
+using Ludots.Core.Modding;
+using Ludots.Core.Scripting;
 using NUnit.Framework;
 
 namespace Ludots.Tests.GAS
@@ -17,7 +20,7 @@ namespace Ludots.Tests.GAS
     public sealed class InputOrderContractTests
     {
         [Test]
-        public void HeldStartEnd_DoesNotFallbackToBaseOrderType()
+        public void HeldStartEnd_UnknownStartOrderType_ThrowsInsteadOfFallingBack()
         {
             var (backend, handler) = BuildHandler();
             var accumulator = new AuthoritativeInputAccumulator();
@@ -41,7 +44,6 @@ namespace Ludots.Tests.GAS
 
             var system = new InputOrderMappingSystem(snapshot, config);
             var orders = new List<Ludots.Core.Gameplay.GAS.Orders.Order>();
-            system.SetOrderTypeKeyResolver(key => key == "beam" ? 100 : 0);
             system.SetOrderSubmitHandler((in Ludots.Core.Gameplay.GAS.Orders.Order order) => orders.Add(order));
 
             using var world = World.Create();
@@ -56,9 +58,125 @@ namespace Ludots.Tests.GAS
             accumulator.CaptureVisualFrame(handler);
 
             accumulator.BuildTickSnapshot(snapshot);
-            system.Update(0f);
 
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => system.SetOrderTypeKeyResolver(key => key == "beam" ? 100 : 0));
+
+            Assert.That(ex!.Message, Does.Contain("beam.Start"));
             Assert.That(orders, Is.Empty);
+        }
+
+        [Test]
+        public void UnknownOrderTypeKey_ThrowsDuringResolverInstall()
+        {
+            var input = new FrozenInputActionReader();
+            input.SetActionState("Attack", Vector3.Zero, isDown: true, pressedThisFrame: true, releasedThisFrame: false);
+            var config = new InputOrderMappingConfig
+            {
+                Mappings = new List<InputOrderMapping>
+                {
+                    new()
+                    {
+                        ActionId = "Attack",
+                        Trigger = InputTriggerType.PressedThisFrame,
+                        OrderTypeKey = "typoOrder",
+                        SelectionType = OrderSelectionType.None,
+                        RequireSelection = false,
+                        IsSkillMapping = false
+                    }
+                }
+            };
+
+            using var world = World.Create();
+            var system = new InputOrderMappingSystem(input, config);
+            system.SetLocalPlayer(world.Create(), 1);
+            system.SetOrderSubmitHandler((in Ludots.Core.Gameplay.GAS.Orders.Order _) => { });
+
+            var ex = Assert.Throws<InvalidOperationException>(() => system.SetOrderTypeKeyResolver(_ => 0));
+
+            Assert.That(ex!.Message, Does.Contain("typoOrder"));
+            Assert.That(ex.Message, Does.Contain("orderTypeKey"));
+        }
+
+        [Test]
+        public void DuplicateActionId_IsRejectedDuringConstruction()
+        {
+            var config = new InputOrderMappingConfig
+            {
+                Mappings = new List<InputOrderMapping>
+                {
+                    new()
+                    {
+                        ActionId = "Attack",
+                        OrderTypeKey = "castAbility"
+                    },
+                    new()
+                    {
+                        ActionId = "Attack",
+                        OrderTypeKey = "stop"
+                    }
+                }
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => new InputOrderMappingSystem(new FrozenInputActionReader(), config));
+
+            Assert.That(ex!.Message, Does.Contain("duplicates"));
+            Assert.That(ex.Message, Does.Contain("Attack"));
+        }
+
+        [Test]
+        public void EmptyActionId_IsRejectedDuringConstruction()
+        {
+            var config = new InputOrderMappingConfig
+            {
+                Mappings = new List<InputOrderMapping>
+                {
+                    new()
+                    {
+                        ActionId = "",
+                        OrderTypeKey = "castAbility"
+                    }
+                }
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => new InputOrderMappingSystem(new FrozenInputActionReader(), config));
+
+            Assert.That(ex!.Message, Does.Contain("actionId"));
+            Assert.That(ex.Message, Does.Contain("non-empty"));
+        }
+
+        [Test]
+        public void Loader_MissingInputOrderMappingsConfig_IsRejected()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "Ludots_InputOrderContractTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(root);
+            try
+            {
+                var vfs = new VirtualFileSystem();
+                vfs.Mount("Core", root);
+                var modLoader = new ModLoader(vfs, new FunctionRegistry(), new TriggerManager());
+                var pipeline = new ConfigPipeline(vfs, modLoader);
+                var catalog = new ConfigCatalog();
+                catalog.Add(new ConfigCatalogEntry("Input/input_order_mappings.json", ConfigMergePolicy.DeepObject));
+                var loader = new InputOrderMappingLoader(pipeline);
+
+                var ex = Assert.Throws<InvalidOperationException>(
+                    () => loader.Load(catalog, relativePath: "Input/input_order_mappings.json"));
+
+                Assert.That(ex!.Message, Does.Contain("Input/input_order_mappings.json"));
+            }
+            finally
+            {
+                try
+                {
+                    if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+                }
+                catch
+                {
+                }
+            }
         }
 
         [Test]

--- a/src/Tests/GasTests/InteractionSelectionConvergenceTests.cs
+++ b/src/Tests/GasTests/InteractionSelectionConvergenceTests.cs
@@ -581,7 +581,7 @@ namespace Ludots.Tests.GAS
             var queue = new OrderQueue();
             var order = new Order
             {
-                OrderTypeId = 1001,
+                OrderTypeId = 101,
                 Actor = first,
                 Args = new OrderArgs
                 {

--- a/src/Tests/GasTests/InteractiveWindowStressTests.cs
+++ b/src/Tests/GasTests/InteractiveWindowStressTests.cs
@@ -70,7 +70,18 @@ namespace Ludots.Tests.GAS
                 var inputReq = new InputRequestQueue();
                 var chainOrders = new OrderQueue();
 
-                var processing = new EffectProcessingLoopSystem(world, requests, clock, conditions, budget, templates, inputReq, chainOrders, new ResponseChainTelemetryBuffer(), new OrderRequestQueue())
+                var processing = new EffectProcessingLoopSystem(
+                    world,
+                    requests,
+                    clock,
+                    conditions,
+                    budget,
+                    templates,
+                    inputReq,
+                    chainOrders,
+                    new ResponseChainTelemetryBuffer(),
+                    new OrderRequestQueue(),
+                    responseChainOrderTypes: TestResponseChainOrderTypeIds.Types)
                 {
                     MaxWorkUnitsPerSlice = int.MaxValue
                 };

--- a/src/Tests/GasTests/MapVisualHeightmapContractTests.cs
+++ b/src/Tests/GasTests/MapVisualHeightmapContractTests.cs
@@ -12,58 +12,15 @@ namespace Ludots.Tests.Gas
     public sealed class MapVisualHeightmapContractTests
     {
         private string _root = string.Empty;
-        private string _coreRoot = string.Empty;
         private string _modRoot = string.Empty;
 
         [SetUp]
         public void SetUp()
         {
             _root = Path.Combine(Path.GetTempPath(), "Ludots_MapVisualHeightmapContractTests", Guid.NewGuid().ToString("N"));
-            _coreRoot = Path.Combine(_root, "assets");
             _modRoot = Path.Combine(_root, "mods", "TestMapMod");
-            Directory.CreateDirectory(Path.Combine(_coreRoot, "Configs", "Maps"));
-            Directory.CreateDirectory(Path.Combine(_coreRoot, "Configs", "Navigation"));
             Directory.CreateDirectory(Path.Combine(_modRoot, "assets", "Configs", "Maps"));
             Directory.CreateDirectory(Path.Combine(_modRoot, "assets", "terrain"));
-
-            File.WriteAllText(Path.Combine(_coreRoot, "Configs", "game.json"), """
-            {
-              "startupMapId": "outer_map",
-              "worldWidthInTiles": 16,
-              "worldHeightInTiles": 16,
-              "gridCellSizeCm": 100
-            }
-            """);
-
-            File.WriteAllText(Path.Combine(_coreRoot, "Configs", "Navigation", "pathing.json"), """
-            {
-              "agentTypes": [
-                {
-                  "id": "Humanoid",
-                  "profileId": "Small",
-                  "layer": 0,
-                  "selection": {
-                    "mode": "AutoCheapest",
-                    "graphBias": 0.0,
-                    "meshBias": 0.0,
-                    "graphCostWeight": 1.0,
-                    "meshCostWeight": 1.0
-                  },
-                  "navMesh": {
-                    "areaCosts": [
-                      { "areaId": 0, "cost": 1.0 }
-                    ]
-                  },
-                  "nodeGraph": {
-                    "projectionMaxRadiusCm": 200000,
-                    "forbiddenTagsAny": [],
-                    "requiredTagsAll": [],
-                    "tagCostRules": []
-                  }
-                }
-              ]
-            }
-            """);
 
             File.WriteAllText(Path.Combine(_modRoot, "mod.json"), """
             {
@@ -231,8 +188,19 @@ namespace Ludots.Tests.Gas
         public void LoadMap_WhenVisualHeightAssetResolvesToMultipleMountedSources_ThrowsExplicitly()
         {
             WriteHeightmap("shared.vhtm", 80);
-            Directory.CreateDirectory(Path.Combine(_coreRoot, "assets", "terrain"));
-            using (var stream = File.Create(Path.Combine(_coreRoot, "assets", "terrain", "shared.vhtm")))
+            string duplicateModRoot = Path.Combine(_root, "mods", "DuplicateAssetMod");
+            Directory.CreateDirectory(Path.Combine(duplicateModRoot, "assets", "terrain"));
+            File.WriteAllText(Path.Combine(duplicateModRoot, "mod.json"), """
+            {
+              "name": "DuplicateAssetMod",
+              "version": "1.0.0",
+              "description": "duplicate asset test mod",
+              "main": "",
+              "priority": 0,
+              "dependencies": {}
+            }
+            """);
+            using (var stream = File.Create(Path.Combine(duplicateModRoot, "assets", "terrain", "shared.vhtm")))
             {
                 VisualHeightmapBinary.Write(stream, VisualHeightmapAsset.CreateSingleLayer(
                     new Ludots.Core.Mathematics.WorldAabbCm(0, 0, 100, 100),
@@ -261,10 +229,12 @@ namespace Ludots.Tests.Gas
                 Path.Combine(repoRoot, "mods", "LudotsCoreMod"),
                 Path.Combine(repoRoot, "mods", "CoreInputMod"),
                 _modRoot,
+                Directory.Exists(Path.Combine(_root, "mods", "DuplicateAssetMod")) ? Path.Combine(_root, "mods", "DuplicateAssetMod") : null,
             }.ToList();
+            modPaths.RemoveAll(string.IsNullOrWhiteSpace);
 
             var engine = new GameEngine();
-            engine.InitializeWithConfigPipeline(modPaths, _coreRoot);
+            engine.InitializeWithConfigPipeline(modPaths!, Path.Combine(repoRoot, "assets"));
             engine.Start();
             return engine;
         }

--- a/src/Tests/GasTests/MudAbilityChainStressDemoTests.cs
+++ b/src/Tests/GasTests/MudAbilityChainStressDemoTests.cs
@@ -141,7 +141,18 @@ namespace Ludots.Tests.GAS
                 world.Get<AttributeBuffer>(goblinB).SetCurrent(attrHealth, 100f);
 
                 var abilitySystem = new AbilitySystem(world, requests, abilityDefs);
-                var processing = new EffectProcessingLoopSystem(world, requests, clock, conditions, budget, templates, null, null, new ResponseChainTelemetryBuffer(), new OrderRequestQueue())
+                var processing = new EffectProcessingLoopSystem(
+                    world,
+                    requests,
+                    clock,
+                    conditions,
+                    budget,
+                    templates,
+                    null,
+                    null,
+                    new ResponseChainTelemetryBuffer(),
+                    new OrderRequestQueue(),
+                    responseChainOrderTypes: TestResponseChainOrderTypeIds.Types)
                 {
                     MaxWorkUnitsPerSlice = 2048
                 };
@@ -302,7 +313,18 @@ namespace Ludots.Tests.GAS
                 abilities.AddAbility(7001);
 
                 var abilitySystem = new AbilitySystem(world, requests, abilityDefs);
-                var processing = new EffectProcessingLoopSystem(world, requests, clock, conditions, budget, templates, null, null, new ResponseChainTelemetryBuffer(), new OrderRequestQueue())
+                var processing = new EffectProcessingLoopSystem(
+                    world,
+                    requests,
+                    clock,
+                    conditions,
+                    budget,
+                    templates,
+                    null,
+                    null,
+                    new ResponseChainTelemetryBuffer(),
+                    new OrderRequestQueue(),
+                    responseChainOrderTypes: TestResponseChainOrderTypeIds.Types)
                 {
                     MaxWorkUnitsPerSlice = int.MaxValue
                 };

--- a/src/Tests/GasTests/MudSc2AndYgoDemoTests.cs
+++ b/src/Tests/GasTests/MudSc2AndYgoDemoTests.cs
@@ -136,7 +136,18 @@ namespace Ludots.Tests.GAS
                 var clockSystem = new GasClockSystem(clock, clockPolicy);
                 var timedTags = new TimedTagExpirationSystem(world, clock);
                 var abilityExec = new AbilityExecSystem(world, clock, inputReq, inputResp, selReq, selResp, effectRequests, abilityDefs, eventBus, orderCastAbility, orderTypeRegistry: orderTypeRegistry);
-                var effectLoop = new EffectProcessingLoopSystem(world, effectRequests, clock, conditions, budget, templates, inputReq, chainOrders, new ResponseChainTelemetryBuffer(), new OrderRequestQueue())
+                var effectLoop = new EffectProcessingLoopSystem(
+                    world,
+                    effectRequests,
+                    clock,
+                    conditions,
+                    budget,
+                    templates,
+                    inputReq,
+                    chainOrders,
+                    new ResponseChainTelemetryBuffer(),
+                    new OrderRequestQueue(),
+                    responseChainOrderTypes: TestResponseChainOrderTypeIds.Types)
                 {
                     MaxWorkUnitsPerSlice = int.MaxValue
                 };
@@ -348,7 +359,18 @@ namespace Ludots.Tests.GAS
 
                 var (orderTypeRegistry2, orderRuleRegistry2) = CreateTestOrderRuntime(orderCastAbility);
                 var orderBufferSystem2 = new OrderBufferSystem(world, clock, orderTypeRegistry2, orderRuleRegistry2, incomingOrders, 30);
-                var effectLoop = new EffectProcessingLoopSystem(world, effectRequests, clock, conditions, budget, templates, inputReq, chainOrders, new ResponseChainTelemetryBuffer(), new OrderRequestQueue());
+                var effectLoop = new EffectProcessingLoopSystem(
+                    world,
+                    effectRequests,
+                    clock,
+                    conditions,
+                    budget,
+                    templates,
+                    inputReq,
+                    chainOrders,
+                    new ResponseChainTelemetryBuffer(),
+                    new OrderRequestQueue(),
+                    responseChainOrderTypes: TestResponseChainOrderTypeIds.Types);
                 var agg = new AttributeAggregatorSystem(world);
                 var clockPolicy = new GasClockStepPolicy(1);
                 var clockSystem = new GasClockSystem(clock, clockPolicy);
@@ -465,7 +487,18 @@ namespace Ludots.Tests.GAS
                 var (orderTypeRegistry3, orderRuleRegistry3) = CreateTestOrderRuntime(orderCastAbility);
                 var orderBufferSystem3 = new OrderBufferSystem(world, clock, orderTypeRegistry3, orderRuleRegistry3, incomingOrders, 30);
                 var abilityExec = new AbilityExecSystem(world, clock, inputReq, inputResp, selReq, selResp, effectRequests, abilityDefs, eventBus, orderCastAbility, orderTypeRegistry: orderTypeRegistry3);
-                var effectLoop = new EffectProcessingLoopSystem(world, effectRequests, clock, conditions, budget, templates, null, chainOrders, new ResponseChainTelemetryBuffer(), new OrderRequestQueue())
+                var effectLoop = new EffectProcessingLoopSystem(
+                    world,
+                    effectRequests,
+                    clock,
+                    conditions,
+                    budget,
+                    templates,
+                    null,
+                    chainOrders,
+                    new ResponseChainTelemetryBuffer(),
+                    new OrderRequestQueue(),
+                    responseChainOrderTypes: TestResponseChainOrderTypeIds.Types)
                 {
                     MaxWorkUnitsPerSlice = int.MaxValue
                 };

--- a/src/Tests/GasTests/PresetTypeSystemTests.cs
+++ b/src/Tests/GasTests/PresetTypeSystemTests.cs
@@ -3,6 +3,7 @@ using Arch.Core;
 using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Components;
 using Ludots.Core.Gameplay.GAS.Config;
+using Ludots.Core.NodeLibraries.GASGraph.Host;
 using NUnit.Framework;
 using static NUnit.Framework.Assert;
 
@@ -412,8 +413,11 @@ namespace Ludots.Tests.GAS
         }
 
         [Test]
-        public void PresetTypeLoader_GraphHandler_ParsesNumericId()
+        public void PresetTypeLoader_GraphHandler_ResolvesRegisteredGraphName()
         {
+            GraphIdRegistry.Clear();
+            int graphId = GraphIdRegistry.Register("Graph.Test.Heal.Calculate");
+
             const string json = @"[
               {
                 ""id"": ""Heal"",
@@ -421,7 +425,7 @@ namespace Ludots.Tests.GAS
                 ""activePhases"": [""OnCalculate""],
                 ""allowedLifetimes"": [""Instant""],
                 ""defaultPhaseHandlers"": {
-                  ""OnCalculate"": { ""type"": ""graph"", ""id"": ""42"" }
+                  ""OnCalculate"": { ""type"": ""graph"", ""id"": ""Graph.Test.Heal.Calculate"" }
                 }
               }
             ]";
@@ -432,7 +436,7 @@ namespace Ludots.Tests.GAS
             ref readonly var def = ref reg.Get(EffectPresetType.Heal);
             var h = def.DefaultPhaseHandlers[EffectPhaseId.OnCalculate];
             That(h.Kind, Is.EqualTo(PhaseHandlerKind.Graph));
-            That(h.HandlerId, Is.EqualTo(42));
+            That(h.HandlerId, Is.EqualTo(graphId));
         }
 
         [Test]

--- a/src/Tests/GasTests/Production/ChampionSkillSandboxConfigTests.cs
+++ b/src/Tests/GasTests/Production/ChampionSkillSandboxConfigTests.cs
@@ -871,7 +871,7 @@ namespace Ludots.Tests.GAS.Production
         private static void InstallInput(GameEngine engine)
         {
             var inputConfig = new InputConfigPipelineLoader(engine.ConfigPipeline).Load();
-            var backend = new NullInputBackend();
+            var backend = new NullInputBackend(new Vector2(960f, 540f));
             var inputHandler = new PlayerInputHandler(backend, inputConfig);
             for (int i = 0; i < engine.MergedConfig.StartupInputContexts.Count; i++)
             {
@@ -1569,9 +1569,16 @@ namespace Ludots.Tests.GAS.Production
 
         private sealed class NullInputBackend : IInputBackend
         {
+            private readonly Vector2 _mousePosition;
+
+            public NullInputBackend(Vector2 mousePosition)
+            {
+                _mousePosition = mousePosition;
+            }
+
             public float GetAxis(string devicePath) => 0f;
             public bool GetButton(string devicePath) => false;
-            public System.Numerics.Vector2 GetMousePosition() => System.Numerics.Vector2.Zero;
+            public Vector2 GetMousePosition() => _mousePosition;
             public float GetMouseWheel() => 0f;
             public void EnableIME(bool enable) { }
             public void SetIMECandidatePosition(int x, int y) { }

--- a/src/Tests/GasTests/Production/InputOrderConvergenceValidationTests.cs
+++ b/src/Tests/GasTests/Production/InputOrderConvergenceValidationTests.cs
@@ -150,6 +150,74 @@ namespace Ludots.Tests.GAS.Production
             Assert.That(source, Does.Contain("RequireRegisteredOrderTypeId(orderTypeRegistry, \"castAbility.End\")"));
         }
 
+        [Test]
+        public void InputAndPanelSources_HaveNoImplicitOrderTypeFallbacks()
+        {
+            string repoRoot = FindRepoRoot();
+            string inputMappingLoader = File.ReadAllText(Path.Combine(repoRoot, "src", "Core", "Input", "Orders", "InputOrderMappingLoader.cs"));
+            string inputMappingSystem = File.ReadAllText(Path.Combine(repoRoot, "src", "Core", "Input", "Orders", "InputOrderMappingSystem.cs"));
+            string localOrderSource = File.ReadAllText(Path.Combine(repoRoot, "mods", "CoreInputMod", "Systems", "LocalOrderSourceHelper.cs"));
+            string responseChainSource = File.ReadAllText(Path.Combine(repoRoot, "src", "Core", "Presentation", "Systems", "ResponseChainHumanOrderSourceSystem.cs"));
+            string commandPanelSource = File.ReadAllText(Path.Combine(repoRoot, "mods", "EntityCommandPanelMod", "Runtime", "GasEntityCommandPanelSource.cs"));
+
+            Assert.That(inputMappingLoader, Does.Not.Contain("CreateDefaultMobaConfig"));
+            Assert.That(inputMappingSystem, Does.Not.Contain("orderTypeId <= 0) return false"));
+            Assert.That(localOrderSource, Does.Not.Contain("? configOrderTypeId : 0"));
+            Assert.That(responseChainSource, Does.Not.Contain("GetValueOrDefault(\"chainPass\""));
+            Assert.That(responseChainSource, Does.Not.Contain("ResponseChainOrderTypes.Default"));
+            Assert.That(commandPanelSource, Does.Not.Contain("OrderTypeId == 100"));
+        }
+
+        [Test]
+        public void Cfg4Guardrails_FailFastAntipatternsDoNotReturn()
+        {
+            string repoRoot = FindRepoRoot();
+            string aiConfigLoader = File.ReadAllText(Path.Combine(repoRoot, "src", "Core", "Gameplay", "AI", "Config", "AiConfigLoader.cs"));
+            string abilityExecLoader = File.ReadAllText(Path.Combine(repoRoot, "src", "Core", "Gameplay", "GAS", "Config", "AbilityExecLoader.cs"));
+            string configMerger = File.ReadAllText(Path.Combine(repoRoot, "src", "Core", "Config", "ConfigMerger.cs"));
+            string inputMappingLoader = File.ReadAllText(Path.Combine(repoRoot, "src", "Core", "Input", "Orders", "InputOrderMappingLoader.cs"));
+            string localOrderSource = File.ReadAllText(Path.Combine(repoRoot, "mods", "CoreInputMod", "Systems", "LocalOrderSourceHelper.cs"));
+            string responseChainSource = File.ReadAllText(Path.Combine(repoRoot, "src", "Core", "Presentation", "Systems", "ResponseChainHumanOrderSourceSystem.cs"));
+            string commandPanelSource = File.ReadAllText(Path.Combine(repoRoot, "mods", "EntityCommandPanelMod", "Runtime", "GasEntityCommandPanelSource.cs"));
+
+            Assert.That(aiConfigLoader, Does.Contain("OrderTagId is not a supported AI order contract field"));
+            Assert.That(aiConfigLoader, Does.Contain("Order blackboard key must be a semantic string"));
+            Assert.That(aiConfigLoader, Does.Not.Contain("? ot : 0"));
+            Assert.That(aiConfigLoader, Does.Not.Contain("TryGetValue(\"OrderTypeId\""));
+
+            Assert.That(inputMappingLoader, Does.Not.Contain("CreateDefaultMobaConfig"));
+            Assert.That(localOrderSource, Does.Not.Contain("? v : 0"));
+            Assert.That(responseChainSource, Does.Not.Contain("GetValueOrDefault(\"chainPass\""));
+            Assert.That(responseChainSource, Does.Not.Contain("ResponseChainOrderTypes.Default"));
+            Assert.That(commandPanelSource, Does.Not.Contain("OrderTypeId == 100"));
+
+            Assert.That(abilityExecLoader, Does.Contain("field 'exec' is required"));
+            Assert.That(abilityExecLoader, Does.Not.Contain("if (idx >= AbilityExecSpec.MAX_ITEMS) break"));
+            Assert.That(abilityExecLoader, Does.Not.Contain("if (tid <= 0) continue"));
+
+            Assert.That(configMerger, Does.Contain("must define non-empty string field"));
+            Assert.That(configMerger, Does.Not.Contain("if (!TryReadId(obj, entry.IdField, out string id)) continue"));
+        }
+
+        [Test]
+        public void Cfg4Guardrails_ProductionAiConfigsUseSemanticKeys()
+        {
+            string repoRoot = FindRepoRoot();
+            var aiConfigFiles = Directory.GetFiles(Path.Combine(repoRoot, "mods"), "*.json", SearchOption.AllDirectories);
+            foreach (string file in aiConfigFiles)
+            {
+                string normalized = file.Replace('\\', '/');
+                if (!normalized.Contains("/assets/Configs/AI/", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                string source = File.ReadAllText(file);
+                Assert.That(source, Does.Not.Contain("\"OrderTagId\""), file);
+                Assert.That(Regex.IsMatch(source, @"""(?:EntityKey|IntKey)""\s*:\s*\d+"), Is.False, file);
+            }
+        }
+
         private static List<ISystem<float>> GetSystems(GameEngine engine, SystemGroup group)
         {
             var field = typeof(GameEngine).GetField("_systemGroups", BindingFlags.Instance | BindingFlags.NonPublic);

--- a/src/Tests/GasTests/Production/InteractionShowcaseFormRoutingConfigTests.cs
+++ b/src/Tests/GasTests/Production/InteractionShowcaseFormRoutingConfigTests.cs
@@ -26,7 +26,7 @@ namespace Ludots.Tests.GAS.Production
 
             using var engine = new GameEngine();
             engine.InitializeWithConfigPipeline(
-                RepoModPaths.ResolveExplicit(repoRoot, new[] { "LudotsCoreMod", "CoreInputMod", "CameraProfilesMod", "InteractionShowcaseMod" }),
+                RepoModPaths.ResolveExplicit(repoRoot, new[] { "LudotsCoreMod", "CoreInputMod", "CameraProfilesMod", "EntityInfoPanelsMod", "InteractionShowcaseMod" }),
                 assetsRoot);
 
             var templates = new Dictionary<string, EntityTemplate>(StringComparer.OrdinalIgnoreCase);
@@ -76,7 +76,7 @@ namespace Ludots.Tests.GAS.Production
 
             using var engine = new GameEngine();
             engine.InitializeWithConfigPipeline(
-                RepoModPaths.ResolveExplicit(repoRoot, new[] { "LudotsCoreMod", "CoreInputMod", "CameraProfilesMod", "InteractionShowcaseMod" }),
+                RepoModPaths.ResolveExplicit(repoRoot, new[] { "LudotsCoreMod", "CoreInputMod", "CameraProfilesMod", "EntityInfoPanelsMod", "InteractionShowcaseMod" }),
                 assetsRoot);
             engine.Start();
             engine.LoadMap("interaction_showcase_hub");

--- a/src/Tests/GasTests/ResponseChainPresenterPipelineTests.cs
+++ b/src/Tests/GasTests/ResponseChainPresenterPipelineTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Numerics;
 using Arch.Core;
+using Ludots.Core.Config;
 using Ludots.Core.Engine;
 using Ludots.Core.Gameplay.Components;
 using Ludots.Core.Gameplay.GAS;
@@ -57,7 +58,18 @@ namespace Ludots.Tests.GAS
                 var telemetry = new ResponseChainTelemetryBuffer();
                 var orderReq = new OrderRequestQueue();
  
-                var processing = new EffectProcessingLoopSystem(world, requests, clock, conditions, budget, templates, inputReq, chainOrders, telemetry, orderReq)
+                var processing = new EffectProcessingLoopSystem(
+                    world,
+                    requests,
+                    clock,
+                    conditions,
+                    budget,
+                    templates,
+                    inputReq,
+                    chainOrders,
+                    telemetry,
+                    orderReq,
+                    responseChainOrderTypes: TestResponseChainOrderTypeIds.Types)
                 {
                     MaxWorkUnitsPerSlice = int.MaxValue
                 };
@@ -242,6 +254,18 @@ namespace Ludots.Tests.GAS
             var globals = new Dictionary<string, object>
             {
                 [CoreServiceKeys.InputHandler.Name] = handler,
+                [CoreServiceKeys.GameConfig.Name] = new GameConfig
+                {
+                    Constants = new GameConstants
+                    {
+                        ResponseChainOrderTypeIds = new Dictionary<string, int>
+                        {
+                            ["chainPass"] = TestResponseChainOrderTypeIds.ChainPass,
+                            ["chainNegate"] = TestResponseChainOrderTypeIds.ChainNegate,
+                            ["chainActivateEffect"] = TestResponseChainOrderTypeIds.ChainActivateEffect
+                        }
+                    }
+                },
                 [CoreServiceKeys.InteractionActionBindings.Name] = new InteractionActionBindings
                 {
                     ResponseChainPassActionId = "UiPass",
@@ -272,6 +296,29 @@ namespace Ludots.Tests.GAS
             That(chainOrders.TryDequeue(out var activate), Is.True);
             That(activate.OrderTypeId, Is.EqualTo(TestResponseChainOrderTypeIds.ChainActivateEffect));
             That(activate.Args.I0, Is.EqualTo(9001));
+        }
+
+        [Test]
+        public void ResponseChainHumanOrderSourceSystem_MissingOrderTypes_IsRejected()
+        {
+            using var world = World.Create();
+            var (_, handler) = BuildResponseChainHandler();
+            var globals = new Dictionary<string, object>
+            {
+                [CoreServiceKeys.InputHandler.Name] = handler,
+                [CoreServiceKeys.InteractionActionBindings.Name] = new InteractionActionBindings
+                {
+                    ResponseChainPassActionId = "UiPass",
+                    ResponseChainNegateActionId = "UiNegate",
+                    ResponseChainActivateActionId = "UiActivate"
+                }
+            };
+
+            var ex = Throws<InvalidOperationException>(() =>
+                new ResponseChainHumanOrderSourceSystem(globals, new ResponseChainUiState(), new OrderQueue()));
+
+            That(ex!.Message, Does.Contain("GameConfig"));
+            That(ex.Message, Does.Contain("chainPass"));
         }
 
         [Test]

--- a/src/Tests/GasTests/TestResponseChainOrderTypeIds.cs
+++ b/src/Tests/GasTests/TestResponseChainOrderTypeIds.cs
@@ -1,3 +1,5 @@
+using Ludots.Core.Gameplay.GAS.Systems;
+
 namespace Ludots.Tests.GAS
 {
     /// <summary>
@@ -9,5 +11,12 @@ namespace Ludots.Tests.GAS
         public const int ChainPass = 1;
         public const int ChainNegate = 2;
         public const int ChainActivateEffect = 3;
+
+        public static ResponseChainOrderTypes Types => new ResponseChainOrderTypes
+        {
+            ChainPass = ChainPass,
+            ChainNegate = ChainNegate,
+            ChainActivateEffect = ChainActivateEffect
+        };
     }
 }


### PR DESCRIPTION
﻿## Summary
- Harden CFG-1 AI/order contracts to require semantic order keys and reject invalid order submissions.
- Harden CFG-2 GAS ability/effect loaders with conditional fail-fast rules and clean existing configs to match the new contracts.
- Harden CFG-3 input/order sources so order keys resolve through registries and response-chain order ids are explicitly configured.
- Add CFG-4 guardrails for config merge/loader fail-fast anti-patterns.

Intentional contract narrowing: placementPattern=Scatter 下 facingPattern 现为 RequireAbsent，Scatter 朝向锁定为 PreserveTemplate；RadialOutward/Tangent* 仅 Circle 可用。现有内容无损（原 Scatter 项均为 PreserveTemplate）。同时 placementRadiusCm 在 Scatter 下禁用，散布半径统一走 offsetRadius（旧配置里二者同值，无语义丢失）。

## Verification
- dotnet test src/Tests/GasTests/GasTests.csproj --no-restore --filter "AiConfigLoaderTests|AbilityExecLoaderFailFastTests|EffectTemplateLoaderTests|InputOrderAbilityAuditTests|InputOrderContractTests|ConfigMergerEntriesTests" — passed 116/116
- dotnet test src/Tests/GasTests/GasTests.csproj --no-restore --filter "ChampionSkillSandboxConfigTests|InteractionShowcaseFormRoutingConfigTests|InputOrderConvergenceValidationTests" — passed 21/21
- git diff --check origin/main..HEAD — clean
