### PR TITLE
docs(rfc): RFC-0061–0064 interaction architecture epics

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -29,13 +29,13 @@
 * [RFC-0060 通用存档系统](RFC-0060-universal-save-system.md)
   * Epic #292 引用的通用存档 RFC 回写；编号与 AI Utility Autocast 历史文件重叠，正式结论以 `gitbook/architecture/save-system.md` 为准
 * [RFC-0061 Interaction → EntityView → Order → MassNav 职责边界收敛](RFC-0061-interaction-view-order-massnav-boundary-unification.md)
-  * Epic #522 SSOT：OrderQueue 唯一 intake、Selection 退役、EntityView + Collection 命令目标集
+  * [#522](https://github.com/MightyBubble/Ludots/issues/522) SSOT：OrderQueue 唯一 intake、Selection 退役、EntityView + Collection 命令目标集
 * [RFC-0062 Interaction Context Stack — Input 基建](RFC-0062-interaction-context-stack-input-infrastructure.md)
-  * Context 栈决定 active collection key；InputCast geometry 无关；Selection 仅为 default context 俗名
+  * [#536](https://github.com/MightyBubble/Ludots/issues/536)：Context 栈决定 active collection key；InputCast geometry 无关
 * [RFC-0063 Participant Control Plane — Association 归属/代理控制](RFC-0063-participant-control-plane-via-association.md)
-  * 退役 unit 上 PlayerOwner/Team；controls/owns 关系边；掉线代理不迁移 collection
+  * [#537](https://github.com/MightyBubble/Ludots/issues/537)：退役 unit 上 PlayerOwner/Team；掉线代理不迁移 collection
 * [RFC-0064 Collection Provenance & Performer 多观战投影](RFC-0064-collection-provenance-performer-multi-viewer.md)
-  * Row provenance；多控制域 marker；裁判 multi-collection 读
+  * [#538](https://github.com/MightyBubble/Ludots/issues/538)：Row provenance；裁判 multi-collection 读
 
 ## 2 使用规则
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -28,6 +28,14 @@
   * 定稿 Intent / Behavior / Deliberation 三层、普攻=autocast、AI Order/GAS 边界与加载期 fail-fast 契约
 * [RFC-0060 通用存档系统](RFC-0060-universal-save-system.md)
   * Epic #292 引用的通用存档 RFC 回写；编号与 AI Utility Autocast 历史文件重叠，正式结论以 `gitbook/architecture/save-system.md` 为准
+* [RFC-0061 Interaction → EntityView → Order → MassNav 职责边界收敛](RFC-0061-interaction-view-order-massnav-boundary-unification.md)
+  * Epic #522 SSOT：OrderQueue 唯一 intake、Selection 退役、EntityView + Collection 命令目标集
+* [RFC-0062 Interaction Context Stack — Input 基建](RFC-0062-interaction-context-stack-input-infrastructure.md)
+  * Context 栈决定 active collection key；InputCast geometry 无关；Selection 仅为 default context 俗名
+* [RFC-0063 Participant Control Plane — Association 归属/代理控制](RFC-0063-participant-control-plane-via-association.md)
+  * 退役 unit 上 PlayerOwner/Team；controls/owns 关系边；掉线代理不迁移 collection
+* [RFC-0064 Collection Provenance & Performer 多观战投影](RFC-0064-collection-provenance-performer-multi-viewer.md)
+  * Row provenance；多控制域 marker；裁判 multi-collection 读
 
 ## 2 使用规则
 

--- a/docs/rfcs/RFC-0061-interaction-view-order-massnav-boundary-unification.md
+++ b/docs/rfcs/RFC-0061-interaction-view-order-massnav-boundary-unification.md
@@ -1,0 +1,119 @@
+# RFC-0061 Interaction → EntityView → Order → MassNav 职责边界收敛
+
+Status: Proposed（Epic #522 SSOT）  
+Parent Epic: [#522](https://github.com/MightyBubble/Ludots/issues/522)
+
+## 1. 问题
+
+当前 MassNavigation 与 Input / Selection 职责交叉：
+
+- MassNav 直接读 `AuthoritativeInput`、`SelectionRuntime`，旁路 `OrderQueue` 调 `OrderBufferSystem.SubmitOrder`
+- Selection 同时承担 Input 子模块与全栈 gameplay SSOT
+- 框选、命令、移动、表现各走不同「选中真相」，Mod 无法数据驱动扩展
+
+本 RFC 收敛为 **单向依赖链**，并为后续 Context Stack（RFC-0062）、Control Plane（RFC-0063）、Provenance Performer（RFC-0064）留出挂点。
+
+## 2. 目标链路
+
+```text
+CastProfile / InputCastSpec (geometry 无关)
+  → Client raw collection (UiAcquisition)
+    → FilterProfile (association / eligibility)
+      → (playerRepEntity, activeCollectionKey)   ← Context Stack 决定 key
+        → EntityView profile (viewKey → collection + role)
+          → OrderQueue（唯一 intake）
+            → OrderBuffer
+              → MassNavigation ingestion（纯 execution）
+```
+
+## 3. 三条铁律
+
+1. **OrderQueue 是唯一 order intake** — MassNav / evidence / AI / input 不得旁路直写 `SubmitOrder`
+2. **MassNav 不读 Input / Selection** — 只消费 OrderBuffer 中已提交的 movement order
+3. **Selection 概念退役** — 「命令目标集」由 `EntityCollectionStore` + `EntityCollectionRoleKind.CommandSource`（及 context-bound key）表达；`SelectionRuntime` 不得再作为 hub
+
+## 4. EntityView 与 Collection
+
+### 4.1 地址模型
+
+Collection 真相地址：`(owner entity, collection key string)`。
+
+- **owner** = participant representative entity（player rep），不是 `PlayerId` 整数，不是全局 service bag
+- **key** = 由 Interaction Context Stack 决定的 active key（见 RFC-0062）
+
+### 4.2 EntityView Profile（data）
+
+```json
+{
+  "viewKey": "command.default",
+  "collectionKey": "collection.command.source",
+  "role": "CommandSource"
+}
+```
+
+EntityView 是 **只读绑定**：`viewKey → (collectionKey, role)`。不复制 row，不创造第二套选中真相。
+
+### 4.3 与 RFC-0059 的关系
+
+RFC-0059 的 selection container / member relation **不得**继续作为命令 intake SSOT。允许：
+
+- 短期：acquisition 仍写 `collection.ui.selection.acquisition`，经 filter 写入 command collection
+- 终态：删除 `SelectionRuntime` 作为命令 hub 的所有 consumer；formation / snapshot 若仍需容器语义，迁移为 keyed collection + lease descriptor
+
+## 5. CastProfile 与 InputCast
+
+CastProfile 描述 **client input cast 的几何与空间**，与 commit 语义正交：
+
+| 轴 | 归属 | 示例 |
+|----|------|------|
+| Geometry | InputCastSpec | box / polygon / ray / lasso |
+| Space | InputCastSpec | screen / world / minimap |
+| Filter | FilterProfile | controllable_by(localPlayerRep) |
+| Commit | Order mapping | press / release / smartcast |
+| Active collection key | Context Stack | default vs ability.nuke.targets |
+
+禁止把「框选语义」硬编码进 `InteractionModeType` 单一 enum。
+
+## 6. 分层边界
+
+| 层 | 职责 | 禁止 |
+|----|------|------|
+| Input Cast | 几何 → raw hits collection | 写 command collection、改 association |
+| Context Stack | active key / push-pop | 存 selection 真相 |
+| Filter Profile | raw → filtered | 改 relationship graph |
+| Collection Write | filtered → `(playerRep, key)` | merge 跨 player 的 namespace |
+| Order Intake | 读 command collection + fan-out | 读 SelectionRuntime hub |
+| MassNav | OrderBuffer execution | 读 Input / Selection |
+
+## 7. Sub-issues（ORD-*）
+
+| ID | 标题 | 要点 |
+|----|------|------|
+| ORD-1 | MassNav 停止读取 Input / Selection | 删 direct input/selection 依赖 |
+| ORD-2 | OrderQueue 统一 intake 护栏 | ArchitectureTests 禁止旁路 SubmitOrder |
+| ORD-3 | EntityView profile registry | viewKey → collection + role |
+| ORD-4 | CommandSource collection → Order fan-out | 替代 `InputOrderMappingSystem` 读 Selection |
+| ORD-5 | Acquisition → Filter → CommandSource 管线 | 对接 RFC-0062 filter |
+| ORD-6 | Retire SelectionRuntime command consumers | champion sandbox / MassNav / panel |
+| ORD-7 | `#499` publisher 改 relationship query | 见 RFC-0063 |
+| ORD-8 | 文档回写 + playable showcase | entity_query_tactics 或新 capability mod |
+
+## 8. 依赖
+
+- 前置：EntityCollectionStore、OrderQueue（已有）
+- 并行：[#239 AAC](https://github.com/MightyBubble/Ludots/issues/239)（association 基座）
+- 后续：RFC-0062 Context Stack、RFC-0063 Control Plane、RFC-0064 Provenance
+
+## 9. 非目标
+
+- 不重写 MassNavigationFlow solver
+- 不在本 Epic 实现完整 AbilityAim 退役（见 RFC-0062 interaction phase）
+- 不做向后兼容 shim
+
+## 10. 验收
+
+- [ ] MassNav / movement 路径零 `SelectionRuntime` / `AuthoritativeInput` 读取
+- [ ] 所有 move/cast order 经 OrderQueue
+- [ ] Command 目标集来自 `(playerRepEntity, collection.command.source)` 或 context active key
+- [ ] ArchitectureTests 覆盖旁路禁止
+- [ ] Playable showcase 演示 box → filter → move order → MassNav

--- a/docs/rfcs/RFC-0061-interaction-view-order-massnav-boundary-unification.md
+++ b/docs/rfcs/RFC-0061-interaction-view-order-massnav-boundary-unification.md
@@ -87,6 +87,21 @@ CastProfile 描述 **client input cast 的几何与空间**，与 commit 语义�
 
 ## 7. Sub-issues（ORD-*）
 
+Parent: [#522](https://github.com/MightyBubble/Ludots/issues/522)
+
+| ID | Issue | 要点 |
+|----|-------|------|
+| ORD-1 | [#567](https://github.com/MightyBubble/Ludots/issues/567) | MassNav 停止读取 Input / Selection |
+| ORD-2 | [#568](https://github.com/MightyBubble/Ludots/issues/568) | OrderQueue 统一 intake 护栏 |
+| ORD-3 | [#569](https://github.com/MightyBubble/Ludots/issues/569) | EntityView profile registry |
+| ORD-4 | [#570](https://github.com/MightyBubble/Ludots/issues/570) | CommandSource collection → Order fan-out |
+| ORD-5 | [#571](https://github.com/MightyBubble/Ludots/issues/571) | Acquisition → Filter → CommandSource 管线 |
+| ORD-6 | [#572](https://github.com/MightyBubble/Ludots/issues/572) | Retire SelectionRuntime command consumers |
+| ORD-7 | [#573](https://github.com/MightyBubble/Ludots/issues/573) | `#499` publisher 改 relationship query |
+| ORD-8 | [#574](https://github.com/MightyBubble/Ludots/issues/574) | 文档回写 + playable showcase |
+
+<details><summary>原表格（策划摘要）</summary>
+
 | ID | 标题 | 要点 |
 |----|------|------|
 | ORD-1 | MassNav 停止读取 Input / Selection | 删 direct input/selection 依赖 |
@@ -97,6 +112,8 @@ CastProfile 描述 **client input cast 的几何与空间**，与 commit 语义�
 | ORD-6 | Retire SelectionRuntime command consumers | champion sandbox / MassNav / panel |
 | ORD-7 | `#499` publisher 改 relationship query | 见 RFC-0063 |
 | ORD-8 | 文档回写 + playable showcase | entity_query_tactics 或新 capability mod |
+
+</details>
 
 ## 8. 依赖
 

--- a/docs/rfcs/RFC-0062-interaction-context-stack-input-infrastructure.md
+++ b/docs/rfcs/RFC-0062-interaction-context-stack-input-infrastructure.md
@@ -1,7 +1,7 @@
 # RFC-0062 Interaction Context Stack — Input 基建与 Context-Bound Collection 路由
 
 Status: Proposed  
-Epic: （创建后回填 GitHub issue 编号）
+Epic: [#536](https://github.com/MightyBubble/Ludots/issues/536)
 
 ## 1. 问题
 
@@ -133,18 +133,20 @@ Filter 只读 association graph（RFC-0063），不改 relationship。
 
 ## 7. Sub-issues（CTX-*）
 
-| ID | 标题 | 要点 |
-|----|------|------|
-| CTX-1 | InteractionContextStack Core 契约 | service + tests |
-| CTX-2 | Default frame 与 map load 初始化 | push default |
-| CTX-3 | InputCast → raw collection | geometry / space 无关 |
-| CTX-4 | FilterProfile registry + evaluate | association query |
-| CTX-5 | Context-bound collection write | 替代 selection commit |
-| CTX-6 | AbilityExec lifecycle push/pop | 替代 IsAiming 驱动 context |
-| CTX-7 | CastProfile / InteractionMode 正交拆分 | 禁止 enum 捆绑 |
-| CTX-8 | ClientCastPreference per-slot | global + per-slot SSOT |
-| CTX-9 | Showcase：superweapon 框选 + pop 恢复 | playable acceptance |
-| CTX-10 | ArchitectureTests + 文档回写 | guard 禁止 Selection hub |
+Parent: [#536](https://github.com/MightyBubble/Ludots/issues/536)
+
+| ID | Issue |
+|----|-------|
+| CTX-1 | [#539](https://github.com/MightyBubble/Ludots/issues/539) InteractionContextStack Core |
+| CTX-2 | [#540](https://github.com/MightyBubble/Ludots/issues/540) Default frame 初始化 |
+| CTX-3 | [#541](https://github.com/MightyBubble/Ludots/issues/541) InputCast → raw collection |
+| CTX-4 | [#542](https://github.com/MightyBubble/Ludots/issues/542) FilterProfile registry |
+| CTX-5 | [#543](https://github.com/MightyBubble/Ludots/issues/543) Context-bound collection write |
+| CTX-6 | [#544](https://github.com/MightyBubble/Ludots/issues/544) AbilityExec push/pop |
+| CTX-7 | [#546](https://github.com/MightyBubble/Ludots/issues/546) CastProfile 正交拆分 |
+| CTX-8 | [#548](https://github.com/MightyBubble/Ludots/issues/548) ClientCastPreference per-slot |
+| CTX-9 | [#550](https://github.com/MightyBubble/Ludots/issues/550) Showcase superweapon |
+| CTX-10 | [#552](https://github.com/MightyBubble/Ludots/issues/552) ArchitectureTests + 文档 |
 
 ## 8. 依赖
 

--- a/docs/rfcs/RFC-0062-interaction-context-stack-input-infrastructure.md
+++ b/docs/rfcs/RFC-0062-interaction-context-stack-input-infrastructure.md
@@ -1,0 +1,167 @@
+# RFC-0062 Interaction Context Stack — Input 基建与 Context-Bound Collection 路由
+
+Status: Proposed  
+Epic: （创建后回填 GitHub issue 编号）
+
+## 1. 问题
+
+「Selection」被实现成单一全局语义，无法表达：
+
+- 默认 RTS 框选指挥 vs 超级武器施法中「指定单位」框选
+- 技能结束回到默认 context 后，框选语义自动恢复
+- MOBA 单英雄 vs RTS 多选共用同一 input cast 基建、不同 collection key
+
+`InteractionModeType` 把 commit、presentation、targeting 捆在一个 enum，导致 SmartCast 陷阱与 per-ability 域无法正交扩展。
+
+**Context Stack 是 Input 基建**，不属于 ParticipantView Mode，不属于 Selection hub。
+
+## 2. 结论
+
+引入 **InteractionContextStack**（Input 层 SSOT）：
+
+- 每个 local client session 维护 **context 栈**（push / pop）
+- 栈顶决定 **activeCollectionKey** 与 **activeEntityViewKey**
+- 同一 InputCast（box / polygon / screen / world）始终走同一 cast 管线，仅 **写入 key** 随 context 变化
+
+```text
+默认 context:
+  activeKey = collection.command.source
+  activeView  = view.command.default
+
+超级武器 ConfirmTargets context:
+  activeKey = collection.ability.superweapon.targets
+  activeView  = view.ability.superweapon.targets
+  contextEntity = abilityExecInstanceEntity（descriptor.ContextEntity）
+
+pop → 恢复 default，command.source 未被 superweapon 污染
+```
+
+## 3. Context Stack 数据模型
+
+### 3.1 Core 契约（拟新增）
+
+```csharp
+public readonly record struct InteractionContextFrame(
+    string ContextId,              // e.g. "default", "ability:nuke:exec42"
+    string ActiveCollectionKey,
+    string ActiveEntityViewKey,
+    Entity ContextEntity,          // ability exec / order lease / default null
+    Entity FilterProfileEntity);   // optional, data-driven filter binding
+
+public sealed class InteractionContextStack
+{
+    void Push(in InteractionContextFrame frame);
+    bool TryPop(out InteractionContextFrame frame);
+    bool TryPeek(out InteractionContextFrame frame);
+}
+```
+
+### 3.2 挂载点
+
+| 选项 | 结论 |
+|------|------|
+| Client session service | **首选**：`CoreServiceKeys.InteractionContextStack`，local-only，不参与 sim 同步 |
+| Player rep 组件 | 仅当需要 replay / 观战同步 context 时才考虑；默认不做 |
+
+Input 系统在 `InputCollection` phase 读 stack top，决定：
+
+1. InputCast 结果写入哪个 `(playerRepEntity, activeCollectionKey)`
+2. Order mapping 读哪个 EntityView / collection role
+
+### 3.3 Context 生命周期来源
+
+| 来源 | 动作 |
+|------|------|
+| Map load | push `default` frame |
+| AbilityExec 进入 PendingConfirm / Channel | push ability frame（data：`AbilityDefinition.interactionContextProfile`） |
+| AbilityExec 结束 / cancel | pop |
+| Super weapon / multi-phase skill | 多个 frame 可嵌套 |
+
+禁止 `_isAiming` / `AbilityAimPresentationRuntime` 作为 context SSOT；presentation 读 entity tag + collection revision。
+
+## 4. Input Cast 管线（geometry 无关）
+
+```text
+InputCastSpec (from binding / CastProfile)
+  → spatial / screen query
+  → (clientSession, collection.ui.cast.raw)     // 原始命中，不过滤
+  → FilterProfile.evaluate(localPlayerRep, raw)
+  → (playerRepEntity, stack.activeCollectionKey) // 语义写入
+  → PresentationEvent / EntityCollection revision
+```
+
+### 4.1 FilterProfile（data）
+
+```json
+{
+  "id": "filter.controllable.default",
+  "associationQuery": {
+    "anchor": "localPlayerRep",
+    "edgeTypes": ["owns", "controls"],
+    "exclude": ["dead", "hidden"]
+  }
+}
+```
+
+Filter 只读 association graph（RFC-0063），不改 relationship。
+
+### 4.2 与「Selection」一词的关系
+
+**Selection 只是 default context 下 `collection.command.source` 的俗名**，不是 Core 类型名。文档与 Mod 配置可使用 `selection` 作为 viewKey alias，Core 不得保留 `SelectionRuntime` hub。
+
+## 5. 技能域 Collection 示例
+
+| 场景 | ContextId | CollectionKey |
+|------|-----------|---------------|
+| RTS 默认指挥 | default | collection.command.source |
+| 超级武器指定单位 | ability:nuke | collection.ability.nuke.targets |
+| MOBA 地面指示器 | ability:skillw | collection.ability.skillw.ground |
+| Tab 循环候选 | input:tabcycle | collection.input.tab.candidates |
+
+同一 `InputCastSpec.BoxScreen` 在各行写入不同 key。
+
+## 6. 分层边界
+
+| 模块 | 做 | 不做 |
+|------|-----|------|
+| InteractionContextStack | push/pop/peek；暴露 active key | 存 entity 列表 |
+| InputCastSystem | 几何查询 → raw collection | 判断 controllable |
+| FilterProfileRuntime | association 过滤 | 写 order |
+| CollectionWriteSystem | filtered → playerRep collection | merge 跨 player namespace |
+| AbilityExec | 触发 push/pop | 直接写 SelectionRuntime |
+| Performer | 读 collection revision + provenance | 决定 active key |
+
+## 7. Sub-issues（CTX-*）
+
+| ID | 标题 | 要点 |
+|----|------|------|
+| CTX-1 | InteractionContextStack Core 契约 | service + tests |
+| CTX-2 | Default frame 与 map load 初始化 | push default |
+| CTX-3 | InputCast → raw collection | geometry / space 无关 |
+| CTX-4 | FilterProfile registry + evaluate | association query |
+| CTX-5 | Context-bound collection write | 替代 selection commit |
+| CTX-6 | AbilityExec lifecycle push/pop | 替代 IsAiming 驱动 context |
+| CTX-7 | CastProfile / InteractionMode 正交拆分 | 禁止 enum 捆绑 |
+| CTX-8 | ClientCastPreference per-slot | global + per-slot SSOT |
+| CTX-9 | Showcase：superweapon 框选 + pop 恢复 | playable acceptance |
+| CTX-10 | ArchitectureTests + 文档回写 | guard 禁止 Selection hub |
+
+## 8. 依赖
+
+- RFC-0061（Order intake 读 active collection）
+- RFC-0063（FilterProfile association query）
+- 可选并行：#522 ORD-5
+
+## 9. 非目标
+
+- 不实现 ParticipantView Mode enum
+- 不在 Core 硬编码 RTS/MOBA 分支
+- 不做 SelectionRuntime 兼容层
+
+## 10. 验收
+
+- [ ] box / polygon / screen / world 共用 InputCastSystem
+- [ ] superweapon 施法框选写入独立 key，pop 后 default 恢复
+- [ ] 零 `SelectionRuntime` 作为 context 路由 SSOT
+- [ ] FilterProfile 数据驱动，Core 无 `if (rts)` 分支
+- [ ] Playable showcase + headless acceptance

--- a/docs/rfcs/RFC-0063-participant-control-plane-via-association.md
+++ b/docs/rfcs/RFC-0063-participant-control-plane-via-association.md
@@ -1,0 +1,167 @@
+# RFC-0063 Participant Control Plane — Association 归属/代理控制与 Player Entity Collection 域
+
+Status: Proposed  
+Epic: （创建后回填 GitHub issue 编号）
+
+## 1. 问题
+
+当前实现把 **归属** 写成 embodied entity 上的组件：
+
+- `PlayerOwner { PlayerId }`、`Team { Id }` 散落在每个 unit 上
+- `ResolvePlayerMembers` / `#499` publisher 扫描 `PlayerOwner` 组件
+- 掉线队友单位接管需要「迁移 selection / 重写 PlayerOwner」等 ad-hoc 系统
+- Collection 与 `PlayerId` 数据 bag 混谈，重连无法归还框选状态
+
+**归属是游戏场景语义，不是 unit 上的 identity 组件。** 真相应是 **entity 之间的 relationship edge**（AAC #248 `OwnershipResolver` 方向）。
+
+## 2. 结论
+
+### 2.1 实体分类
+
+| 类型 | 组件 | 职责 |
+|------|------|------|
+| Player rep entity | `PlayerIdentity` | client 在游戏 sim 中的化身 anchor |
+| Team rep entity | `TeamIdentity` | 阵营 anchor |
+| Embodied entity | GAS / 空间 / 标签 | **无** `PlayerOwner` / `Team` / `PlayerIdentity` |
+
+### 2.2 关系边（catalog SSOT）
+
+| TypeKey | 语义 | 示例 |
+|---------|------|------|
+| `owns` | 归属 / 所有权 | playerRep ──owns──► marine |
+| `controls` | 当前可指挥 | playerRep ──controls──► marine（含代理） |
+| `member_of` | 阵营成员 | playerRep ──member_of──► teamRep |
+| `ally` | 玩家间同盟 | playerRep1 ──ally──► playerRep2 |
+
+`controls` 是 `owns` 的超集扩展边：正常时 `controls ≡ owns`；代理时仅增 `controls` 边，**不迁移 collection**。
+
+### 2.3 Collection 域
+
+每个 player rep entity 拥有 **完整 collection namespace**：
+
+```text
+(player1Rep, collection.command.source) = [m07, m12]
+(player2Rep, collection.command.source) = [m99]   // 队友掉线期间仍保留在其 entity 域
+```
+
+本地 client 代理指挥 m99 时：
+
+- **Order intake** 通过 filter 读 `controls(player1Rep, ?)` 包含 m99
+- **Collection 写入** 默认仍写 `(player1Rep, activeKey)` 供本地操作
+- **player2Rep 上的 collection 不搬家** — 重连后 client bind player2Rep 即归还
+
+禁止 `PlayerId → SelectionMap` 全局表。
+
+## 3. 代理控制：Profile + Runtime
+
+### 3.1 静态 Profile（authoring）
+
+```json
+{
+  "id": "profile.control.offline_teammate_proxy",
+  "when": {
+    "all": [
+      { "relationship": "ally", "between": ["localPlayerRep", "targetPlayerRep"] },
+      { "tag": "participant.offline", "on": "targetPlayerRep" }
+    ]
+  },
+  "then": {
+    "grantControls": {
+      "fromOwner": "targetPlayerRep",
+      "toController": "localPlayerRep",
+      "edgeType": "controls",
+      "scope": "all_owned"
+    }
+  },
+  "revokeWhen": {
+    "not": { "tag": "participant.offline", "on": "targetPlayerRep" }
+  }
+}
+```
+
+### 3.2 Runtime
+
+- `AssociationControlProfileRuntime` 评估 profile → `OwnershipResolver` / `RelationshipRuntime` 增删 `controls` 边
+- **不** copy collection、**不** 改 `owns` 边、**不** 写 unit 组件
+
+### 3.3 重连归还
+
+```text
+T0: player2 offline → controls(p1, m99) granted
+T1: player1 框选 [m07, m99] → 写 (p1Rep, command.source)
+    (p2Rep, command.source)=[m99] frozen
+T2: player2 online → revoke controls(p1, m99)
+T3: player2 client bind p2Rep → 读 (p2Rep, command.source)=[m99]
+```
+
+无需「归还系统」— 状态从未离开 p2Rep entity 域。
+
+## 4. 控制平面 Query API
+
+拟新增 / 收口：
+
+```csharp
+public sealed class ControlDomainQuery
+{
+    int CollectControlled(Entity controllerRep, Span<Entity> buffer, ControlQueryFlags flags);
+    bool IsControllableBy(Entity controllerRep, Entity target);
+    bool TryResolveControlDomain(Entity target, out Entity domainRep, out ControlRelationKind kind);
+}
+```
+
+`CollectControlled` 替代 `ResolvePlayerMembers` 的 `PlayerOwner` 扫描。
+
+## 5. 与 map-owned-participant-contract 的迁移
+
+当前 contract 要求 rep 写 `PlayerOwner` + `Team`，unit 模板带 `PlayerOwner`。
+
+**迁移目标**：
+
+1. Map load 建立 `owns(playerRep, unit)`、`member_of(playerRep, teamRep)` 边
+2. 删除 embodied entity 上 `PlayerOwner` / `Team` 组件 authoring
+3. `ParticipantBindingResolver` 不再向 rep 以外实体写 owner 组件
+4. `#499` `MatchesOwner` 改 `ControlDomainQuery`
+
+## 6. ParticipantView 退役路径
+
+`ParticipantViewCapabilityMod` 写 `SelectionRuntime.LivePrimary` — **错误方向**。
+
+改为：
+
+- Member projection = `ControlDomainQuery` + catalog profile id（非 UX Mode enum）
+- Observer focus = 可选 QA entity，不是 `Players | Teams` Mode
+
+## 7. Sub-issues（CTRL-*）
+
+| ID | 标题 | 要点 |
+|----|------|------|
+| CTRL-1 | ControlDomainQuery API | 替代 PlayerOwner 扫描 |
+| CTRL-2 | Map load owns/member_of 边建立 | 替代 unit PlayerOwner authoring |
+| CTRL-3 | 删除 embodied PlayerOwner/Team | breaking + migrate showcases |
+| CTRL-4 | AssociationControlProfile catalog + runtime | offline proxy |
+| CTRL-5 | `#499` publisher relationship 化 | MatchesOwner → ControlDomainQuery |
+| CTRL-6 | Per-playerRep collection namespace 护栏 | 禁止 cross-player merge |
+| CTRL-7 | ParticipantView 停止写 Selection | projection read-only |
+| CTRL-8 | Showcase：offline proxy + reconnect handback | RTS 场景 |
+| CTRL-9 | ArchitectureTests | 禁止 unit PlayerOwner 新增 |
+| CTRL-10 | gitbook map-owned-participant-contract 回写 | 正式规范 |
+
+## 8. 依赖
+
+- [#239 AAC](https://github.com/MightyBubble/Ludots/issues/239) / #248 OwnershipResolver（已有）
+- RFC-0062 FilterProfile（controllable 过滤）
+- RFC-0061 Order intake
+
+## 9. 非目标
+
+- 不重做 RelationshipRuntime 存储
+- 不引入 PlayerId 全局 selection service
+- 不做 PlayerOwner 兼容读取 fallback
+
+## 10. 验收
+
+- [ ] embodied entity 零 `PlayerOwner` / `Team`（showcase 迁移完成）
+- [ ] 控制集合来自 `controls` 边 query
+- [ ] offline proxy 仅增删 `controls` 边，collection 不迁移
+- [ ] 重连 showcase 证明 p2Rep collection 归还
+- [ ] ArchitectureTests 禁止新 PlayerOwner on units

--- a/docs/rfcs/RFC-0063-participant-control-plane-via-association.md
+++ b/docs/rfcs/RFC-0063-participant-control-plane-via-association.md
@@ -1,7 +1,7 @@
 # RFC-0063 Participant Control Plane — Association 归属/代理控制与 Player Entity Collection 域
 
 Status: Proposed  
-Epic: （创建后回填 GitHub issue 编号）
+Epic: [#537](https://github.com/MightyBubble/Ludots/issues/537)
 
 ## 1. 问题
 
@@ -133,18 +133,20 @@ public sealed class ControlDomainQuery
 
 ## 7. Sub-issues（CTRL-*）
 
-| ID | 标题 | 要点 |
-|----|------|------|
-| CTRL-1 | ControlDomainQuery API | 替代 PlayerOwner 扫描 |
-| CTRL-2 | Map load owns/member_of 边建立 | 替代 unit PlayerOwner authoring |
-| CTRL-3 | 删除 embodied PlayerOwner/Team | breaking + migrate showcases |
-| CTRL-4 | AssociationControlProfile catalog + runtime | offline proxy |
-| CTRL-5 | `#499` publisher relationship 化 | MatchesOwner → ControlDomainQuery |
-| CTRL-6 | Per-playerRep collection namespace 护栏 | 禁止 cross-player merge |
-| CTRL-7 | ParticipantView 停止写 Selection | projection read-only |
-| CTRL-8 | Showcase：offline proxy + reconnect handback | RTS 场景 |
-| CTRL-9 | ArchitectureTests | 禁止 unit PlayerOwner 新增 |
-| CTRL-10 | gitbook map-owned-participant-contract 回写 | 正式规范 |
+Parent: [#537](https://github.com/MightyBubble/Ludots/issues/537)
+
+| ID | Issue |
+|----|-------|
+| CTRL-1 | [#554](https://github.com/MightyBubble/Ludots/issues/554) ControlDomainQuery API |
+| CTRL-2 | [#556](https://github.com/MightyBubble/Ludots/issues/556) Map load owns/member_of |
+| CTRL-3 | [#558](https://github.com/MightyBubble/Ludots/issues/558) 删除 embodied PlayerOwner/Team |
+| CTRL-4 | [#560](https://github.com/MightyBubble/Ludots/issues/560) AssociationControlProfile |
+| CTRL-5 | [#562](https://github.com/MightyBubble/Ludots/issues/562) #499 publisher relationship 化 |
+| CTRL-6 | [#545](https://github.com/MightyBubble/Ludots/issues/545) collection namespace 护栏 |
+| CTRL-7 | [#547](https://github.com/MightyBubble/Ludots/issues/547) ParticipantView 停止写 Selection |
+| CTRL-8 | [#549](https://github.com/MightyBubble/Ludots/issues/549) Showcase offline proxy |
+| CTRL-9 | [#551](https://github.com/MightyBubble/Ludots/issues/551) ArchitectureTests |
+| CTRL-10 | [#553](https://github.com/MightyBubble/Ludots/issues/553) gitbook 回写 |
 
 ## 8. 依赖
 

--- a/docs/rfcs/RFC-0064-collection-provenance-performer-multi-viewer.md
+++ b/docs/rfcs/RFC-0064-collection-provenance-performer-multi-viewer.md
@@ -1,0 +1,148 @@
+# RFC-0064 Collection Provenance & Performer — 多控制域 Marker 与观战投影
+
+Status: Proposed  
+Epic: （创建后回填 GitHub issue 编号）
+
+## 1. 问题
+
+框选 collection 混合多个 control domain（自有 unit + 代理队友 unit）时：
+
+- 本地玩家需区分 marker 颜色（深绿 vs 浅绿）
+- 直播裁判需同时看到所有玩家的 selection collection，并按队伍色 + 相位差异渲染（红 vs 橘）
+- Performer 若读 `PlayerOwner` 组件或单一 Selection hub，无法表达 **provenance**
+
+Collection row 目前仅有 `entity, ordinal, roleId, flags`，缺少 **control domain** 语义。
+
+## 2. 结论
+
+### 2.1 Provenance 模型
+
+每条 collection row 必须可解析：
+
+```text
+row.entity          → 被选中的 embodied entity
+row.controlDomain   → 哪个 player rep entity 拥有该行的「指挥域」
+row.relationKind    → owns | controls (proxy)
+```
+
+两种实现路径（Epic 内择一，禁止双轨）：
+
+| 方案 | 做法 | 优劣 |
+|------|------|------|
+| A. 显式 row metadata | 写入时填 `rowRoleId` / descriptor 扩展 | 热路径快，Performer 零图遍历 |
+| B. 运行时反查 | Performer 调 `ControlDomainQuery.TryResolveControlDomain` | 无 duplicate，但热路径贵 |
+
+**推荐 A**：CollectionWrite 在 filter 后写入时填充 provenance；ArchitectureTests 保证与 association 一致。
+
+### 2.2 Performer 职责
+
+Performer **只读** collection + provenance + catalog，**不写** collection、**不改** association。
+
+```text
+(localClient, collection.command.source) rows
+  → for each row:
+      style = PerformerCatalog.resolve(
+        viewerRole: LocalPlayer,
+        controlDomain: row.controlDomain,
+        relationKind: row.relationKind,
+        teamPalette: teamRep)
+```
+
+示例 catalog：
+
+```json
+{
+  "id": "performer.selection.marker.local",
+  "when": { "viewer": "localPlayer", "relationKind": "owns" },
+  "asset": "selection_ring_deep_green"
+},
+{
+  "id": "performer.selection.marker.proxy",
+  "when": { "viewer": "localPlayer", "relationKind": "controls" },
+  "asset": "selection_ring_light_green"
+}
+```
+
+### 2.3 裁判 / 观战 multi-viewer
+
+中立 player rep entity（refereeRep）通过 **Knowledge grant** 获得读其他 playerRep collection 的能力：
+
+```text
+refereeRep reads:
+  (player1Rep, collection.command.source)
+  (player2Rep, collection.command.source)
+  ...
+Performer(viewer=refereeRep):
+  player1 domain → team_red_phase0
+  player2 domain → team_red_phase1  // 同队色 + 相位差
+```
+
+禁止专用「RefereeSelectionService」— 复用 `EntityCollectionStore.TryGetView` + knowledge visibility。
+
+### 2.4 事件
+
+复用现有 Performer 事件：
+
+- `EntityCollectionMemberAdded` / `Removed` + collection key
+- revision tick 驱动 diff
+
+Performer rule 条件增加：
+
+- `collectionKey` match
+- `controlDomain` match（from row metadata）
+- `viewerRole` match（local / referee / spectator profile）
+
+## 3. 与 Context Stack 的配合
+
+不同 context 的 collection 可绑定不同 performer catalog：
+
+| activeKey | Performer profile |
+|-----------|-------------------|
+| collection.command.source | selection.marker.* |
+| collection.ability.nuke.targets | ability.nuke.target_marker |
+
+Context pop 后 performer 订阅 revision 自动切换样式。
+
+## 4. 分层边界
+
+| 层 | 做 | 不做 |
+|----|-----|------|
+| CollectionWrite | 写 row + provenance | 选颜色 |
+| ControlDomainQuery | 解析 domain | 渲染 |
+| KnowledgeProjection | 裁判 visibility | 复制 collection |
+| PerformerRuleSystem | 读 provenance → spawn marker | 写 selection |
+| PresentationEventStream | 通知 revision | gameplay 语义 |
+
+## 5. Sub-issues（PROV-*）
+
+| ID | 标题 | 要点 |
+|----|------|------|
+| PROV-1 | Collection row provenance schema | rowRoleId 或扩展字段 |
+| PROV-2 | CollectionWrite 填充 provenance | filter 后写入 |
+| PROV-3 | PerformerCatalog selection marker profiles | deep/light green |
+| PROV-4 | Performer rules EntityCollection + provenance | 替代 selection ring hardcode |
+| PROV-5 | Referee knowledge grant 读多 player collection | 无 RefereeSelectionService |
+| PROV-6 | Team palette + phase offset catalog | 红 / 橘 |
+| PROV-7 | Showcase：本地 proxy marker + 裁判视角 | playable + screenshot |
+| PROV-8 | 文档 + ArchitectureTests | provenance 与 association 一致 |
+
+## 6. 依赖
+
+- RFC-0063 ControlDomainQuery（provenance 来源）
+- RFC-0062 Context Stack（active key → performer profile）
+- EntityCollectionStore revision 事件（已有）
+- KnowledgeProjection（#190）
+
+## 7. 非目标
+
+- 不在 Performer 内实现 box cast
+- 不新增 Selection 兼容 ring API
+- 不为裁判写 gameplay order 路径
+
+## 8. 验收
+
+- [ ] 混合 owns + proxy controls 框选，本地深绿/浅绿 marker 正确
+- [ ] 裁判同时见 player1/player2 collection，颜色相位正确
+- [ ] Performer 零 `PlayerOwner` 读取
+- [ ] Collection revision 驱动 marker diff，无全量 rebuild 抖动
+- [ ] Playable showcase artifacts

--- a/docs/rfcs/RFC-0064-collection-provenance-performer-multi-viewer.md
+++ b/docs/rfcs/RFC-0064-collection-provenance-performer-multi-viewer.md
@@ -1,7 +1,7 @@
 # RFC-0064 Collection Provenance & Performer — 多控制域 Marker 与观战投影
 
 Status: Proposed  
-Epic: （创建后回填 GitHub issue 编号）
+Epic: [#538](https://github.com/MightyBubble/Ludots/issues/538)
 
 ## 1. 问题
 
@@ -115,16 +115,18 @@ Context pop 后 performer 订阅 revision 自动切换样式。
 
 ## 5. Sub-issues（PROV-*）
 
-| ID | 标题 | 要点 |
-|----|------|------|
-| PROV-1 | Collection row provenance schema | rowRoleId 或扩展字段 |
-| PROV-2 | CollectionWrite 填充 provenance | filter 后写入 |
-| PROV-3 | PerformerCatalog selection marker profiles | deep/light green |
-| PROV-4 | Performer rules EntityCollection + provenance | 替代 selection ring hardcode |
-| PROV-5 | Referee knowledge grant 读多 player collection | 无 RefereeSelectionService |
-| PROV-6 | Team palette + phase offset catalog | 红 / 橘 |
-| PROV-7 | Showcase：本地 proxy marker + 裁判视角 | playable + screenshot |
-| PROV-8 | 文档 + ArchitectureTests | provenance 与 association 一致 |
+Parent: [#538](https://github.com/MightyBubble/Ludots/issues/538)
+
+| ID | Issue |
+|----|-------|
+| PROV-1 | [#555](https://github.com/MightyBubble/Ludots/issues/555) provenance schema |
+| PROV-2 | [#557](https://github.com/MightyBubble/Ludots/issues/557) CollectionWrite provenance |
+| PROV-3 | [#559](https://github.com/MightyBubble/Ludots/issues/559) PerformerCatalog markers |
+| PROV-4 | [#561](https://github.com/MightyBubble/Ludots/issues/561) Performer rules |
+| PROV-5 | [#563](https://github.com/MightyBubble/Ludots/issues/563) Referee knowledge grant |
+| PROV-6 | [#564](https://github.com/MightyBubble/Ludots/issues/564) Team palette + phase |
+| PROV-7 | [#565](https://github.com/MightyBubble/Ludots/issues/565) Showcase |
+| PROV-8 | [#566](https://github.com/MightyBubble/Ludots/issues/566) 文档 + tests |
 
 ## 6. 依赖
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds architecture RFC proposals and GitHub epic/sub-issue backlinks for the interaction/control-plane refactor discussed in design sessions.

## RFCs

| RFC | Epic | Scope |
|-----|------|-------|
| RFC-0061 | [#522](https://github.com/MightyBubble/Ludots/issues/522) | OrderQueue intake, Selection retirement, EntityView + Collection |
| RFC-0062 | [#536](https://github.com/MightyBubble/Ludots/issues/536) | **Interaction Context Stack** (Input 基建), context-bound collection keys |
| RFC-0063 | [#537](https://github.com/MightyBubble/Ludots/issues/537) | Association control plane, offline proxy, per-playerRep collection domain |
| RFC-0064 | [#538](https://github.com/MightyBubble/Ludots/issues/538) | Collection row provenance, Performer markers, referee multi-view |

## Sub-issues created

- ORD-1..8 → #567–574 (under #522)
- CTX-1..10 → #539–552 (under #536)
- CTRL-1..10 → #545–562 (under #537)
- PROV-1..8 → #555–566 (under #538)

## Dependency chain

```text
#522 RFC-0061 (Order/Collection SSOT)
  → #536 RFC-0062 Context Stack + InputCast
  → #537 RFC-0063 Association control plane
  → #538 RFC-0064 Provenance + Performer
```

## Notes

- Proposal-only PR; no runtime code changes.
- Epic #522 body can be updated to point at merged `docs/rfcs/RFC-0061-*.md` after merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae899c7d-22e0-41c9-8532-353692aa5eb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae899c7d-22e0-41c9-8532-353692aa5eb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

