### PR TITLE
docs(governance): Entity Lifecycle refactor design + GAS composition gate skill

### DIFF
--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -14,6 +14,7 @@
   - [UI 渲染控制与 Surface 所有权](architecture/ui-rendering-and-surface-ownership.md)
   - [Mod 架构](architecture/mod-architecture.md)
   - [GAS 分层架构](architecture/gas-layered-architecture.md)
+  - [Entity Lifecycle 原子 Op](architecture/entity-lifecycle-atomic-ops.md)
   - [Exchange Operations](architecture/exchange-operations.md)
   - [通用存档系统](architecture/save-system.md)
   - [AI Utility Autocast 契约](architecture/ai-utility-autocast-contract.md)

--- a/gitbook/architecture/README.md
+++ b/gitbook/architecture/README.md
@@ -8,6 +8,7 @@
 - [UI 渲染控制与 Surface 所有权](ui-rendering-and-surface-ownership.md)
 - [Mod 架构](mod-architecture.md)
 - [GAS 分层架构](gas-layered-architecture.md)
+- [Entity Lifecycle 原子 Op](entity-lifecycle-atomic-ops.md)
 - [Exchange Operations](exchange-operations.md)
 - [通用存档系统](save-system.md)
 - [AI Utility Autocast 契约](ai-utility-autocast-contract.md)

--- a/gitbook/architecture/entity-lifecycle-atomic-ops.md
+++ b/gitbook/architecture/entity-lifecycle-atomic-ops.md
@@ -1,0 +1,94 @@
+# Entity Lifecycle 原子 Op 与组合架构（设计）
+
+> **状态**：设计稿，跟踪 GitHub issue [#494](https://github.com/MightyBubble/Ludots/issues/494)  
+> **取代方向**：收敛 P0 `Entity Morph` spike（#490 / PR #491），不再扩展 `morph_profiles.json` schema。
+
+## 1 问题陈述
+
+P0 Morph 将「结构替换事务」与「业务继承策略」揉进单一 `morph_profiles.json` DSL（placement、stableId、inherit.*、effects.mode…）。每增加一种 deploy 变体，就倾向于新增 profile 开关或 enum，违反：
+
+- 禁止重复造轮子（与 `CreateUnit` / GAS handler 平行管线）
+- 禁止跨越职责（placement 校验、effect 清理、selection 重接本可独立）
+- 数据驱动 SSOT（应组合现有 effect/graph，而非二级配置语言）
+
+## 2 目标分层
+
+```text
+Layer 0  Atomic ops        单一结构操作，无业务命名
+Layer 1  Transaction       有序执行 + rollback（薄）
+Layer 2  Composition       Effect 链 / Graph program（Mod 可改）
+Layer 3  Preset           DeployConsumeSource 等封装名（给人抄）
+```
+
+**判断标准（开工前必过）**：新变体应新增 **graph 节点连线 / effect 步骤**，而不是给 profile / preset 加 enum 或开关。
+
+## 3 Layer 0 — 原子 Op 清单（草案）
+
+| Op | BuiltinHandler / Queue | 职责 |
+|----|------------------------|------|
+| `MaterializeTemplate` | 复用 spawn 物化 + performer/map | 按 templateId 创建实体 |
+| `ConsumeEntity` | 新或 presentation lifecycle 包装 | 标记/销毁源实体 |
+| `TransferStableId` | 新 | 源 → 目标 presentation id |
+| `CopyAttributeSlice` | 新或扩展 `ApplyModifiers` | 显式 attribute 列表 + Base/Current |
+| `CopyIdentityComponents` | 新 | PlayerOwner / Team（registry 扩展） |
+| `ClearActiveEffects` | 新 | 清空目标 `ActiveEffectContainer`（现 Morph `StripAll`） |
+| `RewireSelection` | 新或暴露 Morph 内部 | selection 源 → 目标 |
+| `CopyMapOwnership` | `RuntimeEntityMapOwnershipSupport` | 已有 |
+
+坐标：**不在任何 op profile 内**；SSOT 为 `EffectTargetPointResolver` + ability propose 阶段 placement validation（独立基建）。
+
+## 4 Layer 1 — 事务壳
+
+`RuntimeEntityLifecycleTransaction`（名称待定）：
+
+- 输入：有序 op 列表 + `EffectContext` + rollback 策略
+- 执行：`EffectProcessing` 阶段同步或专用 queue（与 spawn/morph queue 收敛）
+- 失败：按已执行步骤逆序 rollback（与现 Morph rollback 同构）
+- **不解析** inherit.mode / tags.mode 等 DSL
+
+P0 Morph system 迁移目标：瘦身为 transaction executor，或并入 unified lifecycle queue。
+
+## 5 Layer 2 — 组合
+
+**Deploy consume source** 示例（effect 链，非 profile）：
+
+```text
+OnApply:
+  1. MaterializeTemplate @ EffectTargetPoint
+  2. CopyIdentityComponents (Source → Target)
+  3. CopyAttributeSlice (Health, Current)
+  4. ClearActiveEffects (Target)
+  5. TransferStableId (Source → Target)
+  6. RewireSelection (Source → Target)
+  7. ConsumeEntity (Source)
+```
+
+Mod 可通过 graph 调整顺序、增删步骤；Core 不新增 `inherit.effects.mode`。
+
+## 6 Layer 3 — Preset
+
+| Preset | 用途 |
+|--------|------|
+| `DeployConsumeSource` | 预编译上述链（或 graph 名） |
+| `MorphInPlace` | AtSource + 不 Consume 的变体 |
+
+`presetType: Morph` **deprecated** → 具名 lifecycle preset 或 graph entry。
+
+## 7 迁移计划（无向后兼容）
+
+| 阶段 | 动作 |
+|------|------|
+| M0 | 冻结 `morph_profiles.json` schema；本设计 + skill 落地 |
+| M1 | 实现 Layer 0 ops + transaction executor |
+| M2 | `DeployConsumeSource` preset/graph 替换 `morph.rts.deploy_consume_source` |
+| M3 | 删除 Morph profile DSL、Morph preset、并行管线；gitbook 更新 |
+
+## 8 非目标
+
+- placement 地形/阻挡校验（ability propose 基建，另 issue）
+- Presentation `EntityMorphed` 事件（可选 follow-up）
+
+## 9 参考实现（待删除）
+
+- `src/Core/Gameplay/Morph/` — P0 spike
+- `assets/Configs/GAS/morph_profiles.json` — 待废弃

--- a/gitbook/contributing/README.md
+++ b/gitbook/contributing/README.md
@@ -12,7 +12,7 @@
 
 1. [编码标准](coding-standards.md)
 2. [Feature 开发工作流](feature-development-workflow.md)
-3. [AI 辅助开发规范](ai-assisted-development.md)
+3. [AI 辅助开发规范](ai-assisted-development.md) — 含 GAS 组合自审（§4.5 / skill `ludots-gas-composition-gate`）
 4. [环境与构建](environment-setup.md)
 5. [文档治理](documentation-governance.md)
 

--- a/gitbook/contributing/ai-assisted-development.md
+++ b/gitbook/contributing/ai-assisted-development.md
@@ -10,6 +10,8 @@
 
 前三步不得跳过。
 
+**GAS / 实体生命周期 / effect preset / graph op 类任务**：编码前还必须执行共享 skill `ludots-gas-composition-gate`（见 `skills/governance/ludots-gas-composition-gate/`），填写自审清单并产出 `artifacts/gas-composition-gate.md`。核心判断标准：新变体应新增 graph 节点或 effect 步骤，而不是 profile enum 或 preset 开关。
+
 ## 2 防幻觉条款
 
 - 禁止凭空发明类、方法、字段、Registry 能力和 NuGet API。
@@ -50,6 +52,15 @@
 - 只服务当前 Mod 的逻辑，放在当前 Mod。
 - 两个以上 Mod 可能复用的逻辑，提取到 Core 或可复用基础设施。
 - 完整独立功能，提取为独立 Mod。
+
+### 4.5 GAS 组合自审（与 skill 绑定）
+
+适用：新增/修改 `BuiltinHandler`、`EffectPresetType`、实体 spawn/morph/lifecycle、graph op、或 `*_profiles.json` 类 schema。
+
+1. 加载 skill `ludots-gas-composition-gate` 及 `gitbook/architecture/entity-lifecycle-atomic-ops.md`。
+2. 回答判断标准：新变体是 **op 组合** 还是 **新 enum/开关**；后者禁止直接开工。
+3. 填写 `references/self-review-checklist.md` 模板，写入 `artifacts/gas-composition-gate.md`。
+4. 实现 PR 须链接该自审产物或等效填写内容。
 
 ## 5 现有能力速查
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -28,6 +28,7 @@
 | Skill | 层级 | 用途 |
 |------|------|------|
 | `ludots-doc-governance` | governance | 文档 SSOT、链接与证据治理 |
+| `ludots-gas-composition-gate` | governance | GAS/生命周期开工前组合自审（禁止 profile DSL 膨胀） |
 | `ludots-feature-delivery` | delivery | 基建优先的功能交付、showcase/UI 验收与证据 |
 | `ludots-tech-debt-fuse` | audit | 跨层技术债升级与熔断 |
 | `ludots-cloud-handoff` | collaboration | 云端开发接力与上下文交接 |

--- a/skills/governance/ludots-gas-composition-gate/SKILL.md
+++ b/skills/governance/ludots-gas-composition-gate/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: ludots-gas-composition-gate
+description: Mandatory self-review gate before Ludots GAS, entity lifecycle, or effect-preset work. Enforces atomic-op composition over declarative profile DSL. Use when starting any issue, feature, or refactor touching BuiltinHandlers, effect presets, graph ops, spawn/morph/lifecycle, or new gameplay config schemas.
+---
+
+# Ludots GAS Composition Gate
+
+**写第一行代码前必须完成本 skill。** 与 `gitbook/contributing/ai-assisted-development.md` §4 并列，不替代 §4。
+
+## Load References
+
+1. `references/composition-judgment-standard.md` — 硬性判断标准
+2. `references/self-review-checklist.md` — 自审清单（必须逐项填写）
+3. `references/layer-model.md` — Layer 0–3 分层
+4. `gitbook/architecture/entity-lifecycle-atomic-ops.md` — 当前设计 SSOT（entity lifecycle 相关任务）
+
+## Workflow
+
+### Step 0 — 适用范围判定
+
+若任务涉及以下任一项，**必须**跑完整 gate；否则可跳过并一句说明：
+
+- 新增/扩展 `BuiltinHandlerId`、`EffectPresetType`
+- 新增 JSON profile / catalog schema（如 `*_profiles.json`）
+- `RuntimeEntitySpawn*` / `RuntimeEntityMorph*` / 实体结构替换
+- Graph op 或 effect 链编排
+- `inherit.*`、`placement`、`destroySource` 类声明式开关
+
+### Step 1 — 判断标准（硬性）
+
+回答 `references/composition-judgment-standard.md` 中的核心问题：
+
+> **新变体是新增 graph 节点 / effect 步骤，还是新增 profile enum / preset 开关？**
+
+- 若答案是后者 → **停止编码**，改为设计 atomic op + composition，或开重构 issue。
+- 若无法回答 → **停止**，先补发现阶段。
+
+### Step 2 — 自审清单
+
+复制 `references/self-review-checklist.md` 模板，填写后附在 issue 评论、PR 描述或 `artifacts/gas-composition-gate.md`。
+
+**未附完整自审表，不得提交实现 PR。**
+
+### Step 3 — 复用 / 新增清单
+
+与 `ai-assisted-development.md` §4.2 合并输出：
+
+| 类型 | 项 |
+|------|-----|
+| 复用 | 已有 handler、resolver、queue、registry |
+| 新增 Layer 0 op | 仅当单一职责且无法由现有 op 组合 |
+| 新增 Layer 1 | 仅 transaction / rollback |
+| 新增 Layer 2 | effect 链或 graph（Mod 可改部分） |
+| 禁止 | 新 profile DSL、平行加载器、inherit.mode 枚举 |
+
+### Step 4 — 输出
+
+产出 `artifacts/gas-composition-gate.md`，包含：
+
+- 任务摘要
+- 判断标准结论（通过 / 不通过 / 需重构）
+- 填写的自审清单
+- 复用/新增表
+- 若不通过：建议 issue 标题与下一步
+
+## Red Flags — 立即不通过
+
+- 「给 morph profile 加一个 mode」
+- 「新 preset 内嵌 5+ 继承开关」
+- 「再建一条与 spawn 平行的物化管线」
+- 「placement 校验写进 morph/profile」
+- 「无法列出 atomic op 边界」
+
+## Related
+
+- Issue [#494](https://github.com/MightyBubble/Ludots/issues/494) — Entity Lifecycle 原子 op 重构（设计 SSOT）
+- Issue #490 / PR #491 — Morph P0 spike（迁移源，非扩展目标）
+- `gitbook/architecture/entity-morph.md` — 现行文档（将随重构 supersede）

--- a/skills/governance/ludots-gas-composition-gate/agents/claude.md
+++ b/skills/governance/ludots-gas-composition-gate/agents/claude.md
@@ -1,0 +1,20 @@
+# Ludots GAS Composition Gate
+
+**Mandatory before any GAS entity lifecycle, morph/spawn, effect preset, or graph op implementation.**
+
+## Load
+
+- `references/composition-judgment-standard.md`
+- `references/self-review-checklist.md`
+- `references/layer-model.md`
+- `gitbook/architecture/entity-lifecycle-atomic-ops.md`
+
+## Rules
+
+- New variant = graph node / effect step, **not** profile enum or preset switch.
+- Do not extend `morph_profiles.json` or similar DSL.
+- Output `artifacts/gas-composition-gate.md` with filled checklist before coding.
+
+## Hard stop
+
+If the answer to the core judgment question is "new profile field / inherit mode" → do not implement; design atomic ops or open refactor issue.

--- a/skills/governance/ludots-gas-composition-gate/agents/openai.yaml
+++ b/skills/governance/ludots-gas-composition-gate/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ludots GAS Composition Gate"
+  short_description: "Self-review gate before GAS/lifecycle/preset work"
+  default_prompt: "Use $ludots-gas-composition-gate before coding any GAS entity lifecycle, effect preset, or graph op task. Fill the self-review checklist and output artifacts/gas-composition-gate.md."

--- a/skills/governance/ludots-gas-composition-gate/references/composition-judgment-standard.md
+++ b/skills/governance/ludots-gas-composition-gate/references/composition-judgment-standard.md
@@ -1,0 +1,37 @@
+# Composition Judgment Standard
+
+## 核心问题（必答）
+
+为本次需求新增能力时，主要交付物是什么？
+
+| 答案 | 判定 | 行动 |
+|------|------|------|
+| A. 新的 graph 节点、effect 步骤、或已有 op 的连线/参数 | **通过** | 继续自审；优先 Layer 2 组合 |
+| B. 新的 profile 字段、inherit mode、placement enum、preset 内声明式开关 | **不通过** | 停止实现；拆 atomic op 或开重构 issue |
+| C. 新的整条并行管线（第二个 Morph/Spawn DSL） | **不通过** | 停止；合并进 Layer 0/1 |
+| D. 说不清 | **阻塞** | 补发现；不得编码 |
+
+## 辅助问题
+
+1. **事务边界**：哪些步骤必须 all-or-nothing rollback？（仅 Layer 1 壳承担）
+2. **坐标 SSOT**：是否复用 `EffectTargetPointResolver`？placement 校验是否在 propose 阶段？
+3. **物化 SSOT**：是否复用 `EntityBuilder` + `PerformerEntitySpawnBootstrap`？是否新建第二套物化？
+4. **配置 SSOT**：行为是 `effect template` + `graph` 组合，还是新 JSON schema？
+5. **变体扩展**：下一个 Mod 变体改连线还是改 Core enum？
+
+## 通过条件（全部满足）
+
+- [ ] 新变体可用 **op 组合** 表达，无需新 enum
+- [ ] 未新增平行 profile loader / registry（除非 Layer 0 op 注册表且职责单一）
+- [ ] 已列出复用 handler / queue / resolver
+- [ ] 事务与组合职责分离
+- [ ] 文档更新路径明确（`gitbook/`，非 `docs/adr` 平行 ADR）
+
+## Morph 反例（写入记忆）
+
+| 需求 | 错误做法 | 正确做法 |
+|------|----------|----------|
+| deploy 清 effect | `inherit.effects.mode: StripAll` | effect 链加 `ClearActiveEffects` |
+| deploy 继承血量 | `inherit.attributes.mode` | `CopyAttributeSlice` 步骤 + 参数 |
+| deploy 落点 | `placement: AtTargetPoint` in profile | `EffectTargetPointResolver` + propose 校验 |
+| 新 deploy 变体 | 新 morph profile id | 新 graph 连线或 effect 链副本 |

--- a/skills/governance/ludots-gas-composition-gate/references/layer-model.md
+++ b/skills/governance/ludots-gas-composition-gate/references/layer-model.md
@@ -1,0 +1,33 @@
+# Entity Lifecycle Layer Model
+
+```text
+Layer 3  Preset          DeployConsumeSource — 给人抄的封装名
+Layer 2  Composition      Effect chain / Graph program — Mod 可改
+Layer 1  Transaction       Ordered ops + rollback — 薄 executor
+Layer 0  Atomic ops       Materialize / Consume / TransferStableId / Copy* / Clear*
+```
+
+## Layer 0 原则
+
+- 一个 handler 一件事
+- 无业务命名（无 deploy、morph、RTS）
+- 可无头测试
+
+## Layer 1 原则
+
+- 只保证顺序与 rollback
+- 不解析 inherit.mode
+
+## Layer 2 原则
+
+- 数据驱动行为差异
+- SSOT 在 effect template + graph assets
+
+## Layer 3 原则
+
+- 可选糖衣
+- 编译到 Layer 2，无独立运行时解释器
+
+## 设计 SSOT
+
+`gitbook/architecture/entity-lifecycle-atomic-ops.md`

--- a/skills/governance/ludots-gas-composition-gate/references/self-review-checklist.md
+++ b/skills/governance/ludots-gas-composition-gate/references/self-review-checklist.md
@@ -1,0 +1,63 @@
+# GAS Composition Self-Review Checklist
+
+复制以下模板，在开工前填写。PR 描述或 `artifacts/gas-composition-gate.md` 必须包含完整填写版。
+
+```markdown
+## GAS Composition Gate — Self Review
+
+- **Task / Issue**:
+- **Date**:
+- **Agent / Author**:
+
+### 1. Core judgment
+
+新变体主要交付物是（A/B/C/D）: ___
+
+结论: PASS / FAIL / BLOCKED
+
+一句话理由: ___
+
+### 2. Layer assignment
+
+| 步骤/能力 | Layer (0/1/2/3) | 实现载体 |
+|-----------|-----------------|----------|
+| | | |
+
+### 3. Reuse list
+
+- Handlers:
+- Queues / Systems:
+- Resolvers / Registries:
+- Existing presets / graphs:
+
+### 4. New Layer 0 ops (if any)
+
+| Op 名 | 单一职责 | 为何不能组合现有 op |
+|-------|----------|---------------------|
+| | | |
+
+（无则写 N/A）
+
+### 5. Transaction boundary
+
+必须原子 rollback 的步骤: ___
+
+### 6. Config SSOT
+
+行为配置落在: effect template / graph / catalog（路径）: ___
+
+是否新增 JSON schema: YES / NO — 若 YES 说明为何不通过组合表达: ___
+
+### 7. Red flag scan
+
+- [ ] 未新增 profile inherit/placement enum
+- [ ] 未新建与 spawn 平行的物化管线
+- [ ] 未把 placement 校验塞进 lifecycle op
+- [ ] 未添加「说不清的」默认 fallback
+
+### 8. Next variant test
+
+「下一个 Mod 变体」将修改: graph 连线 / effect 步骤 / Core enum（只能选前两项之一）
+
+若选了 Core enum → FAIL
+```

--- a/skills/registry.json
+++ b/skills/registry.json
@@ -196,6 +196,29 @@
                                           ]
                    },
                    {
+                       "name":  "ludots-gas-composition-gate",
+                       "description":  "Mandatory self-review before GAS entity lifecycle, effect preset, or graph op work; blocks profile DSL expansion.",
+                       "layer":  "governance",
+                       "path":  "skills/governance/ludots-gas-composition-gate",
+                       "install_name":  "ludots-gas-composition-gate",
+                       "agents":  {
+                                      "openai":  "skills/governance/ludots-gas-composition-gate/agents/openai.yaml",
+                                      "claude":  "skills/governance/ludots-gas-composition-gate/agents/claude.md"
+                                  },
+                       "references":  [
+                                          "skills/governance/ludots-gas-composition-gate/references/composition-judgment-standard.md",
+                                          "skills/governance/ludots-gas-composition-gate/references/self-review-checklist.md",
+                                          "skills/governance/ludots-gas-composition-gate/references/layer-model.md",
+                                          "gitbook/architecture/entity-lifecycle-atomic-ops.md"
+                                      ],
+                       "consumes_hooks":  [
+
+                                          ],
+                       "produces_hooks":  [
+
+                                          ]
+                   },
+                   {
                        "name":  "ludots-feature-delivery",
                        "description":  "Deliver features with infrastructure reuse, headless evidence, showcase UI acceptance, and linked artifacts.",
                        "layer":  "delivery",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Opens the **Entity Lifecycle atomic ops** refactor track ([#494](https://github.com/MightyBubble/Ludots/issues/494)) and adds mandatory pre-task self-review skill for GAS / lifecycle / preset work.

## Changes

### Technical design SSOT

- `gitbook/architecture/entity-lifecycle-atomic-ops.md` — Layer 0–3 model, atomic op inventory, deploy recipe example, migration from Morph P0 (#490 / PR #491)
- **`morph_profiles.json` schema frozen** — no further DSL expansion

### Skill: `ludots-gas-composition-gate`

- Path: `skills/governance/ludots-gas-composition-gate/`
- Registered in `skills/registry.json` + `skills/README.md`
- References: judgment standard, self-review checklist, layer model

### Process wiring

- `gitbook/contributing/ai-assisted-development.md` §4.5 — GAS composition self-review before coding
- `gitbook/contributing/README.md` — links to §4.5
- `gitbook/SUMMARY.md` + architecture index

## Core judgment standard (写死)

> 新变体应新增 **graph 节点 / effect 步骤**，而不是 profile enum 或 preset 开关。

Agents must output `artifacts/gas-composition-gate.md` with filled checklist before implementation PRs.

## Related

- #494 — refactor implementation tracking
- #490 / PR #491 — Morph P0 spike (migration source, not extension target)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17c6aadd-e696-44a9-998e-291895b8ea2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17c6aadd-e696-44a9-998e-291895b8ea2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

