### PR TITLE
fix(mass-navigation): clear stale dirty flags on rebuild

### DIFF
--- a/src/Core/MassNavigation/Runtime/MassNavigationFlowSolverEntitySync.cs
+++ b/src/Core/MassNavigation/Runtime/MassNavigationFlowSolverEntitySync.cs
@@ -100,12 +100,12 @@ public sealed partial class MassNavigationFlowSolverState
     private void MarkAllEntitiesDirty()
     {
         _entitySyncDirtyCount = 0;
+        Array.Clear(_entitySyncDirtyFlags, 0, _entitySyncDirtyFlags.Length);
         if (UnitCount <= 0)
         {
             return;
         }
 
-        Array.Clear(_entitySyncDirtyFlags, 0, UnitCount);
         for (int i = 0; i < UnitCount; i++)
         {
             _entitySyncDirtyFlags[i] = 1;

--- a/src/Tests/PresentationTests/MassNavigationAuthoredAgentBindingIncrementalTests.cs
+++ b/src/Tests/PresentationTests/MassNavigationAuthoredAgentBindingIncrementalTests.cs
@@ -148,6 +148,44 @@ namespace Ludots.Tests.Presentation
         }
 
         [Test]
+        public void AppendAuthoredAgents_AfterShrinkRebuild_MarksReusedAgentSlotDirtyForFirstEntitySync()
+        {
+            using var world = World.Create();
+            MassNavigationSimulationRuntime simulation = CreateSimulation(
+                world,
+                out Entity agent0,
+                out Entity agent1,
+                out MassNavigationAgentLayer layer,
+                membershipCapacity: 4);
+            world.Remove<MassNavigationAgent>(agent1);
+            simulation.RebuildFromAuthoredAgents(
+                world,
+                new[] { agent0 },
+                new[] { CreateSeed(localX: 1000f, localY: 1000f, layer) },
+                new[] { true });
+
+            float appendedLocalX = simulation.MassNavigationFlow.PlayAreaMaxXCm + 1000f;
+            float appendedLocalY = simulation.MassNavigationFlow.PlayAreaMaxYCm + 1000f;
+            Entity newAgent = CreateAuthoredAgentEntity(
+                world,
+                simulation.ToWorldXCm(appendedLocalX),
+                simulation.ToWorldYCm(appendedLocalY),
+                layer);
+            var newSeed = CreateSeed(appendedLocalX, appendedLocalY, layer);
+
+            simulation.AppendAuthoredAgents(world, new[] { newAgent }, new[] { newSeed }, new[] { true });
+            simulation.MassNavigationFlow.SyncEntities(world, simulation.AgentState);
+
+            WorldPositionCm worldPosition = world.Get<WorldPositionCm>(newAgent);
+            Assert.That(
+                worldPosition.Value.X.ToFloat(),
+                Is.EqualTo(simulation.ToWorldXCm(simulation.MassNavigationFlow.PlayAreaMaxXCm)).Within(PositionToleranceCm));
+            Assert.That(
+                worldPosition.Value.Y.ToFloat(),
+                Is.EqualTo(simulation.ToWorldYCm(simulation.MassNavigationFlow.PlayAreaMaxYCm)).Within(PositionToleranceCm));
+        }
+
+        [Test]
         public void AuthoredAgentBindingSystem_IncrementalInsert_DoesNotBumpAuthoredRuntimeBindingRevision()
         {
             using BindingHarness harness = CreateBindingHarness(membershipCapacity: 8);


### PR DESCRIPTION
## Summary
- Clear the full MassNavigation entity-sync dirty flag buffer when marking all current agents dirty, so shrink rebuilds cannot leave stale high-slot flags behind.
- Add a regression covering shrink rebuild followed by append reusing a dense agent slot and requiring first ECS WorldPositionCm writeback.

## Verification
- Red: new AppendAuthoredAgents_AfterShrinkRebuild_MarksReusedAgentSlotDirtyForFirstEntitySync failed before the runtime fix (appended agent stayed unclamped at 10950cm instead of 9950cm).
- Green: dotnet test src/Tests/PresentationTests/PresentationTests.csproj --filter FullyQualifiedName~AppendAuthoredAgents_AfterShrinkRebuild_MarksReusedAgentSlotDirtyForFirstEntitySync
- Green: dotnet test src/Tests/PresentationTests/PresentationTests.csproj --filter FullyQualifiedName~MassNavigationAuthoredAgentBindingIncrementalTests
- Green: dotnet test src/Tests/PresentationTests/PresentationTests.csproj --filter FullyQualifiedName~FormationCapabilityShowcaseContractTests|FullyQualifiedName~MassNavigationLocomotionAnimatorParamSystemTests|FullyQualifiedName~MassNavigationRouteExecutionContractTests|FullyQualifiedName~MassNavigationExecutionAvoidanceContractTests

## Audit Notes
- Fix is reset/rebuild cold-path only; no solver Step/StepRange structure change.
- No allocations, fallback, or parallel binding path added.
- Subagent follow-up review found no must-fix issues.