### PR TITLE
[#435][#436] Remove input fallbacks and stabilize order resolution

### DIFF
--- a/src/Core/Gameplay/GAS/Benchmarks/GasBenchmark.cs
+++ b/src/Core/Gameplay/GAS/Benchmarks/GasBenchmark.cs
@@ -12,6 +12,13 @@ namespace Ludots.Core.Gameplay.GAS.Benchmarks
 {
     public class GasBenchmark
     {
+        private static readonly ResponseChainOrderTypes BenchmarkResponseChainOrderTypes = new ResponseChainOrderTypes
+        {
+            ChainPass = 1,
+            ChainNegate = 2,
+            ChainActivateEffect = 3
+        };
+
         public static void Run()
         {
             Console.WriteLine("Initializing GAS Benchmark (Abilities & Hooks)...");
@@ -51,7 +58,12 @@ namespace Ludots.Core.Gameplay.GAS.Benchmarks
             var durSystem = new EffectLifetimeSystem(world, clock, conditions, effectRequests);
             var aggSystem = new AttributeAggregatorSystem(world);
 
-            var proposalSystem = new EffectProposalProcessingSystem(world, effectRequests, null, effectTemplates);
+            var proposalSystem = new EffectProposalProcessingSystem(
+                world,
+                effectRequests,
+                null,
+                effectTemplates,
+                responseChainOrderTypes: BenchmarkResponseChainOrderTypes);
             var abilitySystem = new AbilitySystem(world, effectRequests);
             var reactionSystem = new ReactionSystem(world, abilitySystem, eventBus);
             

--- a/src/Core/Gameplay/GAS/Orders/OrderBlackboardKeyRegistry.cs
+++ b/src/Core/Gameplay/GAS/Orders/OrderBlackboardKeyRegistry.cs
@@ -49,6 +49,12 @@ namespace Ludots.Core.Gameplay.GAS.Orders
             }
         }
 
+        public static bool IsBuiltinKey(string key)
+        {
+            return TryRequireCanonicalKey(key, out string canonicalKey) &&
+                   BuiltinIdsByKey.ContainsKey(canonicalKey);
+        }
+
         public static string GetKey(int id)
         {
             if (BuiltinKeysById.TryGetValue(id, out string? builtinKey))

--- a/src/Core/Gameplay/GAS/Orders/OrderTypeConfigLoader.cs
+++ b/src/Core/Gameplay/GAS/Orders/OrderTypeConfigLoader.cs
@@ -325,6 +325,12 @@ namespace Ludots.Core.Gameplay.GAS.Orders
             {
                 string key = RequireConfiguredBlackboardKey(kvp.Key, path);
                 RequireConfiguredBlackboardKeyDeclaration(kvp.Value, key, path);
+                if (OrderBlackboardKeyRegistry.IsBuiltinKey(key))
+                {
+                    throw new InvalidOperationException(
+                        $"LUDOTS_GAS_ORDER_BLACKBOARD_BUILTIN_REDECLARED: order blackboard key '{key}' in '{path}' is built in and must only be referenced, not redeclared in orderBlackboardKeys.");
+                }
+
                 keys.Add(key);
             }
 

--- a/src/Core/Gameplay/GAS/Systems/AbilitySystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/AbilitySystem.cs
@@ -21,14 +21,15 @@ namespace Ludots.Core.Gameplay.GAS.Systems
 
         public AbilitySystem(
             World world,
-            EffectRequestQueue effectRequests = null,
+            EffectRequestQueue effectRequests,
             AbilityDefinitionRegistry abilityDefinitions = null,
             TagOps tagOps = null,
             GraphProgramRegistry graphPrograms = null,
             IGraphRuntimeApi graphApi = null,
             ProgressionRequirementEvaluator progressionRequirements = null) : base(world)
         {
-            _effectRequests = effectRequests;
+            _effectRequests = effectRequests ?? throw new InvalidOperationException(
+                "LUDOTS_GAS_ABILITY_EFFECT_QUEUE_REQUIRED: AbilitySystem requires EffectRequestQueue to publish activation effects.");
             _abilityDefinitions = abilityDefinitions;
             _tagOps = tagOps ?? new TagOps();
             _graphPrograms = graphPrograms;
@@ -124,7 +125,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                     return false;
                 }
 
-                if (_effectRequests == null) return true;
                 if (!def.HasOnActivateEffects || def.OnActivateEffects.Count <= 0) return true;
 
                 var effects = def.OnActivateEffects;
@@ -196,8 +196,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             {
                 return false;
             }
-
-            if (_effectRequests == null) return true;
 
             ref var effectsEntity = ref World.TryGetRef<AbilityOnActivateEffects>(templateEntity, out bool hasOnActivateEntity);
             if (hasOnActivateEntity)

--- a/src/Core/Gameplay/GAS/Systems/EffectProcessingLoopSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/EffectProcessingLoopSystem.cs
@@ -66,7 +66,10 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             _chainOrders = chainOrders;
             _orderRequests = orderRequests;
 
-            _proposal = new EffectProposalProcessingSystem(world, effectRequests, budget, templates, inputRequests, chainOrders, telemetry, orderRequests, responseChainOrderTypes, presentationEvents, phaseExecutor, graphApi);
+            var configuredResponseChainOrderTypes = ResponseChainOrderTypes.RequireConfigured(
+                responseChainOrderTypes,
+                nameof(EffectProcessingLoopSystem));
+            _proposal = new EffectProposalProcessingSystem(world, effectRequests, budget, templates, inputRequests, chainOrders, telemetry, orderRequests, configuredResponseChainOrderTypes, presentationEvents, phaseExecutor, graphApi);
             _application = new EffectApplicationSystem(world, effectRequests, budget, presentationEvents, templates, spatialQueries, spawnRequests, phaseExecutor, graphApi, tagOps, exchangeRuntime, progressionEvaluator);
             _lifetime = new EffectLifetimeSystem(world, clock, conditions, effectRequests, budget, templates, spatialQueries, spawnRequests, phaseExecutor, graphApi, tagOps, exchangeRuntime, progressionEvaluator);
             _runtimeStateEntity = world.Create(new GasRuntimeState());

--- a/src/Core/Gameplay/GAS/Systems/EffectProposalProcessingSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/EffectProposalProcessingSystem.cs
@@ -22,6 +22,26 @@ namespace Ludots.Core.Gameplay.GAS.Systems
         public int ChainPass;
         public int ChainNegate;
         public int ChainActivateEffect;
+
+        public static ResponseChainOrderTypes RequireConfigured(ResponseChainOrderTypes? value, string consumerName)
+        {
+            if (value == null)
+            {
+                throw new InvalidOperationException(
+                    $"LUDOTS_GAS_RESPONSE_CHAIN_ORDER_TYPES_REQUIRED: {consumerName} requires response-chain order type ids injected from GameConfig.Constants.ResponseChainOrderTypeIds.");
+            }
+
+            var configured = value.Value;
+            if (configured.ChainPass <= 0 ||
+                configured.ChainNegate <= 0 ||
+                configured.ChainActivateEffect <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"LUDOTS_GAS_RESPONSE_CHAIN_ORDER_TYPES_INVALID: {consumerName} requires positive response-chain order type ids for chainPass, chainNegate, and chainActivateEffect.");
+            }
+
+            return configured;
+        }
     }
 
     public sealed class EffectProposalProcessingSystem : BaseSystem<World, float>, ITimeSlicedSystem
@@ -238,13 +258,9 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             _chainOrders = chainOrders;
             _telemetry = telemetry;
             _orderRequests = orderRequests;
-            if ((chainOrders != null || orderRequests != null) && responseChainOrderTypes == null)
-            {
-                throw new InvalidOperationException(
-                    $"{nameof(EffectProposalProcessingSystem)} requires configured response-chain order type ids when response-chain queues are enabled.");
-            }
-
-            _responseChainOrderTypes = responseChainOrderTypes ?? default;
+            _responseChainOrderTypes = ResponseChainOrderTypes.RequireConfigured(
+                responseChainOrderTypes,
+                nameof(EffectProposalProcessingSystem));
             _presentationEvents = presentationEvents;
             _tagOps = tagOps ?? new TagOps();
             _phaseExecutor = phaseExecutor;

--- a/src/Core/Input/Config/InputConfigModels.cs
+++ b/src/Core/Input/Config/InputConfigModels.cs
@@ -17,7 +17,7 @@ namespace Ludots.Core.Input.Config
     /// </summary>
     public class InputActionDef
     {
-        public string Id { get; set; } = Guid.NewGuid().ToString();
+        public string Id { get; set; } = string.Empty;
         public string Name { get; set; }
         [JsonConverter(typeof(JsonStringEnumConverter))]
         public InputActionType Type { get; set; } = InputActionType.Button;

--- a/src/Core/Input/Config/InputConfigPipelineLoader.cs
+++ b/src/Core/Input/Config/InputConfigPipelineLoader.cs
@@ -47,7 +47,8 @@ namespace Ludots.Core.Input.Config
                 var fragmentConfig = obj.Deserialize<InputConfigRoot>(_options);
                 if (fragmentConfig == null) continue;
 
-                MergeActions(fragmentConfig.Actions, actions, actionOrder);
+                Validate(fragmentConfig, fragments[i].SourceUri);
+                MergeActions(fragmentConfig.Actions, actions, actionOrder, fragments[i].SourceUri);
                 MergeContexts(fragmentConfig.Contexts, contexts, contextOrder);
             }
 
@@ -67,14 +68,54 @@ namespace Ludots.Core.Input.Config
             return result;
         }
 
-        private static void MergeActions(List<InputActionDef> incoming, Dictionary<string, InputActionDef> byId, List<string> order)
+        public static void Validate(InputConfigRoot config, string source)
         {
-            if (incoming == null) return;
+            if (config == null) throw new ArgumentNullException(nameof(config));
+            if (config.Actions == null)
+            {
+                throw new InvalidOperationException(
+                    $"LUDOTS_INPUT_ACTIONS_REQUIRED: input config '{source}' must explicitly define actions.");
+            }
+
+            var actionIds = new HashSet<string>(StringComparer.Ordinal);
+            for (int i = 0; i < config.Actions.Count; i++)
+            {
+                InputActionDef action = config.Actions[i] ??
+                    throw new InvalidOperationException(
+                        $"LUDOTS_INPUT_ACTION_REQUIRED: input config '{source}' actions[{i}] must be an object.");
+
+                string path = $"input config '{source}' actions[{i}]";
+                if (string.IsNullOrWhiteSpace(action.Id))
+                {
+                    throw new InvalidOperationException(
+                        $"LUDOTS_INPUT_ACTION_ID_REQUIRED: {path}.id must be a non-empty string.");
+                }
+
+                if (!string.Equals(action.Id, action.Id.Trim(), StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"LUDOTS_INPUT_ACTION_ID_REQUIRED: {path}.id must not contain leading or trailing whitespace.");
+                }
+
+                if (!actionIds.Add(action.Id))
+                {
+                    throw new InvalidOperationException(
+                        $"LUDOTS_INPUT_ACTION_ID_DUPLICATE: {path}.id duplicates input action '{action.Id}'.");
+                }
+            }
+        }
+
+        private static void MergeActions(List<InputActionDef> incoming, Dictionary<string, InputActionDef> byId, List<string> order, string source)
+        {
+            if (incoming == null)
+            {
+                throw new InvalidOperationException(
+                    $"LUDOTS_INPUT_ACTIONS_REQUIRED: input config '{source}' must explicitly define actions.");
+            }
+
             for (int i = 0; i < incoming.Count; i++)
             {
                 var a = incoming[i];
-                if (a == null) continue;
-                if (string.IsNullOrWhiteSpace(a.Id)) continue;
 
                 if (!byId.ContainsKey(a.Id)) order.Add(a.Id);
                 byId[a.Id] = a;

--- a/src/Core/Input/Orders/ContextScoredOrderResolver.cs
+++ b/src/Core/Input/Orders/ContextScoredOrderResolver.cs
@@ -97,7 +97,8 @@ namespace Ludots.Core.Input.Orders
 
                 if (!candidate.RequiresTarget)
                 {
-                    if (TryScoreCandidate(actor, default, hoveredEntity, actorWorldCm, candidate, out float score) && score > bestScore)
+                    if (TryScoreCandidate(actor, default, hoveredEntity, actorWorldCm, candidate, out float score) &&
+                        IsBetterCandidate(score, default, candidateSlotIndex, bestScore, bestTarget, bestSlotIndex))
                     {
                         bestScore = score;
                         bestSlotIndex = candidateSlotIndex;
@@ -114,7 +115,8 @@ namespace Ludots.Core.Input.Orders
                         continue;
                     }
 
-                    if (TryScoreCandidate(actor, target, hoveredEntity, actorWorldCm, candidate, out float score) && score > bestScore)
+                    if (TryScoreCandidate(actor, target, hoveredEntity, actorWorldCm, candidate, out float score) &&
+                        IsBetterCandidate(score, target, candidateSlotIndex, bestScore, bestTarget, bestSlotIndex))
                     {
                         bestScore = score;
                         bestSlotIndex = candidateSlotIndex;
@@ -259,6 +261,50 @@ namespace Ludots.Core.Input.Orders
             float dx = b.X - a.X;
             float dy = b.Y - a.Y;
             return MathF.Sqrt(dx * dx + dy * dy);
+        }
+
+        private static bool IsBetterCandidate(
+            float score,
+            Entity target,
+            int slotIndex,
+            float bestScore,
+            Entity bestTarget,
+            int bestSlotIndex)
+        {
+            if (score > bestScore)
+            {
+                return true;
+            }
+
+            if (score < bestScore)
+            {
+                return false;
+            }
+
+            int entityCompare = CompareEntityId(target, bestTarget);
+            if (entityCompare != 0)
+            {
+                return entityCompare < 0;
+            }
+
+            return bestSlotIndex < 0 || slotIndex < bestSlotIndex;
+        }
+
+        private static int CompareEntityId(Entity left, Entity right)
+        {
+            int id = left.Id.CompareTo(right.Id);
+            if (id != 0)
+            {
+                return id;
+            }
+
+            int worldId = left.WorldId.CompareTo(right.WorldId);
+            if (worldId != 0)
+            {
+                return worldId;
+            }
+
+            return left.Version.CompareTo(right.Version);
         }
 
         private static float ComputeAngleToTargetDeg(WorldCmInt2 actorWorldCm, WorldCmInt2 targetWorldCm, float facingAngleRad)

--- a/src/Core/Input/Orders/InputOrderMappingLoader.cs
+++ b/src/Core/Input/Orders/InputOrderMappingLoader.cs
@@ -148,6 +148,19 @@ namespace Ludots.Core.Input.Orders
                         $"{path}.heldPolicy StartEnd requires trigger Held.");
                 }
 
+                if (mapping.ArgsTemplate == null)
+                {
+                    throw new InvalidOperationException(
+                        $"LUDOTS_INPUT_ORDER_ARGS_TEMPLATE_REQUIRED: {path}.argsTemplate must be an object.");
+                }
+
+                if (mapping.IsSkillMapping &&
+                    (mapping.ArgsTemplate.I0 is not int priority || priority < 0))
+                {
+                    throw new InvalidOperationException(
+                        $"LUDOTS_INPUT_ORDER_SKILL_PRIORITY_REQUIRED: {path}.argsTemplate.i0 must define a non-negative skill priority.");
+                }
+
                 if (mapping.AutoTargetPolicy != AutoTargetPolicy.None && mapping.AutoTargetRangeCm <= 0)
                 {
                     throw new InvalidOperationException(
@@ -164,4 +177,3 @@ namespace Ludots.Core.Input.Orders
 
     }
 }
-

--- a/src/Core/Input/Orders/InputOrderMappingSystem.cs
+++ b/src/Core/Input/Orders/InputOrderMappingSystem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Numerics;
 using Arch.Core;
 using Ludots.Core.Gameplay.GAS.Orders;
+using Ludots.Core.Input.Interaction;
 using Ludots.Core.Input.Runtime;
 
 namespace Ludots.Core.Input.Orders
@@ -146,11 +147,21 @@ namespace Ludots.Core.Input.Orders
             public InputOrderMapping Mapping { get; }
         }
 
+        private readonly record struct MappingEntry(
+            string ActionId,
+            InputOrderMapping Mapping,
+            int Priority,
+            int ActionIdOrdinal);
+
         private readonly IInputActionReader _input;
         private readonly InputOrderMappingConfig _config;
         private readonly Dictionary<string, InputOrderMapping> _mappingsByActionId;
         private readonly Dictionary<string, InputOrderMapping> _userOverrides;
+        private readonly MappingEntry[] _orderedMappings;
         private readonly Dictionary<string, float> _lastPressedAtSecondsByActionId = new();
+        private string _confirmActionId = string.Empty;
+        private string _cancelActionId = string.Empty;
+        private string _commandActionId = string.Empty;
         
         // Callbacks
         private OrderTypeKeyResolver? _orderTypeKeyResolver;
@@ -230,14 +241,26 @@ namespace Ludots.Core.Input.Orders
         /// <summary>The locked origin for vector aiming. Valid only during direction phase.</summary>
         public Vector3 VectorAimOrigin => _vectorAimOrigin;
 
-        /// <summary>The confirm action ID used to fire the aimed ability. Default: "Select" (left-click).</summary>
-        public string ConfirmActionId { get; set; } = "Select";
+        /// <summary>The confirm action ID used to fire the aimed ability.</summary>
+        public string ConfirmActionId
+        {
+            get => _confirmActionId;
+            set => _confirmActionId = RequireConfiguredActionId(value, nameof(ConfirmActionId));
+        }
 
-        /// <summary>The cancel action ID. Default: "Cancel" (ESC).</summary>
-        public string CancelActionId { get; set; } = "Cancel";
+        /// <summary>The cancel action ID.</summary>
+        public string CancelActionId
+        {
+            get => _cancelActionId;
+            set => _cancelActionId = RequireConfiguredActionId(value, nameof(CancelActionId));
+        }
 
-        /// <summary>The secondary cancel / command action ID. Default: "Command" (right-click).</summary>
-        public string CommandActionId { get; set; } = "Command";
+        /// <summary>The secondary cancel / command action ID.</summary>
+        public string CommandActionId
+        {
+            get => _commandActionId;
+            set => _commandActionId = RequireConfiguredActionId(value, nameof(CommandActionId));
+        }
         
         public InputOrderMappingSystem(IInputActionReader input, InputOrderMappingConfig config)
         {
@@ -247,12 +270,37 @@ namespace Ludots.Core.Input.Orders
             
             _mappingsByActionId = new Dictionary<string, InputOrderMapping>();
             _userOverrides = new Dictionary<string, InputOrderMapping>();
-            
-            // Index mappings by action ID
+
             foreach (var mapping in config.Mappings)
             {
                 _mappingsByActionId.Add(mapping.ActionId, mapping);
             }
+
+            var actionIds = new string[config.Mappings.Count];
+            for (int i = 0; i < config.Mappings.Count; i++)
+            {
+                actionIds[i] = config.Mappings[i].ActionId;
+            }
+
+            Array.Sort(actionIds, StringComparer.Ordinal);
+            var actionIdOrdinals = new Dictionary<string, int>(StringComparer.Ordinal);
+            for (int i = 0; i < actionIds.Length; i++)
+            {
+                actionIdOrdinals.Add(actionIds[i], i);
+            }
+
+            _orderedMappings = new MappingEntry[config.Mappings.Count];
+            for (int i = 0; i < config.Mappings.Count; i++)
+            {
+                var mapping = config.Mappings[i];
+                _orderedMappings[i] = new MappingEntry(
+                    mapping.ActionId,
+                    mapping,
+                    ResolveMappingPriority(mapping),
+                    actionIdOrdinals[mapping.ActionId]);
+            }
+
+            Array.Sort(_orderedMappings, CompareMappingEntries);
         }
         
         // Callback setters (unchanged API + new ones)
@@ -277,6 +325,19 @@ namespace Ludots.Core.Input.Orders
         public void SetCursorTargetProvider(CursorTargetProvider provider) => _cursorTargetProvider = provider;
         public void SetContextScoredProvider(ContextScoredResolutionProvider provider) => _contextScoredProvider = provider;
         public void SetSkillMappingOverrideProvider(SkillMappingOverrideProvider provider) => _skillMappingOverrideProvider = provider;
+
+        public void SetInteractionActionBindings(InteractionActionBindings bindings)
+        {
+            if (bindings == null)
+            {
+                throw new InvalidOperationException(
+                    $"LUDOTS_INPUT_ORDER_ACTION_BINDING_REQUIRED: {nameof(InputOrderMappingSystem)} requires {nameof(InteractionActionBindings)}.");
+            }
+
+            ConfirmActionId = bindings.ConfirmActionId;
+            CancelActionId = bindings.CancelActionId;
+            CommandActionId = bindings.CommandActionId;
+        }
         
         public void SetLocalPlayer(Entity entity, int playerId)
         {
@@ -321,8 +382,10 @@ namespace Ludots.Core.Input.Orders
             ProcessPressReleaseAimPending();
             
             // 2. Process all mappings
-            foreach (var (actionId, mapping) in _mappingsByActionId)
+            foreach (var entry in _orderedMappings)
             {
+                string actionId = entry.ActionId;
+                InputOrderMapping mapping = entry.Mapping;
                 var effectiveMapping = ResolveEffectiveMapping(actionId, mapping, out var resolvedActor);
 
                 // Held+StartEnd is handled separately via press/release detection
@@ -383,12 +446,16 @@ namespace Ludots.Core.Input.Orders
             
             // Collect releases to avoid modifying set during iteration
             List<string>? toRemove = null;
-            foreach (var kvp in _activeHeldStartEndActions)
+            foreach (var entry in _orderedMappings)
             {
-                string actionId = kvp.Key;
+                string actionId = entry.ActionId;
+                if (!_activeHeldStartEndActions.TryGetValue(actionId, out var state))
+                {
+                    continue;
+                }
+
                 if (_input.ReleasedThisFrame(actionId))
                 {
-                    HeldStartEndState state = kvp.Value;
                     if (TryBuildOrderWithOrderTypeSuffix(state.Mapping, state.Actor, ".End", out var endOrder))
                     {
                         SubmitOrder(state.Mapping, in endOrder);
@@ -550,7 +617,10 @@ namespace Ludots.Core.Input.Orders
                 return;
             }
 
-            if (_input.PressedThisFrame(CancelActionId) || _input.PressedThisFrame(CommandActionId))
+            string cancelActionId = RequireCancelActionId();
+            string commandActionId = RequireCommandActionId();
+
+            if (_input.PressedThisFrame(cancelActionId) || _input.PressedThisFrame(commandActionId))
             {
                 ClearPressReleaseAimPending();
                 return;
@@ -581,10 +651,14 @@ namespace Ludots.Core.Input.Orders
         {
             if (_aimingMapping == null) { ExitAimingState(); return; }
 
+            string confirmActionId = RequireConfirmActionId();
+            string cancelActionId = RequireCancelActionId();
+            string commandActionId = RequireCommandActionId();
+
             // Vector aiming (two-point targeting)
             if (_isVectorAiming)
             {
-                HandleVectorAimingState();
+                HandleVectorAimingState(confirmActionId, cancelActionId, commandActionId);
                 return;
             }
 
@@ -602,7 +676,7 @@ namespace Ludots.Core.Input.Orders
                 }
                 
                 // Cancel: right-click or ESC
-                if (_input.PressedThisFrame(CancelActionId) || _input.PressedThisFrame(CommandActionId))
+                if (_input.PressedThisFrame(cancelActionId) || _input.PressedThisFrame(commandActionId))
                 {
                     ExitAimingState();
                     return;
@@ -614,7 +688,7 @@ namespace Ludots.Core.Input.Orders
             }
 
             // AimCast: Confirm by left-click
-            if (_input.PressedThisFrame(ConfirmActionId))
+            if (_input.PressedThisFrame(confirmActionId))
             {
                 // Build order using current cursor/selection
                 if (TryBuildOrderSmartCast(_aimingMapping, out var order))
@@ -626,15 +700,17 @@ namespace Ludots.Core.Input.Orders
             }
 
             // Cancel: right-click or ESC
-            if (_input.PressedThisFrame(CancelActionId) || _input.PressedThisFrame(CommandActionId))
+            if (_input.PressedThisFrame(cancelActionId) || _input.PressedThisFrame(commandActionId))
             {
                 ExitAimingState();
                 return;
             }
 
             // Pressing a different skill key while aiming switches to that skill
-            foreach (var (actionId, mapping) in _mappingsByActionId)
+            foreach (var entry in _orderedMappings)
             {
+                string actionId = entry.ActionId;
+                InputOrderMapping mapping = entry.Mapping;
                 if (actionId == _aimingActionId) continue;
                 var effectiveMapping = _userOverrides.TryGetValue(actionId, out var overrideMapping)
                     ? overrideMapping
@@ -656,10 +732,10 @@ namespace Ludots.Core.Input.Orders
         /// Phase Origin: click to lock origin point.
         /// Phase Direction: click to lock endpoint, then build and submit order.
         /// </summary>
-        private void HandleVectorAimingState()
+        private void HandleVectorAimingState(string confirmActionId, string cancelActionId, string commandActionId)
         {
             // Cancel: right-click or ESC at any phase
-            if (_input.PressedThisFrame(CancelActionId) || _input.PressedThisFrame(CommandActionId))
+            if (_input.PressedThisFrame(cancelActionId) || _input.PressedThisFrame(commandActionId))
             {
                 ExitAimingState();
                 return;
@@ -679,7 +755,7 @@ namespace Ludots.Core.Input.Orders
                     }
                     
                     // Confirm origin with left-click
-                    if (_input.PressedThisFrame(ConfirmActionId) && hasCursor)
+                    if (_input.PressedThisFrame(confirmActionId) && hasCursor)
                     {
                         _vectorAimOrigin = cursorPos;
                         _vectorAimPhase = VectorAimPhase.Direction;
@@ -694,7 +770,7 @@ namespace Ludots.Core.Input.Orders
                     }
                     
                     // Confirm direction with left-click -> build and submit vector order
-                    if (_input.PressedThisFrame(ConfirmActionId) && hasCursor)
+                    if (_input.PressedThisFrame(confirmActionId) && hasCursor)
                     {
                         if (TryBuildVectorOrder(_aimingMapping!, _vectorAimOrigin, cursorPos, out var order))
                         {
@@ -1281,7 +1357,13 @@ namespace Ludots.Core.Input.Orders
             return null;
         }
 
-        public IEnumerable<string> GetMappedActionIds() => _mappingsByActionId.Keys;
+        public IEnumerable<string> GetMappedActionIds()
+        {
+            for (int i = 0; i < _orderedMappings.Length; i++)
+            {
+                yield return _orderedMappings[i].ActionId;
+            }
+        }
 
         public int CopyPrimarySkillActionIds(Span<string> destination)
         {
@@ -1298,12 +1380,12 @@ namespace Ludots.Core.Input.Orders
             }
 
             int resolved = 0;
-            foreach (var pair in _mappingsByActionId)
+            foreach (var entry in _orderedMappings)
             {
-                string actionId = pair.Key;
+                string actionId = entry.ActionId;
                 InputOrderMapping mapping = _userOverrides.TryGetValue(actionId, out var overrideMapping)
                     ? overrideMapping
-                    : pair.Value;
+                    : entry.Mapping;
                 if (!mapping.IsSkillMapping ||
                     !mapping.ArgsTemplate.I0.HasValue)
                 {
@@ -1316,7 +1398,7 @@ namespace Ludots.Core.Input.Orders
                     continue;
                 }
 
-                int priority = ResolveSkillActionPriority(actionId);
+                int priority = ResolveSkillActionPriority(actionId, mapping);
                 string current = destination[slotIndex];
                 if (priority < priorities[slotIndex] ||
                     (priority == priorities[slotIndex] && string.CompareOrdinal(actionId, current) < 0))
@@ -1392,16 +1474,15 @@ namespace Ludots.Core.Input.Orders
             return true;
         }
 
-        private static int ResolveSkillActionPriority(string actionId)
+        private static int ResolveSkillActionPriority(string actionId, InputOrderMapping mapping)
         {
-            return actionId switch
+            if (mapping.ArgsTemplate.I0 is not int priority || priority < 0)
             {
-                "SkillQ" => 0,
-                "SkillW" => 1,
-                "SkillE" => 2,
-                "SkillR" => 3,
-                _ => 100
-            };
+                throw new InvalidOperationException(
+                    $"LUDOTS_INPUT_ORDER_SKILL_PRIORITY_REQUIRED: skill mapping '{actionId}' must define argsTemplate.i0 as its data-driven priority.");
+            }
+
+            return priority;
         }
 
         public void SaveUserPreferences(string? path = null)
@@ -1415,7 +1496,7 @@ namespace Ludots.Core.Input.Orders
             }
             var overrideConfig = new InputOrderMappingConfig
             {
-                Mappings = new List<InputOrderMapping>(_userOverrides.Values)
+                Mappings = CopyOrderedUserOverrides()
             };
             InputOrderMappingLoader.SaveToFile(effectivePath, overrideConfig);
         }
@@ -1449,9 +1530,9 @@ namespace Ludots.Core.Input.Orders
 
         private void ValidateAllOrderTypeKeys()
         {
-            foreach (var mapping in _mappingsByActionId.Values)
+            foreach (var entry in _orderedMappings)
             {
-                ValidateOrderTypeKeys(mapping);
+                ValidateOrderTypeKeys(entry.Mapping);
             }
 
             foreach (var mapping in _userOverrides.Values)
@@ -1483,7 +1564,55 @@ namespace Ludots.Core.Input.Orders
             ExitAimingState();
         }
 
+        private List<InputOrderMapping> CopyOrderedUserOverrides()
+        {
+            var mappings = new List<InputOrderMapping>(_userOverrides.Count);
+            for (int i = 0; i < _orderedMappings.Length; i++)
+            {
+                if (_userOverrides.TryGetValue(_orderedMappings[i].ActionId, out var mapping))
+                {
+                    mappings.Add(mapping);
+                }
+            }
+
+            return mappings;
+        }
+
+        private static int ResolveMappingPriority(InputOrderMapping mapping)
+        {
+            return mapping.IsSkillMapping
+                ? ResolveSkillActionPriority(mapping.ActionId, mapping)
+                : int.MaxValue;
+        }
+
+        private static int CompareMappingEntries(MappingEntry left, MappingEntry right)
+        {
+            int priority = left.Priority.CompareTo(right.Priority);
+            if (priority != 0)
+            {
+                return priority;
+            }
+
+            return left.ActionIdOrdinal.CompareTo(right.ActionIdOrdinal);
+        }
+
+        private static string RequireConfiguredActionId(string actionId, string propertyName)
+        {
+            if (string.IsNullOrWhiteSpace(actionId) ||
+                !string.Equals(actionId, actionId.Trim(), StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"LUDOTS_INPUT_ORDER_ACTION_BINDING_REQUIRED: {nameof(InputOrderMappingSystem)} requires {propertyName} from {nameof(InteractionActionBindings)}.");
+            }
+
+            return actionId;
+        }
+
+        private string RequireConfirmActionId() => RequireConfiguredActionId(_confirmActionId, nameof(ConfirmActionId));
+
+        private string RequireCancelActionId() => RequireConfiguredActionId(_cancelActionId, nameof(CancelActionId));
+
+        private string RequireCommandActionId() => RequireConfiguredActionId(_commandActionId, nameof(CommandActionId));
+
     }
 }
-
-

--- a/src/Core/Input/Runtime/PlayerInputHandler.cs
+++ b/src/Core/Input/Runtime/PlayerInputHandler.cs
@@ -28,6 +28,7 @@ namespace Ludots.Core.Input.Runtime
         {
             _backend = backend;
             if (config == null) throw new ArgumentNullException(nameof(config));
+            InputConfigPipelineLoader.Validate(config, "PlayerInputHandler config");
 
             _actionStates = new InputActionInstance[config.Actions.Count];
             _tempValues = new Vector3[config.Actions.Count];
@@ -349,8 +350,8 @@ namespace Ludots.Core.Input.Runtime
                 compiled[i] = def.Type switch
                 {
                     "Normalize" => new CompiledProcessor(ProcessorKind.Normalize, 0f),
-                    "Deadzone" => new CompiledProcessor(ProcessorKind.Deadzone, GetParameter(def.Parameters, "Min", 0.1f)),
-                    "Scale" => new CompiledProcessor(ProcessorKind.Scale, GetParameter(def.Parameters, "Factor", 1f)),
+                    "Deadzone" => new CompiledProcessor(ProcessorKind.Deadzone, RequireParameter(def.Parameters, "Min", def.Type)),
+                    "Scale" => new CompiledProcessor(ProcessorKind.Scale, RequireParameter(def.Parameters, "Factor", def.Type)),
                     "Invert" => new CompiledProcessor(ProcessorKind.Invert, 0f, GetAxisMask(def.Parameters)),
                     _ => new CompiledProcessor(ProcessorKind.Unknown, 0f)
                 };
@@ -359,23 +360,22 @@ namespace Ludots.Core.Input.Runtime
             return compiled;
         }
 
-        private static float GetParameter(IReadOnlyList<InputParameterDef> parameters, string name, float fallback)
+        private static float RequireParameter(IReadOnlyList<InputParameterDef> parameters, string name, string processorType)
         {
-            if (parameters == null)
+            if (parameters != null)
             {
-                return fallback;
-            }
-
-            for (int i = 0; i < parameters.Count; i++)
-            {
-                var parameter = parameters[i];
-                if (string.Equals(parameter.Name, name, StringComparison.Ordinal))
+                for (int i = 0; i < parameters.Count; i++)
                 {
-                    return parameter.Value;
+                    var parameter = parameters[i];
+                    if (parameter != null && string.Equals(parameter.Name, name, StringComparison.Ordinal))
+                    {
+                        return parameter.Value;
+                    }
                 }
             }
 
-            return fallback;
+            throw new InvalidOperationException(
+                $"LUDOTS_INPUT_PROCESSOR_PARAMETER_REQUIRED: input processor '{processorType}' must explicitly define parameter '{name}'.");
         }
 
         private static byte GetAxisMask(IReadOnlyList<InputParameterDef> parameters)

--- a/src/Tests/GasTests/AllocationTests.cs
+++ b/src/Tests/GasTests/AllocationTests.cs
@@ -57,7 +57,12 @@ namespace Ludots.Tests.GAS
                 attr.SetCurrent(0, 1000f);
 
                 var abilitySystem = new AbilitySystem(world, requests, abilityDefs);
-                var proposalSystem = new EffectProposalProcessingSystem(world, requests, budget: null, templates: templates);
+                var proposalSystem = new EffectProposalProcessingSystem(
+                    world,
+                    requests,
+                    budget: null,
+                    templates: templates,
+                    responseChainOrderTypes: TestResponseChainOrderTypeIds.Types);
 
                 var args = new AbilitySystem.AbilityActivationArgs(explicitTarget: target);
 
@@ -178,4 +183,3 @@ namespace Ludots.Tests.GAS
         }
     }
 }
-

--- a/src/Tests/GasTests/AttributeAggregatorTests.cs
+++ b/src/Tests/GasTests/AttributeAggregatorTests.cs
@@ -283,7 +283,11 @@ namespace Ludots.Tests.GAS
             });
 
             var requests = new EffectRequestQueue();
-            var proposal = new EffectProposalProcessingSystem(world, requests, templates: templates);
+            var proposal = new EffectProposalProcessingSystem(
+                world,
+                requests,
+                templates: templates,
+                responseChainOrderTypes: TestResponseChainOrderTypeIds.Types);
             var application = new EffectApplicationSystem(world, requests, templates: templates);
             var aggregator = new AttributeAggregatorSystem(world);
 
@@ -337,6 +341,7 @@ namespace Ludots.Tests.GAS
                 world,
                 requests,
                 templates: templates,
+                responseChainOrderTypes: TestResponseChainOrderTypeIds.Types,
                 presentationEvents: presentationEvents);
 
             requests.Publish(new EffectRequest
@@ -388,7 +393,11 @@ namespace Ludots.Tests.GAS
             });
 
             var requests = new EffectRequestQueue();
-            var proposal = new EffectProposalProcessingSystem(world, requests, templates: templates);
+            var proposal = new EffectProposalProcessingSystem(
+                world,
+                requests,
+                templates: templates,
+                responseChainOrderTypes: TestResponseChainOrderTypeIds.Types);
             var application = new EffectApplicationSystem(world, requests, templates: templates);
             var aggregator = new AttributeAggregatorSystem(world);
 

--- a/src/Tests/GasTests/AuditCoverageTests.cs
+++ b/src/Tests/GasTests/AuditCoverageTests.cs
@@ -160,7 +160,14 @@ namespace Ludots.Tests.GAS
                     TemplateId = tplInstant,
                 });
 
-                var sys = new EffectProposalProcessingSystem(world, queue, budget, templates, inputRequests: null, chainOrders: null)
+                var sys = new EffectProposalProcessingSystem(
+                    world,
+                    queue,
+                    budget,
+                    templates,
+                    inputRequests: null,
+                    chainOrders: null,
+                    responseChainOrderTypes: TestResponseChainOrderTypeIds.Types)
                 {
                     MaxWorkUnitsPerSlice = 1 // Force partial processing
                 };
@@ -404,7 +411,7 @@ namespace Ludots.Tests.GAS
             EffectTemplateIdRegistry.Clear();
 
             // Pre-register graph programs referenced by MobaDemoMod effect templates.
-            // In production, GraphProgramLoader runs before EffectTemplateLoader.
+            // In production, GraphProgramConfigLoader registers graph names before EffectTemplateLoader.
             Ludots.Core.NodeLibraries.GASGraph.Host.GraphIdRegistry.Clear();
             Ludots.Core.NodeLibraries.GASGraph.Host.GraphIdRegistry.Register("Graph.Shield.Absorb");
 

--- a/src/Tests/GasTests/ContextScoredResolverTests.cs
+++ b/src/Tests/GasTests/ContextScoredResolverTests.cs
@@ -200,6 +200,82 @@ namespace Ludots.Tests.GAS
             Assert.That(resolution.Target, Is.EqualTo(target));
         }
 
+        [Test]
+        public void ContextScoredResolver_TiesBreakByEntityIdThenSlot()
+        {
+            using var world = World.Create();
+
+            const int rootAbilityId = 1200;
+            const int highSlotAbilityId = 1201;
+            const int lowSlotAbilityId = 1202;
+
+            var actor = world.Create();
+            var abilities = new AbilityStateBuffer();
+            abilities.AddAbility(rootAbilityId);
+            abilities.AddAbility(lowSlotAbilityId);
+            abilities.AddAbility(highSlotAbilityId);
+            world.Add(actor, abilities);
+            world.Add(actor, WorldPositionCm.FromCm(0, 0));
+            world.Add(actor, new FacingDirection { AngleRad = 0f });
+
+            var lowerEntityIdTarget = world.Create();
+            world.Add(lowerEntityIdTarget, WorldPositionCm.FromCm(100, 0));
+            world.Add(lowerEntityIdTarget, new GameplayTagContainer());
+
+            var higherEntityIdTarget = world.Create();
+            world.Add(higherEntityIdTarget, WorldPositionCm.FromCm(100, 0));
+            world.Add(higherEntityIdTarget, new GameplayTagContainer());
+
+            var contextGroups = new ContextGroupRegistry();
+            contextGroups.Register(
+                groupId: 1,
+                rootAbilityId: rootAbilityId,
+                new ContextGroupDefinition(
+                    searchRadiusCm: 300,
+                    new[]
+                    {
+                        new ContextGroupCandidate(
+                            abilityId: highSlotAbilityId,
+                            preconditionGraphId: 0,
+                            scoreGraphId: 0,
+                            basePriority: 10f,
+                            maxDistanceCm: 300,
+                            distanceWeight: 0f,
+                            maxAngleDeg: 180,
+                            angleWeight: 0f,
+                            hoveredBiasScore: 0f,
+                            requiresTarget: true),
+                        new ContextGroupCandidate(
+                            abilityId: lowSlotAbilityId,
+                            preconditionGraphId: 0,
+                            scoreGraphId: 0,
+                            basePriority: 10f,
+                            maxDistanceCm: 300,
+                            distanceWeight: 0f,
+                            maxAngleDeg: 180,
+                            angleWeight: 0f,
+                            hoveredBiasScore: 0f,
+                            requiresTarget: true),
+                    }));
+
+            var resolver = new ContextScoredOrderResolver(
+                world,
+                contextGroups,
+                new GraphProgramRegistry(),
+                new StubSpatialQueryService(higherEntityIdTarget, lowerEntityIdTarget),
+                new StubGraphApi(world));
+
+            bool resolved = resolver.TryResolve(
+                actor,
+                new InputOrderMapping { ArgsTemplate = new OrderArgsTemplate { I0 = 0 } },
+                default,
+                out var resolution);
+
+            Assert.That(resolved, Is.True);
+            Assert.That(resolution.Target, Is.EqualTo(lowerEntityIdTarget));
+            Assert.That(resolution.SlotIndex, Is.EqualTo(1));
+        }
+
         private static InputConfigRoot CreateInputConfig()
         {
             return new InputConfigRoot

--- a/src/Tests/GasTests/DisplacementPresetTests.cs
+++ b/src/Tests/GasTests/DisplacementPresetTests.cs
@@ -266,7 +266,12 @@ namespace Ludots.Tests.GAS
                 TemplateId = templateId
             });
 
-            var proposal = new EffectProposalProcessingSystem(world, requests, budget: null, templates: templates);
+            var proposal = new EffectProposalProcessingSystem(
+                world,
+                requests,
+                budget: null,
+                templates: templates,
+                responseChainOrderTypes: TestResponseChainOrderTypeIds.Types);
             proposal.Update(0f);
 
             int effectCount = 0;

--- a/src/Tests/GasTests/EffectPresetInteractionModeTests.cs
+++ b/src/Tests/GasTests/EffectPresetInteractionModeTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Nodes;
 using Arch.Core;
 using Ludots.Core.Gameplay.GAS.Config;
 using Ludots.Core.Input.Config;
+using Ludots.Core.Input.Interaction;
 using Ludots.Core.Input.Orders;
 using Ludots.Core.Input.Runtime;
 using NUnit.Framework;
@@ -66,6 +67,7 @@ namespace Ludots.Tests.GAS
                         ActionId = "SkillQ",
                         Trigger = InputTriggerType.PressedThisFrame,
                         OrderTypeKey = "castAbility",
+                        ArgsTemplate = new OrderArgsTemplate { I0 = 0 },
                         IsSkillMapping = true,
                         RequireSelection = false,
                         SelectionType = OrderSelectionType.Entity
@@ -73,7 +75,9 @@ namespace Ludots.Tests.GAS
                 }
             };
 
+            var bindings = new InteractionActionBindings();
             var mapping = new InputOrderMappingSystem(input, cfg);
+            mapping.SetInteractionActionBindings(bindings);
             using var world = World.Create();
             var actor = world.Create();
             var target = world.Create();
@@ -104,7 +108,7 @@ namespace Ludots.Tests.GAS
             input.Update();
             mapping.Update(0f);
 
-            // SC2 / AimCast: press skill -> enter aiming (no immediate order), then Select confirms
+            // SC2 / AimCast: press skill -> enter aiming (no immediate order), then configured confirm action confirms
             mapping.SetInteractionMode(InteractionModeType.AimCast);
             input.InjectButtonPress("SkillQ");
             input.Update();
@@ -112,14 +116,14 @@ namespace Ludots.Tests.GAS
             Assert.That(mapping.IsAiming, Is.True);
             Assert.That(orders.Count, Is.EqualTo(2));
 
-            input.InjectButtonPress("Select");
+            input.InjectButtonPress(bindings.ConfirmActionId);
             input.Update();
             mapping.Update(0f);
             Assert.That(mapping.IsAiming, Is.False);
             Assert.That(orders.Count, Is.EqualTo(3));
             Assert.That(orders[2].Target, Is.EqualTo(target));
 
-            // PressReleaseAimCast: press -> pending, release -> enter aiming, Select confirms
+            // PressReleaseAimCast: press -> pending, release -> enter aiming, configured confirm action confirms
             mapping.SetInteractionMode(InteractionModeType.PressReleaseAimCast);
             input.InjectButtonPress("SkillQ");
             input.Update();
@@ -132,7 +136,7 @@ namespace Ludots.Tests.GAS
             Assert.That(mapping.IsAiming, Is.True);
             Assert.That(orders.Count, Is.EqualTo(3));
 
-            input.InjectButtonPress("Select");
+            input.InjectButtonPress(bindings.ConfirmActionId);
             input.Update();
             mapping.Update(0f);
             Assert.That(mapping.IsAiming, Is.False);
@@ -187,6 +191,7 @@ namespace Ludots.Tests.GAS
                     new() { Id = "SkillQ", Name = "SkillQ", Type = InputActionType.Button },
                     new() { Id = "Select", Name = "Select", Type = InputActionType.Button },
                     new() { Id = "Cancel", Name = "Cancel", Type = InputActionType.Button },
+                    new() { Id = "Command", Name = "Command", Type = InputActionType.Button },
                 },
                 Contexts = new List<InputContextDef>
                 {
@@ -219,4 +224,3 @@ namespace Ludots.Tests.GAS
         }
     }
 }
-

--- a/src/Tests/GasTests/InputOrderAbilityAuditTests.cs
+++ b/src/Tests/GasTests/InputOrderAbilityAuditTests.cs
@@ -36,6 +36,28 @@ namespace Ludots.Tests.GAS
     [TestFixture]
     public class InputOrderAbilityAuditTests
     {
+        [Test]
+        public void AbilitySystem_MissingEffectRequestQueue_ThrowsStableErrorCode()
+        {
+            using var world = World.Create();
+
+            var ex = Throws<InvalidOperationException>(
+                () => new AbilitySystem(world, null!));
+
+            That(ex!.Message, Does.Contain("LUDOTS_GAS_ABILITY_EFFECT_QUEUE_REQUIRED"));
+        }
+
+        [Test]
+        public void EffectProposalProcessing_MissingResponseChainOrderTypes_ThrowsStableErrorCode()
+        {
+            using var world = World.Create();
+
+            var ex = Throws<InvalidOperationException>(
+                () => new EffectProposalProcessingSystem(world, new EffectRequestQueue(), templates: new EffectTemplateRegistry()));
+
+            That(ex!.Message, Does.Contain("LUDOTS_GAS_RESPONSE_CHAIN_ORDER_TYPES_REQUIRED"));
+        }
+
         // ════════════════════════════════════════════════════════════════════
         // Region: OrderBuffer / PendingBuffer
         // ════════════════════════════════════════════════════════════════════

--- a/src/Tests/GasTests/InputOrderContractTests.cs
+++ b/src/Tests/GasTests/InputOrderContractTests.cs
@@ -284,6 +284,7 @@ namespace Ludots.Tests.GAS
                         ActionId = "SkillR",
                         Trigger = InputTriggerType.PressedThisFrame,
                         OrderTypeKey = "castAbility",
+                        ArgsTemplate = new OrderArgsTemplate { I0 = 3 },
                         SelectionType = OrderSelectionType.Direction,
                         RequireSelection = false,
                         IsSkillMapping = true,

--- a/src/Tests/GasTests/InteractionSelectionConvergenceTests.cs
+++ b/src/Tests/GasTests/InteractionSelectionConvergenceTests.cs
@@ -479,6 +479,7 @@ namespace Ludots.Tests.GAS
             SeedLivePrimarySelection(world, globals, local, first, second);
 
             var mapping = new InputOrderMappingSystem(input, cfg);
+            mapping.SetLocalPlayer(local, 1);
             mapping.SetOrderTypeKeyResolver(key => key == "castAbility" ? 1001 : 0);
             mapping.SetSelectedContainerProvider((string setKey, out Entity container) =>
                 selectionRuntime.TryCreateSnapshotLease(local, SelectionSetKeys.LivePrimary, SelectionSetKeys.CommandSnapshot, SelectionContainerKind.Snapshot, out _, out container));
@@ -533,6 +534,7 @@ namespace Ludots.Tests.GAS
             SeedLivePrimarySelection(world, globals, local, first, second);
 
             var mapping = new InputOrderMappingSystem(input, cfg);
+            mapping.SetLocalPlayer(local, 1);
             mapping.SetOrderTypeKeyResolver(key => key == "castAbility" ? 1001 : 0);
             mapping.SetSelectedContainerProvider((string setKey, out Entity container) =>
                 selectionRuntime.TryCreateSnapshotLease(local, SelectionSetKeys.LivePrimary, SelectionSetKeys.CommandSnapshot, SelectionContainerKind.Snapshot, out _, out container));
@@ -1266,6 +1268,7 @@ namespace Ludots.Tests.GAS
             var local = world.Create();
             var actor = world.Create(WorldPositionCm.FromCm(1600, 1200), new VisualTransform { Position = new Vector3(16f, 0f, 12f) }, new CullState { IsVisible = true }, new SelectionSelectableTag());
             var enemy = world.Create(WorldPositionCm.FromCm(2600, 1600), new VisualTransform { Position = new Vector3(26f, 0f, 16f) }, new CullState { IsVisible = true }, new SelectionSelectableTag());
+            var bindings = new InteractionActionBindings();
 
             var globals = new Dictionary<string, object>
             {
@@ -1276,7 +1279,7 @@ namespace Ludots.Tests.GAS
                 [CoreServiceKeys.ScreenProjector.Name] = new WorldMappedScreenProjector(),
                 [CoreServiceKeys.WorldSizeSpec.Name] = CreateWorldSizeSpec(),
                 [CoreServiceKeys.LocalPlayerEntity.Name] = local,
-                [CoreServiceKeys.InteractionActionBindings.Name] = new InteractionActionBindings(),
+                [CoreServiceKeys.InteractionActionBindings.Name] = bindings,
             };
             var selectionRuntime = CreateSelectionRuntime(world, globals);
             SeedLivePrimarySelection(world, globals, local, actor);
@@ -1292,12 +1295,14 @@ namespace Ludots.Tests.GAS
                         ActionId = "SkillQ",
                         Trigger = InputTriggerType.PressedThisFrame,
                         OrderTypeKey = "castAbility",
+                        ArgsTemplate = new OrderArgsTemplate { I0 = 0 },
                         RequireSelection = false,
                         SelectionType = OrderSelectionType.Entity,
                         IsSkillMapping = true,
                     },
                 },
             });
+            mapping.SetInteractionActionBindings(bindings);
 
             mapping.SetLocalPlayer(actor, 1);
             mapping.SetOrderTypeKeyResolver(key => key == "castAbility" ? 1001 : 0);

--- a/src/Tests/GasTests/ProgressionRequirementTests.cs
+++ b/src/Tests/GasTests/ProgressionRequirementTests.cs
@@ -357,7 +357,7 @@ namespace Ludots.Tests.GAS
             PrepareScopeMember(world, barracks);
             Assert.That(evaluator.TryBindScope(barracks, cityScopeId, city), Is.True);
 
-            var system = new AbilitySystem(world, effectRequests: null, definitions, progressionRequirements: evaluator);
+            var system = new AbilitySystem(world, new EffectRequestQueue(), definitions, progressionRequirements: evaluator);
             Assert.That(system.TryActivateAbility(barracks, 0), Is.False);
 
             Assert.That(evaluator.TryComplete(city, progressionId), Is.True);
@@ -544,6 +544,7 @@ namespace Ludots.Tests.GAS
                 new DiscreteClock(),
                 new GasConditionRegistry(),
                 templates: templates,
+                responseChainOrderTypes: TestResponseChainOrderTypeIds.Types,
                 phaseExecutor: phaseExecutor,
                 graphApi: graphApi,
                 progressionEvaluator: evaluator);
@@ -595,7 +596,7 @@ namespace Ludots.Tests.GAS
             Entity barracks = world.Create(abilities);
             Assert.That(evaluator.TryComplete(city, progressionId), Is.True);
 
-            var system = new AbilitySystem(world, effectRequests: null, definitions, progressionRequirements: evaluator);
+            var system = new AbilitySystem(world, new EffectRequestQueue(), definitions, progressionRequirements: evaluator);
             Assert.That(system.TryActivateAbility(barracks, 0), Is.False);
 
             var args = new AbilitySystem.AbilityActivationArgs(barracks, ReadOnlySpan<Entity>.Empty, city);

--- a/src/Tests/GasTests/ResponseWindowRobustnessTests.cs
+++ b/src/Tests/GasTests/ResponseWindowRobustnessTests.cs
@@ -52,7 +52,14 @@ namespace Ludots.Tests.GAS
                     TemplateId = tplInstant
                 });
 
-                var sys = new EffectProposalProcessingSystem(world, queue, budget, templates, inputRequests: null, chainOrders: null)
+                var sys = new EffectProposalProcessingSystem(
+                    world,
+                    queue,
+                    budget,
+                    templates,
+                    inputRequests: null,
+                    chainOrders: null,
+                    responseChainOrderTypes: TestResponseChainOrderTypeIds.Types)
                 {
                     MaxWorkUnitsPerSlice = 2
                 };
@@ -141,7 +148,14 @@ namespace Ludots.Tests.GAS
                     TemplateId = tplRoot
                 });
 
-                var sys = new EffectProposalProcessingSystem(world, queue, budget, templates, inputRequests: null, chainOrders: null)
+                var sys = new EffectProposalProcessingSystem(
+                    world,
+                    queue,
+                    budget,
+                    templates,
+                    inputRequests: null,
+                    chainOrders: null,
+                    responseChainOrderTypes: TestResponseChainOrderTypeIds.Types)
                 {
                     MaxWorkUnitsPerSlice = int.MaxValue
                 };

--- a/src/Tests/GasTests/RootBudgetTests.cs
+++ b/src/Tests/GasTests/RootBudgetTests.cs
@@ -151,7 +151,11 @@ namespace Ludots.Tests.GAS
             using var world = World.Create();
             var requests = new EffectRequestQueue();
             var templates = new EffectTemplateRegistry();
-            var proposal = new EffectProposalProcessingSystem(world, requests, templates: templates);
+            var proposal = new EffectProposalProcessingSystem(
+                world,
+                requests,
+                templates: templates,
+                responseChainOrderTypes: TestResponseChainOrderTypeIds.Types);
             var application = new EffectApplicationSystem(world, requests, templates: templates);
 
             var source = world.Create();

--- a/src/Tests/GasTests/SystemIntegrationTests.cs
+++ b/src/Tests/GasTests/SystemIntegrationTests.cs
@@ -59,7 +59,12 @@ namespace Ludots.Tests.GAS
             var clocks = new GasClocks(clock);
             var conditions = new GasConditionRegistry();
             var abilitySystem = new AbilitySystem(_world, effectRequests);
-            var proposalSystem = new EffectProposalProcessingSystem(_world, effectRequests, null, effectTemplates);
+            var proposalSystem = new EffectProposalProcessingSystem(
+                _world,
+                effectRequests,
+                null,
+                effectTemplates,
+                responseChainOrderTypes: TestResponseChainOrderTypeIds.Types);
             var appSystem = new EffectApplicationSystem(_world, effectRequests);
             var aggSystem = new AttributeAggregatorSystem(_world);
             var lifetimeSystem = new EffectLifetimeSystem(_world, clock, conditions, effectRequests);

--- a/src/Tests/GasTests/TagEffectiveAndTimingTests.cs
+++ b/src/Tests/GasTests/TagEffectiveAndTimingTests.cs
@@ -128,7 +128,7 @@ namespace Ludots.Tests.GAS
                 tags.AddTag(tagA);
                 tags.AddTag(tagBlock);
 
-                var sys = new AbilitySystem(world, effectRequests: null, abilityDefinitions: defs, tagOps: _tagOps);
+                var sys = new AbilitySystem(world, new EffectRequestQueue(), abilityDefinitions: defs, tagOps: _tagOps);
                 That(sys.TryActivateAbility(caster, slotIndex: 0), Is.False);
             }
             finally

--- a/src/Tests/PresentationTests/MassNavigationPerformerContractTests.cs
+++ b/src/Tests/PresentationTests/MassNavigationPerformerContractTests.cs
@@ -442,6 +442,75 @@ namespace Ludots.Tests.Presentation
         }
 
         [Test]
+        public void OrderBlackboardKeys_BuiltinKeysCannotBeRedeclaredInConfig()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "Ludots_OrderBlackboardKeys", Guid.NewGuid().ToString("N"));
+            string gasDir = Path.Combine(root, "assets", "GAS");
+            Directory.CreateDirectory(gasDir);
+            File.WriteAllText(
+                Path.Combine(gasDir, "order_types.json"),
+                """
+                {
+                  "orderBlackboardKeys": {
+                    "Cast.SlotIndex": true
+                  },
+                  "orderTypes": {
+                    "testOrder": {
+                      "orderTypeId": "testOrder",
+                      "label": "Test",
+                      "maxQueueSize": 1,
+                      "sameTypePolicy": "Replace",
+                      "queueFullPolicy": "RejectNew",
+                      "priority": 1,
+                      "bufferWindowMs": 0,
+                      "pendingBufferWindowMs": 0,
+                      "canInterruptSelf": false,
+                      "queuedModeMaxSize": 1,
+                      "allowQueuedMode": false,
+                      "clearQueueOnActivate": false,
+                      "spatialBlackboardKey": "none",
+                      "entityBlackboardKey": "none",
+                      "intArg0BlackboardKey": "Cast.SlotIndex",
+                      "validationGraph": "none"
+                    }
+                  },
+                  "orderRules": {}
+                }
+                """);
+
+            try
+            {
+                OrderBlackboardKeyRegistry.ResetToBuiltins();
+                var vfs = new Ludots.Core.Modding.VirtualFileSystem();
+                vfs.Mount("TestMod", root);
+                var modLoader = new Ludots.Core.Modding.ModLoader(
+                    vfs,
+                    new Ludots.Core.Scripting.FunctionRegistry(),
+                    new Ludots.Core.Scripting.TriggerManager());
+                modLoader.LoadedModIds.Add("TestMod");
+                var pipeline = new Ludots.Core.Config.ConfigPipeline(vfs, modLoader);
+                var catalog = new Ludots.Core.Config.ConfigCatalog();
+                catalog.Add(new Ludots.Core.Config.ConfigCatalogEntry("GAS/order_types.json", Ludots.Core.Config.ConfigMergePolicy.DeepObject));
+
+                var ex = Assert.Throws<InvalidOperationException>(
+                    () => new OrderTypeConfigLoader(pipeline).Load(new OrderTypeRegistry(), new OrderRuleRegistry(), catalog));
+
+                Assert.That(ex!.Message, Does.Contain("LUDOTS_GAS_ORDER_BLACKBOARD_BUILTIN_REDECLARED"));
+            }
+            finally
+            {
+                OrderBlackboardKeyRegistry.ResetToBuiltins();
+                try
+                {
+                    if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        [Test]
         public void ConfigLoader_UsesConfigPipelineReplaceMerge()
         {
             string modRoot = MassNavigationModRoot();


### PR DESCRIPTION
## Summary
- Removes input-order fallback/default paths: no default MOBA mapping, skill priority is loaded from `argsTemplate.i0`, semantic confirm/cancel/command ids come from `InteractionActionBindings`, input action ids are required, and processor parameters fail fast when omitted.
- Makes input-order and ContextScored decisions deterministic: mapping traversal uses a stable `(priority, actionId ordinal)` array, and ContextScored ties resolve by `(score desc, entity id asc, slot asc)`.
- Removes GAS silent/default behavior: `AbilitySystem` requires `EffectRequestQueue`, response-chain order ids must be injected/configured, and builtin order blackboard keys cannot be redeclared in runtime config.

## No fallback / no hardcoding evidence
- `InputOrderMappingLoader` no longer contains `CreateDefaultMobaConfig`; missing mapping config and missing `argsTemplate`/skill priority now throw stable error codes.
- `InputOrderMappingSystem` no longer owns `Select/Cancel/Command` defaults; it requires `InteractionActionBindings` and validates action ids with `LUDOTS_INPUT_ORDER_ACTION_BINDING_REQUIRED`.
- `PlayerInputHandler` no longer supplies Deadzone/Scale defaults; missing `Min`/`Factor` throws `LUDOTS_INPUT_PROCESSOR_PARAMETER_REQUIRED`.
- `InputActionDef.Id` no longer auto-generates a Guid; loader validation rejects missing/duplicate ids.
- `ResponseChainOrderTypes.Default` is gone; GAS consumers require injected positive ids from `GameConfig.Constants.ResponseChainOrderTypeIds`.
- `AbilitySystem` construction fails with `LUDOTS_GAS_ABILITY_EFFECT_QUEUE_REQUIRED` when effect queue DI is missing.
- `OrderTypeConfigLoader` rejects builtin blackboard key redeclarations with `LUDOTS_GAS_ORDER_BLACKBOARD_BUILTIN_REDECLARED`.

## Determinism tests
- Added coverage for same-frame multi-mapping order remaining stable when registration order is shuffled.
- Added ContextScored same-score winner coverage for stable entity/slot tie-breaks.

## Verification
- `dotnet build src/Core/Ludots.Core.csproj --no-restore -m:1 -clp:ErrorsOnly` ✅
- `dotnet build src/Tests/GasTests/GasTests.csproj --no-restore -m:1 -clp:ErrorsOnly` ✅
- `dotnet build src/Tests/PresentationTests/PresentationTests.csproj --no-restore -m:1 -clp:ErrorsOnly` ✅
- `dotnet test src/Tests/GasTests/GasTests.csproj --no-build -m:1 --filter InputOrderContractTests|ContextScoredResolverTests|InputOrderAbilityAuditTests|ResponseWindowRobustnessTests|AttributeAggregatorTests|AllocationTests|RootBudgetTests|SystemIntegrationTests|ProgressionRequirementTests|TagEffectiveAndTimingTests|EffectPresetInteractionModeTests|InteractionSelectionConvergenceTests` ✅ 153 passed
- `dotnet test src/Tests/PresentationTests/PresentationTests.csproj --no-build -m:1 --filter MassNavigationPerformerContractTests` ✅ 14 passed

## Scope notes
- Did not edit `mods/MobaDemoMod/Systems/MobaLocalOrderSourceSystem.cs` because this task's hard constraint was to modify only `src/` main worktree.
- Did not touch the #436 missing graph-program policy item (`EffectPhaseExecutor` / `AbilityActivationPreconditionEvaluator`), which was explicitly assigned elsewhere.
- A broad full `GasTests` run was attempted and stopped after repeated unrelated production/showcase/mod failures outside this issue scope, including invalid `mods/` GAS configs and missing restore assets for showcase mod builds.

Refs #435
Refs #436