### PR TITLE
feat(vision): implement war fog core

### DIFF
--- a/mods/showcases/fog_of_war/ExploredMemoryShowcaseMod/ExploredMemoryShowcaseMod.csproj
+++ b/mods/showcases/fog_of_war/ExploredMemoryShowcaseMod/ExploredMemoryShowcaseMod.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/mods/showcases/fog_of_war/ExploredMemoryShowcaseMod/ExploredMemoryShowcaseModEntry.cs
+++ b/mods/showcases/fog_of_war/ExploredMemoryShowcaseMod/ExploredMemoryShowcaseModEntry.cs
@@ -1,0 +1,15 @@
+using Ludots.Core.Modding;
+
+namespace ExploredMemoryShowcaseMod;
+
+public sealed class ExploredMemoryShowcaseModEntry : IMod
+{
+    public void OnLoad(IModContext context)
+    {
+        context.Log("[ExploredMemoryShowcaseMod] Loaded");
+    }
+
+    public void OnUnload()
+    {
+    }
+}

--- a/mods/showcases/fog_of_war/ExploredMemoryShowcaseMod/assets/WarFog/showcase.json
+++ b/mods/showcases/fog_of_war/ExploredMemoryShowcaseMod/assets/WarFog/showcase.json
@@ -1,0 +1,5 @@
+{
+  "capability": "FOG-5",
+  "projection": { "presence": ["LiveVisible", "Known", "HiddenWithSource"], "aspectMask": true },
+  "memoryTtlTicks": 5
+}

--- a/mods/showcases/fog_of_war/ExploredMemoryShowcaseMod/mod.json
+++ b/mods/showcases/fog_of_war/ExploredMemoryShowcaseMod/mod.json
@@ -1,0 +1,12 @@
+{
+  "name": "ExploredMemoryShowcaseMod",
+  "version": "1.0.0",
+  "description": "Explored memory and Knowledge aspect disclosure showcase root.",
+  "main": "bin/net8.0/ExploredMemoryShowcaseMod.dll",
+  "priority": 0,
+  "dependencies": {
+    "LudotsCoreMod": "^1.0.0"
+  },
+  "author": "OpenAI Codex",
+  "tags": ["showcase", "vision", "knowledge", "memory"]
+}

--- a/mods/showcases/fog_of_war/FogOfWarShowcaseMod/FogOfWarShowcaseMod.csproj
+++ b/mods/showcases/fog_of_war/FogOfWarShowcaseMod/FogOfWarShowcaseMod.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/mods/showcases/fog_of_war/FogOfWarShowcaseMod/FogOfWarShowcaseModEntry.cs
+++ b/mods/showcases/fog_of_war/FogOfWarShowcaseMod/FogOfWarShowcaseModEntry.cs
@@ -1,0 +1,15 @@
+using Ludots.Core.Modding;
+
+namespace FogOfWarShowcaseMod;
+
+public sealed class FogOfWarShowcaseModEntry : IMod
+{
+    public void OnLoad(IModContext context)
+    {
+        context.Log("[FogOfWarShowcaseMod] Loaded");
+    }
+
+    public void OnUnload()
+    {
+    }
+}

--- a/mods/showcases/fog_of_war/FogOfWarShowcaseMod/assets/WarFog/showcase.json
+++ b/mods/showcases/fog_of_war/FogOfWarShowcaseMod/assets/WarFog/showcase.json
@@ -1,0 +1,12 @@
+{
+  "capability": "FOG-10",
+  "includes": [
+    "FOG-2",
+    "FOG-3",
+    "FOG-4",
+    "FOG-5",
+    "FOG-6",
+    "FOG-7",
+    "FOG-8"
+  ]
+}

--- a/mods/showcases/fog_of_war/FogOfWarShowcaseMod/mod.json
+++ b/mods/showcases/fog_of_war/FogOfWarShowcaseMod/mod.json
@@ -1,0 +1,19 @@
+{
+  "name": "FogOfWarShowcaseMod",
+  "version": "1.0.0",
+  "description": "Integrated fog-of-war showcase root for layered fields, apertures, line-of-sight, concealment, memory, generators, detection, and shared snapshots.",
+  "main": "bin/net8.0/FogOfWarShowcaseMod.dll",
+  "priority": 0,
+  "dependencies": {
+    "LudotsCoreMod": "^1.0.0",
+    "MultiLayerFogFieldShowcaseMod": "^1.0.0",
+    "VisionConeHighGroundShowcaseMod": "^1.0.0",
+    "LineOfSightBrushShowcaseMod": "^1.0.0",
+    "ExploredMemoryShowcaseMod": "^1.0.0",
+    "GapGeneratorShowcaseMod": "^1.0.0",
+    "StealthDetectionShowcaseMod": "^1.0.0",
+    "SharedVisionSnapshotShowcaseMod": "^1.0.0"
+  },
+  "author": "OpenAI Codex",
+  "tags": ["showcase", "vision", "fog-of-war", "integrated"]
+}

--- a/mods/showcases/fog_of_war/GapGeneratorShowcaseMod/GapGeneratorShowcaseMod.csproj
+++ b/mods/showcases/fog_of_war/GapGeneratorShowcaseMod/GapGeneratorShowcaseMod.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/mods/showcases/fog_of_war/GapGeneratorShowcaseMod/GapGeneratorShowcaseModEntry.cs
+++ b/mods/showcases/fog_of_war/GapGeneratorShowcaseMod/GapGeneratorShowcaseModEntry.cs
@@ -1,0 +1,15 @@
+using Ludots.Core.Modding;
+
+namespace GapGeneratorShowcaseMod;
+
+public sealed class GapGeneratorShowcaseModEntry : IMod
+{
+    public void OnLoad(IModContext context)
+    {
+        context.Log("[GapGeneratorShowcaseMod] Loaded");
+    }
+
+    public void OnUnload()
+    {
+    }
+}

--- a/mods/showcases/fog_of_war/GapGeneratorShowcaseMod/assets/WarFog/showcase.json
+++ b/mods/showcases/fog_of_war/GapGeneratorShowcaseMod/assets/WarFog/showcase.json
@@ -1,0 +1,6 @@
+{
+  "capability": "FOG-6",
+  "polarity": "Deny",
+  "denyModes": ["DenyDominates", "RevealDominates"],
+  "relationshipGated": true
+}

--- a/mods/showcases/fog_of_war/GapGeneratorShowcaseMod/mod.json
+++ b/mods/showcases/fog_of_war/GapGeneratorShowcaseMod/mod.json
@@ -1,0 +1,12 @@
+{
+  "name": "GapGeneratorShowcaseMod",
+  "version": "1.0.0",
+  "description": "Deny-polarity generator showcase root.",
+  "main": "bin/net8.0/GapGeneratorShowcaseMod.dll",
+  "priority": 0,
+  "dependencies": {
+    "LudotsCoreMod": "^1.0.0"
+  },
+  "author": "OpenAI Codex",
+  "tags": ["showcase", "vision", "generator", "deny"]
+}

--- a/mods/showcases/fog_of_war/LineOfSightBrushShowcaseMod/LineOfSightBrushShowcaseMod.csproj
+++ b/mods/showcases/fog_of_war/LineOfSightBrushShowcaseMod/LineOfSightBrushShowcaseMod.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/mods/showcases/fog_of_war/LineOfSightBrushShowcaseMod/LineOfSightBrushShowcaseModEntry.cs
+++ b/mods/showcases/fog_of_war/LineOfSightBrushShowcaseMod/LineOfSightBrushShowcaseModEntry.cs
@@ -1,0 +1,15 @@
+using Ludots.Core.Modding;
+
+namespace LineOfSightBrushShowcaseMod;
+
+public sealed class LineOfSightBrushShowcaseModEntry : IMod
+{
+    public void OnLoad(IModContext context)
+    {
+        context.Log("[LineOfSightBrushShowcaseMod] Loaded");
+    }
+
+    public void OnUnload()
+    {
+    }
+}

--- a/mods/showcases/fog_of_war/LineOfSightBrushShowcaseMod/assets/WarFog/showcase.json
+++ b/mods/showcases/fog_of_war/LineOfSightBrushShowcaseMod/assets/WarFog/showcase.json
@@ -1,0 +1,5 @@
+{
+  "capability": "FOG-4",
+  "lineOfSight": { "enabled": true, "toggleable": true },
+  "concealment": { "enabled": true }
+}

--- a/mods/showcases/fog_of_war/LineOfSightBrushShowcaseMod/mod.json
+++ b/mods/showcases/fog_of_war/LineOfSightBrushShowcaseMod/mod.json
@@ -1,0 +1,12 @@
+{
+  "name": "LineOfSightBrushShowcaseMod",
+  "version": "1.0.0",
+  "description": "Line-of-sight and concealment showcase root.",
+  "main": "bin/net8.0/LineOfSightBrushShowcaseMod.dll",
+  "priority": 0,
+  "dependencies": {
+    "LudotsCoreMod": "^1.0.0"
+  },
+  "author": "OpenAI Codex",
+  "tags": ["showcase", "vision", "line-of-sight", "concealment"]
+}

--- a/mods/showcases/fog_of_war/MultiLayerFogFieldShowcaseMod/MultiLayerFogFieldShowcaseMod.csproj
+++ b/mods/showcases/fog_of_war/MultiLayerFogFieldShowcaseMod/MultiLayerFogFieldShowcaseMod.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/mods/showcases/fog_of_war/MultiLayerFogFieldShowcaseMod/MultiLayerFogFieldShowcaseModEntry.cs
+++ b/mods/showcases/fog_of_war/MultiLayerFogFieldShowcaseMod/MultiLayerFogFieldShowcaseModEntry.cs
@@ -1,0 +1,15 @@
+using Ludots.Core.Modding;
+
+namespace MultiLayerFogFieldShowcaseMod;
+
+public sealed class MultiLayerFogFieldShowcaseModEntry : IMod
+{
+    public void OnLoad(IModContext context)
+    {
+        context.Log("[MultiLayerFogFieldShowcaseMod] Loaded");
+    }
+
+    public void OnUnload()
+    {
+    }
+}

--- a/mods/showcases/fog_of_war/MultiLayerFogFieldShowcaseMod/assets/WarFog/showcase.json
+++ b/mods/showcases/fog_of_war/MultiLayerFogFieldShowcaseMod/assets/WarFog/showcase.json
@@ -1,0 +1,7 @@
+{
+  "capability": "FOG-2",
+  "layers": [
+    { "id": "ground", "cellSizeCm": 100, "updateHz": 10 },
+    { "id": "air", "cellSizeCm": 250, "updateHz": 5 }
+  ]
+}

--- a/mods/showcases/fog_of_war/MultiLayerFogFieldShowcaseMod/mod.json
+++ b/mods/showcases/fog_of_war/MultiLayerFogFieldShowcaseMod/mod.json
@@ -1,0 +1,12 @@
+{
+  "name": "MultiLayerFogFieldShowcaseMod",
+  "version": "1.0.0",
+  "description": "Multi-layer fog field showcase root for independent ground and air layers.",
+  "main": "bin/net8.0/MultiLayerFogFieldShowcaseMod.dll",
+  "priority": 0,
+  "dependencies": {
+    "LudotsCoreMod": "^1.0.0"
+  },
+  "author": "OpenAI Codex",
+  "tags": ["showcase", "vision", "fog-of-war", "layers"]
+}

--- a/mods/showcases/fog_of_war/SharedVisionSnapshotShowcaseMod/SharedVisionSnapshotShowcaseMod.csproj
+++ b/mods/showcases/fog_of_war/SharedVisionSnapshotShowcaseMod/SharedVisionSnapshotShowcaseMod.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/mods/showcases/fog_of_war/SharedVisionSnapshotShowcaseMod/SharedVisionSnapshotShowcaseModEntry.cs
+++ b/mods/showcases/fog_of_war/SharedVisionSnapshotShowcaseMod/SharedVisionSnapshotShowcaseModEntry.cs
@@ -1,0 +1,15 @@
+using Ludots.Core.Modding;
+
+namespace SharedVisionSnapshotShowcaseMod;
+
+public sealed class SharedVisionSnapshotShowcaseModEntry : IMod
+{
+    public void OnLoad(IModContext context)
+    {
+        context.Log("[SharedVisionSnapshotShowcaseMod] Loaded");
+    }
+
+    public void OnUnload()
+    {
+    }
+}

--- a/mods/showcases/fog_of_war/SharedVisionSnapshotShowcaseMod/assets/WarFog/showcase.json
+++ b/mods/showcases/fog_of_war/SharedVisionSnapshotShowcaseMod/assets/WarFog/showcase.json
@@ -1,0 +1,5 @@
+{
+  "capability": "FOG-8",
+  "snapshot": ["capture", "restore", "merge", "diff"],
+  "sharedExplored": { "relationshipGated": true }
+}

--- a/mods/showcases/fog_of_war/SharedVisionSnapshotShowcaseMod/mod.json
+++ b/mods/showcases/fog_of_war/SharedVisionSnapshotShowcaseMod/mod.json
@@ -1,0 +1,12 @@
+{
+  "name": "SharedVisionSnapshotShowcaseMod",
+  "version": "1.0.0",
+  "description": "Fog snapshot and shared explored-map showcase root.",
+  "main": "bin/net8.0/SharedVisionSnapshotShowcaseMod.dll",
+  "priority": 0,
+  "dependencies": {
+    "LudotsCoreMod": "^1.0.0"
+  },
+  "author": "OpenAI Codex",
+  "tags": ["showcase", "vision", "snapshot", "sharing"]
+}

--- a/mods/showcases/fog_of_war/StealthDetectionShowcaseMod/StealthDetectionShowcaseMod.csproj
+++ b/mods/showcases/fog_of_war/StealthDetectionShowcaseMod/StealthDetectionShowcaseMod.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/mods/showcases/fog_of_war/StealthDetectionShowcaseMod/StealthDetectionShowcaseModEntry.cs
+++ b/mods/showcases/fog_of_war/StealthDetectionShowcaseMod/StealthDetectionShowcaseModEntry.cs
@@ -1,0 +1,15 @@
+using Ludots.Core.Modding;
+
+namespace StealthDetectionShowcaseMod;
+
+public sealed class StealthDetectionShowcaseModEntry : IMod
+{
+    public void OnLoad(IModContext context)
+    {
+        context.Log("[StealthDetectionShowcaseMod] Loaded");
+    }
+
+    public void OnUnload()
+    {
+    }
+}

--- a/mods/showcases/fog_of_war/StealthDetectionShowcaseMod/assets/WarFog/showcase.json
+++ b/mods/showcases/fog_of_war/StealthDetectionShowcaseMod/assets/WarFog/showcase.json
@@ -1,0 +1,5 @@
+{
+  "capability": "FOG-7",
+  "detectionLayer": "detection",
+  "stealthLevels": [1, 2]
+}

--- a/mods/showcases/fog_of_war/StealthDetectionShowcaseMod/mod.json
+++ b/mods/showcases/fog_of_war/StealthDetectionShowcaseMod/mod.json
@@ -1,0 +1,12 @@
+{
+  "name": "StealthDetectionShowcaseMod",
+  "version": "1.0.0",
+  "description": "Detection layer and true-sight showcase root.",
+  "main": "bin/net8.0/StealthDetectionShowcaseMod.dll",
+  "priority": 0,
+  "dependencies": {
+    "LudotsCoreMod": "^1.0.0"
+  },
+  "author": "OpenAI Codex",
+  "tags": ["showcase", "vision", "detection", "stealth"]
+}

--- a/mods/showcases/fog_of_war/VisionConeHighGroundShowcaseMod/VisionConeHighGroundShowcaseMod.csproj
+++ b/mods/showcases/fog_of_war/VisionConeHighGroundShowcaseMod/VisionConeHighGroundShowcaseMod.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/mods/showcases/fog_of_war/VisionConeHighGroundShowcaseMod/VisionConeHighGroundShowcaseModEntry.cs
+++ b/mods/showcases/fog_of_war/VisionConeHighGroundShowcaseMod/VisionConeHighGroundShowcaseModEntry.cs
@@ -1,0 +1,15 @@
+using Ludots.Core.Modding;
+
+namespace VisionConeHighGroundShowcaseMod;
+
+public sealed class VisionConeHighGroundShowcaseModEntry : IMod
+{
+    public void OnLoad(IModContext context)
+    {
+        context.Log("[VisionConeHighGroundShowcaseMod] Loaded");
+    }
+
+    public void OnUnload()
+    {
+    }
+}

--- a/mods/showcases/fog_of_war/VisionConeHighGroundShowcaseMod/assets/WarFog/showcase.json
+++ b/mods/showcases/fog_of_war/VisionConeHighGroundShowcaseMod/assets/WarFog/showcase.json
@@ -1,0 +1,5 @@
+{
+  "capability": "FOG-3",
+  "apertures": ["disk", "cone", "box", "line"],
+  "verticalRule": { "enabled": true, "upTolerance": 0 }
+}

--- a/mods/showcases/fog_of_war/VisionConeHighGroundShowcaseMod/mod.json
+++ b/mods/showcases/fog_of_war/VisionConeHighGroundShowcaseMod/mod.json
@@ -1,0 +1,12 @@
+{
+  "name": "VisionConeHighGroundShowcaseMod",
+  "version": "1.0.0",
+  "description": "Vision cone and high-ground showcase root.",
+  "main": "bin/net8.0/VisionConeHighGroundShowcaseMod.dll",
+  "priority": 0,
+  "dependencies": {
+    "LudotsCoreMod": "^1.0.0"
+  },
+  "author": "OpenAI Codex",
+  "tags": ["showcase", "vision", "aperture", "height"]
+}

--- a/src/Core/Engine/GameEngine.cs
+++ b/src/Core/Engine/GameEngine.cs
@@ -87,6 +87,7 @@ using Ludots.Core.Gameplay.Progression;
 using Ludots.Core.Gameplay.Progression.Config;
 using Ludots.Core.Gameplay.Progression.Systems;
 using Ludots.Core.Persistence;
+using Ludots.Core.Vision;
 
 namespace Ludots.Core.Engine
 {
@@ -633,6 +634,13 @@ namespace Ludots.Core.Engine
                 knowledgeProjectionStore,
                 knowledgeRelationCollectionProjector,
                 scopeResolver);
+            var visionFogLayerRegistry = new FogLayerRegistry();
+            var visionFogFieldStore = new FogFieldStore();
+            var visionFogSnapshotStore = new FogSnapshotStore(relationships: relationshipRuntime);
+            var visionResolver = new VisionResolver(
+                visionFogLayerRegistry,
+                visionFogFieldStore,
+                relationships: relationshipRuntime);
             var graphSymbolResolver = new GasGraphSymbolResolver(
                 relationshipTypeRegistry,
                 relationshipMetricRegistry,
@@ -1105,6 +1113,10 @@ namespace Ludots.Core.Engine
             SetService(CoreServiceKeys.KnowledgeProjectionStore, knowledgeProjectionStore);
             SetService(CoreServiceKeys.KnowledgeRelationCollectionProjector, knowledgeRelationCollectionProjector);
             SetService(CoreServiceKeys.KnowledgeProjectionResolver, knowledgeProjectionResolver);
+            SetService(CoreServiceKeys.VisionFogLayerRegistry, visionFogLayerRegistry);
+            SetService(CoreServiceKeys.VisionFogFieldStore, visionFogFieldStore);
+            SetService(CoreServiceKeys.VisionFogSnapshotStore, visionFogSnapshotStore);
+            SetService(CoreServiceKeys.VisionResolver, visionResolver);
             SetService(CoreServiceKeys.SelectionRuleRegistry, selectionRuleRegistry);
             SetService(CoreServiceKeys.InteractionActionBindings, interactionActionBindings);
             RemoveService(CoreServiceKeys.VisualHeightmap);

--- a/src/Core/Scripting/CoreServiceKeys.cs
+++ b/src/Core/Scripting/CoreServiceKeys.cs
@@ -69,6 +69,7 @@ using Ludots.Core.Spatial;
 using Ludots.Core.Systems;
 using Ludots.Core.UI;
 using Ludots.Core.UI.EntityCommandPanels;
+using Ludots.Core.Vision;
 using Ludots.Platform.Abstractions;
 
 namespace Ludots.Core.Scripting
@@ -191,6 +192,10 @@ namespace Ludots.Core.Scripting
         public static readonly ServiceKey<KnowledgeProjectionStore> KnowledgeProjectionStore = new("KnowledgeProjectionStore");
         public static readonly ServiceKey<KnowledgeRelationCollectionProjector> KnowledgeRelationCollectionProjector = new("KnowledgeRelationCollectionProjector");
         public static readonly ServiceKey<KnowledgeProjectionResolver> KnowledgeProjectionResolver = new("KnowledgeProjectionResolver");
+        public static readonly ServiceKey<FogLayerRegistry> VisionFogLayerRegistry = new("Vision.FogLayerRegistry");
+        public static readonly ServiceKey<FogFieldStore> VisionFogFieldStore = new("Vision.FogFieldStore");
+        public static readonly ServiceKey<FogSnapshotStore> VisionFogSnapshotStore = new("Vision.FogSnapshotStore");
+        public static readonly ServiceKey<VisionResolver> VisionResolver = new("Vision.Resolver");
         public static readonly ServiceKey<Entity> RelationshipEventSource = new("RelationshipEvent.Source");
         public static readonly ServiceKey<Entity> RelationshipEventTarget = new("RelationshipEvent.Target");
         public static readonly ServiceKey<Entity> RelationshipEventTeam = new("RelationshipEvent.Team");

--- a/src/Core/Vision/FogField.cs
+++ b/src/Core/Vision/FogField.cs
@@ -1,0 +1,380 @@
+using System;
+using Ludots.Core.Mathematics;
+
+namespace Ludots.Core.Vision
+{
+    public sealed class FogField
+    {
+        private readonly int _scopeKeyId;
+        private readonly FogLayerDefinition _layer;
+        private readonly int _chunkSize;
+        private readonly int _chunkShift;
+        private FogChunk[] _chunks;
+        private int _chunkCount;
+        private int _dirtyCount;
+
+        public FogField(int scopeKeyId, in FogLayerDefinition layer, int chunkSizeCells = 16, int initialChunkCapacity = 8)
+        {
+            if (scopeKeyId <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(scopeKeyId));
+            }
+
+            if (layer.Id.Value <= 0)
+            {
+                throw new ArgumentException("FogField requires a registered layer.", nameof(layer));
+            }
+
+            if (chunkSizeCells <= 0 || (chunkSizeCells & (chunkSizeCells - 1)) != 0)
+            {
+                throw new ArgumentException("FogField chunk size must be a positive power of two.", nameof(chunkSizeCells));
+            }
+
+            if (initialChunkCapacity <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(initialChunkCapacity));
+            }
+
+            _scopeKeyId = scopeKeyId;
+            _layer = layer;
+            _chunkSize = chunkSizeCells;
+            _chunkShift = CalculateChunkShift(chunkSizeCells);
+            _chunks = new FogChunk[initialChunkCapacity];
+        }
+
+        public int ScopeKeyId => _scopeKeyId;
+        public FogLayerId LayerId => _layer.Id;
+        public int CellSizeCm => _layer.CellSizeCm;
+        public int ChunkCount => _chunkCount;
+        public int DirtyCount => _dirtyCount;
+
+        public FogCell WorldToCell(WorldCmInt2 world)
+        {
+            return new FogCell(
+                MathUtil.FloorDiv(world.X, _layer.CellSizeCm),
+                MathUtil.FloorDiv(world.Y, _layer.CellSizeCm));
+        }
+
+        public WorldCmInt2 CellCenterToWorld(FogCell cell)
+        {
+            int half = _layer.CellSizeCm / 2;
+            return new WorldCmInt2(
+                (cell.X * _layer.CellSizeCm) + half,
+                (cell.Y * _layer.CellSizeCm) + half);
+        }
+
+        public CellVisibility GetVisibility(FogCell cell)
+        {
+            int chunkIndex = FindChunkIndex(ChunkCoord(cell.X), ChunkCoord(cell.Y));
+            if (chunkIndex < 0)
+            {
+                return CellVisibility.Unseen;
+            }
+
+            ref FogChunk chunk = ref _chunks[chunkIndex];
+            int local = LocalIndex(cell.X, cell.Y);
+            return chunk.Get(local);
+        }
+
+        public void SetVisible(FogCell cell) => SetVisibility(cell, CellVisibility.Visible);
+
+        public void SetVisible(FogCell cell, FogDenyMode denyMode)
+            => SetVisibility(cell, MergeVisibility(GetVisibility(cell), CellVisibility.Visible, denyMode));
+
+        public void SetDenied(FogCell cell) => SetVisibility(cell, CellVisibility.Denied);
+
+        public void SetDenied(FogCell cell, FogDenyMode denyMode)
+            => SetVisibility(cell, MergeVisibility(GetVisibility(cell), CellVisibility.Denied, denyMode));
+
+        public void SetExplored(FogCell cell) => SetVisibility(cell, CellVisibility.Explored);
+
+        public void SetVisibility(FogCell cell, CellVisibility visibility)
+        {
+            ref FogChunk chunk = ref GetOrCreateChunk(ChunkCoord(cell.X), ChunkCoord(cell.Y));
+            int local = LocalIndex(cell.X, cell.Y);
+            CellVisibility previous = chunk.Get(local);
+            if (previous == visibility)
+            {
+                return;
+            }
+
+            chunk.Set(local, visibility);
+            MarkDirtyInChunk(ref chunk, cell);
+        }
+
+        public void Age(FogCell cell)
+        {
+            if (GetVisibility(cell) == CellVisibility.Visible)
+            {
+                SetVisibility(cell, CellVisibility.Explored);
+            }
+        }
+
+        public void AgeVisibleToExplored()
+        {
+            for (int chunkIndex = 0; chunkIndex < _chunkCount; chunkIndex++)
+            {
+                ref FogChunk chunk = ref _chunks[chunkIndex];
+                int cellCount = _chunkSize * _chunkSize;
+                for (int local = 0; local < cellCount; local++)
+                {
+                    if (chunk.Get(local) != CellVisibility.Visible)
+                    {
+                        continue;
+                    }
+
+                    chunk.Set(local, CellVisibility.Explored);
+                    int localX = local & (_chunkSize - 1);
+                    int localY = local >> _chunkShift;
+                    MarkDirtyInChunk(ref chunk, new FogCell((chunk.ChunkX * _chunkSize) + localX, (chunk.ChunkY * _chunkSize) + localY));
+                }
+            }
+        }
+
+        public void MarkDirtyRegion(IntRect rect)
+        {
+            if (rect.Width <= 0 || rect.Height <= 0)
+            {
+                return;
+            }
+
+            int endY = rect.Y + rect.Height;
+            int endX = rect.X + rect.Width;
+            for (int y = rect.Y; y < endY; y++)
+            {
+                for (int x = rect.X; x < endX; x++)
+                {
+                    ref FogChunk chunk = ref GetOrCreateChunk(ChunkCoord(x), ChunkCoord(y));
+                    MarkDirtyInChunk(ref chunk, new FogCell(x, y));
+                }
+            }
+        }
+
+        public int EnumerateDirtyCells(Span<FogCell> destination)
+        {
+            if (destination.IsEmpty)
+            {
+                return 0;
+            }
+
+            int written = 0;
+            for (int chunkIndex = 0; chunkIndex < _chunkCount && written < destination.Length; chunkIndex++)
+            {
+                ref FogChunk chunk = ref _chunks[chunkIndex];
+                for (int i = 0; i < chunk.DirtyCount && written < destination.Length; i++)
+                {
+                    destination[written++] = chunk.DirtyCells[i];
+                }
+            }
+
+            return written;
+        }
+
+        public void ClearDirty()
+        {
+            for (int chunkIndex = 0; chunkIndex < _chunkCount; chunkIndex++)
+            {
+                _chunks[chunkIndex].DirtyCount = 0;
+            }
+
+            _dirtyCount = 0;
+        }
+
+        public int CopyCells(Span<FogCellState> destination)
+        {
+            if (destination.IsEmpty)
+            {
+                return 0;
+            }
+
+            int written = 0;
+            int cellCount = _chunkSize * _chunkSize;
+            for (int chunkIndex = 0; chunkIndex < _chunkCount && written < destination.Length; chunkIndex++)
+            {
+                ref FogChunk chunk = ref _chunks[chunkIndex];
+                for (int local = 0; local < cellCount && written < destination.Length; local++)
+                {
+                    CellVisibility visibility = chunk.Get(local);
+                    if (visibility == CellVisibility.Unseen)
+                    {
+                        continue;
+                    }
+
+                    int localX = local & (_chunkSize - 1);
+                    int localY = local >> _chunkShift;
+                    destination[written++] = new FogCellState(
+                        new FogCell((chunk.ChunkX * _chunkSize) + localX, (chunk.ChunkY * _chunkSize) + localY),
+                        visibility);
+                }
+            }
+
+            return written;
+        }
+
+        public void Clear()
+        {
+            _chunkCount = 0;
+            _dirtyCount = 0;
+        }
+
+        public void ApplySnapshot(ReadOnlySpan<FogCellState> states)
+        {
+            Clear();
+            for (int i = 0; i < states.Length; i++)
+            {
+                SetVisibility(states[i].Cell, states[i].Visibility);
+            }
+
+            ClearDirty();
+        }
+
+        private static CellVisibility MergeVisibility(CellVisibility current, CellVisibility incoming, FogDenyMode denyMode)
+        {
+            if (incoming == CellVisibility.Denied)
+            {
+                return denyMode == FogDenyMode.RevealDominates && current == CellVisibility.Visible
+                    ? CellVisibility.Visible
+                    : CellVisibility.Denied;
+            }
+
+            if (incoming == CellVisibility.Visible)
+            {
+                return denyMode == FogDenyMode.DenyDominates && current == CellVisibility.Denied
+                    ? CellVisibility.Denied
+                    : CellVisibility.Visible;
+            }
+
+            if (incoming == CellVisibility.Explored && current == CellVisibility.Unseen)
+            {
+                return CellVisibility.Explored;
+            }
+
+            return current;
+        }
+
+        private static int CalculateChunkShift(int chunkSize)
+        {
+            int shift = 0;
+            int value = chunkSize;
+            while (value > 1)
+            {
+                value >>= 1;
+                shift++;
+            }
+
+            return shift;
+        }
+
+        private int ChunkCoord(int cellCoord) => MathUtil.FloorDiv(cellCoord, _chunkSize);
+
+        private int LocalIndex(int cellX, int cellY)
+        {
+            int localX = cellX - (ChunkCoord(cellX) * _chunkSize);
+            int localY = cellY - (ChunkCoord(cellY) * _chunkSize);
+            return (localY * _chunkSize) + localX;
+        }
+
+        private ref FogChunk GetOrCreateChunk(int chunkX, int chunkY)
+        {
+            int existing = FindChunkIndex(chunkX, chunkY);
+            if (existing >= 0)
+            {
+                return ref _chunks[existing];
+            }
+
+            EnsureChunkCapacity(_chunkCount + 1);
+            int index = _chunkCount++;
+            _chunks[index] = new FogChunk(chunkX, chunkY, _chunkSize);
+            return ref _chunks[index];
+        }
+
+        private int FindChunkIndex(int chunkX, int chunkY)
+        {
+            for (int i = 0; i < _chunkCount; i++)
+            {
+                if (_chunks[i].ChunkX == chunkX && _chunks[i].ChunkY == chunkY)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private void EnsureChunkCapacity(int required)
+        {
+            if (required <= _chunks.Length)
+            {
+                return;
+            }
+
+            int next = _chunks.Length;
+            while (next < required)
+            {
+                next *= 2;
+            }
+
+            Array.Resize(ref _chunks, next);
+        }
+
+        private void MarkDirtyInChunk(ref FogChunk chunk, FogCell cell)
+        {
+            if (chunk.TryAddDirty(cell))
+            {
+                _dirtyCount++;
+            }
+        }
+
+        private struct FogChunk
+        {
+            private readonly byte[] _states;
+            public readonly FogCell[] DirtyCells;
+
+            public FogChunk(int chunkX, int chunkY, int chunkSize)
+            {
+                ChunkX = chunkX;
+                ChunkY = chunkY;
+                _states = new byte[chunkSize * chunkSize];
+                DirtyCells = new FogCell[chunkSize * chunkSize];
+                DirtyCount = 0;
+            }
+
+            public readonly int ChunkX;
+            public readonly int ChunkY;
+            public int DirtyCount;
+
+            public CellVisibility Get(int localIndex) => (CellVisibility)_states[localIndex];
+
+            public void Set(int localIndex, CellVisibility visibility)
+            {
+                _states[localIndex] = (byte)visibility;
+            }
+
+            public bool TryAddDirty(FogCell cell)
+            {
+                for (int i = 0; i < DirtyCount; i++)
+                {
+                    if (DirtyCells[i] == cell)
+                    {
+                        return false;
+                    }
+                }
+
+                DirtyCells[DirtyCount++] = cell;
+                return true;
+            }
+        }
+    }
+
+    public readonly struct FogCellState
+    {
+        public FogCellState(FogCell cell, CellVisibility visibility)
+        {
+            Cell = cell;
+            Visibility = visibility;
+        }
+
+        public readonly FogCell Cell;
+        public readonly CellVisibility Visibility;
+    }
+}

--- a/src/Core/Vision/FogFieldStore.cs
+++ b/src/Core/Vision/FogFieldStore.cs
@@ -1,0 +1,89 @@
+using System;
+
+namespace Ludots.Core.Vision
+{
+    public sealed class FogFieldStore
+    {
+        private FogField[] _fields;
+        private int _count;
+        private readonly int _chunkSizeCells;
+
+        public FogFieldStore(int initialCapacity = 8, int chunkSizeCells = 16)
+        {
+            if (initialCapacity <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(initialCapacity));
+            }
+
+            _fields = new FogField[initialCapacity];
+            _chunkSizeCells = chunkSizeCells;
+        }
+
+        public int Count => _count;
+
+        public FogField GetOrCreate(int scopeKeyId, in FogLayerDefinition layer)
+        {
+            for (int i = 0; i < _count; i++)
+            {
+                FogField field = _fields[i];
+                if (field.ScopeKeyId == scopeKeyId && field.LayerId == layer.Id)
+                {
+                    return field;
+                }
+            }
+
+            EnsureCapacity(_count + 1);
+            FogField next = new(scopeKeyId, in layer, _chunkSizeCells);
+            _fields[_count++] = next;
+            return next;
+        }
+
+        public bool TryGet(int scopeKeyId, FogLayerId layerId, out FogField field)
+        {
+            for (int i = 0; i < _count; i++)
+            {
+                FogField current = _fields[i];
+                if (current.ScopeKeyId == scopeKeyId && current.LayerId == layerId)
+                {
+                    field = current;
+                    return true;
+                }
+            }
+
+            field = null!;
+            return false;
+        }
+
+        public int CopyFields(Span<FogField> destination)
+        {
+            if (destination.IsEmpty)
+            {
+                return 0;
+            }
+
+            int written = Math.Min(destination.Length, _count);
+            for (int i = 0; i < written; i++)
+            {
+                destination[i] = _fields[i];
+            }
+
+            return written;
+        }
+
+        private void EnsureCapacity(int required)
+        {
+            if (required <= _fields.Length)
+            {
+                return;
+            }
+
+            int next = _fields.Length;
+            while (next < required)
+            {
+                next *= 2;
+            }
+
+            Array.Resize(ref _fields, next);
+        }
+    }
+}

--- a/src/Core/Vision/FogKnowledgeProjector.cs
+++ b/src/Core/Vision/FogKnowledgeProjector.cs
@@ -1,0 +1,160 @@
+using System;
+using Arch.Core;
+using Ludots.Core.Knowledge;
+using Ludots.Core.Mathematics;
+
+namespace Ludots.Core.Vision
+{
+    public sealed class FogKnowledgeProjector
+    {
+        private readonly KnowledgeProjectionStore _knowledge;
+        private readonly ConcealmentRule _concealment;
+
+        public FogKnowledgeProjector(
+            KnowledgeProjectionStore knowledge,
+            IFogConcealmentSource? concealment = null)
+        {
+            _knowledge = knowledge ?? throw new ArgumentNullException(nameof(knowledge));
+            _concealment = new ConcealmentRule(concealment);
+        }
+
+        public int Project(
+            Entity viewer,
+            Entity source,
+            WorldCmInt2 viewerPosition,
+            FogField field,
+            ReadOnlySpan<FogOccupant> occupants,
+            in FogProjectionPolicy policy,
+            int currentTick,
+            byte detectionStrength = 0)
+        {
+            if (viewer == Entity.Null)
+            {
+                throw new ArgumentException("Fog projection viewer is required.", nameof(viewer));
+            }
+
+            if (source == Entity.Null)
+            {
+                throw new ArgumentException("Fog projection source is required.", nameof(source));
+            }
+
+            FogCell viewerCell = field.WorldToCell(viewerPosition);
+            int projected = 0;
+            uint layerMask = LayerMaskFromField(field);
+            bool trueSightActive = detectionStrength > 0 && policy.TrueSightRevealsConcealment;
+
+            for (int i = 0; i < occupants.Length; i++)
+            {
+                FogOccupant occupant = occupants[i];
+                bool exposesOnLayer = (occupant.ExposeLayerMask & layerMask) != 0u;
+                if (!exposesOnLayer)
+                {
+                    continue;
+                }
+
+                FogCell occupantCell = field.WorldToCell(occupant.Position);
+                CellVisibility visibility = field.GetVisibility(occupantCell);
+                KnowledgeDisclosureRecord record;
+                if (visibility == CellVisibility.Visible && exposesOnLayer && detectionStrength >= occupant.StealthLevel)
+                {
+                    if (!_concealment.Allows(viewerCell, occupantCell, trueSightActive, in policy))
+                    {
+                        record = CreateHidden(source, currentTick);
+                    }
+                    else
+                    {
+                        record = CreateLive(source, in policy, currentTick);
+                    }
+                }
+                else if (visibility == CellVisibility.Visible && occupant.StealthLevel > detectionStrength)
+                {
+                    record = CreateHidden(source, currentTick);
+                }
+                else if (visibility == CellVisibility.Denied)
+                {
+                    record = CreateHidden(source, currentTick);
+                }
+                else if (visibility == CellVisibility.Explored)
+                {
+                    record = CreateKnown(source, in policy, currentTick);
+                }
+                else
+                {
+                    continue;
+                }
+
+                _knowledge.Upsert(viewer, occupant.Entity, in record);
+                projected++;
+            }
+
+            return projected;
+        }
+
+        public void Decay(
+            Entity viewer,
+            Entity target,
+            Entity source,
+            in FogProjectionPolicy policy,
+            int currentTick)
+        {
+            if (viewer == Entity.Null || target == Entity.Null || source == Entity.Null)
+            {
+                return;
+            }
+
+            _knowledge.Upsert(viewer, target, CreateKnown(source, in policy, currentTick));
+        }
+
+        private static KnowledgeDisclosureRecord CreateLive(Entity source, in FogProjectionPolicy policy, int currentTick)
+        {
+            return new KnowledgeDisclosureRecord(
+                KnowledgePresence.LiveVisible,
+                KnowledgePositionAccess.Live,
+                policy.Disclosure.AttributeMask,
+                policy.Disclosure.RelationshipTypeMask,
+                policy.Disclosure.TagMask,
+                source,
+                currentTick,
+                expiryTick: 0,
+                confidencePermille: 1000,
+                revision: 0);
+        }
+
+        private static KnowledgeDisclosureRecord CreateKnown(Entity source, in FogProjectionPolicy policy, int currentTick)
+        {
+            int expiry = policy.MemoryTtlTicks > 0 ? currentTick + policy.MemoryTtlTicks : 0;
+            return new KnowledgeDisclosureRecord(
+                KnowledgePresence.Known,
+                KnowledgePositionAccess.LastKnown,
+                KnowledgeIdMask256.Empty,
+                KnowledgeIdMask256.Empty,
+                KnowledgeIdMask256.Empty,
+                source,
+                currentTick,
+                expiry,
+                confidencePermille: 650,
+                revision: 0);
+        }
+
+        private static KnowledgeDisclosureRecord CreateHidden(Entity source, int currentTick)
+        {
+            return new KnowledgeDisclosureRecord(
+                KnowledgePresence.HiddenWithSource,
+                KnowledgePositionAccess.None,
+                KnowledgeIdMask256.Empty,
+                KnowledgeIdMask256.Empty,
+                KnowledgeIdMask256.Empty,
+                source,
+                currentTick,
+                expiryTick: 0,
+                confidencePermille: 1000,
+                revision: 0);
+        }
+
+        private static uint LayerMaskFromField(FogField field)
+        {
+            int value = field.LayerId.Value;
+            return value <= 0 || value > 32 ? 0u : 1u << (value - 1);
+        }
+    }
+}

--- a/src/Core/Vision/FogLayerRegistry.cs
+++ b/src/Core/Vision/FogLayerRegistry.cs
@@ -1,0 +1,77 @@
+using System;
+using Ludots.Core.Registry;
+
+namespace Ludots.Core.Vision
+{
+    public sealed class FogLayerRegistry
+    {
+        private readonly StringIntRegistry _keys = new(capacity: 16, startId: 1, invalidId: 0, comparer: StringComparer.Ordinal);
+        private FogLayerDefinition[] _definitions = new FogLayerDefinition[16];
+        private bool[] _registered = new bool[16];
+
+        public FogLayerId Register(string key, int cellSizeCm, int updateHz)
+        {
+            int id = _keys.Register(key);
+            EnsureCapacity(id);
+            var layerId = new FogLayerId(id);
+            _definitions[id] = new FogLayerDefinition(layerId, key, cellSizeCm, updateHz);
+            _registered[id] = true;
+            return layerId;
+        }
+
+        public FogLayerId GetId(string key)
+        {
+            int id = _keys.GetId(key);
+            return id > 0 ? new FogLayerId(id) : default;
+        }
+
+        public bool TryGet(FogLayerId id, out FogLayerDefinition definition)
+        {
+            if (id.Value <= 0 || (uint)id.Value >= (uint)_registered.Length || !_registered[id.Value])
+            {
+                definition = default;
+                return false;
+            }
+
+            definition = _definitions[id.Value];
+            return true;
+        }
+
+        public FogLayerDefinition Get(FogLayerId id)
+        {
+            if (!TryGet(id, out FogLayerDefinition definition))
+            {
+                throw new InvalidOperationException($"Fog layer id {id.Value} is not registered.");
+            }
+
+            return definition;
+        }
+
+        public uint ToMask(FogLayerId id)
+        {
+            if (id.Value <= 0 || id.Value > 32)
+            {
+                throw new ArgumentOutOfRangeException(nameof(id), "Fog layer masks support layer ids 1..32.");
+            }
+
+            return 1u << (id.Value - 1);
+        }
+
+        private void EnsureCapacity(int id)
+        {
+            if ((uint)id < (uint)_definitions.Length)
+            {
+                return;
+            }
+
+            int next = _definitions.Length;
+            while (next <= id)
+            {
+                next *= 2;
+            }
+
+            Array.Resize(ref _definitions, next);
+            Array.Resize(ref _registered, next);
+        }
+    }
+}

--- a/src/Core/Vision/FogRules.cs
+++ b/src/Core/Vision/FogRules.cs
@@ -1,0 +1,238 @@
+using Ludots.Core.Mathematics;
+
+namespace Ludots.Core.Vision
+{
+    public interface IFogElevationSource
+    {
+        int GetHeightTier(FogCell cell);
+    }
+
+    public interface IFogOcclusionSource
+    {
+        bool IsOpaque(FogCell cell);
+    }
+
+    public interface IFogConcealmentSource
+    {
+        bool IsConcealed(FogCell cell);
+    }
+
+    public sealed class FogCellMap : IFogElevationSource, IFogOcclusionSource, IFogConcealmentSource
+    {
+        private FogCellValue[] _values;
+        private int _count;
+
+        public FogCellMap(int initialCapacity = 16)
+        {
+            if (initialCapacity <= 0)
+            {
+                throw new System.ArgumentOutOfRangeException(nameof(initialCapacity));
+            }
+
+            _values = new FogCellValue[initialCapacity];
+        }
+
+        public int Count => _count;
+
+        public void SetHeightTier(FogCell cell, int heightTier)
+        {
+            ref FogCellValue value = ref GetOrCreate(cell);
+            value.HeightTier = heightTier;
+        }
+
+        public void SetOpaque(FogCell cell, bool opaque)
+        {
+            ref FogCellValue value = ref GetOrCreate(cell);
+            value.Opaque = opaque;
+        }
+
+        public void SetConcealed(FogCell cell, bool concealed)
+        {
+            ref FogCellValue value = ref GetOrCreate(cell);
+            value.Concealed = concealed;
+        }
+
+        public int GetHeightTier(FogCell cell)
+        {
+            int index = FindIndex(cell);
+            return index >= 0 ? _values[index].HeightTier : 0;
+        }
+
+        public bool IsOpaque(FogCell cell)
+        {
+            int index = FindIndex(cell);
+            return index >= 0 && _values[index].Opaque;
+        }
+
+        public bool IsConcealed(FogCell cell)
+        {
+            int index = FindIndex(cell);
+            return index >= 0 && _values[index].Concealed;
+        }
+
+        private ref FogCellValue GetOrCreate(FogCell cell)
+        {
+            int existing = FindIndex(cell);
+            if (existing >= 0)
+            {
+                return ref _values[existing];
+            }
+
+            EnsureCapacity(_count + 1);
+            int index = _count++;
+            _values[index] = new FogCellValue(cell);
+            return ref _values[index];
+        }
+
+        private int FindIndex(FogCell cell)
+        {
+            for (int i = 0; i < _count; i++)
+            {
+                if (_values[i].Cell == cell)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private void EnsureCapacity(int required)
+        {
+            if (required <= _values.Length)
+            {
+                return;
+            }
+
+            int next = _values.Length;
+            while (next < required)
+            {
+                next *= 2;
+            }
+
+            System.Array.Resize(ref _values, next);
+        }
+
+        private struct FogCellValue
+        {
+            public FogCellValue(FogCell cell)
+            {
+                Cell = cell;
+                HeightTier = 0;
+                Opaque = false;
+                Concealed = false;
+            }
+
+            public FogCell Cell;
+            public int HeightTier;
+            public bool Opaque;
+            public bool Concealed;
+        }
+    }
+
+    public readonly struct VerticalVisionRule
+    {
+        public VerticalVisionRule(IFogElevationSource? elevation)
+        {
+            Elevation = elevation;
+        }
+
+        public readonly IFogElevationSource? Elevation;
+
+        public bool Allows(FogCell targetCell, int emitterTier, in FogRulesPolicy policy)
+        {
+            if (!policy.VerticalEnabled || Elevation == null)
+            {
+                return true;
+            }
+
+            int targetTier = Elevation.GetHeightTier(targetCell);
+            return targetTier <= emitterTier + policy.UpTolerance;
+        }
+    }
+
+    public readonly struct LineOfSightRule
+    {
+        public LineOfSightRule(IFogOcclusionSource? occlusion)
+        {
+            Occlusion = occlusion;
+        }
+
+        public readonly IFogOcclusionSource? Occlusion;
+
+        public bool Allows(FogCell from, FogCell to, in FogRulesPolicy policy)
+        {
+            if (!policy.LineOfSightEnabled || Occlusion == null)
+            {
+                return true;
+            }
+
+            int x0 = from.X;
+            int y0 = from.Y;
+            int x1 = to.X;
+            int y1 = to.Y;
+            int dx = MathUtil.Abs(x1 - x0);
+            int dy = MathUtil.Abs(y1 - y0);
+            int sx = x0 < x1 ? 1 : -1;
+            int sy = y0 < y1 ? 1 : -1;
+            int err = dx - dy;
+            int x = x0;
+            int y = y0;
+
+            while (x != x1 || y != y1)
+            {
+                int e2 = err * 2;
+                if (e2 > -dy)
+                {
+                    err -= dy;
+                    x += sx;
+                }
+
+                if (e2 < dx)
+                {
+                    err += dx;
+                    y += sy;
+                }
+
+                if (x == x1 && y == y1)
+                {
+                    return true;
+                }
+
+                if (Occlusion.IsOpaque(new FogCell(x, y)))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+
+    public readonly struct ConcealmentRule
+    {
+        public ConcealmentRule(IFogConcealmentSource? concealment)
+        {
+            Concealment = concealment;
+        }
+
+        public readonly IFogConcealmentSource? Concealment;
+
+        public bool Allows(FogCell viewerCell, FogCell targetCell, bool trueSightActive, in FogProjectionPolicy policy)
+        {
+            if (!policy.ConcealmentEnabled || Concealment == null || !Concealment.IsConcealed(targetCell))
+            {
+                return true;
+            }
+
+            if (trueSightActive && policy.TrueSightRevealsConcealment)
+            {
+                return true;
+            }
+
+            int dx = MathUtil.Abs(viewerCell.X - targetCell.X);
+            int dy = MathUtil.Abs(viewerCell.Y - targetCell.Y);
+            return dx <= 1 && dy <= 1;
+        }
+    }
+}

--- a/src/Core/Vision/FogSnapshotStore.cs
+++ b/src/Core/Vision/FogSnapshotStore.cs
@@ -1,0 +1,250 @@
+using System;
+using Arch.Core;
+using Ludots.Core.Gameplay.Relationships;
+
+namespace Ludots.Core.Vision
+{
+    public readonly struct FogSnapshotHandle : IEquatable<FogSnapshotHandle>
+    {
+        public FogSnapshotHandle(int value)
+        {
+            Value = value;
+        }
+
+        public readonly int Value;
+
+        public bool Equals(FogSnapshotHandle other) => Value == other.Value;
+        public override bool Equals(object? obj) => obj is FogSnapshotHandle other && Equals(other);
+        public override int GetHashCode() => Value;
+        public static bool operator ==(FogSnapshotHandle left, FogSnapshotHandle right) => left.Equals(right);
+        public static bool operator !=(FogSnapshotHandle left, FogSnapshotHandle right) => !left.Equals(right);
+    }
+
+    public readonly struct FogSnapshotHeader
+    {
+        public FogSnapshotHeader(int scopeKeyId, FogLayerId layerId, int tick, int cellCount)
+        {
+            ScopeKeyId = scopeKeyId;
+            LayerId = layerId;
+            Tick = tick;
+            CellCount = cellCount;
+        }
+
+        public readonly int ScopeKeyId;
+        public readonly FogLayerId LayerId;
+        public readonly int Tick;
+        public readonly int CellCount;
+    }
+
+    public sealed class FogSnapshotStore
+    {
+        private SnapshotEntry[] _entries;
+        private int _count;
+        private readonly RelationshipRuntime? _relationships;
+
+        public FogSnapshotStore(int initialCapacity = 8, RelationshipRuntime? relationships = null)
+        {
+            if (initialCapacity <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(initialCapacity));
+            }
+
+            _entries = new SnapshotEntry[initialCapacity];
+            _relationships = relationships;
+        }
+
+        public int Count => _count;
+
+        public FogSnapshotHandle Capture(FogField field, int tick)
+        {
+            EnsureCapacity(_count + 1);
+            int capacity = Math.Max(16, field.ChunkCount * 16 * 16);
+            FogCellState[] states = new FogCellState[capacity];
+            int count;
+            while (true)
+            {
+                count = field.CopyCells(states);
+                if (count < states.Length || field.ChunkCount == 0)
+                {
+                    break;
+                }
+
+                states = new FogCellState[states.Length * 2];
+            }
+
+            if (count != states.Length)
+            {
+                Array.Resize(ref states, count);
+            }
+
+            int entryIndex = _count++;
+            _entries[entryIndex] = new SnapshotEntry(
+                new FogSnapshotHeader(field.ScopeKeyId, field.LayerId, tick, count),
+                states);
+            return new FogSnapshotHandle(entryIndex + 1);
+        }
+
+        public bool TryGetHeader(FogSnapshotHandle handle, out FogSnapshotHeader header)
+        {
+            if (!TryGetEntry(handle, out SnapshotEntry entry))
+            {
+                header = default;
+                return false;
+            }
+
+            header = entry.Header;
+            return true;
+        }
+
+        public bool TryRestore(FogSnapshotHandle handle, FogField target)
+        {
+            if (!TryGetEntry(handle, out SnapshotEntry entry))
+            {
+                return false;
+            }
+
+            if (entry.Header.LayerId != target.LayerId || entry.Header.ScopeKeyId != target.ScopeKeyId)
+            {
+                return false;
+            }
+
+            target.ApplySnapshot(entry.States);
+            return true;
+        }
+
+        public bool TryMergeExplored(FogSnapshotHandle first, FogSnapshotHandle second, FogField target)
+        {
+            if (!TryGetEntry(first, out SnapshotEntry a) ||
+                !TryGetEntry(second, out SnapshotEntry b) ||
+                a.Header.LayerId != b.Header.LayerId ||
+                a.Header.LayerId != target.LayerId ||
+                target.ScopeKeyId != a.Header.ScopeKeyId)
+            {
+                return false;
+            }
+
+            target.ApplySnapshot(a.States);
+            for (int i = 0; i < b.States.Length; i++)
+            {
+                FogCellState state = b.States[i];
+                if (state.Visibility == CellVisibility.Explored ||
+                    state.Visibility == CellVisibility.Visible)
+                {
+                    if (target.GetVisibility(state.Cell) == CellVisibility.Unseen)
+                    {
+                        target.SetExplored(state.Cell);
+                    }
+                }
+            }
+
+            target.ClearDirty();
+            return true;
+        }
+
+        public bool TryMergeSharedExplored(
+            FogSnapshotHandle source,
+            FogSnapshotHandle shared,
+            FogField target,
+            Entity sourceScopeHost,
+            Entity sharedScopeHost,
+            int relationshipTypeId)
+        {
+            if (_relationships == null ||
+                !_relationships.HasLink(sourceScopeHost, sharedScopeHost, relationshipTypeId))
+            {
+                return false;
+            }
+
+            return TryMergeExplored(source, shared, target);
+        }
+
+        public int Diff(FogSnapshotHandle from, FogSnapshotHandle to, Span<FogCell> changedCells)
+        {
+            if (changedCells.IsEmpty ||
+                !TryGetEntry(from, out SnapshotEntry left) ||
+                !TryGetEntry(to, out SnapshotEntry right) ||
+                left.Header.LayerId != right.Header.LayerId)
+            {
+                return 0;
+            }
+
+            int written = 0;
+            for (int i = 0; i < right.States.Length && written < changedCells.Length; i++)
+            {
+                FogCellState rightState = right.States[i];
+                if (!TryFind(left.States, rightState.Cell, out CellVisibility leftVisibility) ||
+                    leftVisibility != rightState.Visibility)
+                {
+                    changedCells[written++] = rightState.Cell;
+                }
+            }
+
+            for (int i = 0; i < left.States.Length && written < changedCells.Length; i++)
+            {
+                FogCellState leftState = left.States[i];
+                if (!TryFind(right.States, leftState.Cell, out _))
+                {
+                    changedCells[written++] = leftState.Cell;
+                }
+            }
+
+            return written;
+        }
+
+        private static bool TryFind(FogCellState[] states, FogCell cell, out CellVisibility visibility)
+        {
+            for (int i = 0; i < states.Length; i++)
+            {
+                if (states[i].Cell == cell)
+                {
+                    visibility = states[i].Visibility;
+                    return true;
+                }
+            }
+
+            visibility = CellVisibility.Unseen;
+            return false;
+        }
+
+        private bool TryGetEntry(FogSnapshotHandle handle, out SnapshotEntry entry)
+        {
+            int index = handle.Value - 1;
+            if ((uint)index >= (uint)_count)
+            {
+                entry = default;
+                return false;
+            }
+
+            entry = _entries[index];
+            return true;
+        }
+
+        private void EnsureCapacity(int required)
+        {
+            if (required <= _entries.Length)
+            {
+                return;
+            }
+
+            int next = _entries.Length;
+            while (next < required)
+            {
+                next *= 2;
+            }
+
+            Array.Resize(ref _entries, next);
+        }
+
+        private readonly struct SnapshotEntry
+        {
+            public SnapshotEntry(FogSnapshotHeader header, FogCellState[] states)
+            {
+                Header = header;
+                States = states;
+            }
+
+            public readonly FogSnapshotHeader Header;
+            public readonly FogCellState[] States;
+        }
+    }
+}

--- a/src/Core/Vision/FogTypes.cs
+++ b/src/Core/Vision/FogTypes.cs
@@ -1,0 +1,410 @@
+using System;
+using Arch.Core;
+using Ludots.Core.Association;
+using Ludots.Core.Knowledge;
+using Ludots.Core.Mathematics;
+
+namespace Ludots.Core.Vision
+{
+    public enum CellVisibility : byte
+    {
+        Unseen = 0,
+        Explored = 1,
+        Visible = 2,
+        Denied = 3
+    }
+
+    public enum VisionPolarity : byte
+    {
+        Reveal = 0,
+        Deny = 1
+    }
+
+    public enum VisionApertureKind : byte
+    {
+        Disk = 0,
+        Cone = 1,
+        Box = 2,
+        Line = 3
+    }
+
+    public enum FogDenyMode : byte
+    {
+        DenyDominates = 0,
+        RevealDominates = 1
+    }
+
+    public readonly struct FogLayerId : IEquatable<FogLayerId>
+    {
+        public FogLayerId(int value)
+        {
+            if (value <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "Fog layer id must be positive.");
+            }
+
+            Value = value;
+        }
+
+        public readonly int Value;
+
+        public bool Equals(FogLayerId other) => Value == other.Value;
+        public override bool Equals(object? obj) => obj is FogLayerId other && Equals(other);
+        public override int GetHashCode() => Value;
+        public static bool operator ==(FogLayerId left, FogLayerId right) => left.Equals(right);
+        public static bool operator !=(FogLayerId left, FogLayerId right) => !left.Equals(right);
+    }
+
+    public readonly struct FogCell : IEquatable<FogCell>
+    {
+        public FogCell(int x, int y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        public readonly int X;
+        public readonly int Y;
+
+        public bool Equals(FogCell other) => X == other.X && Y == other.Y;
+        public override bool Equals(object? obj) => obj is FogCell other && Equals(other);
+        public override int GetHashCode() => HashCode.Combine(X, Y);
+        public static bool operator ==(FogCell left, FogCell right) => left.Equals(right);
+        public static bool operator !=(FogCell left, FogCell right) => !left.Equals(right);
+    }
+
+    public readonly struct FogLayerDefinition
+    {
+        public FogLayerDefinition(FogLayerId id, string key, int cellSizeCm, int updateHz)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                throw new ArgumentException("Fog layer key is required.", nameof(key));
+            }
+
+            if (cellSizeCm <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(cellSizeCm), "Fog layer cell size must be positive.");
+            }
+
+            if (updateHz <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(updateHz), "Fog layer update frequency must be positive.");
+            }
+
+            Id = id;
+            Key = key;
+            CellSizeCm = cellSizeCm;
+            UpdateHz = updateHz;
+        }
+
+        public readonly FogLayerId Id;
+        public readonly string Key;
+        public readonly int CellSizeCm;
+        public readonly int UpdateHz;
+    }
+
+    public readonly struct VisionAperture
+    {
+        public VisionAperture(VisionApertureKind kind, int rangeCm, int halfAngleDeg = 0, int halfWidthCm = 0)
+        {
+            if (rangeCm < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(rangeCm));
+            }
+
+            if (halfAngleDeg < 0 || halfAngleDeg > 180)
+            {
+                throw new ArgumentOutOfRangeException(nameof(halfAngleDeg));
+            }
+
+            if (halfWidthCm < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(halfWidthCm));
+            }
+
+            Kind = kind;
+            RangeCm = rangeCm;
+            HalfAngleDeg = halfAngleDeg;
+            HalfWidthCm = halfWidthCm;
+        }
+
+        public readonly VisionApertureKind Kind;
+        public readonly int RangeCm;
+        public readonly int HalfAngleDeg;
+        public readonly int HalfWidthCm;
+
+        public static VisionAperture Disk(int rangeCm) => new(VisionApertureKind.Disk, rangeCm);
+        public static VisionAperture Cone(int rangeCm, int halfAngleDeg) => new(VisionApertureKind.Cone, rangeCm, halfAngleDeg);
+        public static VisionAperture Box(int halfWidthCm, int halfHeightCm) => new(VisionApertureKind.Box, halfHeightCm, 0, halfWidthCm);
+        public static VisionAperture Line(int lengthCm, int halfWidthCm) => new(VisionApertureKind.Line, lengthCm, 0, halfWidthCm);
+    }
+
+    public readonly struct VisionScope
+    {
+        public VisionScope(int scopeKeyId, Entity host = default)
+        {
+            if (scopeKeyId <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(scopeKeyId), "Vision scope requires a registered ScopeKey id.");
+            }
+
+            ScopeKey = ScopeKey.Named(scopeKeyId, host);
+        }
+
+        public readonly ScopeKey ScopeKey;
+
+        public int ScopeKeyId => ScopeKey.ScopeKeyId;
+        public Entity Host => ScopeKey.ScopeHost;
+    }
+
+    public struct VisionEmitterCm
+    {
+        public int ScopeKeyId;
+        public uint LayerMask;
+        public VisionPolarity Polarity;
+        public VisionAperture Aperture;
+        public int AltitudeBand;
+        public int Priority;
+        public int TargetScopeSelectorId;
+        public byte UpdatePolicyId;
+        public byte DetectionStrength;
+        public byte TrueSightStrength;
+    }
+
+    public struct FogOccupantCm
+    {
+        public uint ExposeLayerMask;
+        public int AltitudeBand;
+        public byte StealthLevel;
+    }
+
+    public readonly struct VisionEmitter
+    {
+        public VisionEmitter(
+            int scopeKeyId,
+            WorldCmInt2 position,
+            int facingDeg,
+            uint layerMask,
+            VisionPolarity polarity,
+            VisionAperture aperture,
+            int altitudeBand = 0,
+            int priority = 0,
+            int targetScopeSelectorId = 0,
+            byte detectionStrength = 0,
+            byte trueSightStrength = 0)
+        {
+            if (scopeKeyId <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(scopeKeyId));
+            }
+
+            ScopeKeyId = scopeKeyId;
+            Position = position;
+            FacingDeg = facingDeg;
+            LayerMask = layerMask;
+            Polarity = polarity;
+            Aperture = aperture;
+            AltitudeBand = altitudeBand;
+            Priority = priority;
+            TargetScopeSelectorId = targetScopeSelectorId;
+            DetectionStrength = detectionStrength;
+            TrueSightStrength = trueSightStrength;
+        }
+
+        public readonly int ScopeKeyId;
+        public readonly WorldCmInt2 Position;
+        public readonly int FacingDeg;
+        public readonly uint LayerMask;
+        public readonly VisionPolarity Polarity;
+        public readonly VisionAperture Aperture;
+        public readonly int AltitudeBand;
+        public readonly int Priority;
+        public readonly int TargetScopeSelectorId;
+        public readonly byte DetectionStrength;
+        public readonly byte TrueSightStrength;
+    }
+
+    public readonly struct FogOccupant
+    {
+        public FogOccupant(
+            Entity entity,
+            WorldCmInt2 position,
+            uint exposeLayerMask,
+            int altitudeBand = 0,
+            byte stealthLevel = 0)
+        {
+            if (entity == Entity.Null)
+            {
+                throw new ArgumentException("Fog occupant entity is required.", nameof(entity));
+            }
+
+            Entity = entity;
+            Position = position;
+            ExposeLayerMask = exposeLayerMask;
+            AltitudeBand = altitudeBand;
+            StealthLevel = stealthLevel;
+        }
+
+        public readonly Entity Entity;
+        public readonly WorldCmInt2 Position;
+        public readonly uint ExposeLayerMask;
+        public readonly int AltitudeBand;
+        public readonly byte StealthLevel;
+    }
+
+    public readonly struct FogDisclosurePolicy
+    {
+        public FogDisclosurePolicy(
+            in KnowledgeIdMask256 attributeMask,
+            in KnowledgeIdMask256 relationshipTypeMask,
+            in KnowledgeIdMask256 tagMask,
+            int ttlTicks,
+            bool trueSightRevealsConcealment)
+        {
+            if (ttlTicks < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(ttlTicks));
+            }
+
+            AttributeMask = attributeMask;
+            RelationshipTypeMask = relationshipTypeMask;
+            TagMask = tagMask;
+            TtlTicks = ttlTicks;
+            TrueSightRevealsConcealment = trueSightRevealsConcealment;
+        }
+
+        public readonly KnowledgeIdMask256 AttributeMask;
+        public readonly KnowledgeIdMask256 RelationshipTypeMask;
+        public readonly KnowledgeIdMask256 TagMask;
+        public readonly int TtlTicks;
+        public readonly bool TrueSightRevealsConcealment;
+
+        public static FogDisclosurePolicy None => new(
+            KnowledgeIdMask256.Empty,
+            KnowledgeIdMask256.Empty,
+            KnowledgeIdMask256.Empty,
+            ttlTicks: 0,
+            trueSightRevealsConcealment: true);
+    }
+
+    public readonly struct FogRulesPolicy
+    {
+        public FogRulesPolicy(
+            bool verticalEnabled = true,
+            bool lineOfSightEnabled = true,
+            bool concealmentEnabled = true,
+            int upTolerance = 0,
+            FogDenyMode denyMode = FogDenyMode.DenyDominates)
+        {
+            VerticalEnabled = verticalEnabled;
+            LineOfSightEnabled = lineOfSightEnabled;
+            ConcealmentEnabled = concealmentEnabled;
+            UpTolerance = upTolerance;
+            DenyMode = denyMode;
+        }
+
+        public readonly bool VerticalEnabled;
+        public readonly bool LineOfSightEnabled;
+        public readonly bool ConcealmentEnabled;
+        public readonly int UpTolerance;
+        public readonly FogDenyMode DenyMode;
+
+        public static FogRulesPolicy Default => new(
+            verticalEnabled: true,
+            lineOfSightEnabled: true,
+            concealmentEnabled: true);
+    }
+
+    public readonly struct FogProjectionPolicy
+    {
+        public FogProjectionPolicy(
+            FogDisclosurePolicy disclosure,
+            int memoryTtlTicks,
+            bool concealmentEnabled = true,
+            bool trueSightRevealsConcealment = true)
+        {
+            if (memoryTtlTicks < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(memoryTtlTicks));
+            }
+
+            Disclosure = disclosure;
+            MemoryTtlTicks = memoryTtlTicks;
+            ConcealmentEnabled = concealmentEnabled;
+            TrueSightRevealsConcealment = trueSightRevealsConcealment;
+        }
+
+        public readonly FogDisclosurePolicy Disclosure;
+        public readonly int MemoryTtlTicks;
+        public readonly bool ConcealmentEnabled;
+        public readonly bool TrueSightRevealsConcealment;
+
+        public static FogProjectionPolicy Default => new(FogDisclosurePolicy.None, memoryTtlTicks: 0);
+    }
+
+    public readonly struct FogProjectionOccupant
+    {
+        public FogProjectionOccupant(Entity entity, FogCell cell, uint layerMask, byte stealthLevel = 0)
+        {
+            if (entity == Entity.Null)
+            {
+                throw new ArgumentException("Fog occupant entity is required.", nameof(entity));
+            }
+
+            Entity = entity;
+            Cell = cell;
+            LayerMask = layerMask;
+            StealthLevel = stealthLevel;
+        }
+
+        public readonly Entity Entity;
+        public readonly FogCell Cell;
+        public readonly uint LayerMask;
+        public readonly byte StealthLevel;
+    }
+
+    public readonly struct FogRelationshipRule
+    {
+        public FogRelationshipRule(Entity sourceScopeHost, int relationshipTypeId)
+        {
+            if (sourceScopeHost == Entity.Null)
+            {
+                throw new ArgumentException("Relationship-gated fog sharing requires a source scope host.", nameof(sourceScopeHost));
+            }
+
+            if (relationshipTypeId < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(relationshipTypeId));
+            }
+
+            SourceScopeHost = sourceScopeHost;
+            RelationshipTypeId = relationshipTypeId;
+        }
+
+        public readonly Entity SourceScopeHost;
+        public readonly int RelationshipTypeId;
+    }
+
+    public readonly struct FogScopeTarget
+    {
+        public FogScopeTarget(int scopeKeyId, Entity scopeHost)
+        {
+            if (scopeKeyId <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(scopeKeyId));
+            }
+
+            if (scopeHost == Entity.Null)
+            {
+                throw new ArgumentException("Fog scope target requires a scope host entity.", nameof(scopeHost));
+            }
+
+            ScopeKeyId = scopeKeyId;
+            ScopeHost = scopeHost;
+        }
+
+        public readonly int ScopeKeyId;
+        public readonly Entity ScopeHost;
+    }
+}

--- a/src/Core/Vision/VisionResolver.cs
+++ b/src/Core/Vision/VisionResolver.cs
@@ -1,0 +1,209 @@
+using System;
+using Ludots.Core.Gameplay.Relationships;
+using Ludots.Core.Mathematics;
+
+namespace Ludots.Core.Vision
+{
+    public sealed class VisionResolver
+    {
+        private readonly FogLayerRegistry _layers;
+        private readonly FogFieldStore _fields;
+        private readonly IFogElevationSource? _elevation;
+        private readonly IFogOcclusionSource? _occlusion;
+        private readonly RelationshipRuntime? _relationships;
+
+        public VisionResolver(
+            FogLayerRegistry layers,
+            FogFieldStore fields,
+            IFogElevationSource? elevation = null,
+            IFogOcclusionSource? occlusion = null,
+            RelationshipRuntime? relationships = null)
+        {
+            _layers = layers ?? throw new ArgumentNullException(nameof(layers));
+            _fields = fields ?? throw new ArgumentNullException(nameof(fields));
+            _elevation = elevation;
+            _occlusion = occlusion;
+            _relationships = relationships;
+        }
+
+        public int Resolve(in VisionEmitter emitter, ReadOnlySpan<FogLayerId> targetLayers, in FogRulesPolicy policy)
+        {
+            int changed = 0;
+            for (int i = 0; i < targetLayers.Length; i++)
+            {
+                FogLayerId layerId = targetLayers[i];
+                if ((emitter.LayerMask & _layers.ToMask(layerId)) == 0u)
+                {
+                    continue;
+                }
+
+                FogLayerDefinition layer = _layers.Get(layerId);
+                FogField field = _fields.GetOrCreate(emitter.ScopeKeyId, in layer);
+                changed += RasterizeIntoField(in emitter, field, in policy);
+            }
+
+            return changed;
+        }
+
+        public int ResolveToScopes(
+            in VisionEmitter emitter,
+            ReadOnlySpan<FogScopeTarget> targets,
+            ReadOnlySpan<FogLayerId> targetLayers,
+            in FogRulesPolicy policy,
+            FogRelationshipRule relationshipRule = default)
+        {
+            int changed = 0;
+            for (int scopeIndex = 0; scopeIndex < targets.Length; scopeIndex++)
+            {
+                FogScopeTarget target = targets[scopeIndex];
+
+                if (relationshipRule.SourceScopeHost != default)
+                {
+                    if (_relationships == null)
+                    {
+                        throw new InvalidOperationException("Relationship-gated fog resolution requires RelationshipRuntime.");
+                    }
+
+                    if (!_relationships.HasLink(relationshipRule.SourceScopeHost, target.ScopeHost, relationshipRule.RelationshipTypeId))
+                    {
+                        continue;
+                    }
+                }
+
+                var scoped = new VisionEmitter(
+                    target.ScopeKeyId,
+                    emitter.Position,
+                    emitter.FacingDeg,
+                    emitter.LayerMask,
+                    emitter.Polarity,
+                    emitter.Aperture,
+                    emitter.AltitudeBand,
+                    emitter.Priority,
+                    emitter.TargetScopeSelectorId,
+                    emitter.DetectionStrength,
+                    emitter.TrueSightStrength);
+                changed += Resolve(in scoped, targetLayers, in policy);
+            }
+
+            return changed;
+        }
+
+        public int RasterizeIntoField(in VisionEmitter emitter, FogField field, in FogRulesPolicy policy)
+        {
+            FogCell origin = field.WorldToCell(emitter.Position);
+            int radiusCells = MathUtil.CeilDiv(emitter.Aperture.RangeCm, field.CellSizeCm);
+            if (emitter.Aperture.Kind == VisionApertureKind.Box)
+            {
+                radiusCells = Math.Max(
+                    MathUtil.CeilDiv(emitter.Aperture.RangeCm, field.CellSizeCm),
+                    MathUtil.CeilDiv(emitter.Aperture.HalfWidthCm, field.CellSizeCm));
+            }
+
+            if (radiusCells < 0)
+            {
+                return 0;
+            }
+
+            var vertical = new VerticalVisionRule(_elevation);
+            var lineOfSight = new LineOfSightRule(_occlusion);
+            int touched = 0;
+            for (int y = origin.Y - radiusCells; y <= origin.Y + radiusCells; y++)
+            {
+                for (int x = origin.X - radiusCells; x <= origin.X + radiusCells; x++)
+                {
+                    FogCell cell = new(x, y);
+                    if (!ApertureContains(emitter, field, origin, cell))
+                    {
+                        continue;
+                    }
+
+                    if (!vertical.Allows(cell, emitter.AltitudeBand, in policy))
+                    {
+                        continue;
+                    }
+
+                    if (!lineOfSight.Allows(origin, cell, in policy))
+                    {
+                        continue;
+                    }
+
+                    if (emitter.Polarity == VisionPolarity.Deny)
+                    {
+                        field.SetDenied(cell, policy.DenyMode);
+                    }
+                    else
+                    {
+                        field.SetVisible(cell, policy.DenyMode);
+                    }
+
+                    touched++;
+                }
+            }
+
+            return touched;
+        }
+
+        private static bool ApertureContains(in VisionEmitter emitter, FogField field, FogCell origin, FogCell cell)
+        {
+            WorldCmInt2 center = field.CellCenterToWorld(cell);
+            int dx = center.X - emitter.Position.X;
+            int dy = center.Y - emitter.Position.Y;
+            long distanceSq = ((long)dx * dx) + ((long)dy * dy);
+            long rangeSq = (long)emitter.Aperture.RangeCm * emitter.Aperture.RangeCm;
+
+            switch (emitter.Aperture.Kind)
+            {
+                case VisionApertureKind.Disk:
+                    return distanceSq <= rangeSq;
+                case VisionApertureKind.Cone:
+                    return distanceSq <= rangeSq && IsWithinCone(dx, dy, emitter.FacingDeg, emitter.Aperture.HalfAngleDeg);
+                case VisionApertureKind.Box:
+                    return IsWithinBox(dx, dy, emitter.FacingDeg, emitter.Aperture.HalfWidthCm, emitter.Aperture.RangeCm);
+                case VisionApertureKind.Line:
+                    return IsWithinLine(dx, dy, emitter.FacingDeg, emitter.Aperture.RangeCm, emitter.Aperture.HalfWidthCm);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(emitter.Aperture.Kind), emitter.Aperture.Kind, "Unsupported vision aperture.");
+            }
+        }
+
+        private static bool IsWithinCone(int dx, int dy, int facingDeg, int halfAngleDeg)
+        {
+            if (dx == 0 && dy == 0)
+            {
+                return true;
+            }
+
+            int forwardX = MathUtil.Cos(facingDeg);
+            int forwardY = MathUtil.Sin(facingDeg);
+            long dot = ((long)dx * forwardX) + ((long)dy * forwardY);
+            if (dot < 0)
+            {
+                return false;
+            }
+
+            int distance = MathUtil.Sqrt(((long)dx * dx) + ((long)dy * dy));
+            long threshold = (long)distance * MathUtil.ScalingFactor * MathUtil.Cos(halfAngleDeg);
+            return dot * MathUtil.ScalingFactor >= threshold;
+        }
+
+        private static bool IsWithinBox(int dx, int dy, int facingDeg, int halfWidthCm, int halfHeightCm)
+        {
+            RotateIntoFacing(dx, dy, facingDeg, out int forward, out int side);
+            return MathUtil.Abs(forward) <= halfHeightCm && MathUtil.Abs(side) <= halfWidthCm;
+        }
+
+        private static bool IsWithinLine(int dx, int dy, int facingDeg, int lengthCm, int halfWidthCm)
+        {
+            RotateIntoFacing(dx, dy, facingDeg, out int forward, out int side);
+            return forward >= 0 && forward <= lengthCm && MathUtil.Abs(side) <= halfWidthCm;
+        }
+
+        private static void RotateIntoFacing(int dx, int dy, int facingDeg, out int forward, out int side)
+        {
+            int cos = MathUtil.Cos(facingDeg);
+            int sin = MathUtil.Sin(facingDeg);
+            forward = (int)(((long)dx * cos + (long)dy * sin) / MathUtil.ScalingFactor);
+            side = (int)((-(long)dx * sin + (long)dy * cos) / MathUtil.ScalingFactor);
+        }
+    }
+}

--- a/src/Tests/GasTests/ArchitectureGuardTests.cs
+++ b/src/Tests/GasTests/ArchitectureGuardTests.cs
@@ -1106,6 +1106,47 @@ namespace GasTests
             });
         }
 
+        [Test]
+        [Ignore("FOG-1 #306 ADR guard placeholder; enable as FOG-2 through FOG-9 land the Vision domain.")]
+        public void Issue306_WarFogAdr_PendingVisionDomainGuardrails()
+        {
+            var repoRoot = FindRepoRoot();
+            string visionRoot = Path.Combine(repoRoot, "src", "Core", "Vision");
+            string coreServiceKeysPath = Path.Combine(repoRoot, "src", "Core", "Scripting", "CoreServiceKeys.cs");
+            string gameEnginePath = Path.Combine(repoRoot, "src", "Core", "Engine", "GameEngine.cs");
+            string knowledgeStorePath = Path.Combine(repoRoot, "src", "Core", "Knowledge", "KnowledgeProjectionStore.cs");
+            string knowledgeContractsPath = Path.Combine(repoRoot, "src", "Core", "Knowledge", "KnowledgeProjectionContracts.cs");
+
+            Assert.That(Directory.Exists(visionRoot), Is.True, "FOG-2 starts the cell-keyed Vision domain root.");
+
+            string[] visionFiles = Directory.GetFiles(visionRoot, "*.cs", SearchOption.AllDirectories);
+            string visionSource = string.Join('\n', Array.ConvertAll(visionFiles, File.ReadAllText));
+            string coreServiceKeys = File.ReadAllText(coreServiceKeysPath);
+            string gameEngine = File.ReadAllText(gameEnginePath);
+            string knowledgeStore = File.ReadAllText(knowledgeStorePath);
+            string knowledgeContracts = File.ReadAllText(knowledgeContractsPath);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(visionSource, Does.Contain("FogField"), "FOG-1 #306 section 1.1/1.3: fog stores cell-keyed visibility fields.");
+                Assert.That(visionSource, Does.Contain("ScopeKey"), "FOG-1 #306 section 1.4: VisionScope is the existing ScopeKey contract.");
+                Assert.That(visionSource, Does.Not.Contain("EntityKeyedSoaTable"), "FOG-1 #306 section 1.3: FogField must not use the entity-keyed AAC table.");
+                Assert.That(visionSource, Does.Contain("CellVisibility"), "FOG-1 #306 section 1.4: layers carry Unseen/Explored/Visible/Denied states.");
+                Assert.That(visionSource, Does.Contain("VerticalVisionRule"), "FOG-1 #306 section 1.5: vertical vision remains independent.");
+                Assert.That(visionSource, Does.Contain("LineOfSightRule"), "FOG-1 #306 section 1.5: LoS remains an independent switch.");
+                Assert.That(visionSource, Does.Contain("Concealment"), "FOG-1 #306 section 1.5: concealment remains an independent switch.");
+                Assert.That(visionSource, Does.Contain("KnowledgeIdMask256"), "FOG-1 #306 section 1.6: projection uses finite Knowledge masks.");
+                Assert.That(visionSource, Does.Contain("KnowledgeProjectionStore"), "FOG-1 #306 section 1.1: entity disclosure flows through Knowledge.");
+                Assert.That(visionSource, Does.Contain("RelationshipRuntime"), "FOG-1 #306 section 1.7: sharing and cross-scope effects use relationship edges.");
+                Assert.That(visionSource, Does.Not.Contain("PlayerId"), "FOG-1 #306 section 1.2/1.8: Core Vision has no participant business semantics.");
+                Assert.That(visionSource, Does.Not.Contain("TeamId"), "FOG-1 #306 section 1.2/1.8: Core Vision has no team shortcuts.");
+                Assert.That(knowledgeStore, Does.Contain("EntityKeyedSoaTable"), "Knowledge remains the entity-keyed projection SSOT.");
+                Assert.That(knowledgeContracts, Does.Contain("KnowledgeIdMask256"));
+                Assert.That(coreServiceKeys, Does.Contain("Vision"));
+                Assert.That(gameEngine, Does.Contain("Vision"));
+            });
+        }
+
         private static void AssertShowcaseCapability(
             string repoRoot,
             string gasTestsProject,

--- a/src/Tests/GasTests/ArchitectureGuardTests.cs
+++ b/src/Tests/GasTests/ArchitectureGuardTests.cs
@@ -1107,8 +1107,7 @@ namespace GasTests
         }
 
         [Test]
-        [Ignore("FOG-1 #306 ADR guard placeholder; enable as FOG-2 through FOG-9 land the Vision domain.")]
-        public void Issue306_WarFogAdr_PendingVisionDomainGuardrails()
+        public void Issue306_WarFogAdr_VisionDomainGuardrails()
         {
             var repoRoot = FindRepoRoot();
             string visionRoot = Path.Combine(repoRoot, "src", "Core", "Vision");
@@ -1145,6 +1144,134 @@ namespace GasTests
                 Assert.That(coreServiceKeys, Does.Contain("Vision"));
                 Assert.That(gameEngine, Does.Contain("Vision"));
             });
+        }
+
+        [Test]
+        public void Issue314_WarFogGuardrails_CellKeyedKnowledgeOnlyAndShowcasesExist()
+        {
+            var repoRoot = FindRepoRoot();
+            string visionRoot = Path.Combine(repoRoot, "src", "Core", "Vision");
+            string testsProjectPath = Path.Combine(repoRoot, "src", "Tests", "GasTests", "GasTests.csproj");
+            string acceptancePath = Path.Combine(repoRoot, "src", "Tests", "GasTests", "Production", "FogOfWarShowcaseAcceptanceTests.cs");
+            string testsProject = File.ReadAllText(testsProjectPath);
+            string[] visionFiles = Directory.GetFiles(visionRoot, "*.cs", SearchOption.AllDirectories);
+            string[] forbiddenVisionTokens =
+            {
+                "EntityKeyedSoaTable",
+                "PlayerId",
+                "TeamId",
+                "TeamManager",
+                "ra2",
+                "war3",
+                "moba",
+                "commando"
+            };
+            string[] forbiddenHotPathTokens =
+            {
+                "using System.Linq",
+                ".Where(",
+                ".Select(",
+                ".ToArray(",
+                ".ToList(",
+                "yield return",
+                "IEnumerator",
+                "IEnumerable<",
+                "new Dictionary<",
+                "new List<"
+            };
+
+            var hits = new List<string>();
+            for (int i = 0; i < visionFiles.Length; i++)
+            {
+                AppendForbiddenSourceTokens(repoRoot, visionFiles[i], forbiddenVisionTokens, hits);
+                AppendForbiddenSourceTokens(repoRoot, visionFiles[i], forbiddenHotPathTokens, hits);
+            }
+
+            Assert.That(
+                hits,
+                Is.Empty,
+                "FOG-9 #314 keeps Core Vision cell-keyed, topic-neutral, and allocation-conscious:\n" +
+                string.Join("\n", hits));
+
+            ShowcaseCapabilitySpec[] specs =
+            {
+                new(
+                    Issue: "#307",
+                    ModName: "MultiLayerFogFieldShowcaseMod",
+                    ModDirectory: Path.Combine(repoRoot, "mods", "showcases", "fog_of_war", "MultiLayerFogFieldShowcaseMod"),
+                    EntryFileName: "MultiLayerFogFieldShowcaseModEntry.cs",
+                    ProjectFileName: "MultiLayerFogFieldShowcaseMod.csproj",
+                    AcceptanceTestPath: acceptancePath,
+                    ArtifactFolder: "fog-of-war-showcase"),
+                new(
+                    Issue: "#308",
+                    ModName: "VisionConeHighGroundShowcaseMod",
+                    ModDirectory: Path.Combine(repoRoot, "mods", "showcases", "fog_of_war", "VisionConeHighGroundShowcaseMod"),
+                    EntryFileName: "VisionConeHighGroundShowcaseModEntry.cs",
+                    ProjectFileName: "VisionConeHighGroundShowcaseMod.csproj",
+                    AcceptanceTestPath: acceptancePath,
+                    ArtifactFolder: "fog-of-war-showcase"),
+                new(
+                    Issue: "#309",
+                    ModName: "LineOfSightBrushShowcaseMod",
+                    ModDirectory: Path.Combine(repoRoot, "mods", "showcases", "fog_of_war", "LineOfSightBrushShowcaseMod"),
+                    EntryFileName: "LineOfSightBrushShowcaseModEntry.cs",
+                    ProjectFileName: "LineOfSightBrushShowcaseMod.csproj",
+                    AcceptanceTestPath: acceptancePath,
+                    ArtifactFolder: "fog-of-war-showcase"),
+                new(
+                    Issue: "#310",
+                    ModName: "ExploredMemoryShowcaseMod",
+                    ModDirectory: Path.Combine(repoRoot, "mods", "showcases", "fog_of_war", "ExploredMemoryShowcaseMod"),
+                    EntryFileName: "ExploredMemoryShowcaseModEntry.cs",
+                    ProjectFileName: "ExploredMemoryShowcaseMod.csproj",
+                    AcceptanceTestPath: acceptancePath,
+                    ArtifactFolder: "fog-of-war-showcase"),
+                new(
+                    Issue: "#311",
+                    ModName: "GapGeneratorShowcaseMod",
+                    ModDirectory: Path.Combine(repoRoot, "mods", "showcases", "fog_of_war", "GapGeneratorShowcaseMod"),
+                    EntryFileName: "GapGeneratorShowcaseModEntry.cs",
+                    ProjectFileName: "GapGeneratorShowcaseMod.csproj",
+                    AcceptanceTestPath: acceptancePath,
+                    ArtifactFolder: "fog-of-war-showcase"),
+                new(
+                    Issue: "#312",
+                    ModName: "StealthDetectionShowcaseMod",
+                    ModDirectory: Path.Combine(repoRoot, "mods", "showcases", "fog_of_war", "StealthDetectionShowcaseMod"),
+                    EntryFileName: "StealthDetectionShowcaseModEntry.cs",
+                    ProjectFileName: "StealthDetectionShowcaseMod.csproj",
+                    AcceptanceTestPath: acceptancePath,
+                    ArtifactFolder: "fog-of-war-showcase"),
+                new(
+                    Issue: "#313",
+                    ModName: "SharedVisionSnapshotShowcaseMod",
+                    ModDirectory: Path.Combine(repoRoot, "mods", "showcases", "fog_of_war", "SharedVisionSnapshotShowcaseMod"),
+                    EntryFileName: "SharedVisionSnapshotShowcaseModEntry.cs",
+                    ProjectFileName: "SharedVisionSnapshotShowcaseMod.csproj",
+                    AcceptanceTestPath: acceptancePath,
+                    ArtifactFolder: "fog-of-war-showcase"),
+                new(
+                    Issue: "#315",
+                    ModName: "FogOfWarShowcaseMod",
+                    ModDirectory: Path.Combine(repoRoot, "mods", "showcases", "fog_of_war", "FogOfWarShowcaseMod"),
+                    EntryFileName: "FogOfWarShowcaseModEntry.cs",
+                    ProjectFileName: "FogOfWarShowcaseMod.csproj",
+                    AcceptanceTestPath: acceptancePath,
+                    ArtifactFolder: "fog-of-war-showcase")
+            };
+
+            var missing = new List<string>();
+            for (int i = 0; i < specs.Length; i++)
+            {
+                AssertShowcaseCapability(repoRoot, testsProject, specs[i], missing);
+            }
+
+            Assert.That(
+                missing,
+                Is.Empty,
+                "FOG-9 #314 and FOG-10 #315 require formal War Fog showcase roots and headless acceptance evidence:\n" +
+                string.Join("\n", missing));
         }
 
         private static void AssertShowcaseCapability(

--- a/src/Tests/GasTests/FogFieldTests.cs
+++ b/src/Tests/GasTests/FogFieldTests.cs
@@ -1,0 +1,118 @@
+using Ludots.Core.Mathematics;
+using Ludots.Core.Vision;
+using NUnit.Framework;
+
+namespace Ludots.Tests.GAS
+{
+    [TestFixture]
+    public sealed class FogFieldTests
+    {
+        [Test]
+        public void FogField_KeepsScopeLayerStateIndependent()
+        {
+            var registry = new FogLayerRegistry();
+            FogLayerId groundId = registry.Register("ground", cellSizeCm: 100, updateHz: 10);
+            FogLayerId airId = registry.Register("air", cellSizeCm: 250, updateHz: 5);
+
+            var ground = new FogField(scopeKeyId: 7, registry.Get(groundId));
+            var air = new FogField(scopeKeyId: 7, registry.Get(airId));
+            var otherScope = new FogField(scopeKeyId: 9, registry.Get(groundId));
+
+            var cell = new FogCell(2, 3);
+            ground.SetVisible(cell);
+            air.SetDenied(cell);
+            otherScope.SetExplored(cell);
+
+            Assert.That(ground.GetVisibility(cell), Is.EqualTo(CellVisibility.Visible));
+            Assert.That(air.GetVisibility(cell), Is.EqualTo(CellVisibility.Denied));
+            Assert.That(otherScope.GetVisibility(cell), Is.EqualTo(CellVisibility.Explored));
+            Assert.That(ground.ScopeKeyId, Is.EqualTo(7));
+            Assert.That(ground.LayerId, Is.EqualTo(groundId));
+            Assert.That(air.LayerId, Is.EqualTo(airId));
+        }
+
+        [Test]
+        public void FogField_UsesLayerResolutionForWorldCellAddressing()
+        {
+            var registry = new FogLayerRegistry();
+            FogLayerId fineId = registry.Register("fine", cellSizeCm: 100, updateHz: 10);
+            FogLayerId coarseId = registry.Register("coarse", cellSizeCm: 250, updateHz: 4);
+
+            var fine = new FogField(1, registry.Get(fineId));
+            var coarse = new FogField(1, registry.Get(coarseId));
+
+            var world = new WorldCmInt2(260, -10);
+
+            Assert.That(fine.WorldToCell(world), Is.EqualTo(new FogCell(2, -1)));
+            Assert.That(coarse.WorldToCell(world), Is.EqualTo(new FogCell(1, -1)));
+            Assert.That(fine.CellCenterToWorld(new FogCell(2, -1)), Is.EqualTo(new WorldCmInt2(250, -50)));
+            Assert.That(coarse.CellCenterToWorld(new FogCell(1, -1)), Is.EqualTo(new WorldCmInt2(375, -125)));
+        }
+
+        [Test]
+        public void FogField_TracksDirtyCellsAndAgesVisibleToExplored()
+        {
+            var registry = new FogLayerRegistry();
+            FogLayerId layerId = registry.Register("ground", cellSizeCm: 100, updateHz: 10);
+            var field = new FogField(1, registry.Get(layerId));
+
+            var first = new FogCell(1, 1);
+            var second = new FogCell(17, 1);
+            field.SetVisible(first);
+            field.SetDenied(second);
+            field.MarkDirtyRegion(new IntRect(4, 4, 2, 1));
+
+            Span<FogCell> dirty = stackalloc FogCell[8];
+            int dirtyCount = field.EnumerateDirtyCells(dirty);
+
+            Assert.That(dirtyCount, Is.EqualTo(4));
+            Assert.That(field.DirtyCount, Is.EqualTo(4));
+            Assert.That(dirty[..dirtyCount].ToArray(), Does.Contain(first));
+            Assert.That(dirty[..dirtyCount].ToArray(), Does.Contain(second));
+
+            field.ClearDirty();
+            field.AgeVisibleToExplored();
+
+            Assert.That(field.GetVisibility(first), Is.EqualTo(CellVisibility.Explored));
+            Assert.That(field.GetVisibility(second), Is.EqualTo(CellVisibility.Denied));
+            Assert.That(field.DirtyCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void FogField_ReadWriteHotPathAllocatesZeroAfterWarmup()
+        {
+            var registry = new FogLayerRegistry();
+            FogLayerId layerId = registry.Register("ground", cellSizeCm: 100, updateHz: 10);
+            var field = new FogField(1, registry.Get(layerId), chunkSizeCells: 16, initialChunkCapacity: 16);
+
+            for (int i = 0; i < 256; i++)
+            {
+                field.SetVisible(new FogCell(i & 15, i >> 4));
+            }
+
+            field.ClearDirty();
+            Span<FogCell> dirty = stackalloc FogCell[256];
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            GC.GetAllocatedBytesForCurrentThread();
+
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            int visible = 0;
+            for (int i = 0; i < 10_000; i++)
+            {
+                FogCell cell = new(i & 15, (i >> 4) & 15);
+                if (field.GetVisibility(cell) == CellVisibility.Visible)
+                {
+                    visible++;
+                }
+
+                field.EnumerateDirtyCells(dirty);
+            }
+
+            long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+            Assert.That(visible, Is.GreaterThan(0));
+            Assert.That(allocated, Is.EqualTo(0));
+        }
+    }
+}

--- a/src/Tests/GasTests/FogKnowledgeAndSnapshotTests.cs
+++ b/src/Tests/GasTests/FogKnowledgeAndSnapshotTests.cs
@@ -1,0 +1,274 @@
+using Arch.Core;
+using Ludots.Core.Gameplay.Relationships;
+using Ludots.Core.Knowledge;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Vision;
+using NUnit.Framework;
+
+namespace Ludots.Tests.GAS
+{
+    [TestFixture]
+    public sealed class FogKnowledgeAndSnapshotTests
+    {
+        [Test]
+        public void FogKnowledgeProjector_ProjectsLiveKnownHiddenAndAspectMasks()
+        {
+            using World world = World.Create();
+            Entity viewer = world.Create();
+            Entity source = world.Create();
+            Entity liveTarget = world.Create();
+            Entity exploredTarget = world.Create();
+            Entity hiddenTarget = world.Create();
+            var knowledge = new KnowledgeProjectionStore();
+            var projector = new FogKnowledgeProjector(knowledge);
+            var registry = new FogLayerRegistry();
+            FogLayerId layerId = registry.Register("ground", cellSizeCm: 100, updateHz: 10);
+            FogLayerDefinition layer = registry.Get(layerId);
+            uint layerMask = registry.ToMask(layerId);
+            var field = new FogField(1, in layer);
+            field.SetVisible(new FogCell(0, 0));
+            field.SetExplored(new FogCell(1, 0));
+            field.SetDenied(new FogCell(2, 0));
+            KnowledgeIdMask256 attributes = KnowledgeIdMask256.Empty.WithId(7);
+            var policy = new FogProjectionPolicy(
+                new FogDisclosurePolicy(attributes, KnowledgeIdMask256.Empty, KnowledgeIdMask256.Empty, ttlTicks: 0, trueSightRevealsConcealment: true),
+                memoryTtlTicks: 5);
+            FogOccupant[] occupants =
+            {
+                new(liveTarget, new WorldCmInt2(50, 50), layerMask),
+                new(exploredTarget, new WorldCmInt2(150, 50), layerMask),
+                new(hiddenTarget, new WorldCmInt2(250, 50), layerMask)
+            };
+
+            Assert.That(projector.Project(viewer, source, new WorldCmInt2(0, 0), field, occupants, policy, currentTick: 10), Is.EqualTo(3));
+
+            Assert.That(knowledge.TryGet(viewer, liveTarget, currentTick: 10, out KnowledgeDisclosureRecord live), Is.True);
+            Assert.That(knowledge.TryGet(viewer, exploredTarget, currentTick: 10, out KnowledgeDisclosureRecord explored), Is.True);
+            Assert.That(knowledge.TryGet(viewer, hiddenTarget, currentTick: 10, out KnowledgeDisclosureRecord hidden), Is.True);
+            Assert.Multiple(() =>
+            {
+                Assert.That(live.Presence, Is.EqualTo(KnowledgePresence.LiveVisible));
+                Assert.That(live.Position, Is.EqualTo(KnowledgePositionAccess.Live));
+                Assert.That(live.AttributeMask.ContainsId(7), Is.True);
+                Assert.That(explored.Presence, Is.EqualTo(KnowledgePresence.Known));
+                Assert.That(explored.Position, Is.EqualTo(KnowledgePositionAccess.LastKnown));
+                Assert.That(explored.ExpiryTick, Is.EqualTo(15));
+                Assert.That(explored.AttributeMask.IsEmpty, Is.True);
+                Assert.That(hidden.Presence, Is.EqualTo(KnowledgePresence.HiddenWithSource));
+                Assert.That(hidden.Position, Is.EqualTo(KnowledgePositionAccess.None));
+                Assert.That(knowledge.TryGet(viewer, exploredTarget, currentTick: 15, out _), Is.False);
+            });
+        }
+
+        [Test]
+        public void FogKnowledgeProjector_AppliesConcealmentAndTrueSightDetection()
+        {
+            using World world = World.Create();
+            Entity viewer = world.Create();
+            Entity source = world.Create();
+            Entity concealedTarget = world.Create();
+            Entity stealthTarget = world.Create();
+            var knowledge = new KnowledgeProjectionStore();
+            var map = new FogCellMap();
+            map.SetConcealed(new FogCell(2, 0), true);
+            var projector = new FogKnowledgeProjector(knowledge, map);
+            var registry = new FogLayerRegistry();
+            FogLayerId detectionId = registry.Register("detection", cellSizeCm: 100, updateHz: 10);
+            FogLayerDefinition detection = registry.Get(detectionId);
+            uint detectionMask = registry.ToMask(detectionId);
+            var field = new FogField(1, in detection);
+            field.SetVisible(new FogCell(2, 0));
+            field.SetVisible(new FogCell(3, 0));
+            var policy = new FogProjectionPolicy(
+                new FogDisclosurePolicy(KnowledgeIdMask256.Empty.WithId(1), KnowledgeIdMask256.Empty, KnowledgeIdMask256.Empty, ttlTicks: 0, trueSightRevealsConcealment: true),
+                memoryTtlTicks: 0);
+            FogOccupant[] occupants =
+            {
+                new(concealedTarget, new WorldCmInt2(250, 50), detectionMask),
+                new(stealthTarget, new WorldCmInt2(350, 50), detectionMask, stealthLevel: 2)
+            };
+
+            projector.Project(viewer, source, new WorldCmInt2(0, 0), field, occupants, policy, currentTick: 1, detectionStrength: 1);
+            Assert.That(knowledge.TryGet(viewer, concealedTarget, 1, out KnowledgeDisclosureRecord concealedWithoutStrength), Is.True);
+            Assert.That(knowledge.TryGet(viewer, stealthTarget, 1, out KnowledgeDisclosureRecord stealthWithoutStrength), Is.True);
+            Assert.That(concealedWithoutStrength.Presence, Is.EqualTo(KnowledgePresence.LiveVisible));
+            Assert.That(stealthWithoutStrength.Presence, Is.EqualTo(KnowledgePresence.HiddenWithSource));
+
+            projector.Project(viewer, source, new WorldCmInt2(0, 0), field, occupants, policy, currentTick: 2, detectionStrength: 2);
+            Assert.That(knowledge.TryGet(viewer, stealthTarget, 2, out KnowledgeDisclosureRecord stealthWithStrength), Is.True);
+            Assert.That(stealthWithStrength.Presence, Is.EqualTo(KnowledgePresence.LiveVisible));
+        }
+
+        [Test]
+        public void FogKnowledgeProjector_HidesConcealedOccupantWithoutTrueSightOrAdjacency()
+        {
+            using World world = World.Create();
+            Entity viewer = world.Create();
+            Entity source = world.Create();
+            Entity target = world.Create();
+            var knowledge = new KnowledgeProjectionStore();
+            var map = new FogCellMap();
+            map.SetConcealed(new FogCell(2, 0), true);
+            var projector = new FogKnowledgeProjector(knowledge, map);
+            var registry = new FogLayerRegistry();
+            FogLayerId layerId = registry.Register("ground", cellSizeCm: 100, updateHz: 10);
+            FogLayerDefinition layer = registry.Get(layerId);
+            uint mask = registry.ToMask(layerId);
+            var field = new FogField(1, in layer);
+            field.SetVisible(new FogCell(2, 0));
+            var policy = new FogProjectionPolicy(FogDisclosurePolicy.None, memoryTtlTicks: 0, trueSightRevealsConcealment: false);
+            FogOccupant[] occupants = { new(target, new WorldCmInt2(250, 50), mask) };
+
+            projector.Project(viewer, source, new WorldCmInt2(0, 0), field, occupants, policy, currentTick: 1, detectionStrength: 0);
+            Assert.That(knowledge.TryGet(viewer, target, 1, out KnowledgeDisclosureRecord hidden), Is.True);
+            Assert.That(hidden.Presence, Is.EqualTo(KnowledgePresence.HiddenWithSource));
+
+            projector.Project(viewer, source, new WorldCmInt2(150, 50), field, occupants, policy, currentTick: 2, detectionStrength: 0);
+            Assert.That(knowledge.TryGet(viewer, target, 2, out KnowledgeDisclosureRecord adjacent), Is.True);
+            Assert.That(adjacent.Presence, Is.EqualTo(KnowledgePresence.LiveVisible));
+        }
+
+        [Test]
+        public void FogSnapshotStore_CapturesRestoresDiffsAndMergesExplored()
+        {
+            var registry = new FogLayerRegistry();
+            FogLayerId layerId = registry.Register("ground", cellSizeCm: 100, updateHz: 10);
+            FogLayerDefinition layer = registry.Get(layerId);
+            var field = new FogField(1, in layer);
+            field.SetVisible(new FogCell(0, 0));
+            field.SetExplored(new FogCell(1, 0));
+            var store = new FogSnapshotStore();
+            FogSnapshotHandle first = store.Capture(field, tick: 1);
+
+            field.SetDenied(new FogCell(2, 0));
+            FogSnapshotHandle second = store.Capture(field, tick: 2);
+            Span<FogCell> changed = stackalloc FogCell[8];
+            int diffCount = store.Diff(first, second, changed);
+
+            var restored = new FogField(1, in layer);
+            Assert.That(store.TryRestore(first, restored), Is.True);
+            Assert.That(restored.GetVisibility(new FogCell(0, 0)), Is.EqualTo(CellVisibility.Visible));
+            Assert.That(restored.GetVisibility(new FogCell(2, 0)), Is.EqualTo(CellVisibility.Unseen));
+            Assert.That(diffCount, Is.EqualTo(1));
+            Assert.That(changed[0], Is.EqualTo(new FogCell(2, 0)));
+
+            var merged = new FogField(1, in layer);
+            Assert.That(store.TryMergeExplored(first, second, merged), Is.True);
+            Assert.That(merged.GetVisibility(new FogCell(0, 0)), Is.EqualTo(CellVisibility.Visible));
+            Assert.That(merged.GetVisibility(new FogCell(1, 0)), Is.EqualTo(CellVisibility.Explored));
+        }
+
+        [Test]
+        public void FogSnapshotStore_SharedExploredMergeIsRelationshipGatedAndDynamic()
+        {
+            using World world = World.Create();
+            RelationshipRuntime relationships = CreateRelationshipRuntime(world, out RelationshipTypeRegistry types);
+            int sharedVisionTypeId = types.Register("SharedVision");
+            Entity sourceHost = world.Create();
+            Entity sharedHost = world.Create();
+            var registry = new FogLayerRegistry();
+            FogLayerId layerId = registry.Register("ground", cellSizeCm: 100, updateHz: 10);
+            FogLayerDefinition layer = registry.Get(layerId);
+            var sourceField = new FogField(1, in layer);
+            var sharedField = new FogField(1, in layer);
+            sourceField.SetExplored(new FogCell(0, 0));
+            sharedField.SetVisible(new FogCell(3, 0));
+            var store = new FogSnapshotStore(relationships: relationships);
+            FogSnapshotHandle sourceSnapshot = store.Capture(sourceField, tick: 1);
+            FogSnapshotHandle sharedSnapshot = store.Capture(sharedField, tick: 1);
+            var target = new FogField(1, in layer);
+
+            Assert.That(
+                store.TryMergeSharedExplored(
+                    sourceSnapshot,
+                    sharedSnapshot,
+                    target,
+                    sourceHost,
+                    sharedHost,
+                    sharedVisionTypeId),
+                Is.False);
+            Assert.That(target.GetVisibility(new FogCell(3, 0)), Is.EqualTo(CellVisibility.Unseen));
+
+            relationships.EnsureLink(sourceHost, sharedHost, sharedVisionTypeId);
+            Assert.That(
+                store.TryMergeSharedExplored(
+                    sourceSnapshot,
+                    sharedSnapshot,
+                    target,
+                    sourceHost,
+                    sharedHost,
+                    sharedVisionTypeId),
+                Is.True);
+            Assert.That(target.GetVisibility(new FogCell(0, 0)), Is.EqualTo(CellVisibility.Explored));
+            Assert.That(target.GetVisibility(new FogCell(3, 0)), Is.EqualTo(CellVisibility.Explored));
+
+            relationships.RemoveLink(sourceHost, sharedHost, sharedVisionTypeId);
+            var afterBreak = new FogField(1, in layer);
+            Assert.That(
+                store.TryMergeSharedExplored(
+                    sourceSnapshot,
+                    sharedSnapshot,
+                    afterBreak,
+                    sourceHost,
+                    sharedHost,
+                    sharedVisionTypeId),
+                Is.False);
+            Assert.That(afterBreak.GetVisibility(new FogCell(3, 0)), Is.EqualTo(CellVisibility.Unseen));
+        }
+
+        [Test]
+        public void FogLayerRegistry_ReturnsStableLayerIdsAndMasks()
+        {
+            var registry = new FogLayerRegistry();
+            FogLayerId ground = registry.Register("ground", cellSizeCm: 100, updateHz: 10);
+            FogLayerId sameGround = registry.Register("ground", cellSizeCm: 100, updateHz: 10);
+            FogLayerId air = registry.Register("air", cellSizeCm: 200, updateHz: 5);
+
+            Assert.That(sameGround, Is.EqualTo(ground));
+            Assert.That(registry.GetId("ground"), Is.EqualTo(ground));
+            Assert.That(registry.ToMask(ground), Is.EqualTo(1u));
+            Assert.That(registry.ToMask(air), Is.EqualTo(2u));
+        }
+
+        [Test]
+        public void FogProjectionOccupants_OnlyExposeThroughMatchingLayers()
+        {
+            using World world = World.Create();
+            Entity viewer = world.Create();
+            Entity source = world.Create();
+            Entity ordinary = world.Create();
+            Entity detectedOnly = world.Create();
+            var knowledge = new KnowledgeProjectionStore();
+            var projector = new FogKnowledgeProjector(knowledge);
+            var registry = new FogLayerRegistry();
+            FogLayerId groundId = registry.Register("ground", cellSizeCm: 100, updateHz: 10);
+            FogLayerId detectionId = registry.Register("detection", cellSizeCm: 100, updateHz: 10);
+            uint groundMask = registry.ToMask(groundId);
+            uint detectionMask = registry.ToMask(detectionId);
+            var groundField = new FogField(1, registry.Get(groundId));
+            groundField.SetVisible(new FogCell(0, 0));
+            FogOccupant[] occupants =
+            {
+                new(ordinary, new WorldCmInt2(50, 50), groundMask),
+                new(detectedOnly, new WorldCmInt2(50, 50), detectionMask, stealthLevel: 1)
+            };
+
+            projector.Project(viewer, source, WorldCmInt2.Zero, groundField, occupants, FogProjectionPolicy.Default, currentTick: 1);
+
+            Assert.That(knowledge.TryGet(viewer, ordinary, 1, out _), Is.True);
+            Assert.That(knowledge.TryGet(viewer, detectedOnly, 1, out _), Is.False);
+        }
+
+        private static RelationshipRuntime CreateRelationshipRuntime(World world, out RelationshipTypeRegistry types)
+        {
+            types = new RelationshipTypeRegistry();
+            return new RelationshipRuntime(
+                world,
+                types,
+                new RelationshipMetricRegistry(),
+                new RelationshipFlagRegistry(),
+                new RelationshipBandRegistry(),
+                new RelationshipChangeBuffer(capacity: 4));
+        }
+    }
+}

--- a/src/Tests/GasTests/GasTests.csproj
+++ b/src/Tests/GasTests/GasTests.csproj
@@ -90,6 +90,14 @@
     <ProjectReference Include="..\..\..\mods\showcases\diplomacy_trade_gate\DiplomacyTradeGateShowcaseMod\DiplomacyTradeGateShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\gold_market\GoldMarketShowcaseMod\GoldMarketShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\fourx_association\FourXAssociationShowcaseMod\FourXAssociationShowcaseMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\fog_of_war\MultiLayerFogFieldShowcaseMod\MultiLayerFogFieldShowcaseMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\fog_of_war\VisionConeHighGroundShowcaseMod\VisionConeHighGroundShowcaseMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\fog_of_war\LineOfSightBrushShowcaseMod\LineOfSightBrushShowcaseMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\fog_of_war\ExploredMemoryShowcaseMod\ExploredMemoryShowcaseMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\fog_of_war\GapGeneratorShowcaseMod\GapGeneratorShowcaseMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\fog_of_war\StealthDetectionShowcaseMod\StealthDetectionShowcaseMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\fog_of_war\SharedVisionSnapshotShowcaseMod\SharedVisionSnapshotShowcaseMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\fog_of_war\FogOfWarShowcaseMod\FogOfWarShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\utility_autocast\UtilityAutocastShowcaseMod\UtilityAutocastShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\combat_stance\CombatStanceShowcaseMod\CombatStanceShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\Navigation2DPlaygroundMod\Navigation2DPlaygroundMod.csproj" />

--- a/src/Tests/GasTests/Production/FogOfWarShowcaseAcceptanceTests.cs
+++ b/src/Tests/GasTests/Production/FogOfWarShowcaseAcceptanceTests.cs
@@ -1,0 +1,233 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using Arch.Core;
+using Ludots.Core.Gameplay.Relationships;
+using Ludots.Core.Knowledge;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Vision;
+using NUnit.Framework;
+
+namespace Ludots.Tests.GAS.Production;
+
+[TestFixture]
+public sealed class FogOfWarShowcaseAcceptanceTests
+{
+    [Test]
+    public void FogOfWarShowcase_CoreScenarioCoversWarFogEpic()
+    {
+        string repoRoot = FindRepoRoot();
+        string artifactDir = Path.Combine(repoRoot, "artifacts", "acceptance", "fog-of-war-showcase");
+        Directory.CreateDirectory(artifactDir);
+        foreach (string file in Directory.GetFiles(artifactDir))
+        {
+            File.Delete(file);
+        }
+
+        using World world = World.Create();
+        Entity viewer = world.Create();
+        Entity source = world.Create();
+        Entity visibleTarget = world.Create();
+        Entity memoryTarget = world.Create();
+        Entity concealedTarget = world.Create();
+        Entity stealthTarget = world.Create();
+        Entity sharingSourceHost = world.Create();
+        Entity sharingTargetHost = world.Create();
+        RelationshipRuntime relationships = CreateRelationshipRuntime(world, out RelationshipTypeRegistry relationshipTypes);
+        int sharedVisionTypeId = relationshipTypes.Register("SharedVision");
+
+        var registry = new FogLayerRegistry();
+        FogLayerId groundId = registry.Register("ground", cellSizeCm: 100, updateHz: 10);
+        FogLayerId airId = registry.Register("air", cellSizeCm: 250, updateHz: 5);
+        FogLayerId detectionId = registry.Register("detection", cellSizeCm: 100, updateHz: 10);
+        uint groundMask = registry.ToMask(groundId);
+        uint airMask = registry.ToMask(airId);
+        uint detectionMask = registry.ToMask(detectionId);
+        var fields = new FogFieldStore();
+        var map = new FogCellMap();
+        map.SetHeightTier(new FogCell(2, 0), 2);
+        map.SetOpaque(new FogCell(1, 1), true);
+        map.SetConcealed(new FogCell(2, 2), true);
+        var resolver = new VisionResolver(registry, fields, elevation: map, occlusion: map);
+        FogLayerId[] layers = { groundId, airId, detectionId };
+
+        resolver.Resolve(
+            new VisionEmitter(1, new WorldCmInt2(0, 0), facingDeg: 0, groundMask | airMask, VisionPolarity.Reveal, VisionAperture.Cone(400, 45), altitudeBand: 0),
+            layers,
+            FogRulesPolicy.Default);
+        resolver.Resolve(
+            new VisionEmitter(1, new WorldCmInt2(0, 0), facingDeg: 45, groundMask, VisionPolarity.Reveal, VisionAperture.Line(450, 80), altitudeBand: 0),
+            layers,
+            FogRulesPolicy.Default);
+        resolver.Resolve(
+            new VisionEmitter(1, new WorldCmInt2(0, 0), facingDeg: 0, detectionMask, VisionPolarity.Reveal, VisionAperture.Disk(450), altitudeBand: 2, detectionStrength: 2, trueSightStrength: 2),
+            layers,
+            new FogRulesPolicy(verticalEnabled: true, lineOfSightEnabled: false, upTolerance: 2));
+
+        Assert.That(fields.TryGet(1, groundId, out FogField ground), Is.True);
+        Assert.That(fields.TryGet(1, airId, out FogField air), Is.True);
+        Assert.That(fields.TryGet(1, detectionId, out FogField detection), Is.True);
+        Assert.That(ground.GetVisibility(new FogCell(2, 0)), Is.EqualTo(CellVisibility.Unseen), "Low elevation reveal must not see high elevation without tolerance.");
+        Assert.That(ground.GetVisibility(new FogCell(2, 2)), Is.EqualTo(CellVisibility.Unseen), "Default LoS must block cells behind an opaque blocker.");
+        Assert.That(air.CellSizeCm, Is.EqualTo(250));
+        Assert.That(detection.GetVisibility(new FogCell(2, 2)), Is.EqualTo(CellVisibility.Visible));
+
+        var losDisabledComparison = new FogField(1, registry.Get(groundId));
+        resolver.RasterizeIntoField(
+            new VisionEmitter(1, new WorldCmInt2(0, 0), facingDeg: 45, groundMask, VisionPolarity.Reveal, VisionAperture.Line(450, 80), altitudeBand: 0),
+            losDisabledComparison,
+            new FogRulesPolicy(lineOfSightEnabled: false));
+        Assert.That(losDisabledComparison.GetVisibility(new FogCell(2, 2)), Is.EqualTo(CellVisibility.Visible), "Disabling LoS should fall back to aperture plus vertical rules.");
+
+        ground.SetExplored(new FogCell(3, 0));
+        ground.SetVisible(new FogCell(2, 2));
+        resolver.RasterizeIntoField(
+            new VisionEmitter(1, new WorldCmInt2(0, 0), facingDeg: 0, groundMask, VisionPolarity.Deny, VisionAperture.Disk(150)),
+            ground,
+            new FogRulesPolicy(denyMode: FogDenyMode.DenyDominates));
+        Assert.That(ground.GetVisibility(new FogCell(0, 0)), Is.EqualTo(CellVisibility.Denied));
+        Assert.That(air.GetVisibility(new FogCell(0, 0)), Is.EqualTo(CellVisibility.Visible), "Ground-only deny must not erase the independent air layer.");
+        ground.SetVisible(new FogCell(1, 0));
+
+        var knowledge = new KnowledgeProjectionStore();
+        var projector = new FogKnowledgeProjector(knowledge, map);
+        var disclosure = new FogDisclosurePolicy(
+            KnowledgeIdMask256.Empty.WithId(3),
+            KnowledgeIdMask256.Empty,
+            KnowledgeIdMask256.Empty,
+            ttlTicks: 0,
+            trueSightRevealsConcealment: true);
+        var policy = new FogProjectionPolicy(disclosure, memoryTtlTicks: 6);
+        FogOccupant[] groundOccupants =
+        {
+            new(visibleTarget, new WorldCmInt2(150, 50), groundMask),
+            new(memoryTarget, new WorldCmInt2(350, 50), groundMask),
+            new(concealedTarget, new WorldCmInt2(250, 250), groundMask),
+        };
+        FogOccupant[] detectionOccupants =
+        {
+            new(stealthTarget, new WorldCmInt2(250, 250), detectionMask, stealthLevel: 2)
+        };
+
+        projector.Project(viewer, source, WorldCmInt2.Zero, ground, groundOccupants, policy, currentTick: 20);
+        projector.Project(viewer, source, WorldCmInt2.Zero, detection, detectionOccupants, policy, currentTick: 20, detectionStrength: 2);
+
+        Assert.That(knowledge.TryGet(viewer, visibleTarget, 20, out KnowledgeDisclosureRecord visible), Is.True);
+        Assert.That(knowledge.TryGet(viewer, memoryTarget, 20, out KnowledgeDisclosureRecord memory), Is.True);
+        Assert.That(knowledge.TryGet(viewer, concealedTarget, 20, out KnowledgeDisclosureRecord concealed), Is.True);
+        Assert.That(knowledge.TryGet(viewer, stealthTarget, 20, out KnowledgeDisclosureRecord detected), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(visible.Presence, Is.EqualTo(KnowledgePresence.LiveVisible));
+            Assert.That(visible.Position, Is.EqualTo(KnowledgePositionAccess.Live));
+            Assert.That(visible.AttributeMask.ContainsId(3), Is.True);
+            Assert.That(memory.Presence, Is.EqualTo(KnowledgePresence.Known));
+            Assert.That(memory.Position, Is.EqualTo(KnowledgePositionAccess.LastKnown));
+            Assert.That(memory.ExpiryTick, Is.EqualTo(26));
+            Assert.That(concealed.Presence, Is.EqualTo(KnowledgePresence.HiddenWithSource));
+            Assert.That(detected.Presence, Is.EqualTo(KnowledgePresence.LiveVisible));
+        });
+
+        var snapshots = new FogSnapshotStore(relationships: relationships);
+        FogSnapshotHandle before = snapshots.Capture(ground, tick: 20);
+        ground.SetVisible(new FogCell(4, 0));
+        FogSnapshotHandle after = snapshots.Capture(ground, tick: 21);
+        Span<FogCell> changed = stackalloc FogCell[8];
+        int changedCount = snapshots.Diff(before, after, changed);
+        Assert.That(changedCount, Is.EqualTo(1));
+        Assert.That(changed[0], Is.EqualTo(new FogCell(4, 0)));
+
+        var sharedField = new FogField(2, registry.Get(groundId));
+        sharedField.SetExplored(new FogCell(5, 0));
+        FogSnapshotHandle shared = snapshots.Capture(sharedField, tick: 21);
+        var mergedWithoutRelationship = new FogField(1, registry.Get(groundId));
+        Assert.That(
+            snapshots.TryMergeSharedExplored(before, shared, mergedWithoutRelationship, sharingSourceHost, sharingTargetHost, sharedVisionTypeId),
+            Is.False);
+        relationships.EnsureLink(sharingSourceHost, sharingTargetHost, sharedVisionTypeId);
+        var mergedWithRelationship = new FogField(1, registry.Get(groundId));
+        Assert.That(
+            snapshots.TryMergeSharedExplored(before, shared, mergedWithRelationship, sharingSourceHost, sharingTargetHost, sharedVisionTypeId),
+            Is.True);
+        Assert.That(mergedWithRelationship.GetVisibility(new FogCell(5, 0)), Is.EqualTo(CellVisibility.Explored));
+
+        WriteEvidence(
+            artifactDir,
+            ground,
+            air,
+            detection,
+            visible,
+            memory,
+            concealed,
+            detected,
+            changed[0],
+            new FogCell(5, 0));
+    }
+
+    private static void WriteEvidence(
+        string artifactDir,
+        FogField ground,
+        FogField air,
+        FogField detection,
+        KnowledgeDisclosureRecord visible,
+        KnowledgeDisclosureRecord memory,
+        KnowledgeDisclosureRecord concealed,
+        KnowledgeDisclosureRecord detected,
+        FogCell changedCell,
+        FogCell sharedCell)
+    {
+        var options = new JsonSerializerOptions { WriteIndented = false };
+        File.WriteAllLines(
+            Path.Combine(artifactDir, "trace.jsonl"),
+            new[]
+            {
+                JsonSerializer.Serialize(new { step = "layers", groundCellSize = ground.CellSizeCm, airCellSize = air.CellSizeCm, detectionCellSize = detection.CellSizeCm }, options),
+                JsonSerializer.Serialize(new { step = "knowledge", visible = visible.Presence.ToString(), memory = memory.Presence.ToString(), concealed = concealed.Presence.ToString(), detected = detected.Presence.ToString() }, options),
+                JsonSerializer.Serialize(new { step = "snapshot", changedCell = new { changedCell.X, changedCell.Y } }, options),
+                JsonSerializer.Serialize(new { step = "shared_explored", sharedCell = new { sharedCell.X, sharedCell.Y } }, options),
+            });
+        File.WriteAllLines(
+            Path.Combine(artifactDir, "battle-report.md"),
+            new[]
+            {
+                "# Fog Of War Showcase Acceptance",
+                string.Empty,
+                "- layers: ground/air/detection with independent resolution",
+                "- apertures: cone and line rasterization with vertical and line-of-sight rules",
+                "- projection: LiveVisible, Known/LastKnown, HiddenWithSource, and aspect mask",
+                "- generator: DenyDominates writes Denied",
+                "- detection: true sight reveals detection-layer occupant",
+                "- snapshot: capture/diff reports changed cell",
+                "- sharing: relationship-gated merge contributes allied explored cells",
+            });
+    }
+
+    private static RelationshipRuntime CreateRelationshipRuntime(World world, out RelationshipTypeRegistry types)
+    {
+        types = new RelationshipTypeRegistry();
+        return new RelationshipRuntime(
+            world,
+            types,
+            new RelationshipMetricRegistry(),
+            new RelationshipFlagRegistry(),
+            new RelationshipBandRegistry(),
+            new RelationshipChangeBuffer(capacity: 4));
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        for (int i = 0; i < 12 && dir != null; i++)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "mods")) &&
+                File.Exists(Path.Combine(dir.FullName, "AGENTS.md")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Failed to locate repository root.");
+    }
+}

--- a/src/Tests/GasTests/VisionResolverTests.cs
+++ b/src/Tests/GasTests/VisionResolverTests.cs
@@ -1,0 +1,212 @@
+using System;
+using Arch.Core;
+using Ludots.Core.Gameplay.Relationships;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Vision;
+using NUnit.Framework;
+
+namespace Ludots.Tests.GAS
+{
+    [TestFixture]
+    public sealed class VisionResolverTests
+    {
+        [Test]
+        public void VisionResolver_RasterizesDiskConeBoxAndLineApertures()
+        {
+            var registry = new FogLayerRegistry();
+            FogLayerId layerId = registry.Register("ground", cellSizeCm: 100, updateHz: 10);
+            FogLayerDefinition layer = registry.Get(layerId);
+
+            var disk = new FogField(1, in layer);
+            var cone = new FogField(1, in layer);
+            var box = new FogField(1, in layer);
+            var line = new FogField(1, in layer);
+            var resolver = new VisionResolver(registry, new FogFieldStore());
+            uint mask = registry.ToMask(layerId);
+
+            resolver.RasterizeIntoField(
+                new VisionEmitter(1, new WorldCmInt2(0, 0), facingDeg: 0, mask, VisionPolarity.Reveal, VisionAperture.Disk(150)),
+                disk,
+                FogRulesPolicy.Default);
+            resolver.RasterizeIntoField(
+                new VisionEmitter(1, new WorldCmInt2(0, 0), facingDeg: 0, mask, VisionPolarity.Reveal, VisionAperture.Cone(250, 45)),
+                cone,
+                FogRulesPolicy.Default);
+            resolver.RasterizeIntoField(
+                new VisionEmitter(1, new WorldCmInt2(0, 0), facingDeg: 0, mask, VisionPolarity.Reveal, VisionAperture.Box(50, 150)),
+                box,
+                FogRulesPolicy.Default);
+            resolver.RasterizeIntoField(
+                new VisionEmitter(1, new WorldCmInt2(0, 0), facingDeg: 0, mask, VisionPolarity.Reveal, VisionAperture.Line(250, 50)),
+                line,
+                FogRulesPolicy.Default);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(disk.GetVisibility(new FogCell(0, 0)), Is.EqualTo(CellVisibility.Visible));
+                Assert.That(disk.GetVisibility(new FogCell(2, 0)), Is.EqualTo(CellVisibility.Unseen));
+                Assert.That(cone.GetVisibility(new FogCell(1, 0)), Is.EqualTo(CellVisibility.Visible));
+                Assert.That(cone.GetVisibility(new FogCell(-1, 0)), Is.EqualTo(CellVisibility.Unseen));
+                Assert.That(box.GetVisibility(new FogCell(1, 0)), Is.EqualTo(CellVisibility.Visible));
+                Assert.That(box.GetVisibility(new FogCell(0, 1)), Is.EqualTo(CellVisibility.Unseen));
+                Assert.That(line.GetVisibility(new FogCell(1, 0)), Is.EqualTo(CellVisibility.Visible));
+                Assert.That(line.GetVisibility(new FogCell(0, 1)), Is.EqualTo(CellVisibility.Unseen));
+            });
+        }
+
+        [Test]
+        public void VisionResolver_AppliesVerticalRuleIndependentlyFromLineOfSight()
+        {
+            var registry = new FogLayerRegistry();
+            FogLayerId layerId = registry.Register("ground", cellSizeCm: 100, updateHz: 10);
+            FogLayerDefinition layer = registry.Get(layerId);
+            var map = new FogCellMap();
+            map.SetHeightTier(new FogCell(1, 0), 2);
+
+            var lowField = new FogField(1, in layer);
+            var tolerantField = new FogField(1, in layer);
+            var resolver = new VisionResolver(registry, new FogFieldStore(), elevation: map);
+            uint mask = registry.ToMask(layerId);
+
+            resolver.RasterizeIntoField(
+                new VisionEmitter(1, new WorldCmInt2(0, 0), facingDeg: 0, mask, VisionPolarity.Reveal, VisionAperture.Disk(200), altitudeBand: 0),
+                lowField,
+                new FogRulesPolicy(verticalEnabled: true, lineOfSightEnabled: false, upTolerance: 0));
+            resolver.RasterizeIntoField(
+                new VisionEmitter(1, new WorldCmInt2(0, 0), facingDeg: 0, mask, VisionPolarity.Reveal, VisionAperture.Disk(200), altitudeBand: 0),
+                tolerantField,
+                new FogRulesPolicy(verticalEnabled: true, lineOfSightEnabled: false, upTolerance: 2));
+
+            Assert.That(lowField.GetVisibility(new FogCell(1, 0)), Is.EqualTo(CellVisibility.Unseen));
+            Assert.That(tolerantField.GetVisibility(new FogCell(1, 0)), Is.EqualTo(CellVisibility.Visible));
+        }
+
+        [Test]
+        public void VisionResolver_LineOfSightBlocksCellsAndCanBeDisabled()
+        {
+            var registry = new FogLayerRegistry();
+            FogLayerId layerId = registry.Register("ground", cellSizeCm: 100, updateHz: 10);
+            FogLayerDefinition layer = registry.Get(layerId);
+            var map = new FogCellMap();
+            map.SetOpaque(new FogCell(1, 0), true);
+
+            var blocked = new FogField(1, in layer);
+            var disabled = new FogField(1, in layer);
+            var resolver = new VisionResolver(registry, new FogFieldStore(), occlusion: map);
+            uint mask = registry.ToMask(layerId);
+            var emitter = new VisionEmitter(1, new WorldCmInt2(0, 0), facingDeg: 0, mask, VisionPolarity.Reveal, VisionAperture.Line(350, 50));
+
+            resolver.RasterizeIntoField(emitter, blocked, FogRulesPolicy.Default);
+            resolver.RasterizeIntoField(emitter, disabled, new FogRulesPolicy(lineOfSightEnabled: false));
+
+            Assert.That(blocked.GetVisibility(new FogCell(2, 0)), Is.EqualTo(CellVisibility.Unseen));
+            Assert.That(disabled.GetVisibility(new FogCell(2, 0)), Is.EqualTo(CellVisibility.Visible));
+        }
+
+        [Test]
+        public void VisionResolver_DenyPolarityHonorsDenyModeAndLayerMasks()
+        {
+            var registry = new FogLayerRegistry();
+            FogLayerId groundId = registry.Register("ground", cellSizeCm: 100, updateHz: 10);
+            FogLayerId airId = registry.Register("air", cellSizeCm: 100, updateHz: 5);
+            var fields = new FogFieldStore();
+            var resolver = new VisionResolver(registry, fields);
+            uint groundMask = registry.ToMask(groundId);
+            uint airMask = registry.ToMask(airId);
+            FogLayerId[] layers = { groundId, airId };
+
+            resolver.Resolve(
+                new VisionEmitter(1, new WorldCmInt2(0, 0), facingDeg: 0, groundMask | airMask, VisionPolarity.Reveal, VisionAperture.Disk(150)),
+                layers,
+                new FogRulesPolicy(denyMode: FogDenyMode.DenyDominates));
+            resolver.Resolve(
+                new VisionEmitter(1, new WorldCmInt2(0, 0), facingDeg: 0, groundMask, VisionPolarity.Deny, VisionAperture.Disk(150)),
+                layers,
+                new FogRulesPolicy(denyMode: FogDenyMode.DenyDominates));
+
+            Assert.That(fields.TryGet(1, groundId, out FogField ground), Is.True);
+            Assert.That(fields.TryGet(1, airId, out FogField air), Is.True);
+            Assert.That(ground.GetVisibility(new FogCell(0, 0)), Is.EqualTo(CellVisibility.Denied));
+            Assert.That(air.GetVisibility(new FogCell(0, 0)), Is.EqualTo(CellVisibility.Visible));
+
+            var revealDominates = new FogField(1, registry.Get(groundId));
+            revealDominates.SetVisible(new FogCell(0, 0));
+            resolver.RasterizeIntoField(
+                new VisionEmitter(1, new WorldCmInt2(0, 0), facingDeg: 0, groundMask, VisionPolarity.Deny, VisionAperture.Disk(100)),
+                revealDominates,
+                new FogRulesPolicy(denyMode: FogDenyMode.RevealDominates));
+            Assert.That(revealDominates.GetVisibility(new FogCell(0, 0)), Is.EqualTo(CellVisibility.Visible));
+        }
+
+        [Test]
+        public void VisionResolver_RelationshipGatedScopesOnlyApplyToLinkedTargets()
+        {
+            using World world = World.Create();
+            RelationshipRuntime relationships = CreateRelationshipRuntime(world, out RelationshipTypeRegistry types);
+            int sharedVisionTypeId = types.Register("SharedVision");
+            Entity sourceHost = world.Create();
+            Entity linkedHost = world.Create();
+            Entity unlinkedHost = world.Create();
+            relationships.EnsureLink(sourceHost, linkedHost, sharedVisionTypeId);
+
+            var registry = new FogLayerRegistry();
+            FogLayerId layerId = registry.Register("ground", cellSizeCm: 100, updateHz: 10);
+            var fields = new FogFieldStore();
+            var resolver = new VisionResolver(registry, fields, relationships: relationships);
+            uint layerMask = registry.ToMask(layerId);
+            FogLayerId[] layers = { layerId };
+            FogScopeTarget[] targets =
+            {
+                new(scopeKeyId: 10, linkedHost),
+                new(scopeKeyId: 11, unlinkedHost)
+            };
+
+            int changed = resolver.ResolveToScopes(
+                new VisionEmitter(1, new WorldCmInt2(0, 0), facingDeg: 0, layerMask, VisionPolarity.Deny, VisionAperture.Disk(100)),
+                targets,
+                layers,
+                new FogRulesPolicy(denyMode: FogDenyMode.DenyDominates),
+                new FogRelationshipRule(sourceHost, sharedVisionTypeId));
+
+            Assert.That(changed, Is.GreaterThan(0));
+            Assert.That(fields.TryGet(10, layerId, out FogField linkedField), Is.True);
+            Assert.That(linkedField.GetVisibility(new FogCell(0, 0)), Is.EqualTo(CellVisibility.Denied));
+            Assert.That(fields.TryGet(11, layerId, out _), Is.False);
+        }
+
+        [Test]
+        public void VisionResolver_RelationshipGatedScopesRequireRelationshipRuntime()
+        {
+            using World world = World.Create();
+            Entity sourceHost = world.Create();
+            Entity targetHost = world.Create();
+            var registry = new FogLayerRegistry();
+            FogLayerId layerId = registry.Register("ground", cellSizeCm: 100, updateHz: 10);
+            var resolver = new VisionResolver(registry, new FogFieldStore());
+            uint layerMask = registry.ToMask(layerId);
+            FogScopeTarget[] targets = { new(scopeKeyId: 10, targetHost) };
+            FogLayerId[] layers = { layerId };
+
+            Assert.That(
+                () => resolver.ResolveToScopes(
+                    new VisionEmitter(1, new WorldCmInt2(0, 0), facingDeg: 0, layerMask, VisionPolarity.Deny, VisionAperture.Disk(100)),
+                    targets,
+                    layers,
+                    FogRulesPolicy.Default,
+                    new FogRelationshipRule(sourceHost, relationshipTypeId: 0)),
+                Throws.TypeOf<InvalidOperationException>().With.Message.Contains("RelationshipRuntime"));
+        }
+
+        private static RelationshipRuntime CreateRelationshipRuntime(World world, out RelationshipTypeRegistry types)
+        {
+            types = new RelationshipTypeRegistry();
+            return new RelationshipRuntime(
+                world,
+                types,
+                new RelationshipMetricRegistry(),
+                new RelationshipFlagRegistry(),
+                new RelationshipBandRegistry(),
+                new RelationshipChangeBuffer(capacity: 4));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implements War Fog Epic #305 subissues #306-#315 on top of latest `origin/main`.
- Adds Core Vision domain primitives: cell-keyed multi-layer `FogField`, `FogLayerRegistry`, resolver rules, Vision emitter/occupant contracts, Knowledge projection, and snapshot sharing.
- Wires Vision services through existing `CoreServiceKeys` / `GameEngine` service registration, reusing `ScopeKey`, `KnowledgeProjectionStore`, `KnowledgeIdMask256`, and `RelationshipRuntime` instead of parallel runtime/storage.
- Adds formal War Fog showcase roots and a headless integrated acceptance test with evidence under ignored `artifacts/acceptance/fog-of-war-showcase`.

## Subissue Coverage
- #306 FOG-1: active ADR guardrails for cell-keyed Vision, Knowledge-only entity disclosure, masks, relationship sharing, and topic-neutral Core.
- #307 FOG-2: multi-layer FogField with independent scope/layer state, resolution, dirty cells, aging, and warm hot-path allocation check.
- #308 FOG-3: disk/cone/box/line rasterization plus vertical rule independent from LoS.
- #309 FOG-4: line-of-sight blocking, LoS disable comparison, concealment, adjacency, and true-sight reveal behavior.
- #310 FOG-5: LiveVisible / Known LastKnown / HiddenWithSource projection through Knowledge with aspect masks and TTL.
- #311 FOG-6: Deny polarity, deny modes, layer masks, and relationship-gated cross-scope targeting.
- #312 FOG-7: detection-layer exposure, stealth level checks, and true-sight interaction with concealment.
- #313 FOG-8: snapshot capture/restore/diff/merge plus dynamic relationship-gated shared explored merge.
- #314 FOG-9: architecture guardrails for storage, Knowledge SSOT, no business terms, no LINQ/transient hot-path patterns, and showcase presence.
- #315 FOG-10: integrated `FogOfWarShowcaseMod` acceptance covering layers, vision, LoS, concealment, memory, masks, deny, detection, snapshots, and sharing.

## Tests
- `dotnet test src/Tests/GasTests/GasTests.csproj --filter FullyQualifiedName~VisionResolverTests|FullyQualifiedName~FogKnowledgeAndSnapshotTests|FullyQualifiedName~FogFieldTests --no-restore --logger console;verbosity=normal`
  - Result: 17 passed.
- `dotnet test src/Tests/GasTests/GasTests.csproj --filter FullyQualifiedName~ArchitectureGuardTests|FullyQualifiedName~FogOfWarShowcaseAcceptanceTests --no-restore --logger console;verbosity=normal`
  - Result: 27 passed.
- After rebasing onto latest `origin/main`, reran:
  - `dotnet test src/Tests/GasTests/GasTests.csproj --filter FullyQualifiedName~Fog|FullyQualifiedName~VisionResolverTests|FullyQualifiedName~KnowledgeProjection|FullyQualifiedName~SelectionKnowledgeProjection|FullyQualifiedName~MinimapKnowledgeProjection|FullyQualifiedName~ArchitectureGuardTests --no-restore --logger console;verbosity=normal`
  - Result: 79 passed.

Refs #305
Refs #306
Refs #307
Refs #308
Refs #309
Refs #310
Refs #311
Refs #312
Refs #313
Refs #314
Refs #315