### PR TITLE
fix(mass-navigation): harden authored append binding

### DIFF
--- a/src/Core/MassNavigation/Runtime/MassNavigationFlowSolverState.cs
+++ b/src/Core/MassNavigation/Runtime/MassNavigationFlowSolverState.cs
@@ -201,6 +201,16 @@ public sealed partial class MassNavigationFlowSolverState
         _stepHandles = new JobHandle[_parallelWorkerCount];
     }
 
+    internal void PreallocateAgentCapacity(int unitCapacity)
+    {
+        if (unitCapacity < 0)
+        {
+            throw new InvalidOperationException("MassNavigationFlowSolverState agent capacity preallocation requires unitCapacity >= 0.");
+        }
+
+        EnsureCapacity(unitCapacity);
+    }
+
     public Vector2 WorldToLocalCm(Vector2 worldCm)
     {
         return new Vector2(worldCm.X - _worldOriginXCm, worldCm.Y - _worldOriginYCm);
@@ -425,10 +435,14 @@ public sealed partial class MassNavigationFlowSolverState
             _arrivalEventEmittedFlags[unitIndex] = 0;
             _unitRetryCounts[unitIndex] = 0;
             _unitStuckSeconds[unitIndex] = 0f;
-            MarkEntityDirty(unitIndex);
         }
 
         UnitCount = newTotal;
+        for (int unitIndex = startIndex; unitIndex < newTotal; unitIndex++)
+        {
+            MarkEntityDirty(unitIndex);
+        }
+
         _maxInteractingBodyRadiiDirty = true;
         MarkFlowDirty();
     }

--- a/src/Core/MassNavigation/Runtime/MassNavigationGroupRuntime.cs
+++ b/src/Core/MassNavigation/Runtime/MassNavigationGroupRuntime.cs
@@ -8,6 +8,8 @@ namespace Ludots.Core.MassNavigation.Runtime;
 
 public sealed class MassNavigationGroupRuntime
 {
+    internal const float OrderPathRestoreTargetToleranceCm = 0.001f;
+
     private readonly MassNavigationFormationRuntime _formationLayout;
     private readonly List<NavGroupState?> _groups;
     private readonly HashSet<int> _visitedGroupIds;
@@ -1508,8 +1510,8 @@ public sealed class MassNavigationGroupRuntime
         for (int i = 0; i < restoredMemberCount; i++)
         {
             AuthoredRebuildMemberSnapshot member = captured.Members[memberSnapshotIndices[i]];
-            if (MathF.Abs(group.MemberOrderTargetWorldX[i] - member.OrderTargetWorldX) > 0.001f ||
-                MathF.Abs(group.MemberOrderTargetWorldY[i] - member.OrderTargetWorldY) > 0.001f)
+            if (MathF.Abs(group.MemberOrderTargetWorldX[i] - member.OrderTargetWorldX) > OrderPathRestoreTargetToleranceCm ||
+                MathF.Abs(group.MemberOrderTargetWorldY[i] - member.OrderTargetWorldY) > OrderPathRestoreTargetToleranceCm)
             {
                 allOrderTargetsPreserved = false;
                 continue;

--- a/src/Core/MassNavigation/Runtime/MassNavigationSimulationRuntime.cs
+++ b/src/Core/MassNavigation/Runtime/MassNavigationSimulationRuntime.cs
@@ -242,6 +242,7 @@ public sealed class MassNavigationSimulationRuntime
     {
         Config = config ?? throw new ArgumentNullException(nameof(config));
         MassNavigationFlow = new MassNavigationFlowSolverState(config.Solver);
+        MassNavigationFlow.PreallocateAgentCapacity(config.ScenarioRuntime.RuntimeCapacity.GroupMembershipAgentCapacity);
         WorldConfig = config.World ?? throw new InvalidOperationException("MassNavigationSimulationRuntime requires explicit world config.");
         Cadence = config.Cadence;
         CadenceScheduler = new MassNavigationCadenceScheduler(Cadence);
@@ -707,6 +708,13 @@ public sealed class MassNavigationSimulationRuntime
         if (entities.Length != agentSeeds.Length || entities.Length != controllableFlags.Length)
         {
             throw new InvalidOperationException("MassNavigation authored rebuild requires matching entity, seed, and controllable spans.");
+        }
+
+        int membershipCapacity = Config.ScenarioRuntime.RuntimeCapacity.GroupMembershipAgentCapacity;
+        if (agentSeeds.Length > membershipCapacity)
+        {
+            throw new InvalidOperationException(
+                $"MassNavigation authored rebuild required {agentSeeds.Length} agent slots, exceeding configured scenarioRuntime.runtimeCapacity.groupMembershipAgentCapacity {membershipCapacity}.");
         }
 
         int previousSelectedCount = _selectedCount;

--- a/src/Core/MassNavigation/Systems/MassNavigationAuthoredAgentBindingSystem.cs
+++ b/src/Core/MassNavigation/Systems/MassNavigationAuthoredAgentBindingSystem.cs
@@ -26,15 +26,20 @@ internal sealed class MassNavigationAuthoredAgentBindingSystem : ISystem<float>
 
     private readonly GameEngine _engine;
     private readonly MassNavigationSimulationRuntime _simulation;
-    private readonly List<Entity> _entities = new();
-    private readonly List<MassNavigationAgentSeed> _seeds = new();
-    private readonly List<bool> _controllableFlags = new();
+    private readonly List<Entity> _entities;
+    private readonly List<MassNavigationAgentSeed> _seeds;
+    private readonly List<bool> _controllableFlags;
+    private readonly int _agentCapacity;
     private long _lastAuthoringSignature;
 
     public MassNavigationAuthoredAgentBindingSystem(GameEngine engine, MassNavigationSimulationRuntime simulation)
     {
         _engine = engine ?? throw new ArgumentNullException(nameof(engine));
         _simulation = simulation ?? throw new ArgumentNullException(nameof(simulation));
+        _agentCapacity = simulation.Config.ScenarioRuntime.RuntimeCapacity.GroupMembershipAgentCapacity;
+        _entities = new List<Entity>(_agentCapacity);
+        _seeds = new List<MassNavigationAgentSeed>(_agentCapacity);
+        _controllableFlags = new List<bool>(_agentCapacity);
     }
 
     public void Initialize() { }
@@ -60,6 +65,12 @@ internal sealed class MassNavigationAuthoredAgentBindingSystem : ISystem<float>
             }
 
             return;
+        }
+
+        if (scan.AuthoredCount > _agentCapacity)
+        {
+            throw new InvalidOperationException(
+                $"MassNavigation authored binding observed {scan.AuthoredCount} agents, exceeding configured scenarioRuntime.runtimeCapacity.groupMembershipAgentCapacity {_agentCapacity}.");
         }
 
         if (_simulation.AgentState.TotalAgents == scan.AuthoredCount &&

--- a/src/Tests/PresentationTests/MassNavigationAuthoredAgentBindingIncrementalTests.cs
+++ b/src/Tests/PresentationTests/MassNavigationAuthoredAgentBindingIncrementalTests.cs
@@ -25,6 +25,7 @@ namespace Ludots.Tests.Presentation
     public sealed class MassNavigationAuthoredAgentBindingIncrementalTests
     {
         private const int TeamId = 1;
+        private const float PositionToleranceCm = MassNavigationGroupRuntime.OrderPathRestoreTargetToleranceCm;
 
         [Test]
         public void AppendAuthoredAgents_PreservesActiveMoveGroupState()
@@ -55,11 +56,11 @@ namespace Ludots.Tests.Presentation
 
             Assert.That(simulation.NavGroupRuntime.ActiveGroupCount, Is.EqualTo(1));
             Assert.That(simulation.NavGroupRuntime.TryGetGroupMemberOrderTarget(0, out float preservedOrderX, out float preservedOrderY), Is.True);
-            Assert.That(preservedOrderX, Is.EqualTo(orderTargetX).Within(0.001f));
-            Assert.That(preservedOrderY, Is.EqualTo(orderTargetY).Within(0.001f));
+            Assert.That(preservedOrderX, Is.EqualTo(orderTargetX).Within(PositionToleranceCm));
+            Assert.That(preservedOrderY, Is.EqualTo(orderTargetY).Within(PositionToleranceCm));
             Assert.That(simulation.TryGetAgentNavigationTargetLocalCm(0, out float preservedTarget0X, out float preservedTarget0Y), Is.True);
-            Assert.That(preservedTarget0X, Is.EqualTo(target0X).Within(0.001f));
-            Assert.That(preservedTarget0Y, Is.EqualTo(target0Y).Within(0.001f));
+            Assert.That(preservedTarget0X, Is.EqualTo(target0X).Within(PositionToleranceCm));
+            Assert.That(preservedTarget0Y, Is.EqualTo(target0Y).Within(PositionToleranceCm));
             Assert.That(simulation.AgentState.TotalAgents, Is.EqualTo(3));
             Assert.That(world.Has<MassNavigationAgentIndex>(newAgent), Is.True);
         }
@@ -89,8 +90,8 @@ namespace Ludots.Tests.Presentation
 
             Assert.That(harness.Simulation.NavGroupRuntime.ActiveGroupCount, Is.EqualTo(1));
             Assert.That(harness.Simulation.NavGroupRuntime.TryGetGroupMemberOrderTarget(0, out float preservedOrderX, out float preservedOrderY), Is.True);
-            Assert.That(preservedOrderX, Is.EqualTo(orderTargetX).Within(0.001f));
-            Assert.That(preservedOrderY, Is.EqualTo(orderTargetY).Within(0.001f));
+            Assert.That(preservedOrderX, Is.EqualTo(orderTargetX).Within(PositionToleranceCm));
+            Assert.That(preservedOrderY, Is.EqualTo(orderTargetY).Within(PositionToleranceCm));
             Assert.That(harness.Simulation.AgentState.TotalAgents, Is.EqualTo(3));
             Assert.That(harness.Engine.World.Has<MassNavigationAgentIndex>(newAgent), Is.True);
         }
@@ -112,6 +113,38 @@ namespace Ludots.Tests.Presentation
 
             Assert.That(simulation.AuthoredRuntimeBindingRevision, Is.EqualTo(revisionBeforeAppend));
             Assert.That(simulation.StructuralChangeRevision, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void AppendAuthoredAgents_MarksNewAgentDirtyForFirstEntitySync()
+        {
+            using var world = World.Create();
+            MassNavigationSimulationRuntime simulation = CreateSimulation(
+                world,
+                out _,
+                out _,
+                out MassNavigationAgentLayer layer);
+            simulation.MassNavigationFlow.SyncEntities(world, simulation.AgentState);
+
+            float appendedLocalX = simulation.MassNavigationFlow.PlayAreaMaxXCm + 1000f;
+            float appendedLocalY = simulation.MassNavigationFlow.PlayAreaMaxYCm + 1000f;
+            Entity newAgent = CreateAuthoredAgentEntity(
+                world,
+                simulation.ToWorldXCm(appendedLocalX),
+                simulation.ToWorldYCm(appendedLocalY),
+                layer);
+            var newSeed = CreateSeed(appendedLocalX, appendedLocalY, layer);
+
+            simulation.AppendAuthoredAgents(world, new[] { newAgent }, new[] { newSeed }, new[] { true });
+            simulation.MassNavigationFlow.SyncEntities(world, simulation.AgentState);
+
+            WorldPositionCm worldPosition = world.Get<WorldPositionCm>(newAgent);
+            Assert.That(
+                worldPosition.Value.X.ToFloat(),
+                Is.EqualTo(simulation.ToWorldXCm(simulation.MassNavigationFlow.PlayAreaMaxXCm)).Within(PositionToleranceCm));
+            Assert.That(
+                worldPosition.Value.Y.ToFloat(),
+                Is.EqualTo(simulation.ToWorldYCm(simulation.MassNavigationFlow.PlayAreaMaxYCm)).Within(PositionToleranceCm));
         }
 
         [Test]
@@ -143,6 +176,42 @@ namespace Ludots.Tests.Presentation
 
             var ex = Assert.Throws<InvalidOperationException>(() =>
                 simulation.AppendAuthoredAgents(world, new[] { newAgent }, new[] { seed }, new[] { true }));
+            Assert.That(ex!.Message, Does.Contain("groupMembershipAgentCapacity"));
+        }
+
+        [Test]
+        public void RebuildFromAuthoredAgents_ExceedsMembershipCapacity_Throws()
+        {
+            using var world = World.Create();
+            MassNavigationSimulationRuntime simulation = CreateConfiguredSimulation(CreateTestConfig(membershipCapacity: 2));
+            MassNavigationAgentLayer layer = CreateAgentLayer();
+            Entity agent0 = CreateAuthoredAgentEntity(world, localX: 1000f, localY: 1000f, layer);
+            Entity agent1 = CreateAuthoredAgentEntity(world, localX: 1200f, localY: 1000f, layer);
+            Entity agent2 = CreateAuthoredAgentEntity(world, localX: 1400f, localY: 1000f, layer);
+            MassNavigationAgentSeed[] seeds =
+            {
+                CreateSeed(localX: 1000f, localY: 1000f, layer),
+                CreateSeed(localX: 1200f, localY: 1000f, layer),
+                CreateSeed(localX: 1400f, localY: 1000f, layer),
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                simulation.RebuildFromAuthoredAgents(
+                    world,
+                    new[] { agent0, agent1, agent2 },
+                    seeds,
+                    new[] { true, true, true }));
+            Assert.That(ex!.Message, Does.Contain("groupMembershipAgentCapacity"));
+        }
+
+        [Test]
+        public void AuthoredAgentBindingSystem_ExceedsMembershipCapacity_ThrowsBeforeAppendOrRebuild()
+        {
+            using BindingHarness harness = CreateBindingHarness(membershipCapacity: 2);
+            harness.BindingSystem.Update(0f);
+            CreateAuthoredAgentEntity(harness.Engine.World, localX: 1400f, localY: 1000f, harness.Layer);
+
+            var ex = Assert.Throws<InvalidOperationException>(() => harness.BindingSystem.Update(0f));
             Assert.That(ex!.Message, Does.Contain("groupMembershipAgentCapacity"));
         }
 
@@ -191,11 +260,11 @@ namespace Ludots.Tests.Presentation
             Assert.That(simulation.NavGroupRuntime.ActiveOrderGroupCount, Is.EqualTo(1));
             Assert.That(simulation.NavGroupRuntime.TryGetOrderGroup(orderToken, out _), Is.True);
             Assert.That(simulation.NavGroupRuntime.TryGetGroupMemberOrderTarget(agent0Index.Value, out float restoredOrderX, out float restoredOrderY), Is.True);
-            Assert.That(restoredOrderX, Is.EqualTo(agent0OrderX).Within(0.001f));
-            Assert.That(restoredOrderY, Is.EqualTo(agent0OrderY).Within(0.001f));
+            Assert.That(restoredOrderX, Is.EqualTo(agent0OrderX).Within(PositionToleranceCm));
+            Assert.That(restoredOrderY, Is.EqualTo(agent0OrderY).Within(PositionToleranceCm));
             Assert.That(simulation.TryGetAgentNavigationTargetLocalCm(agent0Index.Value, out float restoredTargetX, out float restoredTargetY), Is.True);
-            Assert.That(restoredTargetX, Is.EqualTo(agent0TargetX).Within(0.001f));
-            Assert.That(restoredTargetY, Is.EqualTo(agent0TargetY).Within(0.001f));
+            Assert.That(restoredTargetX, Is.EqualTo(agent0TargetX).Within(PositionToleranceCm));
+            Assert.That(restoredTargetY, Is.EqualTo(agent0TargetY).Within(PositionToleranceCm));
         }
 
         [Test]
@@ -283,8 +352,8 @@ namespace Ludots.Tests.Presentation
             Assert.That(simulation.NavGroupRuntime.HasGroup(agent0Index.Value), Is.False);
             Assert.That(simulation.NavGroupRuntime.TryGetGroupMemberOrderTarget(agent0Index.Value, out _, out _), Is.False);
             Assert.That(simulation.TryGetAgentNavigationTargetLocalCm(agent0Index.Value, out float heldTargetX, out float heldTargetY), Is.True);
-            Assert.That(heldTargetX, Is.EqualTo(1000f).Within(0.001f));
-            Assert.That(heldTargetY, Is.EqualTo(1000f).Within(0.001f));
+            Assert.That(heldTargetX, Is.EqualTo(1000f).Within(PositionToleranceCm));
+            Assert.That(heldTargetY, Is.EqualTo(1000f).Within(PositionToleranceCm));
         }
 
         [Test]


### PR DESCRIPTION
Summary:
- mark appended authored agents dirty after UnitCount advances so first entity sync writes new agents
- preallocate MassNavigation solver and binding staging capacity from groupMembershipAgentCapacity
- fail fast before over-capacity binding or rebuild, name rebuild restore tolerance, and add regression coverage

Tests:
- MassNavigationAuthoredAgentBindingIncrementalTests: 12 passed
- Formation follower, incremental binding, formation showcase, locomotion animator, flow solver config filtered suite: 92 passed