### PR TITLE
feat(core): add map launch context for scenario/player selection (#496)

### DIFF
--- a/gitbook/architecture/map-owned-participant-contract.md
+++ b/gitbook/architecture/map-owned-participant-contract.md
@@ -33,7 +33,6 @@ team/player representative entity 可以是 logical entity。Core 不得因为 p
 - `Teams[*].RepresentativeInstanceId` 绑定到一个 map-authored entity
 - `Players[*].RepresentativeInstanceId` 绑定到一个 map-authored entity
 - `Players[*].TeamId` 显式声明 player 所属 team
-- `Players[*].IsLocal` 只声明显式 local player，不提供默认值
 
 `InstanceId` 是 representative binding 的稳定键。author 选择不写 `InstanceId` 时，该 entity 只是普通 map entity；一旦写了，就必须非空、已 trim、且在同一 map 内唯一。
 
@@ -95,19 +94,23 @@ focused map 切换时，lookup object identity 必须稳定；系统拿到的是
 正式 local player 链路如下：
 
 ```text
-MapConfig.Players.IsLocal
-  -> PlayerId
+MapLaunchContext.SelectedPlayerId
   -> PlayerEntityLookup
   -> CoreServiceKeys.LocalPlayerId
   -> CoreServiceKeys.LocalPlayerEntity
   -> input / order systems
 ```
 
+`SelectedPlayerId` 属于 map load launch context，不属于 map identity。启动入口通过 `GameConfig.StartupSelectedPlayerId` 声明默认本地玩家，并由 `GameEngine.LoadStartupMap()` 注入 launch context。
+
+Mod 自定义 launch payload 只能走 `MapLaunchContext.Metadata`，Core 不为单个 Mod 需求新增顶层强类型字段。
+
 正式路径禁止：
 
 - 扫描 `PlayerOwner.PlayerId == 1`
 - `_playerId = 1` 之类的隐式默认
 - map load 之后再靠 post-scan 猜测 local player
+- 在 `MapConfig.Players` 里声明静态 local player 标记
 
 兼容边界：
 
@@ -131,7 +134,7 @@ Core 必须在 map load 期间显式失败，禁止 silent fallback：
 - unresolved representative `InstanceId`
 - blank / whitespace / non-trimmed authored `InstanceId`
 - player 引用未绑定 `TeamId`
-- 多个 `IsLocal = true`
+- launch context `SelectedPlayerId` 引用未绑定 player
 - participant relationship 缺少有效 `TypeId`
 
 相关源码：
@@ -148,6 +151,7 @@ participant-focused runtime state属于 map session：
 - `MapSession.LocalPlayerId`
 - `MapSession.LocalPlayerEntity`
 - `MapSession.TeamRelationships`
+- `MapSession.LaunchContext`
 
 focused map 切换、push/pop、resume 时，Core 必须发布当前 session 的 participant state；map unload 时必须清理 focused lookup/local-player service，避免把上一张图的 participant cache 当成当前图真相。
 

--- a/gitbook/reference/move-planning-mass-navigation-flow-road-execution.md
+++ b/gitbook/reference/move-planning-mass-navigation-flow-road-execution.md
@@ -90,7 +90,7 @@ Road map authoring must bind the local participant through the formal map schema
     { "TeamId": 2, "RepresentativeInstanceId": "road.team.red" }
   ],
   "Players": [
-    { "PlayerId": 1, "TeamId": 1, "RepresentativeInstanceId": "road.player.blue", "IsLocal": true }
+    { "PlayerId": 1, "TeamId": 1, "RepresentativeInstanceId": "road.player.blue" }
   ]
 }
 ```
@@ -101,7 +101,7 @@ Road-specific MassNavigationFlow tuning remains in `RoadNetworkShowcaseMod/asset
 
 | Configuration or code fact | Behavior | Contract test |
 |---|---|---|
-| `Players[].IsLocal = true` for `road.player.blue` | `LocalPlayerEntityResolverSystem` keeps a valid selection owner before the confirm press frame | `RoadNetworkShowcase_PlayableInitialDragSelectRightClick_StartsRoadMoveWithoutReset` |
+| `game.json.startupSelectedPlayerId = 1` for `road.player.blue` | `LoadStartupMap()` injects launch context so `LocalPlayerEntityResolverSystem` keeps a valid selection owner before the confirm press frame | `RoadNetworkShowcase_PlayableInitialDragSelectRightClick_StartsRoadMoveWithoutReset` |
 | Road execution source contains no retired execution component references | Road movement is not coupled to the deprecated sink | `RoadNetworkShowcaseMovePlanExecution_DoesNotReferenceLegacyExecutionComponents` |
 | Core `MovePlanning` source contains no road/corridor/fort names | Core seam remains reusable outside the road showcase | `CoreMovePlanningSeam_DoesNotReferenceRoadShowcasePolicy` |
 | Road execution source contains no `.A0` cursor usage | Runtime waypoint cursor lives in `MovePlanRuntime.CurrentWaypointIndex` | `RoadMovePlanRuntimeCursor_DoesNotUseOrderSpatialA0` |

--- a/mods/showcases/capability_standard/CapabilityStandardParticipantViewsMod/assets/Maps/capability_standard_participant_views.json
+++ b/mods/showcases/capability_standard/CapabilityStandardParticipantViewsMod/assets/Maps/capability_standard_participant_views.json
@@ -606,38 +606,32 @@
     {
       "PlayerId": 1,
       "TeamId": 1,
-      "RepresentativeInstanceId": "player-azure-alpha",
-      "IsLocal": true
+      "RepresentativeInstanceId": "player-azure-alpha"
     },
     {
       "PlayerId": 2,
       "TeamId": 1,
-      "RepresentativeInstanceId": "player-azure-beta",
-      "IsLocal": false
+      "RepresentativeInstanceId": "player-azure-beta"
     },
     {
       "PlayerId": 3,
       "TeamId": 2,
-      "RepresentativeInstanceId": "player-crimson-alpha",
-      "IsLocal": false
+      "RepresentativeInstanceId": "player-crimson-alpha"
     },
     {
       "PlayerId": 4,
       "TeamId": 2,
-      "RepresentativeInstanceId": "player-crimson-beta",
-      "IsLocal": false
+      "RepresentativeInstanceId": "player-crimson-beta"
     },
     {
       "PlayerId": 5,
       "TeamId": 3,
-      "RepresentativeInstanceId": "player-amber-alpha",
-      "IsLocal": false
+      "RepresentativeInstanceId": "player-amber-alpha"
     },
     {
       "PlayerId": 6,
       "TeamId": 4,
-      "RepresentativeInstanceId": "player-emerald-alpha",
-      "IsLocal": false
+      "RepresentativeInstanceId": "player-emerald-alpha"
     }
   ],
   "ParticipantRelationships": {

--- a/mods/showcases/capability_standard/CapabilityStandardParticipantViewsMod/assets/game.json
+++ b/mods/showcases/capability_standard/CapabilityStandardParticipantViewsMod/assets/game.json
@@ -1,5 +1,6 @@
 {
   "startupMapId": "capability_standard_participant_views",
+  "startupSelectedPlayerId": 1,
   "windowTitle": "Ludots Engine - Capability Standard Participant Views",
   "targetFps": 0,
   "windowWidth": 1440,

--- a/mods/showcases/combat_stance/CombatStanceShowcaseMod/assets/Maps/combat_stance_showcase.json
+++ b/mods/showcases/combat_stance/CombatStanceShowcaseMod/assets/Maps/combat_stance_showcase.json
@@ -41,8 +41,8 @@
     { "TeamId": 2, "RepresentativeInstanceId": "combat-stance-team-two" }
   ],
   "Players": [
-    { "PlayerId": 1, "TeamId": 1, "RepresentativeInstanceId": "combat-stance-player-one", "IsLocal": true },
-    { "PlayerId": 2, "TeamId": 2, "RepresentativeInstanceId": "combat-stance-player-two", "IsLocal": false }
+    { "PlayerId": 1, "TeamId": 1, "RepresentativeInstanceId": "combat-stance-player-one" },
+    { "PlayerId": 2, "TeamId": 2, "RepresentativeInstanceId": "combat-stance-player-two" }
   ],
   "ParticipantRelationships": {
     "Teams": [

--- a/mods/showcases/combat_stance/CombatStanceShowcaseMod/assets/game.json
+++ b/mods/showcases/combat_stance/CombatStanceShowcaseMod/assets/game.json
@@ -1,3 +1,4 @@
 {
-  "startupMapId": "combat_stance_showcase"
+  "startupMapId": "combat_stance_showcase",
+  "startupSelectedPlayerId": 1
 }

--- a/mods/showcases/road_network/RoadNetworkShowcaseMod/assets/Maps/road_network_showcase_chunked.json
+++ b/mods/showcases/road_network/RoadNetworkShowcaseMod/assets/Maps/road_network_showcase_chunked.json
@@ -41,7 +41,7 @@
     { "TeamId": 2, "RepresentativeInstanceId": "road.team.red" }
   ],
   "Players": [
-    { "PlayerId": 1, "TeamId": 1, "RepresentativeInstanceId": "road.player.blue", "IsLocal": true }
+    { "PlayerId": 1, "TeamId": 1, "RepresentativeInstanceId": "road.player.blue" }
   ],
   "ParticipantRelationships": {
     "Teams": [

--- a/mods/showcases/road_network/RoadNetworkShowcaseMod/assets/game.json
+++ b/mods/showcases/road_network/RoadNetworkShowcaseMod/assets/game.json
@@ -1,5 +1,6 @@
 {
   "startupMapId": "road_network_showcase_chunked",
+  "startupSelectedPlayerId": 1,
   "startupInputContexts": ["Default_Gameplay", "RoadNetwork_Showcase"],
   "constants": {
     "orderTypeIds": {

--- a/mods/showcases/rts_red_alert_like/RtsRedAlertLikeShowcaseMod/assets/Maps/rts_red_alert_like.json
+++ b/mods/showcases/rts_red_alert_like/RtsRedAlertLikeShowcaseMod/assets/Maps/rts_red_alert_like.json
@@ -201,7 +201,7 @@
     { "TeamId": 2, "RepresentativeInstanceId": "soviet_team_anchor" }
   ],
   "Players": [
-    { "PlayerId": 1, "TeamId": 1, "RepresentativeInstanceId": "allied_player_anchor", "IsLocal": true },
-    { "PlayerId": 2, "TeamId": 2, "RepresentativeInstanceId": "soviet_player_anchor", "IsLocal": false }
+    { "PlayerId": 1, "TeamId": 1, "RepresentativeInstanceId": "allied_player_anchor" },
+    { "PlayerId": 2, "TeamId": 2, "RepresentativeInstanceId": "soviet_player_anchor" }
   ]
 }

--- a/mods/showcases/rts_red_alert_like/RtsRedAlertLikeShowcaseMod/assets/game.json
+++ b/mods/showcases/rts_red_alert_like/RtsRedAlertLikeShowcaseMod/assets/game.json
@@ -1,5 +1,6 @@
 {
   "startupMapId": "rts_red_alert_like",
+  "startupSelectedPlayerId": 1,
   "windowTitle": "Ludots Engine - RTS Red Alert Like Production Showcase",
   "windowWidth": 1440,
   "windowHeight": 900,

--- a/mods/showcases/utility_autocast/UtilityAutocastShowcaseMod/assets/Maps/utility_autocast_showcase.json
+++ b/mods/showcases/utility_autocast/UtilityAutocastShowcaseMod/assets/Maps/utility_autocast_showcase.json
@@ -32,8 +32,8 @@
     { "TeamId": 2, "RepresentativeInstanceId": "utility-autocast-enemy-brute" }
   ],
   "Players": [
-    { "PlayerId": 1, "TeamId": 1, "RepresentativeInstanceId": "utility-autocast-mage", "IsLocal": true },
-    { "PlayerId": 2, "TeamId": 2, "RepresentativeInstanceId": "utility-autocast-enemy-brute", "IsLocal": false }
+    { "PlayerId": 1, "TeamId": 1, "RepresentativeInstanceId": "utility-autocast-mage" },
+    { "PlayerId": 2, "TeamId": 2, "RepresentativeInstanceId": "utility-autocast-enemy-brute" }
   ],
   "ParticipantRelationships": {
     "Teams": [

--- a/mods/showcases/utility_autocast/UtilityAutocastShowcaseMod/assets/game.json
+++ b/mods/showcases/utility_autocast/UtilityAutocastShowcaseMod/assets/game.json
@@ -1,3 +1,4 @@
 {
-  "startupMapId": "utility_autocast_showcase"
+  "startupMapId": "utility_autocast_showcase",
+  "startupSelectedPlayerId": 1
 }

--- a/src/Adapters/Raylib/Ludots.Adapter.Raylib/RaylibHostLoop.cs
+++ b/src/Adapters/Raylib/Ludots.Adapter.Raylib/RaylibHostLoop.cs
@@ -296,7 +296,7 @@ namespace Ludots.Adapter.Raylib
                 {
                     throw new InvalidOperationException("Invalid launcher bootstrap: 'StartupMapId' cannot be empty.");
                 }
-                engine.LoadMap(config.StartupMapId);
+                engine.LoadStartupMap();
 
                 int lastW = screenWidth;
                 int lastH = screenHeight;

--- a/src/Adapters/Web/Ludots.Adapter.Web/WebHostLoop.cs
+++ b/src/Adapters/Web/Ludots.Adapter.Web/WebHostLoop.cs
@@ -88,7 +88,7 @@ namespace Ludots.Adapter.Web
                 throw new InvalidOperationException("Invalid launcher bootstrap: 'StartupMapId' cannot be empty.");
             }
 
-            engine.LoadMap(config.StartupMapId);
+            engine.LoadStartupMap();
             engine.SetService(CoreServiceKeys.UiCaptured, false);
 
             BuildAndSendMeshMap(engine, setup.Transport);

--- a/src/Core/Commands/LoadMapCommand.cs
+++ b/src/Core/Commands/LoadMapCommand.cs
@@ -1,4 +1,5 @@
 using Ludots.Core.Engine;
+using Ludots.Core.Map;
 using Ludots.Core.Scripting;
 using System.Threading.Tasks;
 
@@ -7,6 +8,9 @@ namespace Ludots.Core.Commands
     public class LoadMapCommand : GameCommand
     {
         public string MapId { get; set; }
+        public string ScenarioId { get; set; }
+        public int SelectedPlayerId { get; set; }
+        public int SelectedFactionId { get; set; }
 
         public override Task ExecuteAsync(ScriptContext context)
         {
@@ -15,7 +19,11 @@ namespace Ludots.Core.Commands
             var engine = context.GetEngine();
             if (engine != null)
             {
-                engine.LoadMap(MapId);
+                MapLaunchContext? launchContext = MapLaunchContext.FromSelection(
+                    ScenarioId,
+                    SelectedPlayerId,
+                    SelectedFactionId);
+                engine.LoadMap(MapLoadRequest.FromMapId(MapId, launchContext));
             }
             return Task.CompletedTask;
         }

--- a/src/Core/Commands/LoadMapCommand.cs
+++ b/src/Core/Commands/LoadMapCommand.cs
@@ -8,9 +8,7 @@ namespace Ludots.Core.Commands
     public class LoadMapCommand : GameCommand
     {
         public string MapId { get; set; }
-        public string ScenarioId { get; set; }
         public int SelectedPlayerId { get; set; }
-        public int SelectedFactionId { get; set; }
 
         public override Task ExecuteAsync(ScriptContext context)
         {
@@ -19,10 +17,7 @@ namespace Ludots.Core.Commands
             var engine = context.GetEngine();
             if (engine != null)
             {
-                MapLaunchContext? launchContext = MapLaunchContext.FromSelection(
-                    ScenarioId,
-                    SelectedPlayerId,
-                    SelectedFactionId);
+                MapLaunchContext? launchContext = MapLaunchContext.Create(SelectedPlayerId);
                 engine.LoadMap(MapLoadRequest.FromMapId(MapId, launchContext));
             }
             return Task.CompletedTask;

--- a/src/Core/Config/GameConfig.cs
+++ b/src/Core/Config/GameConfig.cs
@@ -27,6 +27,11 @@ namespace Ludots.Core.Config
         /// </summary>
         public string StartupMapId { get; set; }
 
+        /// <summary>
+        /// Initial local player for startup map load. Provided by CoreMod via game.json merge.
+        /// </summary>
+        public int StartupSelectedPlayerId { get; set; }
+
         public List<string> StartupInputContexts { get; set; } = new List<string>();
 
         // Engine-level defaults (these stay in Core's game.json)

--- a/src/Core/Config/MapConfig.cs
+++ b/src/Core/Config/MapConfig.cs
@@ -88,7 +88,6 @@ namespace Ludots.Core.Config
         public int PlayerId { get; set; }
         public int TeamId { get; set; }
         public string RepresentativeInstanceId { get; set; }
-        public bool IsLocal { get; set; }
     }
 
     public class ParticipantRelationshipConfig

--- a/src/Core/Engine/GameEngine.MapLoadLifecycle.cs
+++ b/src/Core/Engine/GameEngine.MapLoadLifecycle.cs
@@ -91,6 +91,7 @@ namespace Ludots.Core.Engine
                 RemoveService(CoreServiceKeys.MapSession);
                 RemoveService(CoreServiceKeys.MapFeatureFlags);
                 RemoveService(CoreServiceKeys.MapLoadStatus);
+                RemoveService(CoreServiceKeys.MapLaunchContext);
                 RemoveService(CoreServiceKeys.VisualHeightmap);
                 ParticipantBindingResolver.ClearFocused(GlobalContext);
                 PublishFocusedMapLoadState();
@@ -101,6 +102,14 @@ namespace Ludots.Core.Engine
             SetService(CoreServiceKeys.MapSession, session);
             SetService(CoreServiceKeys.MapFeatureFlags, MapFeatureFlags.FromTags(session.MapConfig?.Tags));
             SetService(CoreServiceKeys.MapLoadStatus, GetMapLoadStatus(session.MapId));
+            if (session.LaunchContext != null && !session.LaunchContext.IsEmpty)
+            {
+                SetService(CoreServiceKeys.MapLaunchContext, session.LaunchContext);
+            }
+            else
+            {
+                RemoveService(CoreServiceKeys.MapLaunchContext);
+            }
             if (session.VisualHeightmap != null)
             {
                 SetService(CoreServiceKeys.VisualHeightmap, session.VisualHeightmap);
@@ -164,6 +173,11 @@ namespace Ludots.Core.Engine
             ctx.Set(CoreServiceKeys.MapTags, session.MapConfig?.Tags ?? new List<string>());
             ctx.Set(CoreServiceKeys.MapFeatureFlags, MapFeatureFlags.FromTags(session.MapConfig?.Tags));
             ctx.Set(CoreServiceKeys.MapLoadStatus, GetMapLoadStatus(session.MapId));
+            if (session.LaunchContext != null && !session.LaunchContext.IsEmpty)
+            {
+                ctx.Set(CoreServiceKeys.MapLaunchContext, session.LaunchContext);
+            }
+
             return ctx;
         }
 

--- a/src/Core/Engine/GameEngine.cs
+++ b/src/Core/Engine/GameEngine.cs
@@ -1626,10 +1626,13 @@ namespace Ludots.Core.Engine
             return orderTypeId;
         }
 
-        public void LoadMap(string mapId)
+        public void LoadMap(string mapId) => LoadMap(MapLoadRequest.FromMapId(mapId));
+
+        public void LoadMap(MapLoadRequest request)
         {
+            string mapId = request.MapIdValue;
             Diagnostics.Log.Info(in LogChannels.Engine, $"Loading Map: {mapId}");
-            var mid = new MapId(mapId);
+            var mid = request.MapId;
 
             EnsureMapSessionInfrastructure();
 
@@ -1647,6 +1650,7 @@ namespace Ludots.Core.Engine
 
                 // Create new session with boards (additive — old sessions stay)
                 var session = MapSessions.CreateSession(mid, mapConfig, null);
+                session.LaunchContext = request.LaunchContext;
                 session.VisualHeightmap = visualHeightmap;
                 CreateBoardsForSession(session, mapConfig);
                 if (previousFocused != null)
@@ -2724,7 +2728,7 @@ namespace Ludots.Core.Engine
 
         public void LoadEntryMap(string mapId) => LoadMap(mapId);
 
-        public void LoadMap(MapId mapId) => LoadMap(mapId.Value);
+        public void LoadMap(MapId mapId) => LoadMap(MapLoadRequest.FromMapId(mapId.Value));
 
         public void Start()
         {

--- a/src/Core/Engine/GameEngine.cs
+++ b/src/Core/Engine/GameEngine.cs
@@ -2726,7 +2726,35 @@ namespace Ludots.Core.Engine
             return new NavAreaCostTable(arr);
         }
 
-        public void LoadEntryMap(string mapId) => LoadMap(mapId);
+        public void LoadEntryMap(string mapId)
+        {
+            if (string.IsNullOrWhiteSpace(mapId))
+            {
+                throw new ArgumentException("Map id is required.", nameof(mapId));
+            }
+
+            if (!string.Equals(MergedConfig?.StartupMapId, mapId, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    $"LoadEntryMap requires startup map '{MergedConfig?.StartupMapId}', got '{mapId}'.");
+            }
+
+            LoadStartupMap();
+        }
+
+        public void LoadStartupMap()
+        {
+            string mapId = MergedConfig?.StartupMapId;
+            if (string.IsNullOrWhiteSpace(mapId))
+            {
+                throw new InvalidOperationException("StartupMapId is required.");
+            }
+
+            MapLaunchContext? launchContext = MergedConfig!.StartupSelectedPlayerId > 0
+                ? MapLaunchContext.Create(MergedConfig.StartupSelectedPlayerId)
+                : null;
+            LoadMap(new MapLoadRequest(new MapId(mapId), launchContext));
+        }
 
         public void LoadMap(MapId mapId) => LoadMap(MapLoadRequest.FromMapId(mapId.Value));
 

--- a/src/Core/Gameplay/Teams/ParticipantBindingResolver.cs
+++ b/src/Core/Gameplay/Teams/ParticipantBindingResolver.cs
@@ -89,6 +89,8 @@ namespace Ludots.Core.Gameplay.Teams
 
             int localPlayerId = 0;
             Entity localPlayerEntity = Entity.Null;
+            MapLaunchContext? launchContext = session.LaunchContext;
+            bool useLaunchContextPlayer = launchContext?.HasSelectedPlayer == true;
             for (int i = 0; i < mapConfig.Players.Count; i++)
             {
                 PlayerBindingData binding = mapConfig.Players[i] ?? throw new InvalidOperationException($"Map '{mapId}' Players[{i}] requires an object payload.");
@@ -129,7 +131,7 @@ namespace Ludots.Core.Gameplay.Teams
                 Upsert(world, entity, new Team { Id = binding.TeamId });
                 playerLookup.Register(binding.PlayerId, entity);
 
-                if (binding.IsLocal)
+                if (!useLaunchContextPlayer && binding.IsLocal)
                 {
                     if (localPlayerId != 0)
                     {
@@ -139,6 +141,19 @@ namespace Ludots.Core.Gameplay.Teams
                     localPlayerId = binding.PlayerId;
                     localPlayerEntity = entity;
                 }
+            }
+
+            if (useLaunchContextPlayer)
+            {
+                int selectedPlayerId = launchContext!.SelectedPlayerId;
+                if (!playerLookup.TryGet(selectedPlayerId, out Entity selectedEntity))
+                {
+                    throw new InvalidOperationException(
+                        $"Map '{mapId}' launch context SelectedPlayerId {selectedPlayerId} references an unbound player.");
+                }
+
+                localPlayerId = selectedPlayerId;
+                localPlayerEntity = selectedEntity;
             }
 
             ResolveRelationships(mapId, mapConfig, teamLookup, playerLookup, relationships, relationshipTypes);

--- a/src/Core/Gameplay/Teams/ParticipantBindingResolver.cs
+++ b/src/Core/Gameplay/Teams/ParticipantBindingResolver.cs
@@ -89,8 +89,6 @@ namespace Ludots.Core.Gameplay.Teams
 
             int localPlayerId = 0;
             Entity localPlayerEntity = Entity.Null;
-            MapLaunchContext? launchContext = session.LaunchContext;
-            bool useLaunchContextPlayer = launchContext?.HasSelectedPlayer == true;
             for (int i = 0; i < mapConfig.Players.Count; i++)
             {
                 PlayerBindingData binding = mapConfig.Players[i] ?? throw new InvalidOperationException($"Map '{mapId}' Players[{i}] requires an object payload.");
@@ -130,22 +128,12 @@ namespace Ludots.Core.Gameplay.Teams
                 Upsert(world, entity, new PlayerOwner { PlayerId = binding.PlayerId });
                 Upsert(world, entity, new Team { Id = binding.TeamId });
                 playerLookup.Register(binding.PlayerId, entity);
-
-                if (!useLaunchContextPlayer && binding.IsLocal)
-                {
-                    if (localPlayerId != 0)
-                    {
-                        throw new InvalidOperationException($"Map '{mapId}' declares multiple local player bindings.");
-                    }
-
-                    localPlayerId = binding.PlayerId;
-                    localPlayerEntity = entity;
-                }
             }
 
-            if (useLaunchContextPlayer)
+            MapLaunchContext? launchContext = session.LaunchContext;
+            if (launchContext?.HasSelectedPlayer == true)
             {
-                int selectedPlayerId = launchContext!.SelectedPlayerId;
+                int selectedPlayerId = launchContext.SelectedPlayerId;
                 if (!playerLookup.TryGet(selectedPlayerId, out Entity selectedEntity))
                 {
                     throw new InvalidOperationException(

--- a/src/Core/Map/MapLaunchContext.cs
+++ b/src/Core/Map/MapLaunchContext.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace Ludots.Core.Map
@@ -9,31 +8,22 @@ namespace Ludots.Core.Map
     /// </summary>
     public sealed class MapLaunchContext
     {
-        public string? ScenarioId { get; init; }
         public int SelectedPlayerId { get; init; }
-        public int SelectedFactionId { get; init; }
         public IReadOnlyDictionary<string, object>? Metadata { get; init; }
 
         public bool HasSelectedPlayer => SelectedPlayerId > 0;
-        public bool HasSelectedFaction => SelectedFactionId > 0;
 
         public bool IsEmpty =>
-            string.IsNullOrEmpty(ScenarioId) &&
             !HasSelectedPlayer &&
-            !HasSelectedFaction &&
             (Metadata == null || Metadata.Count == 0);
 
-        public static MapLaunchContext? FromSelection(
-            string? scenarioId = null,
+        public static MapLaunchContext? Create(
             int selectedPlayerId = 0,
-            int selectedFactionId = 0,
             IReadOnlyDictionary<string, object>? metadata = null)
         {
             var context = new MapLaunchContext
             {
-                ScenarioId = scenarioId,
                 SelectedPlayerId = selectedPlayerId,
-                SelectedFactionId = selectedFactionId,
                 Metadata = metadata,
             };
             return context.IsEmpty ? null : context;

--- a/src/Core/Map/MapLaunchContext.cs
+++ b/src/Core/Map/MapLaunchContext.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ludots.Core.Map
+{
+    /// <summary>
+    /// Runtime launch/session selection carried with map load.
+    /// Map identity describes world content; launch context describes how that world is entered.
+    /// </summary>
+    public sealed class MapLaunchContext
+    {
+        public string? ScenarioId { get; init; }
+        public int SelectedPlayerId { get; init; }
+        public int SelectedFactionId { get; init; }
+        public IReadOnlyDictionary<string, object>? Metadata { get; init; }
+
+        public bool HasSelectedPlayer => SelectedPlayerId > 0;
+        public bool HasSelectedFaction => SelectedFactionId > 0;
+
+        public bool IsEmpty =>
+            string.IsNullOrEmpty(ScenarioId) &&
+            !HasSelectedPlayer &&
+            !HasSelectedFaction &&
+            (Metadata == null || Metadata.Count == 0);
+
+        public static MapLaunchContext? FromSelection(
+            string? scenarioId = null,
+            int selectedPlayerId = 0,
+            int selectedFactionId = 0,
+            IReadOnlyDictionary<string, object>? metadata = null)
+        {
+            var context = new MapLaunchContext
+            {
+                ScenarioId = scenarioId,
+                SelectedPlayerId = selectedPlayerId,
+                SelectedFactionId = selectedFactionId,
+                Metadata = metadata,
+            };
+            return context.IsEmpty ? null : context;
+        }
+    }
+
+    public readonly record struct MapLoadRequest(MapId MapId, MapLaunchContext? LaunchContext = null)
+    {
+        public static MapLoadRequest FromMapId(string mapId) => new(new MapId(mapId));
+
+        public static MapLoadRequest FromMapId(string mapId, MapLaunchContext? launchContext) =>
+            new(new MapId(mapId), launchContext);
+
+        public string MapIdValue => MapId.Value;
+    }
+}

--- a/src/Core/Map/MapSession.cs
+++ b/src/Core/Map/MapSession.cs
@@ -30,6 +30,7 @@ namespace Ludots.Core.Map
         public int LocalPlayerId { get; set; }
         public Entity LocalPlayerEntity { get; set; }
         public TeamRelationshipSnapshot? TeamRelationships { get; set; }
+        public MapLaunchContext? LaunchContext { get; set; }
 
         private readonly Dictionary<string, IBoard> _boards = new Dictionary<string, IBoard>(StringComparer.OrdinalIgnoreCase);
         private readonly List<Trigger> _triggers = new List<Trigger>();

--- a/src/Core/Map/MapSessionManager.cs
+++ b/src/Core/Map/MapSessionManager.cs
@@ -6,7 +6,10 @@ using Ludots.Core.Diagnostics;
 
 namespace Ludots.Core.Map
 {
-    public sealed record MapSessionEntrySnapshot(string MapId, MapSessionState State);
+    public sealed record MapSessionEntrySnapshot(
+        string MapId,
+        MapSessionState State,
+        MapLaunchContext? LaunchContext = null);
 
     public sealed record MapSessionManagerSnapshot(
         IReadOnlyList<MapSessionEntrySnapshot> Sessions,
@@ -142,7 +145,7 @@ namespace Ludots.Core.Map
             var sessions = new List<MapSessionEntrySnapshot>(_sessions.Count);
             foreach (var pair in _sessions)
             {
-                sessions.Add(new MapSessionEntrySnapshot(pair.Key.Value, pair.Value.State));
+                sessions.Add(new MapSessionEntrySnapshot(pair.Key.Value, pair.Value.State, pair.Value.LaunchContext));
             }
 
             var focusTopFirst = _focusStack.ToArray();
@@ -171,6 +174,7 @@ namespace Ludots.Core.Map
                 }
 
                 session.State = sessionSnapshot.State;
+                session.LaunchContext = sessionSnapshot.LaunchContext;
             }
 
             for (int i = 0; i < snapshot.FocusStack.Count; i++)

--- a/src/Core/Persistence/CoreSaveParticipants.cs
+++ b/src/Core/Persistence/CoreSaveParticipants.cs
@@ -364,11 +364,18 @@ namespace Ludots.Core.Persistence
                 for (int i = 0; i < snapshot.Sessions.Count; i++)
                 {
                     MapSessionEntrySnapshot session = snapshot.Sessions[i];
-                    sessions.Add(new JsonObject
+                    var sessionObject = new JsonObject
                     {
                         ["mapId"] = session.MapId,
                         ["state"] = session.State.ToString()
-                    });
+                    };
+                    JsonObject? launchContext = WriteLaunchContext(session.LaunchContext);
+                    if (launchContext != null)
+                    {
+                        sessionObject["launchContext"] = launchContext;
+                    }
+
+                    sessions.Add(sessionObject);
                 }
 
                 var focusStack = new JsonArray();
@@ -404,7 +411,8 @@ namespace Ludots.Core.Persistence
 
                     sessions.Add(new MapSessionEntrySnapshot(
                         RequireString(session, "mapId"),
-                        sessionState));
+                        sessionState,
+                        ReadLaunchContext(session["launchContext"])));
                 }
 
                 JsonArray focusStackArray = RequireArray(root, "focusStack");
@@ -817,6 +825,71 @@ namespace Ludots.Core.Persistence
             }
 
             return node.GetValue<string>();
+        }
+
+        private static JsonObject? WriteLaunchContext(MapLaunchContext? launchContext)
+        {
+            if (launchContext == null || launchContext.IsEmpty)
+            {
+                return null;
+            }
+
+            var root = new JsonObject();
+            if (!string.IsNullOrEmpty(launchContext.ScenarioId))
+            {
+                root["scenarioId"] = launchContext.ScenarioId;
+            }
+
+            if (launchContext.HasSelectedPlayer)
+            {
+                root["selectedPlayerId"] = launchContext.SelectedPlayerId;
+            }
+
+            if (launchContext.HasSelectedFaction)
+            {
+                root["selectedFactionId"] = launchContext.SelectedFactionId;
+            }
+
+            if (launchContext.Metadata != null && launchContext.Metadata.Count > 0)
+            {
+                var metadata = new JsonObject();
+                foreach (KeyValuePair<string, object> pair in launchContext.Metadata)
+                {
+                    metadata[pair.Key] = WriteGlobal(pair.Key, pair.Value);
+                }
+
+                root["metadata"] = metadata;
+            }
+
+            return root;
+        }
+
+        private static MapLaunchContext? ReadLaunchContext(JsonNode? node)
+        {
+            if (node == null)
+            {
+                return null;
+            }
+
+            JsonObject root = node as JsonObject ??
+                throw new SaveContextException("Map session launchContext must be an object.");
+
+            string? scenarioId = root["scenarioId"]?.GetValue<string>();
+            int selectedPlayerId = root["selectedPlayerId"]?.GetValue<int>() ?? 0;
+            int selectedFactionId = root["selectedFactionId"]?.GetValue<int>() ?? 0;
+            IReadOnlyDictionary<string, object>? metadata = null;
+            if (root["metadata"] is JsonObject metadataObject)
+            {
+                var values = new Dictionary<string, object>(StringComparer.Ordinal);
+                foreach (KeyValuePair<string, JsonNode?> pair in metadataObject)
+                {
+                    values[pair.Key] = ReadGlobal(pair.Key, pair.Value);
+                }
+
+                metadata = values;
+            }
+
+            return MapLaunchContext.FromSelection(scenarioId, selectedPlayerId, selectedFactionId, metadata);
         }
     }
 }

--- a/src/Core/Persistence/CoreSaveParticipants.cs
+++ b/src/Core/Persistence/CoreSaveParticipants.cs
@@ -835,19 +835,9 @@ namespace Ludots.Core.Persistence
             }
 
             var root = new JsonObject();
-            if (!string.IsNullOrEmpty(launchContext.ScenarioId))
-            {
-                root["scenarioId"] = launchContext.ScenarioId;
-            }
-
             if (launchContext.HasSelectedPlayer)
             {
                 root["selectedPlayerId"] = launchContext.SelectedPlayerId;
-            }
-
-            if (launchContext.HasSelectedFaction)
-            {
-                root["selectedFactionId"] = launchContext.SelectedFactionId;
             }
 
             if (launchContext.Metadata != null && launchContext.Metadata.Count > 0)
@@ -874,9 +864,7 @@ namespace Ludots.Core.Persistence
             JsonObject root = node as JsonObject ??
                 throw new SaveContextException("Map session launchContext must be an object.");
 
-            string? scenarioId = root["scenarioId"]?.GetValue<string>();
             int selectedPlayerId = root["selectedPlayerId"]?.GetValue<int>() ?? 0;
-            int selectedFactionId = root["selectedFactionId"]?.GetValue<int>() ?? 0;
             IReadOnlyDictionary<string, object>? metadata = null;
             if (root["metadata"] is JsonObject metadataObject)
             {
@@ -889,7 +877,7 @@ namespace Ludots.Core.Persistence
                 metadata = values;
             }
 
-            return MapLaunchContext.FromSelection(scenarioId, selectedPlayerId, selectedFactionId, metadata);
+            return MapLaunchContext.Create(selectedPlayerId, metadata);
         }
     }
 }

--- a/src/Core/Scripting/CoreServiceKeys.cs
+++ b/src/Core/Scripting/CoreServiceKeys.cs
@@ -105,6 +105,7 @@ namespace Ludots.Core.Scripting
         public static readonly ServiceKey<IFocusedMapLoadStateSink> FocusedMapLoadStateSink = new("FocusedMapLoadStateSink");
         public static readonly ServiceKey<BoardIdRegistry> BoardIdRegistry = new("BoardIdRegistry");
         public static readonly ServiceKey<MapContext> MapContext = new("MapContext");
+        public static readonly ServiceKey<MapLaunchContext> MapLaunchContext = new("MapLaunchContext");
 
         // --- UI ---
         public static readonly ServiceKey<IUiSystem> UISystem = new("UISystem");

--- a/src/Core/Scripting/ScriptContextExtensions.cs
+++ b/src/Core/Scripting/ScriptContextExtensions.cs
@@ -10,6 +10,8 @@ namespace Ludots.Core.Scripting
         public static GameEngine GetEngine(this ScriptContext ctx) => ctx.Get(CoreServiceKeys.Engine);
         public static World GetWorld(this ScriptContext ctx) => ctx.Get(CoreServiceKeys.World);
         public static MapSession GetMapSession(this ScriptContext ctx) => ctx.Get(CoreServiceKeys.MapSession);
+        public static MapLaunchContext? GetMapLaunchContext(this ScriptContext ctx) =>
+            ctx.TryGet(CoreServiceKeys.MapLaunchContext, out MapLaunchContext context) ? context : null;
         public static ILogBackend GetLogBackend(this ScriptContext ctx) => ctx.Get(CoreServiceKeys.LogBackend);
 
         public static bool IsMap(this ScriptContext ctx, MapId mapId)

--- a/src/Tests/GasTests/ParticipantBindingContractTests.cs
+++ b/src/Tests/GasTests/ParticipantBindingContractTests.cs
@@ -203,6 +203,74 @@ namespace Ludots.Tests.GAS
             Assert.That(globals[CoreServiceKeys.LocalPlayerEntity.Name], Is.EqualTo(playerSeven));
         }
 
+        [Test]
+        public void ParticipantBindingResolver_LaunchContextSelectedPlayerId_SelectsLocalPlayerWithoutIsLocal()
+        {
+            using var world = World.Create();
+            var map = CreateMap();
+            map.Players[0].IsLocal = false;
+            var session = new MapSession(new MapId(map.Id), map)
+            {
+                LaunchContext = MapLaunchContext.FromSelection(selectedPlayerId: 8),
+            };
+            var index = CreateEntityIndex(map.Id, world, out _, out _, out _, out Entity playerTwo);
+            var types = new RelationshipTypeRegistry();
+            types.Register("Alliance");
+            types.Register("Rivalry");
+            types.Register("Membership");
+            RelationshipRuntime relationships = CreateRelationshipRuntime(world, types);
+
+            ParticipantBindingResult result = ParticipantBindingResolver.Resolve(session, world, index, relationships, types);
+
+            Assert.That(result.LocalPlayerId, Is.EqualTo(8));
+            Assert.That(result.LocalPlayerEntity, Is.EqualTo(playerTwo));
+        }
+
+        [Test]
+        public void ParticipantBindingResolver_LaunchContextSelectedPlayerId_OverridesAuthoredIsLocal()
+        {
+            using var world = World.Create();
+            var map = CreateMap();
+            var session = new MapSession(new MapId(map.Id), map)
+            {
+                LaunchContext = MapLaunchContext.FromSelection(selectedPlayerId: 8),
+            };
+            var index = CreateEntityIndex(map.Id, world, out _, out _, out Entity playerOne, out Entity playerTwo);
+            var types = new RelationshipTypeRegistry();
+            types.Register("Alliance");
+            types.Register("Rivalry");
+            types.Register("Membership");
+            RelationshipRuntime relationships = CreateRelationshipRuntime(world, types);
+
+            ParticipantBindingResult result = ParticipantBindingResolver.Resolve(session, world, index, relationships, types);
+
+            Assert.That(result.LocalPlayerId, Is.EqualTo(8));
+            Assert.That(result.LocalPlayerEntity, Is.EqualTo(playerTwo));
+            Assert.That(result.LocalPlayerEntity, Is.Not.EqualTo(playerOne));
+        }
+
+        [Test]
+        public void ParticipantBindingResolver_LaunchContextUnknownSelectedPlayerId_FailsExplicitly()
+        {
+            using var world = World.Create();
+            var map = CreateMap();
+            var session = new MapSession(new MapId(map.Id), map)
+            {
+                LaunchContext = MapLaunchContext.FromSelection(selectedPlayerId: 99),
+            };
+            var index = CreateEntityIndex(map.Id, world, out _, out _, out _, out _);
+            var types = new RelationshipTypeRegistry();
+            types.Register("Alliance");
+            types.Register("Rivalry");
+            types.Register("Membership");
+            RelationshipRuntime relationships = CreateRelationshipRuntime(world, types);
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() =>
+                ParticipantBindingResolver.Resolve(session, world, index, relationships, types))!;
+
+            Assert.That(ex.Message, Does.Contain("SelectedPlayerId 99"));
+        }
+
         private static MapConfig CreateMap()
         {
             return new MapConfig

--- a/src/Tests/GasTests/ParticipantBindingContractTests.cs
+++ b/src/Tests/GasTests/ParticipantBindingContractTests.cs
@@ -40,7 +40,10 @@ namespace Ludots.Tests.GAS
         {
             using var world = World.Create();
             var map = CreateMap();
-            var session = new MapSession(new MapId(map.Id), map);
+            var session = new MapSession(new MapId(map.Id), map)
+            {
+                LaunchContext = MapLaunchContext.Create(selectedPlayerId: 7),
+            };
             var index = CreateEntityIndex(map.Id, world, out Entity teamOne, out Entity teamTwo, out Entity playerOne, out Entity playerTwo);
             var types = new RelationshipTypeRegistry();
             int allianceType = types.Register("Alliance");
@@ -98,13 +101,15 @@ namespace Ludots.Tests.GAS
         [TestCase("duplicatePlayerRepresentative")]
         [TestCase("missingRepresentative")]
         [TestCase("unknownTeam")]
-        [TestCase("multipleLocalPlayers")]
         [TestCase("blankRelationshipType")]
         public void ParticipantBindingResolver_InvalidAuthoring_FailsExplicitly(string scenario)
         {
             using var world = World.Create();
             var map = CreateMap();
-            var session = new MapSession(new MapId(map.Id), map);
+            var session = new MapSession(new MapId(map.Id), map)
+            {
+                LaunchContext = MapLaunchContext.Create(selectedPlayerId: 7),
+            };
             var index = CreateEntityIndex(map.Id, world, out _, out _, out _, out _);
             var types = new RelationshipTypeRegistry();
             types.Register("Alliance");
@@ -204,14 +209,13 @@ namespace Ludots.Tests.GAS
         }
 
         [Test]
-        public void ParticipantBindingResolver_LaunchContextSelectedPlayerId_SelectsLocalPlayerWithoutIsLocal()
+        public void ParticipantBindingResolver_LaunchContextSelectedPlayerId_SelectsLocalPlayer()
         {
             using var world = World.Create();
             var map = CreateMap();
-            map.Players[0].IsLocal = false;
             var session = new MapSession(new MapId(map.Id), map)
             {
-                LaunchContext = MapLaunchContext.FromSelection(selectedPlayerId: 8),
+                LaunchContext = MapLaunchContext.Create(selectedPlayerId: 8),
             };
             var index = CreateEntityIndex(map.Id, world, out _, out _, out _, out Entity playerTwo);
             var types = new RelationshipTypeRegistry();
@@ -227,15 +231,12 @@ namespace Ludots.Tests.GAS
         }
 
         [Test]
-        public void ParticipantBindingResolver_LaunchContextSelectedPlayerId_OverridesAuthoredIsLocal()
+        public void ParticipantBindingResolver_WithoutLaunchContext_HasNoLocalPlayer()
         {
             using var world = World.Create();
             var map = CreateMap();
-            var session = new MapSession(new MapId(map.Id), map)
-            {
-                LaunchContext = MapLaunchContext.FromSelection(selectedPlayerId: 8),
-            };
-            var index = CreateEntityIndex(map.Id, world, out _, out _, out Entity playerOne, out Entity playerTwo);
+            var session = new MapSession(new MapId(map.Id), map);
+            var index = CreateEntityIndex(map.Id, world, out _, out _, out _, out _);
             var types = new RelationshipTypeRegistry();
             types.Register("Alliance");
             types.Register("Rivalry");
@@ -244,9 +245,8 @@ namespace Ludots.Tests.GAS
 
             ParticipantBindingResult result = ParticipantBindingResolver.Resolve(session, world, index, relationships, types);
 
-            Assert.That(result.LocalPlayerId, Is.EqualTo(8));
-            Assert.That(result.LocalPlayerEntity, Is.EqualTo(playerTwo));
-            Assert.That(result.LocalPlayerEntity, Is.Not.EqualTo(playerOne));
+            Assert.That(result.LocalPlayerId, Is.EqualTo(0));
+            Assert.That(result.LocalPlayerEntity, Is.EqualTo(Entity.Null));
         }
 
         [Test]
@@ -256,7 +256,7 @@ namespace Ludots.Tests.GAS
             var map = CreateMap();
             var session = new MapSession(new MapId(map.Id), map)
             {
-                LaunchContext = MapLaunchContext.FromSelection(selectedPlayerId: 99),
+                LaunchContext = MapLaunchContext.Create(selectedPlayerId: 99),
             };
             var index = CreateEntityIndex(map.Id, world, out _, out _, out _, out _);
             var types = new RelationshipTypeRegistry();
@@ -283,7 +283,7 @@ namespace Ludots.Tests.GAS
                 },
                 Players =
                 {
-                    new PlayerBindingData { PlayerId = 7, TeamId = 10, RepresentativeInstanceId = "player.local", IsLocal = true },
+                    new PlayerBindingData { PlayerId = 7, TeamId = 10, RepresentativeInstanceId = "player.local" },
                     new PlayerBindingData { PlayerId = 8, TeamId = 20, RepresentativeInstanceId = "player.remote" },
                 },
                 ParticipantRelationships = new ParticipantRelationshipConfig
@@ -391,9 +391,6 @@ namespace Ludots.Tests.GAS
                     return;
                 case "unknownTeam":
                     map.Players[0].TeamId = 999;
-                    return;
-                case "multipleLocalPlayers":
-                    map.Players[1].IsLocal = true;
                     return;
                 case "blankRelationshipType":
                     map.ParticipantRelationships.Teams[0].TypeId = string.Empty;

--- a/src/Tests/GasTests/Production/ProductionAllModsValidationTests.cs
+++ b/src/Tests/GasTests/Production/ProductionAllModsValidationTests.cs
@@ -262,7 +262,7 @@ namespace Ludots.Tests.GAS.Production
                 InstallDummyInput(engine);
 
                 engine.Start();
-                engine.LoadMap(engine.MergedConfig.StartupMapId);
+                engine.LoadStartupMap();
 
                 for (int i = 0; i < 10; i++)
                 {

--- a/src/Tests/GasTests/Production/ProductionMobaValidationTests.cs
+++ b/src/Tests/GasTests/Production/ProductionMobaValidationTests.cs
@@ -31,7 +31,7 @@ namespace Ludots.Tests.GAS.Production
                     assetsRoot);
 
                 engine.Start();
-                engine.LoadMap(engine.MergedConfig.StartupMapId);
+                engine.LoadStartupMap();
                 engine.GlobalContext.Remove(Ludots.Core.Scripting.CoreServiceKeys.CameraPoseRequest.Name);
                 engine.GlobalContext.Remove(Ludots.Core.Scripting.CoreServiceKeys.VirtualCameraRequest.Name);
 

--- a/src/Tests/GasTests/RoadNetworkShowcaseTests.cs
+++ b/src/Tests/GasTests/RoadNetworkShowcaseTests.cs
@@ -25,6 +25,7 @@ using Ludots.Core.Navigation.NavMesh;
 using Ludots.Core.Navigation.NavMesh.Config;
 using Ludots.Core.Navigation.Pathing;
 using Ludots.Core.Navigation.Pathing.Config;
+using Ludots.Core.Map;
 using Ludots.Core.Map.Board;
 using Ludots.Core.Presentation.Camera;
 using Ludots.Core.Presentation.Components;
@@ -609,7 +610,7 @@ namespace Ludots.Tests.GAS
         public void RoadNetworkShowcaseRuntime_EngineBootstrapsGraphOnlyAutoPathService_AndFindsRoadPath()
         {
             using var engine = CreateRoadShowcaseEngine();
-            engine.LoadMap(engine.MergedConfig.StartupMapId);
+            engine.LoadStartupMap();
 
             Assert.That(engine.CurrentMapSession, Is.Not.Null);
             Assert.That(engine.CurrentMapSession!.PrimaryBoard, Is.TypeOf<NodeGraphBoard>());
@@ -652,7 +653,7 @@ namespace Ludots.Tests.GAS
         public void RoadNetworkShowcaseRuntime_HandleMapFocused_PrimesInteractiveBootstrapState()
         {
             using var engine = CreateRoadShowcaseEngine();
-            engine.LoadMap(engine.MergedConfig.StartupMapId);
+            engine.LoadStartupMap();
 
             var runtime = new RoadNetworkShowcaseRuntime();
             var context = new ScriptContext();
@@ -678,7 +679,7 @@ namespace Ludots.Tests.GAS
         public void RoadNetworkShowcaseRuntime_UpdateLoadedChunks_RepairsLocalPlayerAndSeedsLivePrimarySelectionWithoutReset()
         {
             using var engine = CreateRoadShowcaseEngine();
-            engine.LoadMap(engine.MergedConfig.StartupMapId);
+            engine.LoadStartupMap();
 
             var runtime = new RoadNetworkShowcaseRuntime();
             var context = new ScriptContext();
@@ -705,7 +706,7 @@ namespace Ludots.Tests.GAS
         public void RoadNetworkShowcaseRuntime_UpdateLoadedChunks_DoesNotOverwriteValidLivePrimarySelection()
         {
             using var engine = CreateRoadShowcaseEngine();
-            engine.LoadMap(engine.MergedConfig.StartupMapId);
+            engine.LoadStartupMap();
 
             var runtime = new RoadNetworkShowcaseRuntime();
             var context = new ScriptContext();
@@ -735,7 +736,7 @@ namespace Ludots.Tests.GAS
         public void RoadNetworkShowcaseRuntime_BuildPanelState_FollowsLivePrimarySelectionPrimary()
         {
             using var engine = CreateRoadShowcaseEngine();
-            engine.LoadMap(engine.MergedConfig.StartupMapId);
+            engine.LoadStartupMap();
 
             var runtime = new RoadNetworkShowcaseRuntime();
             var context = new ScriptContext();
@@ -868,7 +869,7 @@ namespace Ludots.Tests.GAS
         public void RoadNetworkShowcase_EngineFarRoadMove_ReachesDestinationWithoutStoppingMidRoute()
         {
             using var engine = CreateRoadShowcaseEngine();
-            engine.LoadMap(engine.MergedConfig.StartupMapId);
+            engine.LoadStartupMap();
 
             Entity actor = FindEntityByInstanceId(engine, BlueVanguardInstanceId);
             Assert.That(actor, Is.Not.EqualTo(Entity.Null));
@@ -932,7 +933,7 @@ namespace Ludots.Tests.GAS
         public void RoadNetworkShowcase_EngineCentralRoadMove_DoesNotBacktrackToBehindSampledWaypoint()
         {
             using var engine = CreateRoadShowcaseEngine();
-            engine.LoadMap(engine.MergedConfig.StartupMapId);
+            engine.LoadStartupMap();
 
             Entity actor = FindEntityByInstanceId(engine, BlueVanguardInstanceId);
             Assert.That(actor, Is.Not.EqualTo(Entity.Null));
@@ -982,7 +983,7 @@ namespace Ludots.Tests.GAS
         public void RoadNetworkShowcase_EngineBranchRoadQuery_BuildsFollowRouteForBranchClick()
         {
             using var engine = CreateRoadShowcaseEngine();
-            engine.LoadMap(engine.MergedConfig.StartupMapId);
+            engine.LoadStartupMap();
 
             Entity actor = FindEntityByInstanceId(engine, BlueVanguardInstanceId);
             Assert.That(actor, Is.Not.EqualTo(Entity.Null));
@@ -1023,7 +1024,7 @@ namespace Ludots.Tests.GAS
         public void RoadNetworkShowcase_EngineNorthColumnRoadMove_ReachesDestination()
         {
             using var engine = CreateRoadShowcaseEngine();
-            engine.LoadMap(engine.MergedConfig.StartupMapId);
+            engine.LoadStartupMap();
 
             Entity actor = FindEntityByInstanceId(engine, BlueNorthColumnInstanceId);
             Assert.That(actor, Is.Not.EqualTo(Entity.Null));
@@ -1081,7 +1082,7 @@ namespace Ludots.Tests.GAS
         public void RoadNetworkShowcase_StrategyMatrix_WritesAcceptanceArtifacts_ForProfilesWeightsAndTraits()
         {
             using var engine = CreateRoadShowcaseEngine();
-            engine.LoadMap(engine.MergedConfig.StartupMapId);
+            engine.LoadStartupMap();
 
             int moveToOrderTypeId = engine.MergedConfig.Constants.OrderTypeIds["moveTo"];
             int roadMoveFollowOrderTypeId = engine.MergedConfig.Constants.OrderTypeIds[RoadNetworkShowcaseIds.RoadMoveFollowOrderTypeKey];
@@ -1834,7 +1835,17 @@ namespace Ludots.Tests.GAS
 
         private static void LoadPlayableMap(GameEngine engine, string mapId, int frames = 5)
         {
-            engine.LoadMap(mapId);
+            if (string.Equals(mapId, engine.MergedConfig.StartupMapId, StringComparison.OrdinalIgnoreCase))
+            {
+                engine.LoadStartupMap();
+            }
+            else
+            {
+                MapLaunchContext? launchContext = engine.MergedConfig.StartupSelectedPlayerId > 0
+                    ? MapLaunchContext.Create(engine.MergedConfig.StartupSelectedPlayerId)
+                    : null;
+                engine.LoadMap(MapLoadRequest.FromMapId(mapId, launchContext));
+            }
             Assert.That(engine.CurrentMapSession, Is.Not.Null, $"{mapId} should create a live map session.");
             Tick(engine, frames);
         }

--- a/src/Tests/PersistenceTests/SaveContextHeaderTests.cs
+++ b/src/Tests/PersistenceTests/SaveContextHeaderTests.cs
@@ -117,7 +117,7 @@ public sealed class SaveContextHeaderTests
         engine.InitializeWithConfigPipeline(
             RepoModPaths.ResolveExplicit(repoRoot, new[] { "LudotsCoreMod" }),
             Path.Combine(repoRoot, "assets"));
-        engine.LoadMap(engine.MergedConfig.StartupMapId);
+        engine.LoadStartupMap();
         return engine;
     }
 

--- a/src/Tests/PersistenceTests/SaveParticipantRegistryTests.cs
+++ b/src/Tests/PersistenceTests/SaveParticipantRegistryTests.cs
@@ -344,7 +344,7 @@ public sealed class SaveParticipantRegistryTests
         engine.InitializeWithConfigPipeline(
             RepoModPaths.ResolveExplicit(repoRoot, new[] { "LudotsCoreMod" }),
             Path.Combine(repoRoot, "assets"));
-        engine.LoadMap(engine.MergedConfig.StartupMapId);
+        engine.LoadStartupMap();
         return engine;
     }
 

--- a/src/Tests/PersistenceTests/WorldSnapshotOrchestrationTests.cs
+++ b/src/Tests/PersistenceTests/WorldSnapshotOrchestrationTests.cs
@@ -150,7 +150,7 @@ public sealed class WorldSnapshotOrchestrationTests
         engine.InitializeWithConfigPipeline(
             RepoModPaths.ResolveExplicit(repoRoot, new[] { "LudotsCoreMod" }),
             Path.Combine(repoRoot, "assets"));
-        engine.LoadMap(engine.MergedConfig.StartupMapId);
+        engine.LoadStartupMap();
         Assert.That(engine.GetService(CoreServiceKeys.SaveParticipants), Is.Not.Null);
         return engine;
     }

--- a/src/Tools/Ludots.Launcher.Evidence/LauncherEvidenceRecorder.cs
+++ b/src/Tools/Ludots.Launcher.Evidence/LauncherEvidenceRecorder.cs
@@ -235,7 +235,7 @@ public static class LauncherEvidenceRecorder
             throw new InvalidOperationException("Invalid launcher bootstrap: StartupMapId cannot be empty.");
         }
 
-        engine.LoadMap(config.StartupMapId);
+        engine.LoadStartupMap();
         return new RecordingRuntime(plan.AdapterId, engine, config, inputBackend, screenProjector, cameraPresenter, renderCameraDebug, presentationFrameSetup, hudProjection);
     }
 
@@ -310,7 +310,7 @@ public static class LauncherEvidenceRecorder
             throw new InvalidOperationException("Invalid launcher bootstrap: StartupMapId cannot be empty.");
         }
 
-        engine.LoadMap(config.StartupMapId);
+        engine.LoadStartupMap();
         return new RecordingRuntime(plan.AdapterId, engine, config, inputBackend, screenProjector, cameraPresenter, renderCameraDebug, presentationFrameSetup, hudProjection);
     }
 
@@ -1930,7 +1930,7 @@ public static class LauncherEvidenceRecorder
                 throw new InvalidOperationException("MassNavigation UAT requires a configured startup map.");
             }
 
-            runtime.Engine.LoadMap(runtime.Config.StartupMapId);
+            runtime.Engine.LoadStartupMap();
         }
 
         PresentationTimingDiagnostics timings = runtime.Engine.GetService(CoreServiceKeys.PresentationTimingDiagnostics)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Core-owned map launch contract so callers can load the same `MapId` with different runtime local-player selection without duplicating map configs.

Fixes #496

## Design (revised per review)

**Core launch context is minimal:**

```csharp
MapLaunchContext
  SelectedPlayerId   // Core consumes: participant binding
  Metadata           // mod-owned custom payload only
```

- No `ScenarioId`, `SelectedFactionId`, or other mod-specific top-level fields
- **`Players[].IsLocal` removed** — local player is launch/session context only, not map authoring
- `ParticipantBindingResolver` resolves local player **only** from `LaunchContext.SelectedPlayerId`
- Bootstrap default: `GameConfig.StartupSelectedPlayerId` + `GameEngine.LoadStartupMap()`

## Usage

```csharp
engine.LoadMap(MapLoadRequest.FromMapId(
    "my_scenario_map",
    MapLaunchContext.Create(selectedPlayerId: 3)));

// startup path
engine.LoadStartupMap(); // reads StartupMapId + StartupSelectedPlayerId from merged game.json
```

Mod-specific data (campaign id, difficulty, etc.) goes in `Metadata`, not new Core fields.

## Tests

- `ParticipantBindingContractTests` updated (15 pass)
- Showcase `game.json` files with players declare `startupSelectedPlayerId`
- Map JSON `IsLocal` fields removed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3edab1cb-7a31-41bf-8b09-a42dbf53bf67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3edab1cb-7a31-41bf-8b09-a42dbf53bf67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

