### PR TITLE
fix(core): map launch context follow-up gaps

### DIFF
--- a/mods/showcases/road_network/RoadNetworkShowcaseMod/Runtime/RoadNetworkShowcaseRuntime.cs
+++ b/mods/showcases/road_network/RoadNetworkShowcaseMod/Runtime/RoadNetworkShowcaseRuntime.cs
@@ -7,6 +7,7 @@ using Ludots.Core.Gameplay.Camera;
 using Ludots.Core.Gameplay.Components;
 using Ludots.Core.Input.Selection;
 using Ludots.Core.Knowledge;
+using Ludots.Core.Map;
 using Ludots.Core.Map.Board;
 using Ludots.Core.Navigation.GraphWorld;
 using Ludots.Core.Scripting;
@@ -166,7 +167,9 @@ namespace RoadNetworkShowcaseMod.Runtime
             }
 
             string mapId = _activeMapId;
-            engine.LoadMap(mapId);
+            MapLaunchContext? launchContext = engine.CurrentMapSession?.LaunchContext
+                ?? MapLaunchContext.Create(engine.MergedConfig.StartupSelectedPlayerId);
+            engine.LoadMap(MapLoadRequest.FromMapId(mapId, launchContext));
             LastSubmitStatus = "Scenario reloaded.";
             RefreshPanel(engine);
             return true;

--- a/src/Core/Engine/GameEngine.MapLoadLifecycle.cs
+++ b/src/Core/Engine/GameEngine.MapLoadLifecycle.cs
@@ -430,6 +430,44 @@ namespace Ludots.Core.Engine
                     session.TeamRelationships));
         }
 
+        internal void RestoreMapSessionParticipantsAfterSave()
+        {
+            if (MapSessions == null)
+            {
+                return;
+            }
+
+            foreach (KeyValuePair<MapId, MapSession> pair in MapSessions.All)
+            {
+                MapSession session = pair.Value;
+                MapLaunchContext? launchContext = session.LaunchContext;
+                if (launchContext?.HasSelectedPlayer != true)
+                {
+                    continue;
+                }
+
+                int selectedPlayerId = launchContext.SelectedPlayerId;
+                if (!session.PlayerEntityLookup.TryGet(selectedPlayerId, out Entity entity))
+                {
+                    throw new InvalidOperationException(
+                        $"Cannot restore map session '{session.MapId.Value}' launch context SelectedPlayerId {selectedPlayerId} because the player is not bound.");
+                }
+
+                session.LocalPlayerId = selectedPlayerId;
+                session.LocalPlayerEntity = entity;
+            }
+
+            MapSession? focused = CurrentMapSession ?? MapSessions.FocusedSession;
+            if (focused != null)
+            {
+                PublishSessionParticipants(focused);
+                if (focused.LocalPlayerId > 0)
+                {
+                    GameSession.SelectLocalPlayer(focused.LocalPlayerId);
+                }
+            }
+        }
+
         private void CaptureFocusedParticipantOverrides(MapSession session)
         {
             if (session == null || CurrentMapSession != session)

--- a/src/Core/Engine/GameEngine.SaveRestore.cs
+++ b/src/Core/Engine/GameEngine.SaveRestore.cs
@@ -22,6 +22,7 @@ namespace Ludots.Core.Engine
             LudotsWorldStateImporter.ImportOwnedSnapshotInto(restoredWorld, World);
             SetService(CoreServiceKeys.World, World);
             registry.RestoreDomains(domains);
+            RestoreMapSessionParticipantsAfterSave();
             _cooperativeSimulation?.Reset();
         }
     }

--- a/src/Core/MassNavigation/Runtime/MassNavigationRuntime.cs
+++ b/src/Core/MassNavigation/Runtime/MassNavigationRuntime.cs
@@ -15,8 +15,6 @@ namespace Ludots.Core.MassNavigation.Runtime;
 
 public sealed class MassNavigationRuntime
 {
-    private static readonly QueryDescription AuthoredPlayerOwnerQuery = new QueryDescription().WithAll<PlayerOwner>();
-
     private MassNavigationConfig? _config;
     private bool _configResolved;
     private bool _systemsInstalled;
@@ -264,13 +262,8 @@ public sealed class MassNavigationRuntime
     {
         SelectionRuntime selection = engine.GetService(CoreServiceKeys.SelectionRuntime)
             ?? throw new InvalidOperationException("MassNavigation runtime requires SelectionRuntime.");
-        if (!engine.GlobalContext.TryGetValue(CoreServiceKeys.LocalPlayerEntity.Name, out var localObj) ||
-            localObj is not Entity owner ||
-            !engine.World.IsAlive(owner))
-        {
-            owner = ResolveSingleAuthoredPlayerOwner(engine);
-            engine.GlobalContext[CoreServiceKeys.LocalPlayerEntity.Name] = owner;
-        }
+        Entity owner = ResolveRequiredLocalPlayerEntity(engine);
+        engine.GlobalContext[CoreServiceKeys.LocalPlayerEntity.Name] = owner;
 
         if (!engine.World.Has<PlayerOwner>(owner))
         {
@@ -280,22 +273,23 @@ public sealed class MassNavigationRuntime
         EnsureSelectionOwner(engine.World, owner, selection, engine.GlobalContext);
     }
 
-    private static Entity ResolveSingleAuthoredPlayerOwner(GameEngine engine)
+    private static Entity ResolveRequiredLocalPlayerEntity(GameEngine engine)
     {
-        Entity resolved = Entity.Null;
-        int count = 0;
-        engine.World.Query(in AuthoredPlayerOwnerQuery, (Entity entity, ref PlayerOwner _) =>
+        if (engine.GlobalContext.TryGetValue(CoreServiceKeys.LocalPlayerEntity.Name, out var localObj) &&
+            localObj is Entity entity &&
+            engine.World.IsAlive(entity))
         {
-            resolved = entity;
-            count++;
-        });
+            return entity;
+        }
 
-        return count switch
+        MapSession? session = engine.CurrentMapSession;
+        if (session?.LocalPlayerEntity != Entity.Null && engine.World.IsAlive(session.LocalPlayerEntity))
         {
-            1 => resolved,
-            0 => throw new InvalidOperationException("MassNavigation runtime requires the map to author exactly one PlayerOwner local player entity."),
-            _ => throw new InvalidOperationException("MassNavigation runtime found multiple PlayerOwner entities before LocalPlayerEntity was resolved; author one local player or bind CoreServiceKeys.LocalPlayerEntity explicitly.")
-        };
+            return session.LocalPlayerEntity;
+        }
+
+        throw new InvalidOperationException(
+            "MassNavigation runtime requires map launch context to publish LocalPlayerEntity before binding selection owner.");
     }
 
     private static void EnsureSelectionOwner(World world, Entity owner, SelectionRuntime selection, Dictionary<string, object> globals)

--- a/src/Core/MassNavigation/Systems/MassNavigationLocalCommandInputSystem.cs
+++ b/src/Core/MassNavigation/Systems/MassNavigationLocalCommandInputSystem.cs
@@ -16,8 +16,6 @@ namespace Ludots.Core.MassNavigation.Systems;
 
 internal sealed class MassNavigationLocalCommandInputSystem : ISystem<float>
 {
-    private static readonly QueryDescription AuthoredPlayerOwnerQuery = new QueryDescription().WithAll<PlayerOwner>();
-
     private readonly GameEngine _engine;
     private readonly MassNavigationSimulationRuntime _simulation;
 
@@ -97,37 +95,22 @@ internal sealed class MassNavigationLocalCommandInputSystem : ISystem<float>
 
     private int ResolveLocalPlayerId()
     {
-        if (!_engine.GlobalContext.TryGetValue(CoreServiceKeys.LocalPlayerEntity.Name, out object? localObj) ||
-            localObj is not Entity local ||
-            !_engine.World.IsAlive(local))
+        if (_engine.GlobalContext.TryGetValue(CoreServiceKeys.LocalPlayerId.Name, out object? playerIdObj) &&
+            playerIdObj is int playerId &&
+            playerId > 0)
         {
-            local = ResolveSingleAuthoredPlayerOwner();
-            _engine.GlobalContext[CoreServiceKeys.LocalPlayerEntity.Name] = local;
+            return playerId;
         }
 
-        if (!_engine.World.TryGet(local, out PlayerOwner owner))
+        if (_engine.GlobalContext.TryGetValue(CoreServiceKeys.LocalPlayerEntity.Name, out object? localObj) &&
+            localObj is Entity local &&
+            _engine.World.IsAlive(local) &&
+            _engine.World.TryGet(local, out PlayerOwner owner))
         {
-            throw new InvalidOperationException("MassNavigation runtime LocalPlayerEntity must author PlayerOwner.");
+            return owner.PlayerId;
         }
 
-        return owner.PlayerId;
-    }
-
-    private Entity ResolveSingleAuthoredPlayerOwner()
-    {
-        Entity resolved = Entity.Null;
-        int count = 0;
-        _engine.World.Query(in AuthoredPlayerOwnerQuery, (Entity entity, ref PlayerOwner _) =>
-        {
-            resolved = entity;
-            count++;
-        });
-
-        return count switch
-        {
-            1 => resolved,
-            0 => throw new InvalidOperationException("MassNavigation runtime requires LocalPlayerEntity or exactly one authored PlayerOwner before submitting move orders."),
-            _ => throw new InvalidOperationException("MassNavigation runtime found multiple PlayerOwner entities before LocalPlayerEntity was resolved; author one local player or bind CoreServiceKeys.LocalPlayerEntity explicitly.")
-        };
+        throw new InvalidOperationException(
+            "MassNavigation runtime requires map launch context to publish LocalPlayerId before submitting move orders.");
     }
 }

--- a/src/Tools/Ludots.Launcher.Evidence/LauncherEvidenceRecorder.cs
+++ b/src/Tools/Ludots.Launcher.Evidence/LauncherEvidenceRecorder.cs
@@ -18,6 +18,7 @@ using Ludots.Core.Gameplay.GAS.Systems;
 using Ludots.Core.Hosting;
 using Ludots.Core.Input.Config;
 using Ludots.Core.Input.Selection;
+using Ludots.Core.Map;
 using Ludots.Core.Map.Board;
 using Ludots.Core.Input.Runtime;
 using Ludots.Core.MassNavigation;
@@ -874,7 +875,14 @@ public static class LauncherEvidenceRecorder
         using var runtime = CreateRuntime(request.Plan, request.BootstrapPath);
         if (!string.Equals(runtime.Config.StartupMapId, "road_network_showcase_chunked", StringComparison.OrdinalIgnoreCase))
         {
-            runtime.Engine.LoadMap("road_network_showcase_chunked");
+            if (runtime.Config.StartupSelectedPlayerId <= 0)
+            {
+                throw new InvalidOperationException(
+                    "Road network evidence requires StartupSelectedPlayerId in merged game config.");
+            }
+
+            MapLaunchContext? launchContext = MapLaunchContext.Create(runtime.Config.StartupSelectedPlayerId);
+            runtime.Engine.LoadMap(MapLoadRequest.FromMapId("road_network_showcase_chunked", launchContext));
         }
 
         Tick(runtime, 10, frameTimesMs);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #497 — closes P1 gaps from the launch-context compliance audit.

## Changes

- **MassNavigation**: remove `PlayerOwner` world-scan fallbacks; require `LocalPlayerId` / `LocalPlayerEntity` from map launch context
- **RoadNetworkShowcaseRuntime**: `TryReloadScenario` preserves/reinjects `LaunchContext` on reload
- **Save restore**: `RestoreMapSessionParticipantsAfterSave()` rebinds `LocalPlayerId`/`LocalPlayerEntity` from restored `LaunchContext` and republishes focused globals
- **LauncherEvidenceRecorder**: road evidence path loads map with explicit launch context

## Related

- Merged: #497 (fixes #496)

---

## Downstream migration guide (for repos referencing Ludots Core)

### Breaking changes (since #497)

| Removed / changed | Replacement |
|-------------------|-------------|
| `PlayerBindingData.IsLocal` / map JSON `"IsLocal"` | `MapLaunchContext.SelectedPlayerId` at load time |
| Implicit local player from map authoring | `GameConfig.startupSelectedPlayerId` + `LoadStartupMap()` or explicit `MapLoadRequest` |
| MassNavigation `PlayerOwner` scan fallback | Must have `LocalPlayerId` published via launch context before move orders |

### 1. Map authoring (`assets/Maps/*.json`)

**Before:**
```json
"Players": [
  { "PlayerId": 1, "TeamId": 1, "RepresentativeInstanceId": "player.one", "IsLocal": true }
]
```

**After:**
```json
"Players": [
  { "PlayerId": 1, "TeamId": 1, "RepresentativeInstanceId": "player.one" }
]
```

Remove all `"IsLocal"` fields. Map identity no longer carries local-seat semantics.

### 2. Mod bootstrap (`assets/game.json`)

If the startup map declares `Players` and needs a local controllable seat:

```json
{
  "startupMapId": "my_map",
  "startupSelectedPlayerId": 1
}
```

`startupSelectedPlayerId` must match an authored `Players[].PlayerId` in that map.

### 3. C# load callers

**Startup / entry:**
```csharp
engine.LoadStartupMap(); // replaces LoadMap(config.StartupMapId) when local player needed
```

**Runtime map switch with seat selection:**
```csharp
engine.LoadMap(MapLoadRequest.FromMapId(
    mapId,
    MapLaunchContext.Create(selectedPlayerId: chosenPlayerId)));
```

**Reload same map — preserve launch context:**
```csharp
var ctx = engine.CurrentMapSession?.LaunchContext
    ?? MapLaunchContext.Create(engine.MergedConfig.StartupSelectedPlayerId);
engine.LoadMap(MapLoadRequest.FromMapId(mapId, ctx));
```

**Maps without `Players` bindings** (pure spatial/showcase): `LoadMap(string)` still works; no local player is published.

### 4. Triggers / `LoadMapCommand`

```csharp
new LoadMapCommand
{
    MapId = "scenario_map",
    SelectedPlayerId = 3, // required when map has Players and needs local seat
}
```

### 5. Mod-specific launch data (campaign id, difficulty, etc.)

Do **not** add Core top-level fields. Use `Metadata`:

```csharp
MapLaunchContext.Create(
    selectedPlayerId: 3,
    metadata: new Dictionary<string, object>
    {
        ["campaignId"] = "act-2",
        ["difficulty"] = "hard",
    });
```

Read in triggers: `context.GetMapLaunchContext()?.Metadata` or `session.LaunchContext.Metadata`.

### 6. Adapters (Raylib / Web / custom hosts)

Replace:
```csharp
engine.LoadMap(config.StartupMapId);
```
With:
```csharp
engine.LoadStartupMap();
```

### 7. Save / resume

`mapSessions` domain now persists optional `launchContext`:

```json
{
  "mapId": "my_map",
  "state": "Active",
  "launchContext": { "selectedPlayerId": 1, "metadata": { } }
}
```

After #498: restore rebinds `LocalPlayerId`/`LocalPlayerEntity` from saved launch context. Downstream save consumers do not need a parallel selection store.

### 8. Validation checklist for downstream repos

- [ ] Grep `"IsLocal"` in map JSON — remove all player-authoring uses
- [ ] Grep `LoadMap(` — participant maps must pass `MapLoadRequest` or use `LoadStartupMap`
- [ ] Grep `IsLocal` in C# `PlayerBindingData` — remove
- [ ] Add `startupSelectedPlayerId` to `game.json` if startup map has `Players`
- [ ] Reload paths preserve `CurrentMapSession.LaunchContext`
- [ ] Custom launch payload uses `Metadata`, not new Core properties
- [ ] MassNavigation / input paths assume `LocalPlayerId` exists only after launch context load

### Reference implementations in Ludots

- `mods/showcases/road_network/RoadNetworkShowcaseMod/` — `game.json` + reload
- `gitbook/architecture/map-owned-participant-contract.md` §5 — formal contract
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3edab1cb-7a31-41bf-8b09-a42dbf53bf67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3edab1cb-7a31-41bf-8b09-a42dbf53bf67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

