### PR TITLE
feat(placement): Placement Validation Core (#509)

### DIFF
--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -23,6 +23,7 @@
   - [能力标准 Showcase](architecture/capability-standard-showcases.md)
   - [Map-Owned Participant Contract](architecture/map-owned-participant-contract.md)
   - [Transport Network SSOT](architecture/transport-network-ssot.md)
+  - [Placement Validation SSOT](architecture/placement-validation-ssot.md)
   - [空间尺度与分辨率 SSOT](architecture/spatial-scale-and-resolution-ssot.md)
   - [Prefab Grounding �?Visual Height](architecture/prefab-grounding-and-visual-height.md)
   - [Performer-as-Actor 架构总览](architecture/performer-as-actor-architecture.md)

--- a/gitbook/architecture/README.md
+++ b/gitbook/architecture/README.md
@@ -22,6 +22,7 @@
 - [Global Field Rendering](global-field-rendering.md)
 - [Map-Owned Participant Contract](map-owned-participant-contract.md)
 - [Transport Network SSOT](transport-network-ssot.md)
+- [Placement Validation SSOT](placement-validation-ssot.md)
 - [空间尺度与分辨率 SSOT](spatial-scale-and-resolution-ssot.md)
 - [Logic Terrain and Topology](../reference/logic-terrain-and-topology.md)
 - [NavBakeContext 与统一烘焙服务](../reference/nav-bake-context.md)

--- a/gitbook/architecture/placement-validation-ssot.md
+++ b/gitbook/architecture/placement-validation-ssot.md
@@ -1,0 +1,73 @@
+# Placement Validation SSOT
+
+Parent: GitHub issue #509. 本页是放置位合法性检测（Placement Validation）的正式架构 SSOT。
+
+## 目标
+
+为瞄准、能力激活、Effect phase graph 提供统一的落点解析与合法性原语，避免 presentation、input、GAS 各自维护平行 clamp / snap 逻辑。
+
+## 复用清单
+
+| 能力 | 归属 |
+|---|---|
+| 落点解析 | `EffectTargetPointResolver` |
+| Phase graph `TargetPos` 注入 | `PlacementPhaseTargetPosResolver` |
+| 范围 clamp / 圆内检测 | `PlacementValidation` |
+| Entity collection snap | `EntityCollectionStore` + `PlacementValidation.TrySnapToNearestInCollection` |
+| NodeGraph 边投影 snap | `GraphEdgeProjectionQuery` + `PlacementValidation.TrySnapToNearestGraphEdge` |
+| Graph VM 执行 | `GasGraphOpHandlerTable`, `GraphExecutor.ExecuteValidation` |
+| 激活前校验 | `activationPrecondition.validationGraph` |
+| OnPropose 拒绝 | `EffectPhaseExecutor.ExecutePhaseWithValidationResult` → `B[0]=0` |
+
+不得新增平行 clamp 工具、平行 target resolver 或平行 graph query helper。
+
+## 分层
+
+```text
+Layer 0  PlacementValidation              — Fix64 原语（clamp / circle / collection / graph edge）
+Layer 1  EffectTargetPointResolver        — EffectContext + caller params → 世界坐标
+         PlacementPhaseTargetPosResolver   — Layer 1 → IntVector2 TargetPos
+Layer 2  Graph ops 402–407               — VM 可编排校验 / snap
+Layer 3  Phase graph bindings             — OnPropose / OnCalculate / OnApply / validationGraph
+```
+
+## Graph Ops（402–407）
+
+| Op | ID | 行为 |
+|---|---|---|
+| `LoadTargetPosX` | 402 | `I[dst] = TargetPos.X` |
+| `LoadTargetPosY` | 403 | `I[dst] = TargetPos.Y` |
+| `ClampTargetToRange` | 404 | 以 `E[A]` 为原点、`F[B]` 为射程，clamp `TargetPos`；`B[dst]` = 是否在射程内 |
+| `IsPointInCircle` | 405 | `TargetPos` 是否在 `E[A]` 为圆心、`F[B]` 为半径的圆内 |
+| `SnapToNearestInCollection` | 406 | 将 `TargetPos` snap 到 `E[A]` 的 collection 最近实体 |
+| `SnapToNearestGraphEdge` | 407 | 将 `TargetPos` 投影到 `F[A]` 搜索半径内的最近图边 |
+
+`SnapToNearestGraphEdge` 复用 [Graph Query Services](../reference/graph-query-services.md) 中的 `GraphEdgeProjectionQuery`，需要运行时绑定 `LoadedGraphRuntime`（`GasGraphRuntimeApi.BindLoadedGraphRuntime`）。无图板时返回 `false`，不得 fallback 到原始坐标。
+
+## 管线接线
+
+| 阶段 | `TargetPos` 来源 | 拒绝语义 |
+|---|---|---|
+| Ability activation | `AbilityExecSystem` 黑板上报点 | `activationPrecondition.validationGraph` → `ExecuteValidation` |
+| OnPropose | `PlacementPhaseTargetPosResolver` | phase graph `B[0]=0` → proposal `Cancelled=true` |
+| OnCalculate / OnApply | 同上 | 由 graph 自行决定（无全局硬编码） |
+| Aim preview | `AbilityAimPresentationRuntime` | presentation 仅预览，不写权威位置 |
+| Aim gameplay | `AbilityExecAimSyncSystem` | 写 `AbilityExecInstance.TargetPosCm` + cast blackboard |
+
+Presentation 与 gameplay 共用 Layer 0 `PlacementValidation.ClampToRange`；float 仅在 presentation 边界转换。
+
+## 边界
+
+Placement Validation **不负责**：
+
+- 地形 / navmesh / 障碍扫描（SY37 地形项仍为 backlog）
+- Transport 路线评分、lane 选择、业务 route bias
+- 结构变更（spawn / destroy entity）
+
+这些属于各自正式管线（Navigation、Transport Network SSOT、GAS spawn queue）。
+
+## 验证
+
+- `src/Tests/GasTests/PlacementValidationTests.cs`
+- `src/Tests/GasTests/TransportNetworkCoreTests.cs`（GraphQuery 基座）
+- `InputOrderAbilityAuditTests`、`AbilityAimPresentationRuntimeTests`、`EffectPhaseArchitectureTests`

--- a/gitbook/reference/graph-query-services.md
+++ b/gitbook/reference/graph-query-services.md
@@ -17,6 +17,8 @@ These services are intentionally domain-neutral. They do not score business rout
 
 Use them when a mod needs shared graph mechanics such as edge projection, snapping, or multi-leg stitching. Do not clone equivalent helpers into a showcase-specific namespace.
 
+Placement validation graphs consume `GraphEdgeProjectionQuery` through `PlacementValidation.TrySnapToNearestGraphEdge` and graph op `SnapToNearestGraphEdge` (see [Placement Validation SSOT](../architecture/placement-validation-ssot.md)).
+
 ## Failure Semantics
 
 - Empty or invalid input returns `false` or a short failure string.

--- a/mods/CoreInputMod/Systems/AbilityExecAimSyncSystem.cs
+++ b/mods/CoreInputMod/Systems/AbilityExecAimSyncSystem.cs
@@ -1,8 +1,10 @@
 using Arch.Core;
 using Arch.System;
 using Ludots.Core.Components;
+using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Components;
 using Ludots.Core.Gameplay.GAS.Orders;
+using Ludots.Core.Gameplay.Placement;
 using Ludots.Core.Mathematics;
 using Ludots.Core.Mathematics.FixedPoint;
 
@@ -37,6 +39,8 @@ namespace CoreInputMod.Systems
                 return;
             }
 
+            _context.TryGetAbilityDefinitionRegistry(out AbilityDefinitionRegistry? abilityDefinitions);
+
             World.Query(in Query, (Entity entity, ref AbilityExecInstance exec, ref AbilityExecAimSync sync) =>
             {
                 if (!entity.Equals(actor) || exec.AbilitySlot != sync.AbilitySlot)
@@ -44,12 +48,27 @@ namespace CoreInputMod.Systems
                     return;
                 }
 
-                exec.TargetPosCm = Fix64Vec2.FromInt(worldCm.X, worldCm.Y);
+                Fix64Vec2 targetCm = Fix64Vec2.FromInt(worldCm.X, worldCm.Y);
+                if (abilityDefinitions != null &&
+                    abilityDefinitions.TryGet(exec.AbilityId, out AbilityDefinition definition) &&
+                    definition.HasTargeting &&
+                    definition.Targeting.CastRangeCm > 0f &&
+                    World.TryGet(entity, out WorldPositionCm position))
+                {
+                    Fix64Vec2 originCm = position.Value;
+                    PlacementValidation.ClampToRange(
+                        in originCm,
+                        ref targetCm,
+                        Fix64.FromFloat(definition.Targeting.CastRangeCm),
+                        out _);
+                }
+
+                exec.TargetPosCm = targetCm;
                 exec.HasTargetPos = 1;
 
-                if (sync.SyncFacing != 0 && World.TryGet(entity, out WorldPositionCm position))
+                if (sync.SyncFacing != 0 && World.TryGet(entity, out WorldPositionCm facingPosition))
                 {
-                    Fix64Vec2 delta = exec.TargetPosCm - position.Value;
+                    Fix64Vec2 delta = exec.TargetPosCm - facingPosition.Value;
                     if (delta.X != Fix64.Zero || delta.Y != Fix64.Zero)
                     {
                         Upsert(entity, new FacingDirection { AngleRad = WorldPlane2D.FacingRadFromDirection(in delta) });
@@ -60,7 +79,7 @@ namespace CoreInputMod.Systems
                 {
                     spatial.SetPoint(
                         OrderBlackboardKeys.Cast_TargetPosition,
-                        new System.Numerics.Vector3(worldCm.X, 0f, worldCm.Y));
+                        new System.Numerics.Vector3(targetCm.X.ToFloat(), 0f, targetCm.Y.ToFloat()));
                     World.Set(entity, spatial);
                 }
             });

--- a/mods/CoreInputMod/Systems/InputInteractionContextAccessor.cs
+++ b/mods/CoreInputMod/Systems/InputInteractionContextAccessor.cs
@@ -11,6 +11,7 @@ using Ludots.Core.Input.Orders;
 using Ludots.Core.Input.Runtime;
 using Ludots.Core.Input.Selection;
 using Ludots.Core.Mathematics;
+using Ludots.Core.Navigation.GraphWorld;
 using Ludots.Core.NodeLibraries.GASGraph.Host;
 using Ludots.Core.Presentation.Events;
 using Ludots.Core.Presentation.Utils;
@@ -223,6 +224,11 @@ namespace CoreInputMod.Systems
                     eventBus: null,
                     effectRequests: null,
                     _globals);
+                if (_globals.TryGetValue(CoreServiceKeys.LoadedGraphRuntime.Name, out var graphRuntimeObj) &&
+                    graphRuntimeObj is LoadedGraphRuntime graphRuntime)
+                {
+                    graphApi.BindLoadedGraphRuntime(graphRuntime);
+                }
             }
 
             runtime = new AbilityAimPresentationRuntime(

--- a/mods/CoreInputMod/Systems/InputInteractionContextAccessor.cs
+++ b/mods/CoreInputMod/Systems/InputInteractionContextAccessor.cs
@@ -172,6 +172,19 @@ namespace CoreInputMod.Systems
             return SelectionContextRuntime.TryGetCurrentHovered(_world, _globals, out entity);
         }
 
+        public bool TryGetAbilityDefinitionRegistry(out AbilityDefinitionRegistry registry)
+        {
+            registry = default!;
+            if (_globals.TryGetValue(CoreServiceKeys.AbilityDefinitionRegistry.Name, out var abilitiesObj) &&
+                abilitiesObj is AbilityDefinitionRegistry abilities)
+            {
+                registry = abilities;
+                return true;
+            }
+
+            return false;
+        }
+
         public bool TryCreateAbilityAimPresentationRuntime(out AbilityAimPresentationRuntime runtime)
         {
             runtime = default!;

--- a/src/Core/Engine/GameEngine.cs
+++ b/src/Core/Engine/GameEngine.cs
@@ -224,6 +224,7 @@ namespace Ludots.Core.Engine
         private Ludots.Core.Presentation.Instancing.InstancedBatchRequestBuffer _instancedBatchRequestBuffer;
         private Ludots.Core.Presentation.Instancing.InstancedBatchOperationBuffer _instancedBatchOperationBuffer;
         private GasPresentationEventBuffer _gasPresentationEvents;
+        private GasGraphRuntimeApi _gasGraphRuntimeApi;
         private Ludots.Core.Presentation.Rendering.GroundOverlayBuffer _groundOverlayBuffer;
         private Ludots.Core.Presentation.Rendering.RoadSplineBuffer _roadSplineBuffer;
         private Ludots.Core.Presentation.Hud.WorldHudBatchBuffer _worldHudBuffer;
@@ -804,6 +805,7 @@ namespace Ludots.Core.Engine
                 targetDispatchPresetRegistry,
                 entityCollectionStore,
                 entitySetQueryRuntime);
+            _gasGraphRuntimeApi = gasGraphApi;
             var graphReturnWriter = new GraphReturnWriter(
                 World,
                 graphProgramRegistry,
@@ -2136,10 +2138,12 @@ namespace Ludots.Core.Engine
             if (board is INodeGraphBoard nodeGraphBoard)
             {
                 SetService(CoreServiceKeys.LoadedGraphRuntime, nodeGraphBoard.GraphRuntime);
+                _gasGraphRuntimeApi?.BindLoadedGraphRuntime(nodeGraphBoard.GraphRuntime);
             }
             else
             {
                 RemoveService(CoreServiceKeys.LoadedGraphRuntime);
+                _gasGraphRuntimeApi?.BindLoadedGraphRuntime(null);
             }
 
             // Update GlobalContext with rebuilt services

--- a/src/Core/Gameplay/GAS/EffectTargetPointResolver.cs
+++ b/src/Core/Gameplay/GAS/EffectTargetPointResolver.cs
@@ -1,0 +1,113 @@
+using Arch.Core;
+using Ludots.Core.Components;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.Components;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Mathematics.FixedPoint;
+
+namespace Ludots.Core.Gameplay.GAS
+{
+    /// <summary>
+    /// SSOT for resolving cast/placement target points from effect context and caller params.
+    /// </summary>
+    public static class EffectTargetPointResolver
+    {
+        public static bool TryResolve(
+            World world,
+            in EffectContext context,
+            in EffectConfigParams mergedParams,
+            out Fix64Vec2 positionCm)
+        {
+            if (TryGetPreservedTargetPoint(in mergedParams, out WorldCmInt2 point))
+            {
+                positionCm = Fix64Vec2.FromInt(point.X, point.Y);
+                return true;
+            }
+
+            if (world.IsAlive(context.Target) && world.Has<WorldPositionCm>(context.Target))
+            {
+                positionCm = world.Get<WorldPositionCm>(context.Target).Value;
+                return true;
+            }
+
+            if (world.IsAlive(context.TargetContext) && world.Has<WorldPositionCm>(context.TargetContext))
+            {
+                positionCm = world.Get<WorldPositionCm>(context.TargetContext).Value;
+                return true;
+            }
+
+            if (world.IsAlive(context.Source) &&
+                world.Has<AbilityExecInstance>(context.Source))
+            {
+                ref readonly var exec = ref world.Get<AbilityExecInstance>(context.Source);
+                if (exec.HasTargetPos != 0)
+                {
+                    positionCm = exec.TargetPosCm;
+                    return true;
+                }
+            }
+
+            positionCm = default;
+            return false;
+        }
+
+        public static bool TryResolveOrigin(
+            World world,
+            in EffectContext context,
+            in EffectConfigParams mergedParams,
+            out Fix64Vec2 positionCm)
+        {
+            if (TryGetPreservedTargetOrigin(in mergedParams, out WorldCmInt2 point))
+            {
+                positionCm = Fix64Vec2.FromInt(point.X, point.Y);
+                return true;
+            }
+
+            if (world.IsAlive(context.Source) &&
+                world.Has<AbilityExecInstance>(context.Source))
+            {
+                ref readonly var exec = ref world.Get<AbilityExecInstance>(context.Source);
+                if (exec.HasTargetOriginPos != 0)
+                {
+                    positionCm = exec.TargetOriginPosCm;
+                    return true;
+                }
+            }
+
+            if (world.IsAlive(context.Source) && world.Has<WorldPositionCm>(context.Source))
+            {
+                positionCm = world.Get<WorldPositionCm>(context.Source).Value;
+                return true;
+            }
+
+            positionCm = default;
+            return false;
+        }
+
+        private static bool TryGetPreservedTargetOrigin(in EffectConfigParams mergedParams, out WorldCmInt2 point)
+        {
+            if (mergedParams.TryGetFloat(EffectParamKeys.TargetOriginX, out float x) &&
+                mergedParams.TryGetFloat(EffectParamKeys.TargetOriginY, out float y))
+            {
+                point = new WorldCmInt2((int)x, (int)y);
+                return true;
+            }
+
+            point = default;
+            return false;
+        }
+
+        private static bool TryGetPreservedTargetPoint(in EffectConfigParams mergedParams, out WorldCmInt2 point)
+        {
+            if (mergedParams.TryGetFloat(EffectParamKeys.TargetPosX, out float x) &&
+                mergedParams.TryGetFloat(EffectParamKeys.TargetPosY, out float y))
+            {
+                point = new WorldCmInt2((int)x, (int)y);
+                return true;
+            }
+
+            point = default;
+            return false;
+        }
+    }
+}

--- a/src/Core/Gameplay/GAS/Systems/EffectApplicationSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/EffectApplicationSystem.cs
@@ -1,8 +1,10 @@
 using Arch.Core;
 using Arch.Core.Extensions;
 using Ludots.Core.Gameplay.Exchange;
-using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Mathematics;
 using Ludots.Core.Gameplay.GAS;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.Placement;
 using Ludots.Core.Gameplay.GAS.Presentation;
 using Ludots.Core.Gameplay.Components;
 using Ludots.Core.Gameplay.Teams;
@@ -10,7 +12,6 @@ using Ludots.Core.Gameplay.Spawning;
 using Ludots.Core.Gameplay.Progression;
 using Ludots.Core.Components;
 using Ludots.Core.Spatial;
-using Ludots.Core.Mathematics;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System;
@@ -625,10 +626,11 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             if (_graphApiHost != null && mergedConfig.Count > 0)
                 _graphApiHost.SetConfigContext(in mergedConfig);
 
+            IntVector2 targetPos = PlacementPhaseTargetPosResolver.Resolve(World, in context, in mergedConfig);
             _phaseExecutor.ExecutePhase(
                 World, _graphApi,
                 context.Source, context.Target, context.TargetContext,
-                default,
+                targetPos,
                 phase,
                 in tpl.PhaseGraphBindings,
                 tpl.PresetType,

--- a/src/Core/Gameplay/GAS/Systems/EffectPhaseExecutor.cs
+++ b/src/Core/Gameplay/GAS/Systems/EffectPhaseExecutor.cs
@@ -150,6 +150,44 @@ namespace Ludots.Core.Gameplay.GAS.Systems
         }
 
         /// <summary>
+        /// Execute a phase graph and return whether validation convention B[0] remains set (1 = pass).
+        /// </summary>
+        public bool ExecutePhaseWithValidationResult(
+            World world,
+            IGraphRuntimeApi api,
+            Entity caster,
+            Entity target,
+            Entity targetContext,
+            IntVector2 targetPos,
+            EffectPhaseId phase,
+            in EffectPhaseGraphBindings behavior,
+            EffectPresetType presetType,
+            int effectTagId,
+            int effectTemplateId,
+            in EffectConfigParams mergedParams,
+            BuiltinHandlerExecutionContext? builtinRuntime = null,
+            uint randomSeed = 0)
+        {
+            _boolRegs[0] = 1;
+            ExecutePhase(
+                world,
+                api,
+                caster,
+                target,
+                targetContext,
+                targetPos,
+                phase,
+                behavior,
+                presetType,
+                effectTagId,
+                effectTemplateId,
+                in mergedParams,
+                builtinRuntime,
+                randomSeed);
+            return _boolRegs[0] != 0;
+        }
+
+        /// <summary>
         /// Execute the Main handler for a phase based on PresetTypeDefinition.
         /// </summary>
         private void ExecuteMainHandler(

--- a/src/Core/Gameplay/GAS/Systems/EffectProposalProcessingSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/EffectProposalProcessingSystem.cs
@@ -10,7 +10,9 @@ using Ludots.Core.Gameplay.GAS.Input;
 using Ludots.Core.Gameplay.GAS.Orders;
 using Ludots.Core.Gameplay.GAS.Presentation;
 using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.Gameplay.Placement;
 using Ludots.Core.Gameplay.Components;
+using Ludots.Core.Mathematics;
 
 namespace Ludots.Core.Gameplay.GAS.Systems
 {
@@ -390,7 +392,11 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                     }
 
                     // Execute OnPropose Phase Graphs (before ResponseChain)
-                    ExecuteOnProposePhase(in root, in rootTpl);
+                    if (!ExecuteOnProposePhase(in root, in rootTpl))
+                    {
+                        root.Cancelled = true;
+                        _window[_window.Count - 1] = root;
+                    }
 
                     if (rootTpl.ParticipatesInResponse)
                     {
@@ -1181,20 +1187,29 @@ namespace Ludots.Core.Gameplay.GAS.Systems
         /// <summary>
         /// Execute OnPropose phase graphs for a proposal.
         /// Called after EffectProposal is created, before ResponseChain window.
+        /// Returns false when the phase graph sets B[0]=0 (placement/validation rejection).
         /// </summary>
-        private void ExecuteOnProposePhase(in EffectProposal proposal, in EffectTemplateData tpl)
+        private bool ExecuteOnProposePhase(in EffectProposal proposal, in EffectTemplateData tpl)
         {
-            if (_phaseExecutor == null || _graphApi == null) return;
+            if (_phaseExecutor == null || _graphApi == null) return true;
 
             var mergedConfig = BuildMergedConfig(in tpl, in proposal);
             if (_graphApiHost != null && mergedConfig.Count > 0)
             {
                 _graphApiHost.SetConfigContext(in mergedConfig);
             }
-            _phaseExecutor.ExecutePhase(
+
+            var context = new EffectContext
+            {
+                Source = proposal.Source,
+                Target = proposal.Target,
+                TargetContext = proposal.TargetContext,
+            };
+            IntVector2 targetPos = PlacementPhaseTargetPosResolver.Resolve(World, in context, in mergedConfig);
+            bool accepted = _phaseExecutor.ExecutePhaseWithValidationResult(
                 World, _graphApi,
                 proposal.Source, proposal.Target, proposal.TargetContext,
-                default, // targetPos: not needed for Propose
+                targetPos,
                 EffectPhaseId.OnPropose,
                 in tpl.PhaseGraphBindings,
                 tpl.PresetType,
@@ -1202,6 +1217,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                 proposal.TemplateId,
                 in mergedConfig);
             ClearConfigContext();
+            return accepted;
         }
 
         /// <summary>
@@ -1217,10 +1233,18 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             {
                 _graphApiHost.SetConfigContext(in mergedConfig);
             }
+
+            var context = new EffectContext
+            {
+                Source = proposal.Source,
+                Target = proposal.Target,
+                TargetContext = proposal.TargetContext,
+            };
+            IntVector2 targetPos = PlacementPhaseTargetPosResolver.Resolve(World, in context, in mergedConfig);
             _phaseExecutor.ExecutePhase(
                 World, _graphApi,
                 proposal.Source, proposal.Target, proposal.TargetContext,
-                default,
+                targetPos,
                 EffectPhaseId.OnCalculate,
                 in tpl.PhaseGraphBindings,
                 tpl.PresetType,

--- a/src/Core/Gameplay/GAS/TargetResolverFanOutHelper.cs
+++ b/src/Core/Gameplay/GAS/TargetResolverFanOutHelper.cs
@@ -383,25 +383,9 @@ namespace Ludots.Core.Gameplay.GAS
 
         private static bool TryResolveQueryOrigin(World world, in EffectContext ctx, in EffectConfigParams mergedParams, out WorldCmInt2 point)
         {
-            if (TryGetPreservedTargetOrigin(in mergedParams, out point))
+            if (EffectTargetPointResolver.TryResolveOrigin(world, in ctx, in mergedParams, out Fix64Vec2 positionCm))
             {
-                return true;
-            }
-
-            if (world.IsAlive(ctx.Source) &&
-                world.Has<AbilityExecInstance>(ctx.Source))
-            {
-                ref readonly var exec = ref world.Get<AbilityExecInstance>(ctx.Source);
-                if (exec.HasTargetOriginPos != 0)
-                {
-                    point = exec.TargetOriginPosCm.ToWorldCmInt2();
-                    return true;
-                }
-            }
-
-            if (world.IsAlive(ctx.Source) && world.Has<WorldPositionCm>(ctx.Source))
-            {
-                point = world.Get<WorldPositionCm>(ctx.Source).Value.ToWorldCmInt2();
+                point = positionCm.ToWorldCmInt2();
                 return true;
             }
 
@@ -417,57 +401,9 @@ namespace Ludots.Core.Gameplay.GAS
 
         private static bool TryResolveTargetPoint(World world, in EffectContext ctx, in EffectConfigParams mergedParams, out WorldCmInt2 point)
         {
-            if (TryGetPreservedTargetPoint(in mergedParams, out point))
+            if (EffectTargetPointResolver.TryResolve(world, in ctx, in mergedParams, out Fix64Vec2 positionCm))
             {
-                return true;
-            }
-
-            if (world.IsAlive(ctx.Target) && world.Has<WorldPositionCm>(ctx.Target))
-            {
-                point = world.Get<WorldPositionCm>(ctx.Target).Value.ToWorldCmInt2();
-                return true;
-            }
-
-            if (world.IsAlive(ctx.TargetContext) && world.Has<WorldPositionCm>(ctx.TargetContext))
-            {
-                point = world.Get<WorldPositionCm>(ctx.TargetContext).Value.ToWorldCmInt2();
-                return true;
-            }
-
-            if (world.IsAlive(ctx.Source) &&
-                world.Has<AbilityExecInstance>(ctx.Source))
-            {
-                ref readonly var exec = ref world.Get<AbilityExecInstance>(ctx.Source);
-                if (exec.HasTargetPos != 0)
-                {
-                    point = exec.TargetPosCm.ToWorldCmInt2();
-                    return true;
-                }
-            }
-
-            point = default;
-            return false;
-        }
-
-        private static bool TryGetPreservedTargetOrigin(in EffectConfigParams mergedParams, out WorldCmInt2 point)
-        {
-            if (mergedParams.TryGetFloat(EffectParamKeys.TargetOriginX, out float x) &&
-                mergedParams.TryGetFloat(EffectParamKeys.TargetOriginY, out float y))
-            {
-                point = new WorldCmInt2((int)x, (int)y);
-                return true;
-            }
-
-            point = default;
-            return false;
-        }
-
-        private static bool TryGetPreservedTargetPoint(in EffectConfigParams mergedParams, out WorldCmInt2 point)
-        {
-            if (mergedParams.TryGetFloat(EffectParamKeys.TargetPosX, out float x) &&
-                mergedParams.TryGetFloat(EffectParamKeys.TargetPosY, out float y))
-            {
-                point = new WorldCmInt2((int)x, (int)y);
+                point = positionCm.ToWorldCmInt2();
                 return true;
             }
 

--- a/src/Core/Gameplay/Placement/PlacementPhaseTargetPosResolver.cs
+++ b/src/Core/Gameplay/Placement/PlacementPhaseTargetPosResolver.cs
@@ -1,0 +1,32 @@
+using Arch.Core;
+using Ludots.Core.Gameplay.GAS;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Mathematics.FixedPoint;
+
+namespace Ludots.Core.Gameplay.Placement
+{
+    /// <summary>
+    /// Resolves cast/placement target position for effect phase graph execution.
+    /// </summary>
+    public static class PlacementPhaseTargetPosResolver
+    {
+        public static IntVector2 Resolve(
+            World world,
+            in EffectContext context,
+            in EffectConfigParams mergedParams)
+        {
+            if (!EffectTargetPointResolver.TryResolve(
+                    world,
+                    in context,
+                    in mergedParams,
+                    out Fix64Vec2 positionCm))
+            {
+                return default;
+            }
+
+            var rounded = positionCm.RoundToInt();
+            return new IntVector2(rounded.x, rounded.y);
+        }
+    }
+}

--- a/src/Core/Gameplay/Placement/PlacementValidation.cs
+++ b/src/Core/Gameplay/Placement/PlacementValidation.cs
@@ -2,7 +2,10 @@ using System;
 using Arch.Core;
 using Ludots.Core.Components;
 using Ludots.Core.EntityCollections;
+using Ludots.Core.Mathematics;
 using Ludots.Core.Mathematics.FixedPoint;
+using Ludots.Core.Navigation.GraphCore;
+using Ludots.Core.Navigation.GraphQuery;
 
 namespace Ludots.Core.Gameplay.Placement
 {
@@ -109,6 +112,47 @@ namespace Ludots.Core.Gameplay.Placement
             }
 
             positionCm = world.Get<WorldPositionCm>(entity).Value;
+            return true;
+        }
+
+        /// <summary>
+        /// Projects <paramref name="pointCm"/> onto the nearest outgoing graph edge within
+        /// <paramref name="searchRadiusCm"/>. Reuses <see cref="GraphEdgeProjectionQuery"/>.
+        /// </summary>
+        public static bool TrySnapToNearestGraphEdge(
+            NodeGraph graph,
+            INodeGraphSpatialIndex index,
+            ref Fix64Vec2 pointCm,
+            Fix64 searchRadiusCm,
+            Span<int> candidateScratch,
+            out GraphEdgeProjection projection)
+        {
+            projection = default;
+            if (graph == null || index == null || searchRadiusCm <= Fix64.Zero || candidateScratch.Length == 0)
+            {
+                return false;
+            }
+
+            var rounded = pointCm.RoundToInt();
+            var position = new WorldCmInt2(rounded.x, rounded.y);
+            int radiusCm = searchRadiusCm.RoundToInt();
+            if (radiusCm <= 0)
+            {
+                return false;
+            }
+
+            if (!GraphEdgeProjectionQuery.TryProjectNearestEdge(
+                    graph,
+                    index,
+                    position,
+                    radiusCm,
+                    candidateScratch,
+                    out projection))
+            {
+                return false;
+            }
+
+            pointCm = Fix64Vec2.FromInt(projection.ProjectedXcm, projection.ProjectedYcm);
             return true;
         }
     }

--- a/src/Core/Gameplay/Placement/PlacementValidation.cs
+++ b/src/Core/Gameplay/Placement/PlacementValidation.cs
@@ -1,0 +1,116 @@
+using System;
+using Arch.Core;
+using Ludots.Core.Components;
+using Ludots.Core.EntityCollections;
+using Ludots.Core.Mathematics.FixedPoint;
+
+namespace Ludots.Core.Gameplay.Placement
+{
+    /// <summary>
+    /// Layer 0 placement primitives. Shared by aim snap, ability activation validation,
+    /// OnPropose/OnApply phase graphs, and presentation preview.
+    /// </summary>
+    public static class PlacementValidation
+    {
+        private static readonly Fix64 RangeEpsilon = Fix64.FromFloat(0.01f);
+
+        public static bool ClampToRange(
+            in Fix64Vec2 originCm,
+            ref Fix64Vec2 targetCm,
+            Fix64 rangeCm,
+            out bool inRange)
+        {
+            inRange = true;
+            if (rangeCm <= Fix64.Zero)
+            {
+                return true;
+            }
+
+            Fix64 distance = Fix64Vec2.Distance(originCm, targetCm);
+            if (distance <= rangeCm + RangeEpsilon || distance <= RangeEpsilon)
+            {
+                return true;
+            }
+
+            inRange = false;
+            Fix64 scale = rangeCm / distance;
+            Fix64Vec2 delta = targetCm - originCm;
+            targetCm = originCm + new Fix64Vec2(delta.X * scale, delta.Y * scale);
+            return false;
+        }
+
+        public static bool IsPointInCircle(in Fix64Vec2 pointCm, in Fix64Vec2 centerCm, Fix64 radiusCm)
+        {
+            if (radiusCm <= Fix64.Zero)
+            {
+                return true;
+            }
+
+            return Fix64Vec2.Distance(pointCm, centerCm) <= radiusCm + RangeEpsilon;
+        }
+
+        public static bool TrySnapToNearestInCollection(
+            World world,
+            EntityCollectionStore collections,
+            Entity owner,
+            int collectionKeyId,
+            in Fix64Vec2 pointCm,
+            Fix64 maxDistanceCm,
+            out Fix64Vec2 snappedCm,
+            out Entity snappedEntity)
+        {
+            snappedCm = pointCm;
+            snappedEntity = Entity.Null;
+            if (collections == null || !world.IsAlive(owner) || collectionKeyId <= 0)
+            {
+                return false;
+            }
+
+            Span<Entity> buffer = stackalloc Entity[64];
+            int count = collections.CopyEntities(owner, collectionKeyId, buffer);
+            if (count <= 0)
+            {
+                return false;
+            }
+
+            Fix64 bestDistanceSq = maxDistanceCm > Fix64.Zero ? maxDistanceCm * maxDistanceCm : Fix64.MaxValue;
+            bool found = false;
+
+            for (int i = 0; i < count; i++)
+            {
+                Entity entity = buffer[i];
+                if (!world.IsAlive(entity) || !world.Has<WorldPositionCm>(entity))
+                {
+                    continue;
+                }
+
+                Fix64Vec2 candidate = world.Get<WorldPositionCm>(entity).Value;
+                Fix64 distanceSq = Fix64Vec2.DistanceSquared(pointCm, candidate);
+                if (distanceSq > bestDistanceSq)
+                {
+                    continue;
+                }
+
+                bestDistanceSq = distanceSq;
+                snappedCm = candidate;
+                snappedEntity = entity;
+                found = true;
+            }
+
+            return found;
+        }
+
+        public static bool TryGetEntityWorldPositionCm(World world, Entity entity, out Fix64Vec2 positionCm)
+        {
+            positionCm = default;
+            if (!world.IsAlive(entity) || !world.Has<WorldPositionCm>(entity))
+            {
+                return false;
+            }
+
+            positionCm = world.Get<WorldPositionCm>(entity).Value;
+            return true;
+        }
+    }
+
+}

--- a/src/Core/Input/Orders/AbilityAimPresentationRuntime.cs
+++ b/src/Core/Input/Orders/AbilityAimPresentationRuntime.cs
@@ -9,8 +9,10 @@ using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Components;
 using Ludots.Core.Gameplay.GAS.Registry;
 using Ludots.Core.Gameplay.Items;
+using Ludots.Core.Gameplay.Placement;
 using Ludots.Core.GraphRuntime;
 using Ludots.Core.Mathematics;
+using Ludots.Core.Mathematics.FixedPoint;
 using Ludots.Core.NodeLibraries.GASGraph;
 using Ludots.Core.NodeLibraries.GASGraph.Host;
 using Ludots.Core.Presentation.Components;
@@ -1256,22 +1258,15 @@ namespace Ludots.Core.Input.Orders
 
         private static bool ClampTargetToRange(Vector3 originWorldCm, ref Vector3 targetWorldCm, float rangeCm)
         {
-            if (rangeCm <= 0f)
-            {
-                return true;
-            }
-
-            float dx = targetWorldCm.X - originWorldCm.X;
-            float dz = targetWorldCm.Z - originWorldCm.Z;
-            float distance = MathF.Sqrt((dx * dx) + (dz * dz));
-            if (distance <= rangeCm + 0.01f || distance <= 0.001f)
-            {
-                return true;
-            }
-
-            float scale = rangeCm / distance;
-            targetWorldCm = new Vector3(originWorldCm.X + (dx * scale), targetWorldCm.Y, originWorldCm.Z + (dz * scale));
-            return false;
+            Fix64Vec2 originCm = Fix64Vec2.FromFloat(originWorldCm.X, originWorldCm.Z);
+            Fix64Vec2 targetCm = Fix64Vec2.FromFloat(targetWorldCm.X, targetWorldCm.Z);
+            bool inRange = PlacementValidation.ClampToRange(
+                in originCm,
+                ref targetCm,
+                Fix64.FromFloat(rangeCm),
+                out bool _);
+            targetWorldCm = new Vector3(targetCm.X.ToFloat(), targetWorldCm.Y, targetCm.Y.ToFloat());
+            return inRange;
         }
 
         private static Vector3 ResolveAreaCenter(OrderSelectionType selectionType, in TargetQueryDescriptor query, Vector3 originWorldCm, Vector3 aimWorldCm)

--- a/src/Core/NodeLibraries/GASGraph/GasGraphOpHandlerTable.cs
+++ b/src/Core/NodeLibraries/GASGraph/GasGraphOpHandlerTable.cs
@@ -199,6 +199,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             h[(ushort)GraphNodeOp.ClampTargetToRange] = HandleClampTargetToRange;
             h[(ushort)GraphNodeOp.IsPointInCircle] = HandleIsPointInCircle;
             h[(ushort)GraphNodeOp.SnapToNearestInCollection] = HandleSnapToNearestInCollection;
+            h[(ushort)GraphNodeOp.SnapToNearestGraphEdge] = HandleSnapToNearestGraphEdge;
 
             return h;
         }
@@ -1012,6 +1013,15 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             {
                 s.B[ins.Flags] = (byte)(found ? 1 : 0);
             }
+        }
+
+        private static void HandleSnapToNearestGraphEdge(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)
+        {
+            bool found = s.Api.TrySnapTargetToNearestGraphEdge(
+                ref s.TargetPos,
+                s.F[ins.A],
+                out _);
+            s.B[ins.Dst] = (byte)(found ? 1 : 0);
         }
     }
 }

--- a/src/Core/NodeLibraries/GASGraph/GasGraphOpHandlerTable.cs
+++ b/src/Core/NodeLibraries/GASGraph/GasGraphOpHandlerTable.cs
@@ -2,9 +2,12 @@ using System;
 using Arch.Core;
 using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.Placement;
 using Ludots.Core.Gameplay.Relationships;
 using Ludots.Core.Gameplay.Teams;
 using Ludots.Core.GraphRuntime;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Mathematics.FixedPoint;
 
 namespace Ludots.Core.NodeLibraries.GASGraph
 {
@@ -189,6 +192,13 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             // ── Self attribute access for derived graphs (330-331) ──
             h[(ushort)GraphNodeOp.LoadSelfAttribute] = HandleLoadSelfAttribute;
             h[(ushort)GraphNodeOp.WriteSelfAttribute] = HandleWriteSelfAttribute;
+
+            // ── Placement validation (402-406) ──
+            h[(ushort)GraphNodeOp.LoadTargetPosX] = HandleLoadTargetPosX;
+            h[(ushort)GraphNodeOp.LoadTargetPosY] = HandleLoadTargetPosY;
+            h[(ushort)GraphNodeOp.ClampTargetToRange] = HandleClampTargetToRange;
+            h[(ushort)GraphNodeOp.IsPointInCircle] = HandleIsPointInCircle;
+            h[(ushort)GraphNodeOp.SnapToNearestInCollection] = HandleSnapToNearestInCollection;
 
             return h;
         }
@@ -941,6 +951,66 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             if (s.World.IsAlive(self) && s.World.Has<AttributeBuffer>(self))
             {
                 AttributeMutationOps.SetCurrent(s.World, self, ins.Imm, s.F[ins.A]);
+            }
+        }
+
+        private static void HandleLoadTargetPosX(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)
+        {
+            s.I[ins.Dst] = s.TargetPos.X;
+        }
+
+        private static void HandleLoadTargetPosY(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)
+        {
+            s.I[ins.Dst] = s.TargetPos.Y;
+        }
+
+        private static void HandleClampTargetToRange(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)
+        {
+            if (!PlacementValidation.TryGetEntityWorldPositionCm(s.World, s.E[ins.A], out Fix64Vec2 originCm))
+            {
+                s.B[ins.Dst] = 0;
+                return;
+            }
+
+            Fix64Vec2 targetCm = Fix64Vec2.FromInt(s.TargetPos.X, s.TargetPos.Y);
+            PlacementValidation.ClampToRange(
+                in originCm,
+                ref targetCm,
+                Fix64.FromFloat(s.F[ins.B]),
+                out bool inRange);
+            var rounded = targetCm.RoundToInt();
+            s.TargetPos = new IntVector2(rounded.x, rounded.y);
+            s.B[ins.Dst] = (byte)(inRange ? 1 : 0);
+        }
+
+        private static void HandleIsPointInCircle(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)
+        {
+            if (!PlacementValidation.TryGetEntityWorldPositionCm(s.World, s.E[ins.A], out Fix64Vec2 centerCm))
+            {
+                s.B[ins.Dst] = 0;
+                return;
+            }
+
+            Fix64Vec2 pointCm = Fix64Vec2.FromInt(s.TargetPos.X, s.TargetPos.Y);
+            bool inside = PlacementValidation.IsPointInCircle(
+                in pointCm,
+                in centerCm,
+                Fix64.FromFloat(s.F[ins.B]));
+            s.B[ins.Dst] = (byte)(inside ? 1 : 0);
+        }
+
+        private static void HandleSnapToNearestInCollection(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)
+        {
+            bool found = s.Api.TrySnapTargetToNearestInCollection(
+                s.E[ins.A],
+                ins.Imm,
+                ref s.TargetPos,
+                s.F[ins.B],
+                out Entity snappedEntity);
+            s.E[ins.Dst] = snappedEntity;
+            if (ins.Flags != byte.MaxValue)
+            {
+                s.B[ins.Flags] = (byte)(found ? 1 : 0);
             }
         }
     }

--- a/src/Core/NodeLibraries/GASGraph/GraphCompiler.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphCompiler.cs
@@ -454,6 +454,22 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                         ins.A = RequireInput(node, 0, GraphValueType.Float, valueMap, cfg.Id, diagnostics);
                         ins.Imm = RequireSymbol(node.Attribute, "attribute", node, symbolToIndex, symbols, cfg.Id, diagnostics);
                         break;
+                    case GraphNodeOp.LoadTargetPosX:
+                    case GraphNodeOp.LoadTargetPosY:
+                        break;
+                    case GraphNodeOp.ClampTargetToRange:
+                        ins.A = RequireInput(node, 0, GraphValueType.Entity, valueMap, cfg.Id, diagnostics);
+                        ins.B = RequireInput(node, 1, GraphValueType.Float, valueMap, cfg.Id, diagnostics);
+                        break;
+                    case GraphNodeOp.IsPointInCircle:
+                        ins.A = RequireInput(node, 0, GraphValueType.Entity, valueMap, cfg.Id, diagnostics);
+                        ins.B = RequireInput(node, 1, GraphValueType.Float, valueMap, cfg.Id, diagnostics);
+                        break;
+                    case GraphNodeOp.SnapToNearestInCollection:
+                        ins.A = RequireInput(node, 0, GraphValueType.Entity, valueMap, cfg.Id, diagnostics);
+                        ins.B = RequireInput(node, 1, GraphValueType.Float, valueMap, cfg.Id, diagnostics);
+                        ins.Imm = RequireSymbol(node.CollectionKey, "collectionKey", node, symbolToIndex, symbols, cfg.Id, diagnostics);
+                        break;
                 }
 
                 instructions.Add(ins);
@@ -526,6 +542,11 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 GraphNodeOp.AggMinAttribute => (GraphValueType.Float, null),
                 GraphNodeOp.AggMaxEntityByAttribute => (GraphValueType.Entity, null),
                 GraphNodeOp.AggMinEntityByAttribute => (GraphValueType.Entity, null),
+                GraphNodeOp.LoadTargetPosX => (GraphValueType.Int, null),
+                GraphNodeOp.LoadTargetPosY => (GraphValueType.Int, null),
+                GraphNodeOp.ClampTargetToRange => (GraphValueType.Bool, null),
+                GraphNodeOp.IsPointInCircle => (GraphValueType.Bool, null),
+                GraphNodeOp.SnapToNearestInCollection => (GraphValueType.Entity, null),
                 _ => (GraphValueType.Void, null)
             };
         }

--- a/src/Core/NodeLibraries/GASGraph/GraphCompiler.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphCompiler.cs
@@ -470,6 +470,9 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                         ins.B = RequireInput(node, 1, GraphValueType.Float, valueMap, cfg.Id, diagnostics);
                         ins.Imm = RequireSymbol(node.CollectionKey, "collectionKey", node, symbolToIndex, symbols, cfg.Id, diagnostics);
                         break;
+                    case GraphNodeOp.SnapToNearestGraphEdge:
+                        ins.A = RequireInput(node, 0, GraphValueType.Float, valueMap, cfg.Id, diagnostics);
+                        break;
                 }
 
                 instructions.Add(ins);
@@ -547,6 +550,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 GraphNodeOp.ClampTargetToRange => (GraphValueType.Bool, null),
                 GraphNodeOp.IsPointInCircle => (GraphValueType.Bool, null),
                 GraphNodeOp.SnapToNearestInCollection => (GraphValueType.Entity, null),
+                GraphNodeOp.SnapToNearestGraphEdge => (GraphValueType.Bool, null),
                 _ => (GraphValueType.Void, null)
             };
         }

--- a/src/Core/NodeLibraries/GASGraph/GraphOps.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphOps.cs
@@ -130,6 +130,13 @@ namespace Ludots.Core.NodeLibraries.GASGraph
         RelationshipAggMinMetric = 394,
         RelationshipAggMaxEntityByMetric = 395,
         RelationshipAggMinEntityByMetric = 396,
+
+        // ── Placement validation (402-406) ──
+        LoadTargetPosX = 402,
+        LoadTargetPosY = 403,
+        ClampTargetToRange = 404,
+        IsPointInCircle = 405,
+        SnapToNearestInCollection = 406,
     }
 
     public static class GraphNodeOpParser

--- a/src/Core/NodeLibraries/GASGraph/GraphOps.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphOps.cs
@@ -137,6 +137,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
         ClampTargetToRange = 404,
         IsPointInCircle = 405,
         SnapToNearestInCollection = 406,
+        SnapToNearestGraphEdge = 407,
     }
 
     public static class GraphNodeOpParser

--- a/src/Core/NodeLibraries/GASGraph/Host/GasGraphRuntimeApi.cs
+++ b/src/Core/NodeLibraries/GASGraph/Host/GasGraphRuntimeApi.cs
@@ -16,6 +16,8 @@ using Ludots.Core.Spatial;
 using Ludots.Core.Gameplay.Relationships;
 using Ludots.Core.Gameplay.Placement;
 using Ludots.Core.Mathematics.FixedPoint;
+using Ludots.Core.Navigation.GraphQuery;
+using Ludots.Core.Navigation.GraphWorld;
 
 namespace Ludots.Core.NodeLibraries.GASGraph.Host
 {
@@ -31,6 +33,8 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
         private readonly TargetDispatchPresetRegistry? _targetDispatchPresets;
         private readonly EntityCollectionStore? _entityCollections;
         private readonly EntitySetQueryRuntime? _entityQueries;
+        private LoadedGraphRuntime? _loadedGraphRuntime;
+        private int[] _graphProjectionCandidateScratch = Array.Empty<int>();
 
         // ── Config context: set before each graph execution, cleared after ──
         private EffectConfigParams _currentConfigParams;
@@ -145,6 +149,11 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
         {
             _currentConfigParams = default;
             _hasConfigContext = false;
+        }
+
+        public void BindLoadedGraphRuntime(LoadedGraphRuntime? runtime)
+        {
+            _loadedGraphRuntime = runtime;
         }
 
         public bool TryGetGridPos(Entity entity, out IntVector2 gridPos)
@@ -621,6 +630,52 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
             }
 
             return found;
+        }
+
+        public bool TrySnapTargetToNearestGraphEdge(
+            ref IntVector2 targetPosCm,
+            float searchRadiusCm,
+            out GraphEdgeProjection projection)
+        {
+            projection = default;
+            LoadedGraphRuntime? runtime = _loadedGraphRuntime;
+            if (runtime == null || !runtime.HasLoadedGraph || searchRadiusCm <= 0f)
+            {
+                return false;
+            }
+
+            EnsureGraphProjectionCandidateCapacity(runtime.CurrentGraph.NodeCount);
+            Fix64Vec2 pointCm = Fix64Vec2.FromInt(targetPosCm.X, targetPosCm.Y);
+            bool found = PlacementValidation.TrySnapToNearestGraphEdge(
+                runtime.CurrentGraph,
+                runtime.CurrentSpatialIndex,
+                ref pointCm,
+                Fix64.FromFloat(searchRadiusCm),
+                _graphProjectionCandidateScratch,
+                out projection);
+            if (found)
+            {
+                var rounded = pointCm.RoundToInt();
+                targetPosCm = new IntVector2(rounded.x, rounded.y);
+            }
+
+            return found;
+        }
+
+        private void EnsureGraphProjectionCandidateCapacity(int required)
+        {
+            if (_graphProjectionCandidateScratch.Length >= required)
+            {
+                return;
+            }
+
+            int next = _graphProjectionCandidateScratch.Length == 0 ? 64 : _graphProjectionCandidateScratch.Length * 2;
+            while (next < required)
+            {
+                next *= 2;
+            }
+
+            Array.Resize(ref _graphProjectionCandidateScratch, next);
         }
     }
 }

--- a/src/Core/NodeLibraries/GASGraph/Host/GasGraphRuntimeApi.cs
+++ b/src/Core/NodeLibraries/GASGraph/Host/GasGraphRuntimeApi.cs
@@ -14,6 +14,8 @@ using Ludots.Core.Mathematics;
 using Ludots.Core.Scripting;
 using Ludots.Core.Spatial;
 using Ludots.Core.Gameplay.Relationships;
+using Ludots.Core.Gameplay.Placement;
+using Ludots.Core.Mathematics.FixedPoint;
 
 namespace Ludots.Core.NodeLibraries.GASGraph.Host
 {
@@ -587,6 +589,38 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
             value = 0;
             if (!_hasConfigContext) return false;
             return _currentConfigParams.TryGetInt(keyId, out value);
+        }
+
+        public bool TrySnapTargetToNearestInCollection(
+            Entity owner,
+            int collectionKeyId,
+            ref IntVector2 targetPosCm,
+            float maxDistanceCm,
+            out Entity snappedEntity)
+        {
+            snappedEntity = Entity.Null;
+            if (_entityCollections == null)
+            {
+                return false;
+            }
+
+            Fix64Vec2 pointCm = Fix64Vec2.FromInt(targetPosCm.X, targetPosCm.Y);
+            bool found = PlacementValidation.TrySnapToNearestInCollection(
+                _world,
+                _entityCollections,
+                owner,
+                collectionKeyId,
+                in pointCm,
+                Fix64.FromFloat(maxDistanceCm),
+                out Fix64Vec2 snappedCm,
+                out snappedEntity);
+            if (found)
+            {
+                var rounded = snappedCm.RoundToInt();
+                targetPosCm = new IntVector2(rounded.x, rounded.y);
+            }
+
+            return found;
         }
     }
 }

--- a/src/Core/NodeLibraries/GASGraph/Host/GraphProgramSymbolPatcher.cs
+++ b/src/Core/NodeLibraries/GASGraph/Host/GraphProgramSymbolPatcher.cs
@@ -49,6 +49,9 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
                     case GraphNodeOp.QueryFromCollection:
                         ins.Imm = ResolveEntityCollectionKey(entityCollections, ResolveSymbol(symbols, ins.Imm));
                         break;
+                    case GraphNodeOp.SnapToNearestInCollection:
+                        ins.Imm = ResolveEntityCollectionKey(entityCollections, ResolveSymbol(symbols, ins.Imm));
+                        break;
                     case GraphNodeOp.ApplyEffectTemplate:
                     case GraphNodeOp.FanOutApplyEffect:
                     case GraphNodeOp.RemoveEffectTemplate:

--- a/src/Core/NodeLibraries/GASGraph/IGraphRuntimeApi.cs
+++ b/src/Core/NodeLibraries/GASGraph/IGraphRuntimeApi.cs
@@ -276,6 +276,17 @@ namespace Ludots.Core.NodeLibraries.GASGraph
 
         bool TryLoadConfigFloat(int keyId, out float value);
         bool TryLoadConfigInt(int keyId, out int value);
+
+        bool TrySnapTargetToNearestInCollection(
+            Entity owner,
+            int collectionKeyId,
+            ref IntVector2 targetPosCm,
+            float maxDistanceCm,
+            out Entity snappedEntity)
+        {
+            snappedEntity = Entity.Null;
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/Core/NodeLibraries/GASGraph/IGraphRuntimeApi.cs
+++ b/src/Core/NodeLibraries/GASGraph/IGraphRuntimeApi.cs
@@ -3,6 +3,7 @@ using Arch.Core;
 using Ludots.Core.Gameplay.Relationships;
 using Ludots.Core.Gameplay.Teams;
 using Ludots.Core.Mathematics;
+using Ludots.Core.Navigation.GraphQuery;
 
 namespace Ludots.Core.NodeLibraries.GASGraph
 {
@@ -285,6 +286,15 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             out Entity snappedEntity)
         {
             snappedEntity = Entity.Null;
+            return false;
+        }
+
+        bool TrySnapTargetToNearestGraphEdge(
+            ref IntVector2 targetPosCm,
+            float searchRadiusCm,
+            out GraphEdgeProjection projection)
+        {
+            projection = default;
             return false;
         }
     }

--- a/src/Tests/GasTests/PlacementValidationTests.cs
+++ b/src/Tests/GasTests/PlacementValidationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Arch.Core;
 using Ludots.Core.Components;
 using Ludots.Core.EntityCollections;
@@ -7,6 +8,9 @@ using Ludots.Core.Gameplay.Placement;
 using Ludots.Core.GraphRuntime;
 using Ludots.Core.Mathematics;
 using Ludots.Core.Mathematics.FixedPoint;
+using Ludots.Core.Navigation.GraphCore;
+using Ludots.Core.Navigation.GraphQuery;
+using Ludots.Core.Navigation.GraphWorld;
 using Ludots.Core.NodeLibraries.GASGraph;
 using Ludots.Core.NodeLibraries.GASGraph.Host;
 using NUnit.Framework;
@@ -171,6 +175,86 @@ namespace Ludots.Tests.GAS
 
             That(passedNear, Is.True);
             That(passedFar, Is.False);
+        }
+
+        [Test]
+        public void TrySnapToNearestGraphEdge_ProjectsOntoNearestSegment()
+        {
+            var builder = new NodeGraphBuilder(3, 2);
+            builder.AddNode(0, 0);
+            builder.AddNode(100, 0);
+            builder.AddNode(200, 0);
+            builder.AddEdge(0, 1, 100f);
+            builder.AddEdge(1, 2, 100f);
+            NodeGraph graph = builder.Build();
+            INodeGraphSpatialIndex index = LoadedGraphRuntime.CreateSpatialIndex(graph, preferredCellSizeCm: 100);
+            Span<int> scratch = stackalloc int[8];
+            Fix64Vec2 point = Fix64Vec2.FromInt(50, 25);
+
+            bool found = PlacementValidation.TrySnapToNearestGraphEdge(
+                graph,
+                index,
+                ref point,
+                Fix64.FromInt(100),
+                scratch,
+                out GraphEdgeProjection projection);
+
+            That(found, Is.True);
+            That(point, Is.EqualTo(Fix64Vec2.FromInt(50, 0)));
+            That(projection.FromNodeId, Is.EqualTo(0));
+            That(projection.ToNodeId, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void GraphOps_SnapToNearestGraphEdge_UpdatesTargetPos()
+        {
+            var loadedChunks = new WorldGridLoadedChunks(chunkSizeCm: 1000);
+            var store = new ChunkedNodeGraphStore();
+            store.SubscribeToLoadedChunks(loadedChunks);
+            long chunkKey = GraphChunkKey.Pack(0, 0);
+            var graphBuilder = new NodeGraphBuilder(3, 2);
+            graphBuilder.AddNode(0, 0);
+            graphBuilder.AddNode(100, 0);
+            graphBuilder.AddNode(200, 0);
+            graphBuilder.AddEdge(0, 1, 100f);
+            graphBuilder.AddEdge(1, 2, 100f);
+            store.AddOrReplace(chunkKey, new GraphChunkData(graphBuilder.Build(), Array.Empty<GraphCrossEdge>()));
+            loadedChunks.SetLoaded(chunkKey, loaded: true);
+
+            using var runtime = new LoadedGraphRuntime(store, loadedChunks, preferredProjectionCellSizeCm: 100);
+            using var world = World.Create();
+            var api = new GasGraphRuntimeApi(world, null, null, null);
+            api.BindLoadedGraphRuntime(runtime);
+            var program = new[]
+            {
+                new GraphInstruction { Op = (ushort)GraphNodeOp.ConstFloat, Dst = 1, ImmF = 100f },
+                new GraphInstruction { Op = (ushort)GraphNodeOp.SnapToNearestGraphEdge, A = 1, Dst = 0 },
+            };
+
+            Span<float> f = stackalloc float[GraphVmLimits.MaxFloatRegisters];
+            Span<int> i = stackalloc int[GraphVmLimits.MaxIntRegisters];
+            Span<byte> b = stackalloc byte[GraphVmLimits.MaxBoolRegisters];
+            Span<Entity> e = stackalloc Entity[GraphVmLimits.MaxEntityRegisters];
+            Span<Entity> targets = stackalloc Entity[GraphVmLimits.MaxTargets];
+            f[1] = 100f;
+            var state = new GraphExecutionState
+            {
+                World = world,
+                Caster = Entity.Null,
+                ExplicitTarget = Entity.Null,
+                TargetPos = new IntVector2(50, 25),
+                Api = api,
+                F = f,
+                I = i,
+                B = b,
+                E = e,
+                Targets = targets,
+                TargetList = new GraphTargetList(targets),
+            };
+
+            GasGraphOpHandlerTable.Execute(ref state, program, GasGraphOpHandlerTable.Instance);
+            That(state.B[0], Is.EqualTo(1));
+            That(state.TargetPos, Is.EqualTo(new IntVector2(50, 0)));
         }
     }
 }

--- a/src/Tests/GasTests/PlacementValidationTests.cs
+++ b/src/Tests/GasTests/PlacementValidationTests.cs
@@ -1,0 +1,176 @@
+using Arch.Core;
+using Ludots.Core.Components;
+using Ludots.Core.EntityCollections;
+using Ludots.Core.Gameplay.GAS;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.Placement;
+using Ludots.Core.GraphRuntime;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Mathematics.FixedPoint;
+using Ludots.Core.NodeLibraries.GASGraph;
+using Ludots.Core.NodeLibraries.GASGraph.Host;
+using NUnit.Framework;
+using GasGraphExecutor = Ludots.Core.NodeLibraries.GASGraph.GraphExecutor;
+using static NUnit.Framework.Assert;
+
+namespace Ludots.Tests.GAS
+{
+    [TestFixture]
+    public class PlacementValidationTests
+    {
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            EffectParamKeys.Initialize();
+        }
+
+        [Test]
+        public void ClampToRange_InsideRange_DoesNotMoveTarget()
+        {
+            var origin = Fix64Vec2.FromInt(0, 0);
+            var target = Fix64Vec2.FromInt(300, 400);
+            bool inRange = PlacementValidation.ClampToRange(
+                in origin,
+                ref target,
+                Fix64.FromInt(500),
+                out bool clampedInRange);
+            That(inRange, Is.True);
+            That(clampedInRange, Is.True);
+            That(target, Is.EqualTo(Fix64Vec2.FromInt(300, 400)));
+        }
+
+        [Test]
+        public void ClampToRange_OutsideRange_ClampsToCircleEdge()
+        {
+            var origin = Fix64Vec2.Zero;
+            var target = Fix64Vec2.FromInt(1000, 0);
+            bool inRange = PlacementValidation.ClampToRange(
+                in origin,
+                ref target,
+                Fix64.FromInt(500),
+                out bool clampedInRange);
+            That(inRange, Is.False);
+            That(clampedInRange, Is.False);
+            That(target.X.ToFloat(), Is.EqualTo(500f).Within(0.01f));
+            That(target.Y, Is.EqualTo(Fix64.Zero));
+        }
+
+        [Test]
+        public void IsPointInCircle_RespectsRadius()
+        {
+            var center = Fix64Vec2.FromInt(100, 100);
+            var inside = Fix64Vec2.FromInt(120, 100);
+            var outside = Fix64Vec2.FromInt(300, 100);
+            That(PlacementValidation.IsPointInCircle(in inside, in center, Fix64.FromInt(50)), Is.True);
+            That(PlacementValidation.IsPointInCircle(in outside, in center, Fix64.FromInt(50)), Is.False);
+        }
+
+        [Test]
+        public void EffectTargetPointResolver_UsesCallerParamsFirst()
+        {
+            using var world = World.Create();
+            var source = world.Create();
+            var context = new EffectContext { Source = source };
+            var merged = new EffectConfigParams();
+            merged.TryAddFloat(EffectParamKeys.TargetPosX, 420f);
+            merged.TryAddFloat(EffectParamKeys.TargetPosY, 180f);
+
+            bool resolved = EffectTargetPointResolver.TryResolve(world, in context, in merged, out Fix64Vec2 point);
+            That(resolved, Is.True);
+            That(point, Is.EqualTo(Fix64Vec2.FromInt(420, 180)));
+        }
+
+        [Test]
+        public void PlacementPhaseTargetPosResolver_RoundsResolvedPoint()
+        {
+            using var world = World.Create();
+            var context = new EffectContext();
+            var merged = new EffectConfigParams();
+            merged.TryAddFloat(EffectParamKeys.TargetPosX, 420.6f);
+            merged.TryAddFloat(EffectParamKeys.TargetPosY, 180.4f);
+
+            IntVector2 targetPos = PlacementPhaseTargetPosResolver.Resolve(world, in context, in merged);
+            That(targetPos, Is.EqualTo(new IntVector2(420, 180)));
+        }
+
+        [Test]
+        public void GraphOps_ClampTargetToRange_UpdatesTargetPosAndBool()
+        {
+            using var world = World.Create();
+            var caster = world.Create(new WorldPositionCm { Value = Fix64Vec2.Zero });
+            var api = new GasGraphRuntimeApi(world, null, null, null);
+            var program = new[]
+            {
+                new GraphInstruction
+                {
+                    Op = (ushort)GraphNodeOp.ConstFloat,
+                    Dst = 1,
+                    ImmF = 500f,
+                },
+                new GraphInstruction
+                {
+                    Op = (ushort)GraphNodeOp.ClampTargetToRange,
+                    A = 0,
+                    B = 1,
+                    Dst = 0,
+                },
+            };
+
+            Span<float> f = stackalloc float[GraphVmLimits.MaxFloatRegisters];
+            Span<int> i = stackalloc int[GraphVmLimits.MaxIntRegisters];
+            Span<byte> b = stackalloc byte[GraphVmLimits.MaxBoolRegisters];
+            Span<Entity> e = stackalloc Entity[GraphVmLimits.MaxEntityRegisters];
+            e[0] = caster;
+            Span<Entity> targets = stackalloc Entity[GraphVmLimits.MaxTargets];
+            var state = new GraphExecutionState
+            {
+                World = world,
+                Caster = caster,
+                ExplicitTarget = Entity.Null,
+                TargetPos = new IntVector2(1000, 0),
+                Api = api,
+                F = f,
+                I = i,
+                B = b,
+                E = e,
+                Targets = targets,
+                TargetList = new GraphTargetList(targets),
+            };
+
+            GasGraphOpHandlerTable.Execute(ref state, program, GasGraphOpHandlerTable.Instance);
+            That(state.TargetPos.X, Is.EqualTo(500));
+            That(state.B[0], Is.EqualTo(0));
+        }
+
+        [Test]
+        public void ExecuteValidation_ClampRangeGraph_RejectsOutOfRangeTarget()
+        {
+            using var world = World.Create();
+            var caster = world.Create(new WorldPositionCm { Value = Fix64Vec2.Zero });
+            var api = new GasGraphRuntimeApi(world, null, null, null);
+            var program = new[]
+            {
+                new GraphInstruction { Op = (ushort)GraphNodeOp.ConstFloat, Dst = 1, ImmF = 500f },
+                new GraphInstruction { Op = (ushort)GraphNodeOp.ClampTargetToRange, A = 0, B = 1, Dst = 0 },
+            };
+
+            bool passedNear = GasGraphExecutor.ExecuteValidation(
+                world,
+                caster,
+                Entity.Null,
+                new IntVector2(400, 0),
+                program,
+                api);
+            bool passedFar = GasGraphExecutor.ExecuteValidation(
+                world,
+                caster,
+                Entity.Null,
+                new IntVector2(1000, 0),
+                program,
+                api);
+
+            That(passedNear, Is.True);
+            That(passedFar, Is.False);
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes Placement Validation spike **#509** and sub-issues **#510–#515**.

### Layer 0 — `PlacementValidation` (#511)
- `ClampToRange`, `IsPointInCircle`, `TrySnapToNearestInCollection`, `TryGetEntityWorldPositionCm`
- **`TrySnapToNearestGraphEdge`** — wraps `GraphEdgeProjectionQuery` (#515)

### Target position SSOT
- `EffectTargetPointResolver` — resolves cast/placement point from `EffectContext` + caller params
- `PlacementPhaseTargetPosResolver` — bridges resolver → `IntVector2 TargetPos`

### Graph ops 402–407 (#512, #515)
| Op | ID |
|---|---|
| `LoadTargetPosX/Y` | 402–403 |
| `ClampTargetToRange` | 404 |
| `IsPointInCircle` | 405 |
| `SnapToNearestInCollection` | 406 |
| `SnapToNearestGraphEdge` | 407 |

`SnapToNearestGraphEdge` requires `LoadedGraphRuntime` bound via `GasGraphRuntimeApi.BindLoadedGraphRuntime` (GameEngine board hot-swap + CoreInput aim path). Returns `false` when no graph board — **no fallback**.

### Pipeline wiring (#510, #514)
- **OnPropose / OnCalculate / OnApply**: inject resolved `TargetPos`
- **OnPropose rejection**: `ExecutePhaseWithValidationResult` → `B[0]=0` → proposal `Cancelled=true`
- **Ability activation**: existing `activationPrecondition.validationGraph` composable with placement ops

### Authoritative aim snap (#513)
- `AbilityAimPresentationRuntime` + `AbilityExecAimSyncSystem` share `PlacementValidation.ClampToRange`

### Formal docs
- [`gitbook/architecture/placement-validation-ssot.md`](gitbook/architecture/placement-validation-ssot.md)
- Cross-link in `graph-query-services.md`

### Tests
- `PlacementValidationTests` (9 cases) — all pass
- Regression: `InputOrderAbilityAuditTests`, `AbilityAimPresentationRuntimeTests`, `EffectPhaseArchitectureTests`, `LoadedGraphRuntimeTests`, `TransportNetworkCoreTests` — 103+ cases pass

## Architecture compliance

| Rule | Status |
|---|---|
| 六边形：Core 不引平台 API | ✅ |
| 一切皆 Mod：input 桥在 CoreInputMod | ✅ |
| 禁止 fallback / 平行轮子 | ✅ GraphQuery + Placement SSOT 复用 |
| Fix64 gameplay / float 仅 presentation 边界 | ✅ |
| 数据 SSOT：行为由 graph/config 驱动 | ✅ |
| 正式文档在 gitbook | ✅ |

## Issue mapping

| Issue | Status |
|-------|--------|
| #509 Spike SSOT | ✅ |
| #510 TargetPos inject | ✅ |
| #511 Layer 0 primitives | ✅ |
| #512 Graph ops | ✅ |
| #513 Aim authoritative snap | ✅ |
| #514 Validation wiring | ✅ |
| #515 Transport/nodegraph snap | ✅ |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17c6aadd-e696-44a9-998e-291895b8ea2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17c6aadd-e696-44a9-998e-291895b8ea2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

