### PR TITLE
Set up Cloud Agent dev environment (.NET SDKs + web launcher)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,14 @@ Entity Association Core 的计划与 ADR SSOT 在 GitHub issue #239；ADR 正本
 | 架构文档索引 | `gitbook/architecture/README.md` |
 | 共享 Skill 索引 | `skills/README.md` |
 | 共享 Skill 注册表 | `skills/registry.json` |
+
+## Cursor Cloud specific instructions
+
+环境已预装 .NET 8 + .NET 9 SDK（位于 `~/.dotnet`，并已 symlink 到 `/usr/local/bin/dotnet`，所有 shell 直接可用，无需改 PATH）。Node 22 + npm 已预装。仓库无根 `.sln`、无 `global.json`，默认用 9.0.x SDK；按 `.csproj` 逐项目 build/test。完整命令见 `gitbook/contributing/environment-setup.md` 与 `docs/conventions/03_environment_setup.md`。
+
+非显然要点（仅记不易发现的坑）：
+
+- **产品入口是 launcher**。Linux/Cloud 上用 **web adapter**，不要用 Raylib（需 GPU/显示，云 VM 无法跑）。运行：`dotnet run --project src/Tools/Ludots.Launcher.Cli/Ludots.Launcher.Cli.csproj -c Release -- launch <mod> --adapter web`。仓库脚本是 Windows `.cmd`/`.ps1`，Linux 直接用上面的 `dotnet run` 形式替代 `run-mod-launcher.cmd cli ...`。
+- web adapter 监听 **http://localhost:5200**，C# 引擎 host loop ~30fps，浏览器经 websocket 连接（日志 `Clients=` 会从 0 变 1）。
+- web 前端（`src/Client/Web`，Three.js）的 `dist/` 与 `node_modules/` 都被 gitignore；**launcher 在 web launch 时会自动跑 `npm ci`（仅当缺 node_modules）+ `npm run build`**，无需手动构建。若改了 `src/Client/Web/package.json`，需手动删 `node_modules` 让 launcher 重新 `npm ci`。
+- CI（`.github/workflows/solution-verify.yml`）注明：origin/main 上 **完整 GasTests / PresentationTests 本就是红的**，测试请用 `--filter` 跑定向切片，不要拿整套失败当回归。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the development environment for the Ludots framework on the Cloud Agent VM and documents durable startup notes for future agents.

- Installs .NET 8 + .NET 9 SDKs (symlinked to `/usr/local/bin/dotnet`); Node 22/npm already present.
- Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing non-obvious caveats (web adapter is the headless run path, launcher auto-builds the Three.js client, port 5200, CI baseline test reds).
- Sets a minimal update script that restores the Launcher CLI and Web app projects.

No application code was modified.

## Verification

- ✅ `dotnet build src/Core/Ludots.Core.csproj` — succeeds
- ✅ `dotnet build src/Tools/Ludots.Launcher.Cli/Ludots.Launcher.Cli.csproj -c Release` — succeeds
- ✅ `dotnet build src/Apps/Web/Ludots.App.Web/Ludots.App.Web.csproj -c Release` — succeeds
- ✅ `dotnet test src/Tests/ThreeCTests/ThreeCTests.csproj --filter ...CameraRuntimeConvergenceTests` — 14/14 passed
- ✅ `dotnet run --project src/Tools/Ludots.Launcher.Cli/... -- launch camera_acceptance --adapter web` — engine boots, map `entry` loads, host loop ticks at ~30fps on http://localhost:5200, browser client connects (`Clients=1`).

### Hello-world: live 3D scene served to a connected browser
[ludots_web_adapter_running.mp4](https://cursor.com/agents/bc-cddcd59a-0892-42ff-a4cb-8bb10466e3e7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fludots_web_adapter_running.mp4)
[Ludots web client rendering 3D scene with stats overlay](https://cursor.com/agents/bc-cddcd59a-0892-42ff-a4cb-8bb10466e3e7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fludots_web_scene.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cddcd59a-0892-42ff-a4cb-8bb10466e3e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cddcd59a-0892-42ff-a4cb-8bb10466e3e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

