### PR TITLE
Fix UIRoot input when actions clear the scene

### DIFF
--- a/mods/capabilities/navigation/MassNavigationMod/MassNavigationModEntry.cs
+++ b/mods/capabilities/navigation/MassNavigationMod/MassNavigationModEntry.cs
@@ -1,5 +1,7 @@
 using System.Threading.Tasks;
+using Ludots.Core.Layers;
 using Ludots.Core.MassCrowd.Runtime;
+using Ludots.Core.MassCrowd;
 using Ludots.Core.Modding;
 using Ludots.Core.Scripting;
 using MassNavigationMod.Systems;
@@ -11,6 +13,8 @@ public sealed class MassNavigationModEntry : IMod
 {
     public void OnLoad(IModContext context)
     {
+        LayerRegistry.Register(MassNavigationLayerNames.Agent);
+
         var runtime = new MassNavigationRuntime(context);
         var panelPresenter = new MassNavigationPanelPresenter();
         bool panelSystemInstalled = false;

--- a/src/Libraries/Ludots.UI/UIRoot.cs
+++ b/src/Libraries/Ludots.UI/UIRoot.cs
@@ -83,11 +83,12 @@ public class UIRoot
 
 	public bool HandleInput(InputEvent e)
 	{
-		if (Scene == null)
+		UiScene? scene = Scene;
+		if (scene == null)
 		{
 			return false;
 		}
-		Scene.Layout(Width, Height);
+		scene.Layout(Width, Height);
 		if (e is KeyboardEvent keyboardEvent)
 		{
 			return HandleKeyboardInput(keyboardEvent);
@@ -99,7 +100,7 @@ public class UIRoot
 		}
 		bool flag = false;
 		if (_capturedCanvasNodeId.HasValue &&
-			Scene.FindNode(_capturedCanvasNodeId.Value) is UiNode capturedCanvasNode &&
+			scene.FindNode(_capturedCanvasNodeId.Value) is UiNode capturedCanvasNode &&
 			capturedCanvasNode.CanvasContent is IUiCanvasInputSink capturedInputSink)
 		{
 			bool capturedHandled = capturedInputSink.HandleInput(capturedCanvasNode, pointerEvent);
@@ -119,12 +120,12 @@ public class UIRoot
 			_capturedCanvasNodeId = null;
 		}
 
-		UiNodeId? uiNodeId = Scene.HitTest(pointerEvent.X, pointerEvent.Y)?.Id;
+		UiNodeId? uiNodeId = scene.HitTest(pointerEvent.X, pointerEvent.Y)?.Id;
 		if (uiNodeId.HasValue)
 		{
 			UiNodeId valueOrDefault = uiNodeId.GetValueOrDefault();
 			if (valueOrDefault.IsValid &&
-				Scene.FindNode(valueOrDefault) is UiNode hitNode &&
+				scene.FindNode(valueOrDefault) is UiNode hitNode &&
 				TryHandleCanvasInput(hitNode, pointerEvent, out UiNodeId canvasNodeId))
 			{
 				if (pointerEvent.Action == PointerAction.Down)
@@ -151,18 +152,18 @@ public class UIRoot
 		switch (pointerEvent.Action)
 		{
 		case PointerAction.Move:
-			flag = Scene.Dispatch(new UiPointerEvent(UiPointerEventType.Move, pointerEvent.PointerId, pointerEvent.X, pointerEvent.Y, uiNodeId)).Handled;
+			flag = scene.Dispatch(new UiPointerEvent(UiPointerEventType.Move, pointerEvent.PointerId, pointerEvent.X, pointerEvent.Y, uiNodeId)).Handled;
 			break;
 		case PointerAction.Down:
 		{
 			PointerButton button = RequirePointerButton(pointerEvent);
 			_pressedNodeId = button == PointerButton.Left ? uiNodeId : null;
-			flag = Scene.Dispatch(new UiPointerEvent(UiPointerEventType.Down, pointerEvent.PointerId, pointerEvent.X, pointerEvent.Y, uiNodeId)).Handled;
+			flag = scene.Dispatch(new UiPointerEvent(UiPointerEventType.Down, pointerEvent.PointerId, pointerEvent.X, pointerEvent.Y, uiNodeId)).Handled;
 			break;
 		}
 		case PointerAction.Up:
 		{
-			flag = Scene.Dispatch(new UiPointerEvent(UiPointerEventType.Up, pointerEvent.PointerId, pointerEvent.X, pointerEvent.Y, uiNodeId)).Handled;
+			flag = scene.Dispatch(new UiPointerEvent(UiPointerEventType.Up, pointerEvent.PointerId, pointerEvent.X, pointerEvent.Y, uiNodeId)).Handled;
 			UiNodeId? pressedNodeId = _pressedNodeId;
 			PointerButton button = RequirePointerButton(pointerEvent);
 			if (pressedNodeId.HasValue && button == PointerButton.Left)
@@ -170,7 +171,7 @@ public class UIRoot
 				UiNodeId valueOrDefault = pressedNodeId.GetValueOrDefault();
 				if (valueOrDefault.IsValid && uiNodeId == valueOrDefault)
 				{
-					flag |= Scene.Dispatch(new UiPointerEvent(UiPointerEventType.Click, pointerEvent.PointerId, pointerEvent.X, pointerEvent.Y, valueOrDefault)).Handled;
+					flag |= scene.Dispatch(new UiPointerEvent(UiPointerEventType.Click, pointerEvent.PointerId, pointerEvent.X, pointerEvent.Y, valueOrDefault)).Handled;
 				}
 			}
 			_pressedNodeId = null;
@@ -182,15 +183,25 @@ public class UIRoot
 			_capturedCanvasNodeId = null;
 			break;
 		case PointerAction.Scroll:
-			flag = Scene.Dispatch(new UiPointerEvent(UiPointerEventType.Scroll, pointerEvent.PointerId, pointerEvent.X, pointerEvent.Y, uiNodeId, pointerEvent.DeltaX, pointerEvent.DeltaY)).Handled;
+			flag = scene.Dispatch(new UiPointerEvent(UiPointerEventType.Scroll, pointerEvent.PointerId, pointerEvent.X, pointerEvent.Y, uiNodeId, pointerEvent.DeltaX, pointerEvent.DeltaY)).Handled;
 			break;
 		}
-		bool sceneChanged = Scene.IsDirty;
+		if (!ReferenceEquals(Scene, scene))
+		{
+			IsDirty = true;
+			return flag;
+		}
+		bool sceneChanged = scene.IsDirty;
 		bool runtimeChanged = false;
 		if (flag || sceneChanged)
 		{
 			runtimeChanged = RefreshReactiveSceneRuntime();
-			sceneChanged = Scene.IsDirty;
+			if (!ReferenceEquals(Scene, scene))
+			{
+				IsDirty = true;
+				return flag || runtimeChanged;
+			}
+			sceneChanged = scene.IsDirty;
 		}
 		if (sceneChanged || runtimeChanged)
 		{

--- a/src/Tests/UiShowcaseTests/UiShowcaseAcceptanceTests.cs
+++ b/src/Tests/UiShowcaseTests/UiShowcaseAcceptanceTests.cs
@@ -109,6 +109,51 @@ public sealed class UiShowcaseAcceptanceTests
     }
 
     [Test]
+    public void UIRoot_ClickThatClearsScene_CompletesInputFrame()
+    {
+        var root = new UIRoot(new SkiaUiRenderer());
+        root.Resize(1280f, 720f);
+        UiScene scene = UiSceneComposer.Compose(
+            TextMeasurer,
+            ImageSizeProvider,
+            Ui.Column(
+                Ui.Button("Clear Scene", _ => root.ClearScene())
+                    .Id("clear-scene")
+                    .Width(160f)
+                    .Height(48f)));
+        root.MountScene(scene);
+        scene.Layout(1280f, 720f);
+
+        UiNode button = scene.FindByElementId("clear-scene")!;
+        float x = button.LayoutRect.X + 4f;
+        float y = button.LayoutRect.Y + 4f;
+
+        bool downHandled = root.HandleInput(new PointerEvent
+        {
+            DeviceType = InputDeviceType.Mouse,
+            PointerId = 0,
+            Action = PointerAction.Down,
+            Button = PointerButton.Left,
+            X = x,
+            Y = y
+        });
+        bool upHandled = root.HandleInput(new PointerEvent
+        {
+            DeviceType = InputDeviceType.Mouse,
+            PointerId = 0,
+            Action = PointerAction.Up,
+            Button = PointerButton.Left,
+            X = x,
+            Y = y
+        });
+
+        Assert.That(downHandled, Is.True);
+        Assert.That(upHandled, Is.True);
+        Assert.That(root.Scene, Is.Null);
+        Assert.That(root.IsDirty, Is.True);
+    }
+
+    [Test]
     public void ReactiveScene_ThemeSwitch_ChangesRootComputedStyle()
     {
         var page = UiShowcaseFactory.CreateReactivePage(TextMeasurer, ImageSizeProvider);
@@ -271,4 +316,3 @@ public sealed class UiShowcaseAcceptanceTests
              + (0.0722d * Linearize(color.Blue));
     }
 }
-


### PR DESCRIPTION
## Summary

- Snapshot the active `UiScene` for a `UIRoot.HandleInput` pointer frame.
- Stop the dirty/refresh tail if a dispatched action clears or replaces the mounted scene.
- Add a regression test for a button click action that calls `UIRoot.ClearScene()`.

Fixes #394.

## Validation

```powershell
dotnet test Ludots/src/Tests/UiShowcaseTests/UiShowcaseTests.csproj --filter "UIRoot_ClickThatClearsScene_CompletesInputFrame"
dotnet test Ludots/src/Tests/ThreeCTests/ThreeCTests.csproj --filter "CameraAcceptanceMod_Panel_ClickRtsScenario_LoadsRtsMapWithoutTearingDownUiInput"
```
