### PR TITLE
Complete core hero skill infrastructure for issue 590

### DIFF
--- a/assets/Configs/GAS/preset_types.json
+++ b/assets/Configs/GAS/preset_types.json
@@ -145,5 +145,16 @@
     "defaultPhaseHandlers": {
       "OnApply": { "type": "graph", "id": "Graph.Lifecycle.DeployConsumeSource" }
     }
+  },
+  {
+    "id": "RevealArea",
+    "components": ["RevealAreaParams", "DurationParams"],
+    "activePhases": ["OnApply", "OnPeriod", "OnRemove"],
+    "allowedLifetimes": ["Instant", "After"],
+    "defaultPhaseHandlers": {
+      "OnApply": { "type": "builtin", "id": "RevealArea" },
+      "OnPeriod": { "type": "builtin", "id": "RevealArea" },
+      "OnRemove": { "type": "builtin", "id": "DecayRevealArea" }
+    }
   }
 ]

--- a/assets/Configs/Vision/fog_layers.json
+++ b/assets/Configs/Vision/fog_layers.json
@@ -1,0 +1,5 @@
+[
+  { "id": "ground", "cellSizeCm": 100, "updateHz": 10 },
+  { "id": "air", "cellSizeCm": 250, "updateHz": 5 },
+  { "id": "detection", "cellSizeCm": 100, "updateHz": 10 }
+]

--- a/assets/Configs/config_catalog.json
+++ b/assets/Configs/config_catalog.json
@@ -19,6 +19,8 @@
   { "Path": "GAS/clock.json", "Policy": "DeepObject" },
   { "Path": "GAS/order_types.json", "Policy": "DeepObject" },
 
+  { "Path": "Vision/fog_layers.json", "Policy": "ArrayById", "IdField": "id" },
+
   { "Path": "Progression/scopes.json", "Policy": "ArrayById", "IdField": "id" },
   { "Path": "Progression/progressions.json", "Policy": "ArrayById", "IdField": "id" },
   { "Path": "Progression/requirements.json", "Policy": "ArrayById", "IdField": "id" },

--- a/mods/CoreInputMod/Systems/AbilityExecAimSyncSystem.cs
+++ b/mods/CoreInputMod/Systems/AbilityExecAimSyncSystem.cs
@@ -71,7 +71,9 @@ namespace CoreInputMod.Systems
                     Fix64Vec2 delta = exec.TargetPosCm - facingPosition.Value;
                     if (delta.X != Fix64.Zero || delta.Y != Fix64.Zero)
                     {
-                        Upsert(entity, new FacingDirection { AngleRad = WorldPlane2D.FacingRadFromDirection(in delta) });
+                        float facingRad = WorldPlane2D.FacingRadFromDirection(in delta);
+                        Upsert(entity, new FacingDirection { AngleRad = facingRad });
+                        UpsertBlackboardFacing(entity, facingRad);
                     }
                 }
 
@@ -94,6 +96,24 @@ namespace CoreInputMod.Systems
             else
             {
                 World.Add(entity, component);
+            }
+        }
+
+        private void UpsertBlackboardFacing(Entity entity, float facingRad)
+        {
+            BlackboardFloatBuffer floats = World.TryGet(entity, out BlackboardFloatBuffer existing)
+                ? existing
+                : default;
+            floats.Set(
+                OrderBlackboardKeys.Cast_Facing,
+                WorldPlane2D.NormalizeDegreesPositive(WorldPlane2D.RadToDegValue(facingRad)));
+            if (World.Has<BlackboardFloatBuffer>(entity))
+            {
+                World.Set(entity, floats);
+            }
+            else
+            {
+                World.Add(entity, floats);
             }
         }
     }

--- a/src/Core/Engine/GameEngine.cs
+++ b/src/Core/Engine/GameEngine.cs
@@ -58,6 +58,7 @@ using Ludots.Core.Presentation.Instancing;
 using Ludots.Core.Presentation.Minimap;
 using Ludots.Core.Gameplay.GAS.Presentation;
 using Ludots.Core.Presentation.Surfaces;
+using Ludots.Core.Vision.Config;
 // Indicators directory removed — unified into Performers
 using Ludots.Core.Presentation.Performers;
 using Ludots.Core.NodeLibraries.GASGraph;
@@ -678,7 +679,8 @@ namespace Ludots.Core.Engine
                 gasConditions,
                 targetDispatchPresetRegistry,
                 progressionScopeKeys: progressionScopeKeys,
-                entityTemplateKeys: MapLoader.EntityTemplateKeys);
+                entityTemplateKeys: MapLoader.EntityTemplateKeys,
+                relationshipTypes: relationshipTypeRegistry);
             var gasClockConfigLoader = new GasClockConfigLoader(ConfigPipeline);
             var gasClockConfig = gasClockConfigLoader.Load(ConfigCatalog, ConfigConflictReport);
             var physics2dClockConfigLoader = new Physics2DClockConfigLoader(ConfigPipeline);
@@ -706,6 +708,8 @@ namespace Ludots.Core.Engine
             var visionFogFieldStore = new FogFieldStore();
             var visionFogSnapshotStore = new FogSnapshotStore(relationships: relationshipRuntime);
             var visionFogCellMap = new FogCellMap();
+            new VisionFogLayerConfigLoader(ConfigPipeline, visionFogLayerRegistry)
+                .Load(ConfigCatalog, ConfigConflictReport);
             var fogKnowledgeProjector = new FogKnowledgeProjector(knowledgeProjectionStore, visionFogCellMap);
             var visionResolver = new VisionResolver(
                 visionFogLayerRegistry,
@@ -713,6 +717,12 @@ namespace Ludots.Core.Engine
                 elevation: visionFogCellMap,
                 occlusion: visionFogCellMap,
                 relationships: relationshipRuntime);
+            var knowledgeAreaRevealRuntime = new KnowledgeAreaRevealRuntime(
+                World,
+                visionFogLayerRegistry,
+                visionFogFieldStore,
+                visionResolver,
+                fogKnowledgeProjector);
             var graphSymbolResolver = new GasGraphSymbolResolver(
                 relationshipTypeRegistry,
                 relationshipMetricRegistry,
@@ -772,7 +782,9 @@ namespace Ludots.Core.Engine
                 targetDispatchPresetRegistry,
                 exchangeOperations,
                 progressionScopeKeys,
-                MapLoader.EntityTemplateKeys);
+                MapLoader.EntityTemplateKeys,
+                relationshipTypes: relationshipTypeRegistry,
+                fogLayers: visionFogLayerRegistry);
             _effectTemplateLoader.Load(ConfigCatalog, ConfigConflictReport);
             new AbilityExecLoader(ConfigPipeline, abilityDefinitions).Load(ConfigCatalog, ConfigConflictReport);
             new AbilityFormSetConfigLoader(ConfigPipeline, abilityFormSets).Load(ConfigCatalog, ConfigConflictReport);
@@ -1204,6 +1216,7 @@ namespace Ludots.Core.Engine
             SetService(CoreServiceKeys.VisionFogCellMap, visionFogCellMap);
             SetService(CoreServiceKeys.VisionResolver, visionResolver);
             SetService(CoreServiceKeys.FogKnowledgeProjector, fogKnowledgeProjector);
+            SetService(CoreServiceKeys.KnowledgeAreaRevealRuntime, knowledgeAreaRevealRuntime);
             SetService(CoreServiceKeys.SelectionRuleRegistry, selectionRuleRegistry);
             SetService(CoreServiceKeys.InteractionActionBindings, interactionActionBindings);
             RemoveService(CoreServiceKeys.VisualHeightmap);
@@ -1403,7 +1416,7 @@ namespace Ludots.Core.Engine
                 performerRuntime,
                 performerDefinitions,
                 componentAuthoringContext);
-            RegisterSystem(new EffectProcessingLoopSystem(World, effectRequestQueue, clock, gasConditions, gasBudget, effectTemplateRegistry, inputRequestQueue, chainOrderQueue, responseChainTelemetry, orderRequestQueue, responseChainOrderTypes, gasPresentationEvents, SpatialQueries, runtimeEntitySpawnQueue, runtimeEntityLifecycleQueue, entityLifecycleServices, phaseExecutor: phaseExecutor, graphApi: gasGraphApi, tagOps: tagOps, exchangeRuntime: exchangeRuntime, progressionEvaluator: progressionEvaluator, orderTypeRegistry: orderTypeRegistry, orderRuleRegistry: orderRuleRegistry, stepRateHz: stepRateHz), SystemGroup.EffectProcessing);
+            RegisterSystem(new EffectProcessingLoopSystem(World, effectRequestQueue, clock, gasConditions, gasBudget, effectTemplateRegistry, inputRequestQueue, chainOrderQueue, responseChainTelemetry, orderRequestQueue, responseChainOrderTypes, gasPresentationEvents, SpatialQueries, runtimeEntitySpawnQueue, runtimeEntityLifecycleQueue, entityLifecycleServices, phaseExecutor: phaseExecutor, graphApi: gasGraphApi, tagOps: tagOps, exchangeRuntime: exchangeRuntime, progressionEvaluator: progressionEvaluator, orderTypeRegistry: orderTypeRegistry, orderRuleRegistry: orderRuleRegistry, stepRateHz: stepRateHz, relationshipRuntime: relationshipRuntime, knowledgeAreaRevealRuntime: knowledgeAreaRevealRuntime), SystemGroup.EffectProcessing);
             RegisterSystem(new ProjectileRuntimeSystem(World, effectRequestQueue, SpatialQueries), SystemGroup.EffectProcessing);
             RegisterSystem(
                 new RuntimeEntitySpawnSystem(

--- a/src/Core/Gameplay/GAS/BuiltinHandlerExecutionContext.cs
+++ b/src/Core/Gameplay/GAS/BuiltinHandlerExecutionContext.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using Arch.Core;
 using Ludots.Core.Gameplay.Exchange;
 using Ludots.Core.Gameplay.GAS.Orders;
+using Ludots.Core.Gameplay.Relationships;
 using Ludots.Core.Gameplay.Spawning;
 using Ludots.Core.Gameplay.Lifecycle;
 using Ludots.Core.Gameplay.Progression;
 using Ludots.Core.Spatial;
+using Ludots.Core.Vision;
 
 namespace Ludots.Core.Gameplay.GAS
 {
@@ -26,7 +28,9 @@ namespace Ludots.Core.Gameplay.GAS
         public EntityLifecycleRuntimeServices? LifecycleServices { get; set; }
         public LifecycleTransactionState? LifecycleTransaction { get; set; }
         public ExchangeRuntime? Exchange { get; set; }
+        public RelationshipRuntime? Relationships { get; set; }
         public ProgressionRequirementEvaluator? ProgressionEvaluator { get; set; }
+        public KnowledgeAreaRevealRuntime? KnowledgeAreaReveal { get; set; }
         public OrderTypeRegistry? OrderTypeRegistry { get; set; }
         public OrderRuleRegistry? OrderRuleRegistry { get; set; }
         public int CurrentStep { get; set; }

--- a/src/Core/Gameplay/GAS/BuiltinHandlerId.cs
+++ b/src/Core/Gameplay/GAS/BuiltinHandlerId.cs
@@ -38,6 +38,10 @@ namespace Ludots.Core.Gameplay.GAS
         // ── Entity relations ──
         /// <summary>Read RelationParams and mutate entity parent-child relationships.</summary>
         ApplyRelation = 50,
+        /// <summary>Reveal a configured area through the Vision/Fog/Knowledge runtime.</summary>
+        RevealArea = 51,
+        /// <summary>Downgrade a configured revealed area to last-known Knowledge records.</summary>
+        DecayRevealArea = 52,
 
         // ── Exchange settlement ──
         /// <summary>Read Exchange params and execute an Exchange operation.</summary>

--- a/src/Core/Gameplay/GAS/BuiltinHandlers.cs
+++ b/src/Core/Gameplay/GAS/BuiltinHandlers.cs
@@ -11,10 +11,12 @@ using Ludots.Core.Gameplay.GAS.Orders;
 using Ludots.Core.Gameplay.Spawning;
 using Ludots.Core.Gameplay.Lifecycle;
 using Ludots.Core.Gameplay.Progression;
+using Ludots.Core.Gameplay.Relationships;
 using Ludots.Core.Gameplay.Teams;
 using Ludots.Core.Presentation.Components;
 using Ludots.Core.Mathematics;
 using Ludots.Core.Mathematics.FixedPoint;
+using Ludots.Core.Vision;
 
 namespace Ludots.Core.Gameplay.GAS
 {
@@ -35,6 +37,8 @@ namespace Ludots.Core.Gameplay.GAS
             registry.Register(BuiltinHandlerId.CreateUnit, HandleCreateUnit);
             registry.Register(BuiltinHandlerId.ApplyDisplacement, HandleApplyDisplacement);
             registry.Register(BuiltinHandlerId.ApplyRelation, HandleApplyRelation);
+            registry.Register(BuiltinHandlerId.RevealArea, HandleRevealArea);
+            registry.Register(BuiltinHandlerId.DecayRevealArea, HandleDecayRevealArea);
             registry.Register(BuiltinHandlerId.ExecuteExchange, HandleExecuteExchange);
             registry.Register(BuiltinHandlerId.CompleteProgression, HandleCompleteProgression);
             registry.Register(BuiltinHandlerId.SubmitOrderFromBlackboard, HandleSubmitOrderFromBlackboard);
@@ -401,7 +405,81 @@ namespace Ludots.Core.Gameplay.GAS
                 case RelationOperation.RemoveParent:
                     RelationOps.RemoveParent(world, subject);
                     break;
+                case RelationOperation.EnsureLink:
+                {
+                    Entity target = ResolveRelationEntity(in context, relation.Parent);
+                    if (!world.IsAlive(target))
+                    {
+                        return;
+                    }
+
+                    var runtime = BuiltinHandlerRuntimeScope.Current;
+                    if (runtime?.Relationships == null)
+                    {
+                        throw new InvalidOperationException("Relation operation EnsureLink requires RelationshipRuntime in BuiltinHandlerExecutionContext.");
+                    }
+
+                    if (relation.RelationshipTypeId < 0)
+                    {
+                        throw new InvalidOperationException("Relation operation EnsureLink requires a registered relationship type id.");
+                    }
+
+                    runtime.Relationships.EnsureLink(subject, target, relation.RelationshipTypeId);
+                    break;
+                }
             }
+        }
+
+        public static void HandleRevealArea(
+            World world,
+            Entity effectEntity,
+            ref EffectContext context,
+            in EffectConfigParams mergedParams,
+            in EffectTemplateData templateData)
+        {
+            var runtime = BuiltinHandlerRuntimeScope.Current;
+            if (runtime?.KnowledgeAreaReveal == null)
+            {
+                throw new InvalidOperationException("RevealArea requires KnowledgeAreaRevealRuntime in BuiltinHandlerExecutionContext.");
+            }
+
+            if (!TryResolveRevealAreaCenter(world, in context, in mergedParams, out WorldCmInt2 center))
+            {
+                return;
+            }
+
+            runtime.KnowledgeAreaReveal.Reveal(
+                ResolveRevealViewer(world, in context),
+                context.Source,
+                center,
+                in templateData.RevealArea,
+                runtime.CurrentStep);
+        }
+
+        public static void HandleDecayRevealArea(
+            World world,
+            Entity effectEntity,
+            ref EffectContext context,
+            in EffectConfigParams mergedParams,
+            in EffectTemplateData templateData)
+        {
+            var runtime = BuiltinHandlerRuntimeScope.Current;
+            if (runtime?.KnowledgeAreaReveal == null)
+            {
+                throw new InvalidOperationException("DecayRevealArea requires KnowledgeAreaRevealRuntime in BuiltinHandlerExecutionContext.");
+            }
+
+            if (!TryResolveRevealAreaCenter(world, in context, in mergedParams, out WorldCmInt2 center))
+            {
+                return;
+            }
+
+            runtime.KnowledgeAreaReveal.DecayArea(
+                ResolveRevealViewer(world, in context),
+                context.Source,
+                center,
+                in templateData.RevealArea,
+                runtime.CurrentStep);
         }
 
         public static void HandleExecuteExchange(
@@ -622,6 +700,47 @@ namespace Ludots.Core.Gameplay.GAS
                 RelationEntitySlot.TargetContext => context.TargetContext,
                 _ => Entity.Null,
             };
+        }
+
+        private static bool TryResolveRevealAreaCenter(
+            World world,
+            in EffectContext context,
+            in EffectConfigParams mergedParams,
+            out WorldCmInt2 center)
+        {
+            if (EffectTargetPointResolver.TryResolve(
+                    world,
+                    in context,
+                    in mergedParams,
+                    EffectTargetPointResolveOptions.CreateUnit,
+                    out Fix64Vec2 point))
+            {
+                center = point.ToWorldCmInt2();
+                return true;
+            }
+
+            center = default;
+            return false;
+        }
+
+        private static Entity ResolveRevealViewer(World world, in EffectContext context)
+        {
+            if (world.IsAlive(context.Source))
+            {
+                return context.Source;
+            }
+
+            if (world.IsAlive(context.Target))
+            {
+                return context.Target;
+            }
+
+            if (world.IsAlive(context.TargetContext))
+            {
+                return context.TargetContext;
+            }
+
+            return Entity.Null;
         }
 
         private static void SnapSubjectToParentPosition(World world, Entity subject, Entity parent)

--- a/src/Core/Gameplay/GAS/ComponentFlags.cs
+++ b/src/Core/Gameplay/GAS/ComponentFlags.cs
@@ -32,6 +32,8 @@ namespace Ludots.Core.Gameplay.GAS
         UnitCreationParams = 1 << 7,
         /// <summary>Entity relation parameters (JSON: "relation").</summary>
         RelationParams = 1 << 8,
+        /// <summary>Area reveal parameters (JSON: "revealArea").</summary>
+        RevealAreaParams = 1 << 9,
 
         // ── Capability components (declare structural abilities) ──
 

--- a/src/Core/Gameplay/GAS/Config/EffectTemplateConfig.cs
+++ b/src/Core/Gameplay/GAS/Config/EffectTemplateConfig.cs
@@ -45,6 +45,8 @@ namespace Ludots.Core.Gameplay.GAS.Config
         public DisplacementConfig? Displacement { get; set; }
         /// <summary>Entity relation parameters (garrison, detach, parent-child ownership).</summary>
         public RelationConfig? Relation { get; set; }
+        /// <summary>Area reveal parameters for Vision/Fog/Knowledge projection.</summary>
+        public RevealAreaConfig? RevealArea { get; set; }
         /// <summary>On-spawn order dispatch from configured blackboard stored target keys.</summary>
         public SubmitOrderFromBlackboardConfig? SubmitOrderFromBlackboard { get; set; }
         /// <summary>Entity-scoped progression completion parameters.</summary>
@@ -222,6 +224,16 @@ namespace Ludots.Core.Gameplay.GAS.Config
         public string? Subject { get; set; }
         public string? Parent { get; set; }
         public bool? SnapSubjectToParentPosition { get; set; }
+        public string? RelationshipType { get; set; }
+    }
+
+    public sealed class RevealAreaConfig
+    {
+        public int? Radius { get; set; }
+        public string? Scope { get; set; }
+        public List<string>? Layers { get; set; }
+        public int? MemoryTtlTicks { get; set; }
+        public int? DetectionStrength { get; set; }
     }
 
     public sealed class StoredTargetKeysConfig

--- a/src/Core/Gameplay/GAS/Config/EffectTemplateLoader.cs
+++ b/src/Core/Gameplay/GAS/Config/EffectTemplateLoader.cs
@@ -17,6 +17,7 @@ using Ludots.Core.Gameplay.Spawning;
 using Ludots.Core.Gameplay.Teams;
 using Ludots.Core.Layers;
 using Ludots.Core.NodeLibraries.GASGraph.Host;
+using Ludots.Core.Vision;
 
 namespace Ludots.Core.Gameplay.GAS.Config
 {
@@ -26,9 +27,11 @@ namespace Ludots.Core.Gameplay.GAS.Config
         private readonly EffectTemplateRegistry _registry;
         private readonly GasConditionRegistry _conditions;
         private readonly TargetDispatchPresetRegistry _targetDispatchPresets;
+        private readonly Ludots.Core.Gameplay.Relationships.RelationshipTypeRegistry? _relationshipTypes;
         private readonly ExchangeOperationRegistry? _exchangeOperations;
         private readonly ScopeKeyRegistry? _progressionScopeKeys;
         private readonly EntityTemplateKeyRegistry? _entityTemplateKeys;
+        private readonly FogLayerRegistry? _fogLayers;
 
         private static readonly JsonSerializerOptions JsonOptions = new()
         {
@@ -45,7 +48,9 @@ namespace Ludots.Core.Gameplay.GAS.Config
             TargetDispatchPresetRegistry targetDispatchPresets = null,
             ExchangeOperationRegistry? exchangeOperations = null,
             ScopeKeyRegistry? progressionScopeKeys = null,
-            EntityTemplateKeyRegistry? entityTemplateKeys = null)
+            EntityTemplateKeyRegistry? entityTemplateKeys = null,
+            Ludots.Core.Gameplay.Relationships.RelationshipTypeRegistry? relationshipTypes = null,
+            FogLayerRegistry? fogLayers = null)
         {
             _pipeline = pipeline;
             _registry = registry;
@@ -54,6 +59,8 @@ namespace Ludots.Core.Gameplay.GAS.Config
             _exchangeOperations = exchangeOperations;
             _progressionScopeKeys = progressionScopeKeys;
             _entityTemplateKeys = entityTemplateKeys;
+            _relationshipTypes = relationshipTypes;
+            _fogLayers = fogLayers;
         }
 
         public void Load(
@@ -307,6 +314,7 @@ namespace Ludots.Core.Gameplay.GAS.Config
             var unitCreation = CompileUnitCreation(cfg.UnitCreation, cfg.Id, relativePath);
             var displacement = CompileDisplacement(cfg.Displacement, cfg.Id, relativePath);
             var relation = CompileRelation(cfg.Relation, cfg.Id, relativePath);
+            var revealArea = default(KnowledgeAreaRevealDescriptor);
             var submitOrderFromBlackboard = CompileSubmitOrderFromBlackboard(cfg.SubmitOrderFromBlackboard, cfg.Id, relativePath);
             var progressionScope = ScopeKey.Self;
             var progressionChange = ProgressionLevelChange.Complete;
@@ -350,7 +358,32 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 }
             }
 
-            if (presetType == EffectPresetType.Exchange)
+            if (cfg.RevealArea != null && presetType != EffectPresetType.RevealArea)
+            {
+                throw new InvalidOperationException(
+                    $"Effect template '{cfg.Id}' in {relativePath}: 'revealArea' block is only valid when presetType=RevealArea.");
+            }
+            if (presetType == EffectPresetType.RevealArea)
+            {
+                if (lifetimeKind != EffectLifetimeKind.Instant && lifetimeKind != EffectLifetimeKind.After)
+                {
+                    throw new InvalidOperationException(
+                        $"Effect template '{cfg.Id}' in {relativePath}: presetType RevealArea requires lifetime=Instant or lifetime=After.");
+                }
+                if (lifetimeKind == EffectLifetimeKind.After && periodTicks <= 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Effect template '{cfg.Id}' in {relativePath}: presetType RevealArea with lifetime=After requires duration.periodTicks > 0 for refresh.");
+                }
+                if (cfg.RevealArea == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Effect template '{cfg.Id}' in {relativePath}: presetType RevealArea requires a 'revealArea' block.");
+                }
+
+                revealArea = CompileRevealArea(cfg.RevealArea, cfg.Id, relativePath);
+            }
+
             if (presetType == EffectPresetType.Exchange)
             {
                 if (lifetimeKind != EffectLifetimeKind.Instant)
@@ -490,6 +523,7 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 UnitCreation = unitCreation,
                 Displacement = displacement,
                 Relation = relation,
+                RevealArea = revealArea,
                 SubmitOrderFromBlackboard = submitOrderFromBlackboard,
                 ProgressionScope = progressionScope,
                 ProgressionChange = progressionChange,
@@ -553,7 +587,7 @@ namespace Ludots.Core.Gameplay.GAS.Config
             };
         }
 
-        private static RelationDescriptor CompileRelation(RelationConfig cfg, string ownerId, string relativePath)
+        private RelationDescriptor CompileRelation(RelationConfig cfg, string ownerId, string relativePath)
         {
             if (cfg == null) return default;
 
@@ -586,10 +620,43 @@ namespace Ludots.Core.Gameplay.GAS.Config
                     $"Effect template '{ownerId}' in {relativePath}: relation.parent cannot be None when operation=SetParent.");
             }
 
-            if (operation == RelationOperation.RemoveParent && snapSubjectToParentPosition)
+            if (operation == RelationOperation.EnsureLink && parent == RelationEntitySlot.None)
+            {
+                throw new InvalidOperationException(
+                    $"Effect template '{ownerId}' in {relativePath}: relation.parent cannot be None when operation=EnsureLink.");
+            }
+
+            if (operation != RelationOperation.SetParent && snapSubjectToParentPosition)
             {
                 throw new InvalidOperationException(
                     $"Effect template '{ownerId}' in {relativePath}: relation.snapSubjectToParentPosition is only valid when operation=SetParent.");
+            }
+
+            int relationshipTypeId = 0;
+            if (operation == RelationOperation.EnsureLink)
+            {
+                if (_relationshipTypes == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Effect template '{ownerId}' in {relativePath}: relation.operation=EnsureLink requires RelationshipTypeRegistry.");
+                }
+
+                string relationshipType = RequireString(
+                    cfg.RelationshipType,
+                    ownerId,
+                    relativePath,
+                    "relation.relationshipType");
+                relationshipTypeId = _relationshipTypes.GetId(relationshipType);
+                if (relationshipTypeId < 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Effect template '{ownerId}' in {relativePath}: relation.relationshipType '{relationshipType}' is not registered.");
+                }
+            }
+            else if (!string.IsNullOrWhiteSpace(cfg.RelationshipType))
+            {
+                throw new InvalidOperationException(
+                    $"Effect template '{ownerId}' in {relativePath}: relation.relationshipType is only valid when operation=EnsureLink.");
             }
 
             return new RelationDescriptor
@@ -597,8 +664,82 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 Operation = operation,
                 Subject = subject,
                 Parent = parent,
-                SnapSubjectToParentPosition = snapSubjectToParentPosition
+                SnapSubjectToParentPosition = snapSubjectToParentPosition,
+                RelationshipTypeId = relationshipTypeId
             };
+        }
+
+        private KnowledgeAreaRevealDescriptor CompileRevealArea(RevealAreaConfig cfg, string ownerId, string relativePath)
+        {
+            if (cfg == null) return default;
+
+            if (_progressionScopeKeys == null)
+            {
+                throw new InvalidOperationException(
+                    $"Effect template '{ownerId}' in {relativePath}: revealArea.scope requires ScopeKeyRegistry.");
+            }
+
+            if (_fogLayers == null)
+            {
+                throw new InvalidOperationException(
+                    $"Effect template '{ownerId}' in {relativePath}: revealArea.layers requires FogLayerRegistry.");
+            }
+
+            int radiusCm = RequirePositiveInt(cfg.Radius, ownerId, relativePath, "revealArea.radius");
+            string scope = RequireString(cfg.Scope, ownerId, relativePath, "revealArea.scope");
+            int scopeKeyId = _progressionScopeKeys.GetId(scope);
+            if (scopeKeyId <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"Effect template '{ownerId}' in {relativePath}: revealArea.scope '{scope}' is not registered.");
+            }
+
+            if (cfg.Layers == null || cfg.Layers.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"Effect template '{ownerId}' in {relativePath}: revealArea.layers requires at least one layer.");
+            }
+
+            if (cfg.Layers.Count > KnowledgeAreaRevealDescriptor.MaxLayers)
+            {
+                throw new InvalidOperationException(
+                    $"Effect template '{ownerId}' in {relativePath}: revealArea.layers supports at most {KnowledgeAreaRevealDescriptor.MaxLayers} layers.");
+            }
+
+            Span<FogLayerId> layers = stackalloc FogLayerId[KnowledgeAreaRevealDescriptor.MaxLayers];
+            for (int i = 0; i < cfg.Layers.Count; i++)
+            {
+                string layerName = RequireString(cfg.Layers[i], ownerId, relativePath, $"revealArea.layers[{i}]");
+                FogLayerId layerId = _fogLayers.GetId(layerName);
+                if (layerId.Value <= 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Effect template '{ownerId}' in {relativePath}: revealArea.layers[{i}] '{layerName}' is not registered.");
+                }
+
+                layers[i] = layerId;
+            }
+
+            int memoryTtlTicks = cfg.MemoryTtlTicks ?? 0;
+            if (memoryTtlTicks < 0)
+            {
+                throw new InvalidOperationException(
+                    $"Effect template '{ownerId}' in {relativePath}: revealArea.memoryTtlTicks must be >= 0.");
+            }
+
+            int detectionStrength = cfg.DetectionStrength ?? 0;
+            if ((uint)detectionStrength > byte.MaxValue)
+            {
+                throw new InvalidOperationException(
+                    $"Effect template '{ownerId}' in {relativePath}: revealArea.detectionStrength must be in range 0..255.");
+            }
+
+            return new KnowledgeAreaRevealDescriptor(
+                scopeKeyId,
+                radiusCm,
+                layers[..cfg.Layers.Count],
+                memoryTtlTicks,
+                (byte)detectionStrength);
         }
 
         private static SubmitOrderFromBlackboardDescriptor CompileSubmitOrderFromBlackboard(
@@ -943,8 +1084,9 @@ namespace Ludots.Core.Gameplay.GAS.Config
             {
                 "SetParent" => RelationOperation.SetParent,
                 "RemoveParent" => RelationOperation.RemoveParent,
+                "EnsureLink" => RelationOperation.EnsureLink,
                 _ => throw new InvalidOperationException(
-                    $"Effect template '{ownerId}' in {relativePath}: unsupported relation.operation '{value}'. Supported: SetParent, RemoveParent.")
+                    $"Effect template '{ownerId}' in {relativePath}: unsupported relation.operation '{value}'. Supported: SetParent, RemoveParent, EnsureLink.")
             };
         }
 

--- a/src/Core/Gameplay/GAS/Config/GasEnumParser.cs
+++ b/src/Core/Gameplay/GAS/Config/GasEnumParser.cs
@@ -31,6 +31,7 @@ namespace Ludots.Core.Gameplay.GAS.Config
             { "CompleteProgression", EffectPresetType.CompleteProgression },
             { "SubmitOrderFromBlackboard", EffectPresetType.SubmitOrderFromBlackboard },
             { "DeployConsumeSource", EffectPresetType.DeployConsumeSource },
+            { "RevealArea", EffectPresetType.RevealArea },
         };
 
         /// <summary>
@@ -183,6 +184,8 @@ namespace Ludots.Core.Gameplay.GAS.Config
             { "CreateUnit", BuiltinHandlerId.CreateUnit },
             { "ApplyDisplacement", BuiltinHandlerId.ApplyDisplacement },
             { "ApplyRelation", BuiltinHandlerId.ApplyRelation },
+            { "RevealArea", BuiltinHandlerId.RevealArea },
+            { "DecayRevealArea", BuiltinHandlerId.DecayRevealArea },
             { "ExecuteExchange", BuiltinHandlerId.ExecuteExchange },
             { "CompleteProgression", BuiltinHandlerId.CompleteProgression },
             { "SubmitOrderFromBlackboard", BuiltinHandlerId.SubmitOrderFromBlackboard },
@@ -227,6 +230,7 @@ namespace Ludots.Core.Gameplay.GAS.Config
             { "ProjectileParams", ComponentFlags.ProjectileParams },
             { "UnitCreationParams", ComponentFlags.UnitCreationParams },
             { "RelationParams", ComponentFlags.RelationParams },
+            { "RevealAreaParams", ComponentFlags.RevealAreaParams },
             { "PhaseGraphBindings", ComponentFlags.PhaseGraphBindings },
             { "PhaseListenerSetup", ComponentFlags.PhaseListenerSetup },
         };

--- a/src/Core/Gameplay/GAS/EffectTemplateRegistry.cs
+++ b/src/Core/Gameplay/GAS/EffectTemplateRegistry.cs
@@ -5,6 +5,7 @@ using Ludots.Core.Diagnostics;
 using Ludots.Core.Gameplay.GAS.Components;
 using Ludots.Core.Gameplay.GAS.Orders;
 using Ludots.Core.Gameplay.Teams;
+using Ludots.Core.Vision;
 
 namespace Ludots.Core.Gameplay.GAS
 {
@@ -35,6 +36,8 @@ namespace Ludots.Core.Gameplay.GAS
         SubmitOrderFromBlackboard = 15,
         /// <summary>Atomic entity template replacement with inheritance profile.</summary>
         DeployConsumeSource = 16,
+        /// <summary>Timed area reveal through Vision/Fog/Knowledge projection.</summary>
+        RevealArea = 17,
     }
 
     // ── TargetResolver: pluggable target fan-out for effects ──
@@ -280,6 +283,7 @@ namespace Ludots.Core.Gameplay.GAS
         None = 0,
         SetParent = 1,
         RemoveParent = 2,
+        EnsureLink = 3,
     }
 
     public enum RelationEntitySlot : byte
@@ -296,6 +300,7 @@ namespace Ludots.Core.Gameplay.GAS
         public RelationEntitySlot Subject;
         public RelationEntitySlot Parent;
         public bool SnapSubjectToParentPosition;
+        public int RelationshipTypeId;
     }
 
     /// <summary>
@@ -339,6 +344,7 @@ namespace Ludots.Core.Gameplay.GAS
         public UnitCreationDescriptor UnitCreation;
         public DisplacementDescriptor Displacement;
         public RelationDescriptor Relation;
+        public KnowledgeAreaRevealDescriptor RevealArea;
         public SubmitOrderFromBlackboardDescriptor SubmitOrderFromBlackboard;
         public ScopeKey ProgressionScope;
         public Ludots.Core.Gameplay.Progression.ProgressionLevelChange ProgressionChange;

--- a/src/Core/Gameplay/GAS/Orders/OrderBlackboardKeys.cs
+++ b/src/Core/Gameplay/GAS/Orders/OrderBlackboardKeys.cs
@@ -43,6 +43,12 @@ namespace Ludots.Core.Gameplay.GAS.Orders
         /// If set, use this ability ID instead of the slot's default.
         /// </summary>
         public const int Cast_AbilityId = 113;
+
+        /// <summary>
+        /// Facing angle for the ability in positive degrees (BlackboardFloatBuffer).
+        /// Used by facing-sector queries when a cast has an explicit authored aim direction.
+        /// </summary>
+        public const int Cast_Facing = 114;
         
         // ========== Attack Order (120-129) ==========
         
@@ -130,6 +136,7 @@ namespace Ludots.Core.Gameplay.GAS.Orders
             new("Cast.TargetEntity", Cast_TargetEntity),
             new("Cast.TargetPosition", Cast_TargetPosition),
             new("Cast.AbilityId", Cast_AbilityId),
+            new("Cast.Facing", Cast_Facing),
             new("Attack.TargetEntity", Attack_TargetEntity),
             new("Attack.MovePosition", Attack_MovePosition),
             new("Attack.IsAttackMove", Attack_IsAttackMove),

--- a/src/Core/Gameplay/GAS/Systems/EffectApplicationSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/EffectApplicationSystem.cs
@@ -13,8 +13,10 @@ using Ludots.Core.Gameplay.Teams;
 using Ludots.Core.Gameplay.Spawning;
 using Ludots.Core.Gameplay.Lifecycle;
 using Ludots.Core.Gameplay.Progression;
+using Ludots.Core.Gameplay.Relationships;
 using Ludots.Core.Components;
 using Ludots.Core.Spatial;
+using Ludots.Core.Vision;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System;
@@ -122,7 +124,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
         private readonly IClock? _orderClock;
         private readonly int _stepRateHz;
 
-        public EffectApplicationSystem(World world, EffectRequestQueue effectRequests = null, GasBudget budget = null, GasPresentationEventBuffer presentationEvents = null, EffectTemplateRegistry templates = null, ISpatialQueryService spatialQueries = null, RuntimeEntitySpawnQueue spawnRequests = null, RuntimeEntityLifecycleQueue lifecycleRequests = null, EntityLifecycleRuntimeServices lifecycleServices = null, EffectPhaseExecutor phaseExecutor = null, Ludots.Core.NodeLibraries.GASGraph.Host.GasGraphRuntimeApi graphApi = null, TagOps tagOps = null, ExchangeRuntime exchangeRuntime = null, ProgressionRequirementEvaluator progressionEvaluator = null, OrderTypeRegistry orderTypeRegistry = null, OrderRuleRegistry orderRuleRegistry = null, IClock orderClock = null, int stepRateHz = 30) : base(world)
+        public EffectApplicationSystem(World world, EffectRequestQueue effectRequests = null, GasBudget budget = null, GasPresentationEventBuffer presentationEvents = null, EffectTemplateRegistry templates = null, ISpatialQueryService spatialQueries = null, RuntimeEntitySpawnQueue spawnRequests = null, RuntimeEntityLifecycleQueue lifecycleRequests = null, EntityLifecycleRuntimeServices lifecycleServices = null, EffectPhaseExecutor phaseExecutor = null, Ludots.Core.NodeLibraries.GASGraph.Host.GasGraphRuntimeApi graphApi = null, TagOps tagOps = null, ExchangeRuntime exchangeRuntime = null, ProgressionRequirementEvaluator progressionEvaluator = null, OrderTypeRegistry orderTypeRegistry = null, OrderRuleRegistry orderRuleRegistry = null, IClock orderClock = null, int stepRateHz = 30, RelationshipRuntime relationshipRuntime = null, KnowledgeAreaRevealRuntime knowledgeAreaRevealRuntime = null) : base(world)
         {
             _effectRequests = effectRequests;
             _budget = budget;
@@ -141,7 +143,9 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             _builtinRuntime.LifecycleRequests = lifecycleRequests;
             _builtinRuntime.LifecycleServices = lifecycleServices;
             _builtinRuntime.Exchange = exchangeRuntime;
+            _builtinRuntime.Relationships = relationshipRuntime;
             _builtinRuntime.ProgressionEvaluator = progressionEvaluator;
+            _builtinRuntime.KnowledgeAreaReveal = knowledgeAreaRevealRuntime;
             _orderTypeRegistry = orderTypeRegistry;
             _orderRuleRegistry = orderRuleRegistry;
             _orderClock = orderClock;

--- a/src/Core/Gameplay/GAS/Systems/EffectLifetimeSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/EffectLifetimeSystem.cs
@@ -10,9 +10,12 @@ using Ludots.Core.Gameplay.Teams;
 using Ludots.Core.Gameplay.Spawning;
 using Ludots.Core.Gameplay.Lifecycle;
 using Ludots.Core.Gameplay.Progression;
+using Ludots.Core.Gameplay.Relationships;
+using Ludots.Core.Gameplay.GAS.Presentation;
 using Ludots.Core.Components;
 using Ludots.Core.Spatial;
 using Ludots.Core.Mathematics;
+using Ludots.Core.Vision;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -34,6 +37,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
         private readonly GasConditionRegistry _conditions;
         private readonly EffectTemplateRegistry _templates;
         private readonly ISpatialQueryService _spatialQueries;
+        private readonly GasPresentationEventBuffer _presentationEvents;
 
         // ── Phase Graph execution (optional) ──
         private readonly EffectPhaseExecutor _phaseExecutor;
@@ -86,7 +90,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
         private readonly List<PhaseGraphEntry> _expirePhaseGraphs = new(64);
         private readonly List<PhaseGraphEntry> _removePhaseGraphs = new(64);
 
-        public EffectLifetimeSystem(World world, Ludots.Core.Engine.IClock clock, GasConditionRegistry conditions, EffectRequestQueue effectRequests = null, GasBudget budget = null, EffectTemplateRegistry templates = null, ISpatialQueryService spatialQueries = null, RuntimeEntitySpawnQueue spawnRequests = null, RuntimeEntityLifecycleQueue lifecycleRequests = null, EntityLifecycleRuntimeServices lifecycleServices = null, EffectPhaseExecutor phaseExecutor = null, Ludots.Core.NodeLibraries.GASGraph.Host.GasGraphRuntimeApi graphApi = null, TagOps tagOps = null, ExchangeRuntime exchangeRuntime = null, ProgressionRequirementEvaluator progressionEvaluator = null, OrderTypeRegistry orderTypeRegistry = null, OrderRuleRegistry orderRuleRegistry = null, int stepRateHz = 30) : base(world)
+        public EffectLifetimeSystem(World world, Ludots.Core.Engine.IClock clock, GasConditionRegistry conditions, EffectRequestQueue effectRequests = null, GasBudget budget = null, EffectTemplateRegistry templates = null, ISpatialQueryService spatialQueries = null, RuntimeEntitySpawnQueue spawnRequests = null, RuntimeEntityLifecycleQueue lifecycleRequests = null, EntityLifecycleRuntimeServices lifecycleServices = null, EffectPhaseExecutor phaseExecutor = null, Ludots.Core.NodeLibraries.GASGraph.Host.GasGraphRuntimeApi graphApi = null, TagOps tagOps = null, ExchangeRuntime exchangeRuntime = null, ProgressionRequirementEvaluator progressionEvaluator = null, OrderTypeRegistry orderTypeRegistry = null, OrderRuleRegistry orderRuleRegistry = null, int stepRateHz = 30, RelationshipRuntime relationshipRuntime = null, GasPresentationEventBuffer presentationEvents = null, KnowledgeAreaRevealRuntime knowledgeAreaRevealRuntime = null) : base(world)
         {
             _effectRequests = effectRequests;
             _budget = budget;
@@ -94,6 +98,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             _conditions = conditions;
             _templates = templates;
             _spatialQueries = spatialQueries;
+            _presentationEvents = presentationEvents;
             _phaseExecutor = phaseExecutor;
             _graphApiHost = graphApi;
             _graphApi = graphApi;
@@ -106,7 +111,9 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             _builtinRuntime.LifecycleRequests = lifecycleRequests;
             _builtinRuntime.LifecycleServices = lifecycleServices;
             _builtinRuntime.Exchange = exchangeRuntime;
+            _builtinRuntime.Relationships = relationshipRuntime;
             _builtinRuntime.ProgressionEvaluator = progressionEvaluator;
+            _builtinRuntime.KnowledgeAreaReveal = knowledgeAreaRevealRuntime;
             _orderTypeRegistry = orderTypeRegistry;
             _orderRuleRegistry = orderRuleRegistry;
             _stepRateHz = stepRateHz > 0 ? stepRateHz : 30;
@@ -157,6 +164,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                 OnRemoveCallbacks = _onRemoveCallbacks,
                 ExpirePhaseGraphs = _expirePhaseGraphs,
                 RemovePhaseGraphs = _removePhaseGraphs,
+                PresentationEvents = _presentationEvents,
                 Budget = _callbackCreateBudget,
                 TagOps = _tagOps,
                 GasBudget = _budget
@@ -262,6 +270,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             public List<CallbackCommand> OnRemoveCallbacks;
             public List<PhaseGraphEntry> ExpirePhaseGraphs;
             public List<PhaseGraphEntry> RemovePhaseGraphs;
+            public GasPresentationEventBuffer PresentationEvents;
             public RootBudgetTable Budget;
             public TagOps TagOps;
             public GasBudget GasBudget;
@@ -317,6 +326,13 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                 {
                     int tplId = World.Get<EffectTemplateRef>(entity).TemplateId;
                     var entry = new PhaseGraphEntry { TemplateId = tplId, EffectEntityId = entity.Id, ClockTick = now, EffectEntity = entity, Context = context };
+                    PresentationEvents?.Publish(new GasPresentationEvent
+                    {
+                        Kind = cancelled ? GasPresentationEventKind.EffectCancelled : GasPresentationEventKind.EffectExpired,
+                        Actor = context.Source,
+                        Target = context.Target,
+                        EffectTemplateId = tplId
+                    });
                     if (!cancelled)
                     {
                         ExpirePhaseGraphs.Add(entry);

--- a/src/Core/Gameplay/GAS/Systems/EffectProcessingLoopSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/EffectProcessingLoopSystem.cs
@@ -10,7 +10,9 @@ using Ludots.Core.Gameplay.GAS.Presentation;
 using Ludots.Core.Gameplay.Spawning;
 using Ludots.Core.Gameplay.Lifecycle;
 using Ludots.Core.Gameplay.Progression;
+using Ludots.Core.Gameplay.Relationships;
 using Ludots.Core.Spatial;
+using Ludots.Core.Vision;
 
 namespace Ludots.Core.Gameplay.GAS.Systems
 {
@@ -59,7 +61,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
         public int MaxWorkUnitsPerSlice { get; set; } = int.MaxValue;
         public byte DebugProposalWindowPhase => _proposal.DebugWindowPhase;
 
-        public EffectProcessingLoopSystem(World world, EffectRequestQueue effectRequests, IClock clock, GasConditionRegistry conditions, GasBudget budget = null, EffectTemplateRegistry templates = null, InputRequestQueue inputRequests = null, OrderQueue chainOrders = null, ResponseChainTelemetryBuffer telemetry = null, OrderRequestQueue orderRequests = null, ResponseChainOrderTypes? responseChainOrderTypes = null, GasPresentationEventBuffer presentationEvents = null, ISpatialQueryService spatialQueries = null, RuntimeEntitySpawnQueue spawnRequests = null, RuntimeEntityLifecycleQueue lifecycleRequests = null, EntityLifecycleRuntimeServices lifecycleServices = null, EffectPhaseExecutor phaseExecutor = null, Ludots.Core.NodeLibraries.GASGraph.Host.GasGraphRuntimeApi graphApi = null, TagOps tagOps = null, ExchangeRuntime exchangeRuntime = null, ProgressionRequirementEvaluator progressionEvaluator = null, OrderTypeRegistry orderTypeRegistry = null, OrderRuleRegistry orderRuleRegistry = null, int stepRateHz = 30)
+        public EffectProcessingLoopSystem(World world, EffectRequestQueue effectRequests, IClock clock, GasConditionRegistry conditions, GasBudget budget = null, EffectTemplateRegistry templates = null, InputRequestQueue inputRequests = null, OrderQueue chainOrders = null, ResponseChainTelemetryBuffer telemetry = null, OrderRequestQueue orderRequests = null, ResponseChainOrderTypes? responseChainOrderTypes = null, GasPresentationEventBuffer presentationEvents = null, ISpatialQueryService spatialQueries = null, RuntimeEntitySpawnQueue spawnRequests = null, RuntimeEntityLifecycleQueue lifecycleRequests = null, EntityLifecycleRuntimeServices lifecycleServices = null, EffectPhaseExecutor phaseExecutor = null, Ludots.Core.NodeLibraries.GASGraph.Host.GasGraphRuntimeApi graphApi = null, TagOps tagOps = null, ExchangeRuntime exchangeRuntime = null, ProgressionRequirementEvaluator progressionEvaluator = null, OrderTypeRegistry orderTypeRegistry = null, OrderRuleRegistry orderRuleRegistry = null, int stepRateHz = 30, RelationshipRuntime relationshipRuntime = null, KnowledgeAreaRevealRuntime knowledgeAreaRevealRuntime = null)
             : base(world)
         {
             _effectRequests = effectRequests;
@@ -71,8 +73,8 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                 responseChainOrderTypes,
                 nameof(EffectProcessingLoopSystem));
             _proposal = new EffectProposalProcessingSystem(world, effectRequests, budget, templates, inputRequests, chainOrders, telemetry, orderRequests, configuredResponseChainOrderTypes, presentationEvents, phaseExecutor, graphApi);
-            _application = new EffectApplicationSystem(world, effectRequests, budget, presentationEvents, templates, spatialQueries, spawnRequests, lifecycleRequests, lifecycleServices, phaseExecutor, graphApi, tagOps, exchangeRuntime, progressionEvaluator, orderTypeRegistry, orderRuleRegistry, clock, stepRateHz);
-            _lifetime = new EffectLifetimeSystem(world, clock, conditions, effectRequests, budget, templates, spatialQueries, spawnRequests, lifecycleRequests, lifecycleServices, phaseExecutor, graphApi, tagOps, exchangeRuntime, progressionEvaluator, orderTypeRegistry, orderRuleRegistry, stepRateHz);
+            _application = new EffectApplicationSystem(world, effectRequests, budget, presentationEvents, templates, spatialQueries, spawnRequests, lifecycleRequests, lifecycleServices, phaseExecutor, graphApi, tagOps, exchangeRuntime, progressionEvaluator, orderTypeRegistry, orderRuleRegistry, clock, stepRateHz, relationshipRuntime, knowledgeAreaRevealRuntime);
+            _lifetime = new EffectLifetimeSystem(world, clock, conditions, effectRequests, budget, templates, spatialQueries, spawnRequests, lifecycleRequests, lifecycleServices, phaseExecutor, graphApi, tagOps, exchangeRuntime, progressionEvaluator, orderTypeRegistry, orderRuleRegistry, stepRateHz, relationshipRuntime, presentationEvents, knowledgeAreaRevealRuntime);
             _runtimeStateEntity = world.Create(new GasRuntimeState());
         }
 

--- a/src/Core/Gameplay/GAS/TargetResolverFanOutHelper.cs
+++ b/src/Core/Gameplay/GAS/TargetResolverFanOutHelper.cs
@@ -362,6 +362,18 @@ namespace Ludots.Core.Gameplay.GAS
 
         private static int ComputeDirection(World world, in EffectContext ctx, in EffectConfigParams mergedParams)
         {
+            if (TryResolveBlackboardFacing(world, ctx.Source, out int blackboardFacingDeg))
+            {
+                return blackboardFacingDeg;
+            }
+
+            if (world.IsAlive(ctx.Source) && world.Has<FacingDirection>(ctx.Source))
+            {
+                float degrees = WorldPlane2D.NormalizeDegreesPositive(
+                    WorldPlane2D.RadToDegValue(world.Get<FacingDirection>(ctx.Source).AngleRad));
+                return (int)MathF.Round(degrees);
+            }
+
             if (TryResolveQueryOrigin(world, in ctx, in mergedParams, out var sourcePos) &&
                 TryResolveTargetPoint(world, in ctx, in mergedParams, out var targetPos))
             {
@@ -373,6 +385,24 @@ namespace Ludots.Core.Gameplay.GAS
                 }
             }
             return 0;
+        }
+
+        private static bool TryResolveBlackboardFacing(World world, Entity source, out int facingDeg)
+        {
+            facingDeg = 0;
+            if (!world.IsAlive(source) || !world.Has<BlackboardFloatBuffer>(source))
+            {
+                return false;
+            }
+
+            ref readonly BlackboardFloatBuffer blackboard = ref world.Get<BlackboardFloatBuffer>(source);
+            if (!blackboard.TryGet(Orders.OrderBlackboardKeys.Cast_Facing, out float degrees))
+            {
+                return false;
+            }
+
+            facingDeg = (int)MathF.Round(WorldPlane2D.NormalizeDegreesPositive(degrees));
+            return true;
         }
 
         private static bool TryResolveQueryOrigin(World world, in EffectContext ctx, out WorldCmInt2 point)

--- a/src/Core/Presentation/Events/PresentationEventKind.cs
+++ b/src/Core/Presentation/Events/PresentationEventKind.cs
@@ -18,6 +18,11 @@ namespace Ludots.Core.Presentation.Events
         CastCommitted = 21,
         CastFailed = 22,
         EffectActivated = 23,
+        CastStarted = 24,
+        CastFinished = 25,
+        CastInterrupted = 26,
+        EffectExpired = 27,
+        EffectCancelled = 28,
 
         // Global domain events
         GlobalDayNight = 30,

--- a/src/Core/Presentation/Systems/GameplayPresentationProjectionSystem.cs
+++ b/src/Core/Presentation/Systems/GameplayPresentationProjectionSystem.cs
@@ -102,6 +102,52 @@ namespace Ludots.Core.Presentation.Systems
                                 },
                                 nameof(GasPresentationEventKind.EffectActivated));
                             break;
+                        case GasPresentationEventKind.EffectExpired:
+                            AddEventOrThrow(
+                                _stream,
+                                new PresentationEvent
+                                {
+                                    LogicTickStamp = tick,
+                                    Kind = PresentationEventKind.EffectExpired,
+                                    KeyId = ge.EffectTemplateId,
+                                    Source = ge.Actor,
+                                    Target = ge.Target,
+                                    Magnitude = 0f,
+                                    PayloadA = ge.EffectTemplateId,
+                                },
+                                nameof(GasPresentationEventKind.EffectExpired));
+                            break;
+                        case GasPresentationEventKind.EffectCancelled:
+                            AddEventOrThrow(
+                                _stream,
+                                new PresentationEvent
+                                {
+                                    LogicTickStamp = tick,
+                                    Kind = PresentationEventKind.EffectCancelled,
+                                    KeyId = ge.EffectTemplateId,
+                                    Source = ge.Actor,
+                                    Target = ge.Target,
+                                    Magnitude = 0f,
+                                    PayloadA = ge.EffectTemplateId,
+                                },
+                                nameof(GasPresentationEventKind.EffectCancelled));
+                            break;
+                        case GasPresentationEventKind.CastStarted:
+                            AddEventOrThrow(
+                                _stream,
+                                new PresentationEvent
+                                {
+                                    LogicTickStamp = tick,
+                                    Kind = PresentationEventKind.CastStarted,
+                                    KeyId = ge.AbilityId,
+                                    Source = ge.Actor,
+                                    Target = ge.Target,
+                                    Magnitude = 0f,
+                                    PayloadA = ge.AbilitySlot,
+                                    PayloadB = ge.AbilityId,
+                                },
+                                nameof(GasPresentationEventKind.CastStarted));
+                            break;
                         case GasPresentationEventKind.CastCommitted:
                             AddEventOrThrow(
                                 _stream,
@@ -133,6 +179,38 @@ namespace Ludots.Core.Presentation.Systems
                                     PayloadB = (int)ge.FailReason,
                                 },
                                 nameof(GasPresentationEventKind.CastFailed));
+                            break;
+                        case GasPresentationEventKind.CastFinished:
+                            AddEventOrThrow(
+                                _stream,
+                                new PresentationEvent
+                                {
+                                    LogicTickStamp = tick,
+                                    Kind = PresentationEventKind.CastFinished,
+                                    KeyId = ge.AbilityId,
+                                    Source = ge.Actor,
+                                    Target = ge.Target,
+                                    Magnitude = 0f,
+                                    PayloadA = ge.AbilitySlot,
+                                    PayloadB = ge.AbilityId,
+                                },
+                                nameof(GasPresentationEventKind.CastFinished));
+                            break;
+                        case GasPresentationEventKind.CastInterrupted:
+                            AddEventOrThrow(
+                                _stream,
+                                new PresentationEvent
+                                {
+                                    LogicTickStamp = tick,
+                                    Kind = PresentationEventKind.CastInterrupted,
+                                    KeyId = ge.AbilityId,
+                                    Source = ge.Actor,
+                                    Target = ge.Target,
+                                    Magnitude = 0f,
+                                    PayloadA = ge.AbilitySlot,
+                                    PayloadB = ge.AbilityId,
+                                },
+                                nameof(GasPresentationEventKind.CastInterrupted));
                             break;
                     }
                 }

--- a/src/Core/Scripting/CoreServiceKeys.cs
+++ b/src/Core/Scripting/CoreServiceKeys.cs
@@ -205,6 +205,7 @@ namespace Ludots.Core.Scripting
         public static readonly ServiceKey<FogCellMap> VisionFogCellMap = new("Vision.FogCellMap");
         public static readonly ServiceKey<VisionResolver> VisionResolver = new("Vision.Resolver");
         public static readonly ServiceKey<FogKnowledgeProjector> FogKnowledgeProjector = new("Vision.FogKnowledgeProjector");
+        public static readonly ServiceKey<KnowledgeAreaRevealRuntime> KnowledgeAreaRevealRuntime = new("Vision.KnowledgeAreaRevealRuntime");
         public static readonly ServiceKey<Entity> RelationshipEventSource = new("RelationshipEvent.Source");
         public static readonly ServiceKey<Entity> RelationshipEventTarget = new("RelationshipEvent.Target");
         public static readonly ServiceKey<Entity> RelationshipEventTeam = new("RelationshipEvent.Team");

--- a/src/Core/Vision/Config/VisionFogLayerConfigLoader.cs
+++ b/src/Core/Vision/Config/VisionFogLayerConfigLoader.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Text.Json;
+using Ludots.Core.Config;
+
+namespace Ludots.Core.Vision.Config
+{
+    public sealed class VisionFogLayerConfig : IIdentifiable
+    {
+        public string Id { get; set; } = string.Empty;
+        public int? CellSizeCm { get; set; }
+        public int? UpdateHz { get; set; }
+    }
+
+    public sealed class VisionFogLayerConfigLoader
+    {
+        public const string DefaultRelativePath = "Vision/fog_layers.json";
+
+        private readonly ConfigPipeline _pipeline;
+        private readonly FogLayerRegistry _registry;
+
+        public VisionFogLayerConfigLoader(ConfigPipeline pipeline, FogLayerRegistry registry)
+        {
+            _pipeline = pipeline ?? throw new ArgumentNullException(nameof(pipeline));
+            _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        }
+
+        public void Load(
+            ConfigCatalog? catalog = null,
+            ConfigConflictReport? report = null,
+            string relativePath = DefaultRelativePath)
+        {
+            var entry = ConfigPipeline.RequireEntry(catalog, relativePath, ConfigMergePolicy.ArrayById, "id");
+            var merged = _pipeline.MergeArrayByIdFromCatalog(in entry, report);
+            var options = StrictJsonOptions.CreateCamelCase();
+
+            for (int i = 0; i < merged.Count; i++)
+            {
+                var item = merged[i];
+                var cfg = item.Node.Deserialize<VisionFogLayerConfig>(options)
+                    ?? throw new InvalidOperationException($"Failed to deserialize fog layer '{item.Id}' from {relativePath}.");
+
+                if (!string.Equals(cfg.Id, item.Id, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException($"Fog layer id mismatch in {relativePath}: '{item.Id}' vs '{cfg.Id}'.");
+                }
+
+                string id = RequireCanonicalId(cfg.Id, relativePath);
+                int cellSizeCm = RequirePositive(cfg.CellSizeCm, id, relativePath, "cellSizeCm");
+                int updateHz = RequirePositive(cfg.UpdateHz, id, relativePath, "updateHz");
+                _registry.Register(id, cellSizeCm, updateHz);
+            }
+        }
+
+        private static string RequireCanonicalId(string value, string relativePath)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new InvalidOperationException($"{relativePath}: fog layer id is required.");
+            }
+
+            string trimmed = value.Trim();
+            if (!string.Equals(value, trimmed, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"{relativePath}: fog layer id '{value}' must not include leading or trailing whitespace.");
+            }
+
+            return value;
+        }
+
+        private static int RequirePositive(int? value, string id, string relativePath, string fieldPath)
+        {
+            if (!value.HasValue)
+            {
+                throw new InvalidOperationException($"Fog layer '{id}' in {relativePath}: {fieldPath} is required.");
+            }
+
+            if (value.Value <= 0)
+            {
+                throw new InvalidOperationException($"Fog layer '{id}' in {relativePath}: {fieldPath} must be > 0.");
+            }
+
+            return value.Value;
+        }
+    }
+}

--- a/src/Core/Vision/KnowledgeAreaRevealRuntime.cs
+++ b/src/Core/Vision/KnowledgeAreaRevealRuntime.cs
@@ -1,0 +1,277 @@
+using System;
+using Arch.Core;
+using Ludots.Core.Components;
+using Ludots.Core.Knowledge;
+using Ludots.Core.Mathematics;
+
+namespace Ludots.Core.Vision
+{
+    public readonly struct KnowledgeAreaRevealDescriptor
+    {
+        public const int MaxLayers = 4;
+
+        public KnowledgeAreaRevealDescriptor(
+            int scopeKeyId,
+            int radiusCm,
+            ReadOnlySpan<FogLayerId> layerIds,
+            int memoryTtlTicks = 0,
+            byte detectionStrength = 0)
+        {
+            if (scopeKeyId <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(scopeKeyId), "Knowledge area reveal requires a registered scope key.");
+            }
+
+            if (radiusCm <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(radiusCm), "Knowledge area reveal radius must be positive.");
+            }
+
+            if (layerIds.IsEmpty || layerIds.Length > MaxLayers)
+            {
+                throw new ArgumentOutOfRangeException(nameof(layerIds), $"Knowledge area reveal requires 1..{MaxLayers} fog layers.");
+            }
+
+            ScopeKeyId = scopeKeyId;
+            RadiusCm = radiusCm;
+            MemoryTtlTicks = memoryTtlTicks;
+            DetectionStrength = detectionStrength;
+            LayerCount = layerIds.Length;
+
+            Layer0 = layerIds[0];
+            Layer1 = layerIds.Length > 1 ? layerIds[1] : default;
+            Layer2 = layerIds.Length > 2 ? layerIds[2] : default;
+            Layer3 = layerIds.Length > 3 ? layerIds[3] : default;
+        }
+
+        public readonly int ScopeKeyId;
+        public readonly int RadiusCm;
+        public readonly int MemoryTtlTicks;
+        public readonly byte DetectionStrength;
+        public readonly int LayerCount;
+        public readonly FogLayerId Layer0;
+        public readonly FogLayerId Layer1;
+        public readonly FogLayerId Layer2;
+        public readonly FogLayerId Layer3;
+
+        public void CopyLayers(Span<FogLayerId> destination)
+        {
+            if (destination.Length < LayerCount)
+            {
+                throw new ArgumentException("Destination span is smaller than the reveal layer count.", nameof(destination));
+            }
+
+            if (LayerCount > 0) destination[0] = Layer0;
+            if (LayerCount > 1) destination[1] = Layer1;
+            if (LayerCount > 2) destination[2] = Layer2;
+            if (LayerCount > 3) destination[3] = Layer3;
+        }
+    }
+
+    public readonly struct KnowledgeAreaRevealResult
+    {
+        public KnowledgeAreaRevealResult(int rasterizedCells, int projectedTargets, int decayedTargets)
+        {
+            RasterizedCells = rasterizedCells;
+            ProjectedTargets = projectedTargets;
+            DecayedTargets = decayedTargets;
+        }
+
+        public readonly int RasterizedCells;
+        public readonly int ProjectedTargets;
+        public readonly int DecayedTargets;
+    }
+
+    public sealed class KnowledgeAreaRevealRuntime
+    {
+        private static readonly QueryDescription OccupantQuery = new QueryDescription()
+            .WithAll<FogOccupantCm, WorldPositionCm>();
+
+        private readonly World _world;
+        private readonly FogLayerRegistry _layers;
+        private readonly FogFieldStore _fields;
+        private readonly VisionResolver _resolver;
+        private readonly FogKnowledgeProjector _projector;
+        private FogOccupant[] _occupants = new FogOccupant[32];
+
+        public KnowledgeAreaRevealRuntime(
+            World world,
+            FogLayerRegistry layers,
+            FogFieldStore fields,
+            VisionResolver resolver,
+            FogKnowledgeProjector projector)
+        {
+            _world = world ?? throw new ArgumentNullException(nameof(world));
+            _layers = layers ?? throw new ArgumentNullException(nameof(layers));
+            _fields = fields ?? throw new ArgumentNullException(nameof(fields));
+            _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+            _projector = projector ?? throw new ArgumentNullException(nameof(projector));
+        }
+
+        public KnowledgeAreaRevealResult Reveal(
+            Entity viewer,
+            Entity source,
+            WorldCmInt2 center,
+            in KnowledgeAreaRevealDescriptor descriptor,
+            int currentTick)
+        {
+            if (!_world.IsAlive(viewer))
+            {
+                return default;
+            }
+
+            Entity recordSource = _world.IsAlive(source) ? source : viewer;
+            Span<FogLayerId> layers = stackalloc FogLayerId[KnowledgeAreaRevealDescriptor.MaxLayers];
+            descriptor.CopyLayers(layers);
+            ReadOnlySpan<FogLayerId> activeLayers = layers[..descriptor.LayerCount];
+            uint layerMask = BuildLayerMask(activeLayers);
+
+            var emitter = new VisionEmitter(
+                descriptor.ScopeKeyId,
+                center,
+                facingDeg: 0,
+                layerMask,
+                VisionPolarity.Reveal,
+                VisionAperture.Disk(descriptor.RadiusCm),
+                detectionStrength: descriptor.DetectionStrength);
+
+            int rasterized = _resolver.Resolve(emitter, activeLayers, FogRulesPolicy.Default);
+            int occupantCount = CopyOccupants();
+            if (occupantCount == 0)
+            {
+                return new KnowledgeAreaRevealResult(rasterized, 0, 0);
+            }
+
+            int projected = 0;
+            ReadOnlySpan<FogOccupant> occupants = _occupants.AsSpan(0, occupantCount);
+            var projection = new FogProjectionPolicy(FogDisclosurePolicy.None, descriptor.MemoryTtlTicks);
+            for (int i = 0; i < activeLayers.Length; i++)
+            {
+                FogLayerId layerId = activeLayers[i];
+                if (!_fields.TryGet(descriptor.ScopeKeyId, layerId, out FogField field))
+                {
+                    continue;
+                }
+
+                projected += _projector.Project(
+                    viewer,
+                    recordSource,
+                    center,
+                    field,
+                    occupants,
+                    in projection,
+                    currentTick,
+                    descriptor.DetectionStrength);
+            }
+
+            return new KnowledgeAreaRevealResult(rasterized, projected, 0);
+        }
+
+        public KnowledgeAreaRevealResult DecayArea(
+            Entity viewer,
+            Entity source,
+            WorldCmInt2 center,
+            in KnowledgeAreaRevealDescriptor descriptor,
+            int currentTick)
+        {
+            if (!_world.IsAlive(viewer))
+            {
+                return default;
+            }
+
+            Entity recordSource = _world.IsAlive(source) ? source : viewer;
+            Span<FogLayerId> layers = stackalloc FogLayerId[KnowledgeAreaRevealDescriptor.MaxLayers];
+            descriptor.CopyLayers(layers);
+            ReadOnlySpan<FogLayerId> activeLayers = layers[..descriptor.LayerCount];
+            uint layerMask = BuildLayerMask(activeLayers);
+
+            int occupantCount = CopyOccupants();
+            if (occupantCount == 0)
+            {
+                return default;
+            }
+
+            var projection = new FogProjectionPolicy(FogDisclosurePolicy.None, descriptor.MemoryTtlTicks);
+            long radiusSq = (long)descriptor.RadiusCm * descriptor.RadiusCm;
+            int decayed = 0;
+
+            for (int i = 0; i < occupantCount; i++)
+            {
+                FogOccupant occupant = _occupants[i];
+                if ((occupant.ExposeLayerMask & layerMask) == 0u || !IsWithinRadius(center, occupant.Position, radiusSq))
+                {
+                    continue;
+                }
+
+                _projector.Decay(viewer, occupant.Entity, recordSource, in projection, currentTick);
+                decayed++;
+            }
+
+            return new KnowledgeAreaRevealResult(0, 0, decayed);
+        }
+
+        private uint BuildLayerMask(ReadOnlySpan<FogLayerId> layerIds)
+        {
+            uint mask = 0u;
+            for (int i = 0; i < layerIds.Length; i++)
+            {
+                mask |= _layers.ToMask(layerIds[i]);
+            }
+
+            return mask;
+        }
+
+        private int CopyOccupants()
+        {
+            int count = 0;
+            foreach (ref var chunk in _world.Query(in OccupantQuery))
+            {
+                ref Entity firstEntity = ref chunk.Entity(0);
+                var occupants = chunk.GetSpan<FogOccupantCm>();
+                var positions = chunk.GetSpan<WorldPositionCm>();
+                foreach (int index in chunk)
+                {
+                    ref readonly FogOccupantCm occupant = ref occupants[index];
+                    if (occupant.ExposeLayerMask == 0u)
+                    {
+                        continue;
+                    }
+
+                    EnsureOccupantCapacity(count + 1);
+                    Entity entity = System.Runtime.CompilerServices.Unsafe.Add(ref firstEntity, index);
+                    _occupants[count++] = new FogOccupant(
+                        entity,
+                        positions[index].ToWorldCmInt2(),
+                        occupant.ExposeLayerMask,
+                        occupant.AltitudeBand,
+                        occupant.StealthLevel);
+                }
+            }
+
+            return count;
+        }
+
+        private void EnsureOccupantCapacity(int required)
+        {
+            if (required <= _occupants.Length)
+            {
+                return;
+            }
+
+            int next = _occupants.Length;
+            while (next < required)
+            {
+                next *= 2;
+            }
+
+            Array.Resize(ref _occupants, next);
+        }
+
+        private static bool IsWithinRadius(WorldCmInt2 center, WorldCmInt2 point, long radiusSq)
+        {
+            int dx = point.X - center.X;
+            int dy = point.Y - center.Y;
+            return ((long)dx * dx) + ((long)dy * dy) <= radiusSq;
+        }
+    }
+}

--- a/src/Tests/GasTests/CoreHeroSkillInfraTests.cs
+++ b/src/Tests/GasTests/CoreHeroSkillInfraTests.cs
@@ -1,0 +1,654 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Arch.Core;
+using Ludots.Core.Association;
+using Ludots.Core.Components;
+using Ludots.Core.Config;
+using Ludots.Core.Gameplay;
+using Ludots.Core.Gameplay.GAS;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Config;
+using Ludots.Core.Gameplay.GAS.Orders;
+using Ludots.Core.Gameplay.GAS.Presentation;
+using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.Gameplay.GAS.Systems;
+using Ludots.Core.Gameplay.Progression;
+using Ludots.Core.Gameplay.Relationships;
+using Ludots.Core.Gameplay.Teams;
+using Ludots.Core.GraphRuntime;
+using Ludots.Core.Knowledge;
+using Ludots.Core.Map.Hex;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Mathematics.FixedPoint;
+using Ludots.Core.Modding;
+using Ludots.Core.NodeLibraries.GASGraph;
+using Ludots.Core.NodeLibraries.GASGraph.Host;
+using Ludots.Core.Presentation.Components;
+using Ludots.Core.Presentation.Events;
+using Ludots.Core.Presentation.Systems;
+using Ludots.Core.Scripting;
+using Ludots.Core.Spatial;
+using Ludots.Core.Vision;
+using Ludots.Core.Vision.Config;
+using NUnit.Framework;
+
+namespace Ludots.Tests.GAS
+{
+    [TestFixture]
+    public sealed class CoreHeroSkillInfraTests
+    {
+        [Test]
+        public void VisionFogLayerConfigLoader_LoadsFormalFogLayersThroughConfigPipeline()
+        {
+            string root = CreateTempRoot("Ludots_Issue590_FogLayers");
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(root, "Configs", "Vision"));
+                File.WriteAllText(
+                    Path.Combine(root, "Configs", "config_catalog.json"),
+                    @"[{ ""Path"": ""Vision/fog_layers.json"", ""Policy"": ""ArrayById"", ""IdField"": ""id"" }]");
+                File.WriteAllText(
+                    Path.Combine(root, "Configs", "Vision", "fog_layers.json"),
+                    @"[
+  { ""id"": ""ground"", ""cellSizeCm"": 100, ""updateHz"": 10 },
+  { ""id"": ""detection"", ""cellSizeCm"": 125, ""updateHz"": 5 }
+]");
+
+                ConfigPipeline pipeline = CreatePipeline(root);
+                ConfigCatalog catalog = ConfigCatalogLoader.Load(pipeline);
+                var registry = new FogLayerRegistry();
+
+                new VisionFogLayerConfigLoader(pipeline, registry).Load(catalog);
+
+                FogLayerId ground = registry.GetId("ground");
+                FogLayerId detection = registry.GetId("detection");
+                Assert.That(ground.Value, Is.GreaterThan(0));
+                Assert.That(detection.Value, Is.GreaterThan(0));
+                Assert.That(registry.Get(ground).CellSizeCm, Is.EqualTo(100));
+                Assert.That(registry.Get(detection).UpdateHz, Is.EqualTo(5));
+            }
+            finally
+            {
+                TryDeleteDirectory(root);
+            }
+        }
+
+        [Test]
+        public void KnowledgeAreaRevealRuntime_RevealsAreaAndDecaysProjectionToKnown()
+        {
+            using World world = World.Create();
+            var layers = new FogLayerRegistry();
+            FogLayerId ground = layers.Register("ground", cellSizeCm: 100, updateHz: 10);
+            uint groundMask = layers.ToMask(ground);
+            var fields = new FogFieldStore();
+            var knowledge = new KnowledgeProjectionStore();
+            var resolver = new VisionResolver(layers, fields);
+            var projector = new FogKnowledgeProjector(knowledge);
+            var runtime = new KnowledgeAreaRevealRuntime(world, layers, fields, resolver, projector);
+            Entity viewer = world.Create(WorldPositionCm.FromCm(0, 0));
+            Entity target = world.Create(
+                WorldPositionCm.FromCm(50, 0),
+                new FogOccupantCm { ExposeLayerMask = groundMask });
+            var descriptor = new KnowledgeAreaRevealDescriptor(1, radiusCm: 150, stackalloc[] { ground }, memoryTtlTicks: 20);
+
+            KnowledgeAreaRevealResult reveal = runtime.Reveal(viewer, viewer, new WorldCmInt2(0, 0), in descriptor, currentTick: 7);
+
+            Assert.That(reveal.RasterizedCells, Is.GreaterThan(0));
+            Assert.That(reveal.ProjectedTargets, Is.EqualTo(1));
+            Assert.That(fields.TryGet(1, ground, out FogField field), Is.True);
+            Assert.That(field.GetVisibility(new FogCell(0, 0)), Is.EqualTo(CellVisibility.Visible));
+            Assert.That(knowledge.TryGet(viewer, target, currentTick: 7, out KnowledgeDisclosureRecord live), Is.True);
+            Assert.That(live.Presence, Is.EqualTo(KnowledgePresence.LiveVisible));
+
+            KnowledgeAreaRevealResult decay = runtime.DecayArea(viewer, viewer, new WorldCmInt2(0, 0), in descriptor, currentTick: 9);
+
+            Assert.That(decay.DecayedTargets, Is.EqualTo(1));
+            Assert.That(knowledge.TryGet(viewer, target, currentTick: 9, out KnowledgeDisclosureRecord known), Is.True);
+            Assert.That(known.Presence, Is.EqualTo(KnowledgePresence.Known));
+            Assert.That(known.Position, Is.EqualTo(KnowledgePositionAccess.LastKnown));
+            Assert.That(known.ExpiryTick, Is.EqualTo(29));
+        }
+
+        [Test]
+        public void RevealAreaPreset_ExecutesApplyAndRemoveThroughPhaseExecutor()
+        {
+            using World world = World.Create();
+            var layers = new FogLayerRegistry();
+            FogLayerId ground = layers.Register("ground", cellSizeCm: 100, updateHz: 10);
+            uint groundMask = layers.ToMask(ground);
+            var fields = new FogFieldStore();
+            var knowledge = new KnowledgeProjectionStore();
+            var resolver = new VisionResolver(layers, fields);
+            var projector = new FogKnowledgeProjector(knowledge);
+            var revealRuntime = new KnowledgeAreaRevealRuntime(world, layers, fields, resolver, projector);
+            Entity viewer = world.Create(WorldPositionCm.FromCm(0, 0));
+            Entity target = world.Create(
+                WorldPositionCm.FromCm(50, 0),
+                new FogOccupantCm { ExposeLayerMask = groundMask });
+
+            var presetTypes = new PresetTypeRegistry();
+            var revealPreset = new PresetTypeDefinition { Type = EffectPresetType.RevealArea };
+            revealPreset.DefaultPhaseHandlers[EffectPhaseId.OnApply] = PhaseHandler.Builtin(BuiltinHandlerId.RevealArea);
+            revealPreset.DefaultPhaseHandlers[EffectPhaseId.OnRemove] = PhaseHandler.Builtin(BuiltinHandlerId.DecayRevealArea);
+            presetTypes.Register(in revealPreset);
+
+            var builtinHandlers = new BuiltinHandlerRegistry();
+            BuiltinHandlers.RegisterAll(builtinHandlers);
+            var templates = new EffectTemplateRegistry();
+            const int templateId = 590;
+            templates.Register(templateId, new EffectTemplateData
+            {
+                PresetType = EffectPresetType.RevealArea,
+                RevealArea = new KnowledgeAreaRevealDescriptor(1, radiusCm: 150, stackalloc[] { ground }, memoryTtlTicks: 30)
+            });
+            var executor = new EffectPhaseExecutor(
+                new GraphProgramRegistry(),
+                presetTypes,
+                builtinHandlers,
+                GasGraphOpHandlerTable.Instance,
+                templates);
+            var runtime = new BuiltinHandlerExecutionContext
+            {
+                KnowledgeAreaReveal = revealRuntime,
+                CurrentStep = 3
+            };
+
+            executor.ExecutePhase(
+                world,
+                new GasGraphRuntimeApi(world, null, null, null),
+                viewer,
+                Entity.Null,
+                Entity.Null,
+                default,
+                EffectPhaseId.OnApply,
+                default,
+                EffectPresetType.RevealArea,
+                effectTagId: 0,
+                effectTemplateId: templateId,
+                builtinRuntime: runtime);
+
+            Assert.That(knowledge.TryGet(viewer, target, currentTick: 3, out KnowledgeDisclosureRecord live), Is.True);
+            Assert.That(live.Presence, Is.EqualTo(KnowledgePresence.LiveVisible));
+
+            runtime.CurrentStep = 5;
+            executor.ExecutePhase(
+                world,
+                new GasGraphRuntimeApi(world, null, null, null),
+                viewer,
+                Entity.Null,
+                Entity.Null,
+                default,
+                EffectPhaseId.OnRemove,
+                default,
+                EffectPresetType.RevealArea,
+                effectTagId: 0,
+                effectTemplateId: templateId,
+                builtinRuntime: runtime);
+
+            Assert.That(knowledge.TryGet(viewer, target, currentTick: 5, out KnowledgeDisclosureRecord known), Is.True);
+            Assert.That(known.Presence, Is.EqualTo(KnowledgePresence.Known));
+        }
+
+        [Test]
+        public void EffectTemplateLoader_RevealArea_CompilesRegisteredScopeAndFogLayers()
+        {
+            string root = CreateTempRoot("Ludots_Issue590_RevealAreaEffect");
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(root, "Configs", "GAS"));
+                File.WriteAllText(
+                    Path.Combine(root, "Configs", "config_catalog.json"),
+                    @"[{ ""Path"": ""GAS/effects.json"", ""Policy"": ""ArrayById"", ""IdField"": ""id"" }]");
+                File.WriteAllText(
+                    Path.Combine(root, "Configs", "GAS", "effects.json"),
+                    @"[
+  {
+    ""id"": ""hero_reveal"",
+    ""presetType"": ""RevealArea"",
+    ""lifetime"": ""After"",
+    ""duration"": { ""durationTicks"": 30, ""periodTicks"": 5, ""clockId"": ""FixedFrame"" },
+    ""participatesInResponse"": true,
+    ""revealArea"": {
+      ""radius"": 600,
+      ""scope"": ""team"",
+      ""layers"": [""ground"", ""detection""],
+      ""memoryTtlTicks"": 90,
+      ""detectionStrength"": 2
+    }
+  }
+]");
+
+                ConfigPipeline pipeline = CreatePipeline(root);
+                var templates = new EffectTemplateRegistry();
+                var scopes = new ScopeKeyRegistry();
+                scopes.Register("team");
+                var layers = new FogLayerRegistry();
+                FogLayerId ground = layers.Register("ground", cellSizeCm: 100, updateHz: 10);
+                FogLayerId detection = layers.Register("detection", cellSizeCm: 100, updateHz: 10);
+
+                var loader = new EffectTemplateLoader(
+                    pipeline,
+                    templates,
+                    progressionScopeKeys: scopes,
+                    fogLayers: layers);
+                loader.Load(ConfigCatalogLoader.Load(pipeline), relativePath: "GAS/effects.json");
+
+                int templateId = EffectTemplateIdRegistry.GetId("hero_reveal");
+                Assert.That(templateId, Is.GreaterThan(0));
+                Assert.That(templates.TryGetRef(templateId, out int index), Is.True);
+                ref readonly EffectTemplateData template = ref templates.GetRef(index);
+                Assert.That(template.PresetType, Is.EqualTo(EffectPresetType.RevealArea));
+                Assert.That(template.RevealArea.RadiusCm, Is.EqualTo(600));
+                Assert.That(template.RevealArea.ScopeKeyId, Is.EqualTo(scopes.GetId("team")));
+                Assert.That(template.RevealArea.LayerCount, Is.EqualTo(2));
+                Assert.That(template.RevealArea.Layer0, Is.EqualTo(ground));
+                Assert.That(template.RevealArea.Layer1, Is.EqualTo(detection));
+                Assert.That(template.RevealArea.MemoryTtlTicks, Is.EqualTo(90));
+                Assert.That(template.RevealArea.DetectionStrength, Is.EqualTo(2));
+            }
+            finally
+            {
+                TryDeleteDirectory(root);
+            }
+        }
+
+        [Test]
+        public void EffectTemplateLoader_RevealArea_FailsFastForUnregisteredFogLayer()
+        {
+            string root = CreateTempRoot("Ludots_Issue590_RevealAreaMissingLayer");
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(root, "Configs", "GAS"));
+                File.WriteAllText(
+                    Path.Combine(root, "Configs", "config_catalog.json"),
+                    @"[{ ""Path"": ""GAS/effects.json"", ""Policy"": ""ArrayById"", ""IdField"": ""id"" }]");
+                File.WriteAllText(
+                    Path.Combine(root, "Configs", "GAS", "effects.json"),
+                    @"[
+  {
+    ""id"": ""hero_reveal"",
+    ""presetType"": ""RevealArea"",
+    ""lifetime"": ""Instant"",
+    ""participatesInResponse"": true,
+    ""revealArea"": {
+      ""radius"": 600,
+      ""scope"": ""team"",
+      ""layers"": [""missing""]
+    }
+  }
+]");
+
+                ConfigPipeline pipeline = CreatePipeline(root);
+                var scopes = new ScopeKeyRegistry();
+                scopes.Register("team");
+                var layers = new FogLayerRegistry();
+                var loader = new EffectTemplateLoader(
+                    pipeline,
+                    new EffectTemplateRegistry(),
+                    progressionScopeKeys: scopes,
+                    fogLayers: layers);
+
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                    () => loader.Load(ConfigCatalogLoader.Load(pipeline), relativePath: "GAS/effects.json"))!;
+
+                Assert.That(ex.Message, Does.Contain("not registered"));
+                Assert.That(ex.Message, Does.Contain("missing"));
+            }
+            finally
+            {
+                TryDeleteDirectory(root);
+            }
+        }
+
+        [Test]
+        public void RelationEnsureLink_HandlerCreatesTypedRelationshipLink()
+        {
+            using World world = World.Create();
+            RelationshipRuntime relationships = CreateRelationshipRuntime(world, out RelationshipTypeRegistry types);
+            int captiveTypeId = types.Register("Captive");
+            Entity captor = world.Create();
+            Entity captive = world.Create();
+
+            var presetTypes = new PresetTypeRegistry();
+            var relationPreset = new PresetTypeDefinition { Type = EffectPresetType.Relation };
+            relationPreset.DefaultPhaseHandlers[EffectPhaseId.OnApply] = PhaseHandler.Builtin(BuiltinHandlerId.ApplyRelation);
+            presetTypes.Register(in relationPreset);
+
+            var builtinHandlers = new BuiltinHandlerRegistry();
+            BuiltinHandlers.RegisterAll(builtinHandlers);
+            var templates = new EffectTemplateRegistry();
+            const int templateId = 591;
+            templates.Register(templateId, new EffectTemplateData
+            {
+                PresetType = EffectPresetType.Relation,
+                Relation = new RelationDescriptor
+                {
+                    Operation = RelationOperation.EnsureLink,
+                    Subject = RelationEntitySlot.Source,
+                    Parent = RelationEntitySlot.Target,
+                    RelationshipTypeId = captiveTypeId
+                }
+            });
+            var executor = new EffectPhaseExecutor(
+                new GraphProgramRegistry(),
+                presetTypes,
+                builtinHandlers,
+                GasGraphOpHandlerTable.Instance,
+                templates);
+            var runtime = new BuiltinHandlerExecutionContext { Relationships = relationships };
+
+            executor.ExecutePhase(
+                world,
+                new GasGraphRuntimeApi(world, null, null, null),
+                captor,
+                captive,
+                Entity.Null,
+                default,
+                EffectPhaseId.OnApply,
+                default,
+                EffectPresetType.Relation,
+                effectTagId: 0,
+                effectTemplateId: templateId,
+                builtinRuntime: runtime);
+
+            Assert.That(relationships.HasLink(captor, captive, captiveTypeId), Is.True);
+        }
+
+        [Test]
+        public void EffectTemplateLoader_RelationEnsureLink_CompilesRelationshipType()
+        {
+            string root = CreateTempRoot("Ludots_Issue590_RelationEnsureLink");
+            try
+            {
+                Directory.CreateDirectory(Path.Combine(root, "Configs", "GAS"));
+                File.WriteAllText(
+                    Path.Combine(root, "Configs", "config_catalog.json"),
+                    @"[{ ""Path"": ""GAS/effects.json"", ""Policy"": ""ArrayById"", ""IdField"": ""id"" }]");
+                File.WriteAllText(
+                    Path.Combine(root, "Configs", "GAS", "effects.json"),
+                    @"[
+  {
+    ""id"": ""capture_link"",
+    ""presetType"": ""Relation"",
+    ""lifetime"": ""Instant"",
+    ""participatesInResponse"": true,
+    ""relation"": {
+      ""operation"": ""EnsureLink"",
+      ""subject"": ""Source"",
+      ""parent"": ""Target"",
+      ""snapSubjectToParentPosition"": false,
+      ""relationshipType"": ""Captive""
+    }
+  }
+]");
+
+                ConfigPipeline pipeline = CreatePipeline(root);
+                var templates = new EffectTemplateRegistry();
+                var relationshipTypes = new RelationshipTypeRegistry();
+                int captiveTypeId = relationshipTypes.Register("Captive");
+                var loader = new EffectTemplateLoader(
+                    pipeline,
+                    templates,
+                    relationshipTypes: relationshipTypes);
+
+                loader.Load(ConfigCatalogLoader.Load(pipeline), relativePath: "GAS/effects.json");
+
+                int templateId = EffectTemplateIdRegistry.GetId("capture_link");
+                Assert.That(templates.TryGetRef(templateId, out int index), Is.True);
+                ref readonly EffectTemplateData template = ref templates.GetRef(index);
+                Assert.That(template.Relation.Operation, Is.EqualTo(RelationOperation.EnsureLink));
+                Assert.That(template.Relation.RelationshipTypeId, Is.EqualTo(captiveTypeId));
+            }
+            finally
+            {
+                TryDeleteDirectory(root);
+            }
+        }
+
+        [Test]
+        public void FacingSector_QueryConeUsesBlackboardCastFacingBeforePersistentFacing()
+        {
+            using World world = World.Create();
+            Entity source = world.Create(
+                WorldPositionCm.FromCm(0, 0),
+                new FacingDirection { AngleRad = WorldPlane2D.DegToRadValue(90f) });
+            Entity target = world.Create(WorldPositionCm.FromCm(100, 0));
+            var blackboard = new BlackboardFloatBuffer();
+            blackboard.Set(OrderBlackboardKeys.Cast_Facing, 270f);
+            world.Add(source, blackboard);
+            var query = new TargetQueryDescriptor
+            {
+                Kind = TargetResolverKind.BuiltinSpatial,
+                Spatial = new BuiltinSpatialDescriptor
+                {
+                    Shape = SpatialShape.Cone,
+                    RadiusCm = 500,
+                    HalfAngleDeg = 45,
+                }
+            };
+            var service = new CapturingSpatialQueryService(target);
+            Entity[] buffer = new Entity[4];
+
+            int count = TargetResolverFanOutHelper.ResolveTargets(
+                world,
+                new EffectContext { Source = source, Target = target },
+                in query,
+                service,
+                buffer);
+
+            Assert.That(count, Is.EqualTo(1));
+            Assert.That(service.LastConeDirectionDeg, Is.EqualTo(270));
+        }
+
+        [Test]
+        public void SearchDispatch_LineQueryPublishesResolvedEntityContext()
+        {
+            using World world = World.Create();
+            Entity source = world.Create(WorldPositionCm.FromCm(0, 0));
+            Entity originalTarget = world.Create(WorldPositionCm.FromCm(600, 0));
+            Entity resolved = world.Create(WorldPositionCm.FromCm(300, 0));
+            var query = new TargetQueryDescriptor
+            {
+                Kind = TargetResolverKind.BuiltinSpatial,
+                Spatial = new BuiltinSpatialDescriptor
+                {
+                    Shape = SpatialShape.Line,
+                    LengthCm = 700,
+                    HalfWidthCm = 60,
+                }
+            };
+            var filter = new TargetFilterDescriptor
+            {
+                RelationFilter = RelationshipFilter.All,
+                MaxTargets = 1,
+            };
+            var dispatch = new TargetDispatchDescriptor
+            {
+                PayloadEffectTemplateId = 777,
+                ContextMapping = new TargetResolverContextMapping
+                {
+                    PayloadSource = ContextSlot.OriginalSource,
+                    PayloadTarget = ContextSlot.ResolvedEntity,
+                    PayloadTargetContext = ContextSlot.OriginalTarget,
+                }
+            };
+            var service = new CapturingSpatialQueryService(resolved);
+            var commands = new List<FanOutCommand>();
+            var budget = new RootBudgetTable(16);
+            Entity[] buffer = new Entity[4];
+            int dropped = 0;
+
+            TargetResolverFanOutHelper.CollectFanOutTargets(
+                world,
+                new EffectContext { RootId = 9, Source = source, Target = originalTarget },
+                in query,
+                in filter,
+                in dispatch,
+                service,
+                budget,
+                commands,
+                buffer,
+                ref dropped);
+
+            var queue = new EffectRequestQueue();
+            TargetResolverFanOutHelper.PublishFanOutCommands(commands, queue);
+
+            Assert.That(commands, Has.Count.EqualTo(1));
+            Assert.That(service.LastLineDirectionDeg, Is.EqualTo(0));
+            Assert.That(queue.Count, Is.EqualTo(1));
+            EffectRequest request = queue[0];
+            Assert.That(request.TemplateId, Is.EqualTo(777));
+            Assert.That(request.Source, Is.EqualTo(source));
+            Assert.That(request.Target, Is.EqualTo(resolved));
+            Assert.That(request.TargetContext, Is.EqualTo(originalTarget));
+        }
+
+        [Test]
+        public void GameplayPresentationProjection_ProjectsCastAndEffectLifecycleEvents()
+        {
+            using World world = World.Create();
+            var gasEvents = new GasPresentationEventBuffer(8);
+            var stream = new PresentationEventStream(32);
+            var projection = new GameplayPresentationProjectionSystem(
+                world,
+                new GameplayEventBus(),
+                stream,
+                new GameSession(),
+                gasEvents,
+                new PresentationOwnerChangeBuffer(8));
+            Entity actor = world.Create();
+            Entity target = world.Create();
+            gasEvents.Publish(new GasPresentationEvent { Kind = GasPresentationEventKind.CastStarted, Actor = actor, Target = target, AbilitySlot = 1, AbilityId = 11 });
+            gasEvents.Publish(new GasPresentationEvent { Kind = GasPresentationEventKind.CastFinished, Actor = actor, Target = target, AbilitySlot = 1, AbilityId = 11 });
+            gasEvents.Publish(new GasPresentationEvent { Kind = GasPresentationEventKind.CastInterrupted, Actor = actor, Target = target, AbilitySlot = 2, AbilityId = 12 });
+            gasEvents.Publish(new GasPresentationEvent { Kind = GasPresentationEventKind.EffectExpired, Actor = actor, Target = target, EffectTemplateId = 21 });
+            gasEvents.Publish(new GasPresentationEvent { Kind = GasPresentationEventKind.EffectCancelled, Actor = actor, Target = target, EffectTemplateId = 22 });
+
+            try
+            {
+                projection.Update(1f / 60f);
+            }
+            finally
+            {
+                projection.Dispose();
+            }
+
+            ReadOnlySpan<PresentationEvent> events = stream.GetSpan();
+            bool hasCastStarted = Contains(events, PresentationEventKind.CastStarted, keyId: 11);
+            bool hasCastFinished = Contains(events, PresentationEventKind.CastFinished, keyId: 11);
+            bool hasCastInterrupted = Contains(events, PresentationEventKind.CastInterrupted, keyId: 12);
+            bool hasEffectExpired = Contains(events, PresentationEventKind.EffectExpired, keyId: 21);
+            bool hasEffectCancelled = Contains(events, PresentationEventKind.EffectCancelled, keyId: 22);
+            Assert.Multiple(() =>
+            {
+                Assert.That(hasCastStarted, Is.True);
+                Assert.That(hasCastFinished, Is.True);
+                Assert.That(hasCastInterrupted, Is.True);
+                Assert.That(hasEffectExpired, Is.True);
+                Assert.That(hasEffectCancelled, Is.True);
+                Assert.That(gasEvents.Count, Is.EqualTo(0));
+            });
+        }
+
+        private static bool Contains(ReadOnlySpan<PresentationEvent> events, PresentationEventKind kind, int keyId)
+        {
+            for (int i = 0; i < events.Length; i++)
+            {
+                if (events[i].Kind == kind && events[i].KeyId == keyId)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static RelationshipRuntime CreateRelationshipRuntime(World world, out RelationshipTypeRegistry types)
+        {
+            types = new RelationshipTypeRegistry();
+            return new RelationshipRuntime(
+                world,
+                types,
+                new RelationshipMetricRegistry(),
+                new RelationshipFlagRegistry(),
+                new RelationshipBandRegistry(),
+                new RelationshipChangeBuffer(capacity: 8));
+        }
+
+        private static ConfigPipeline CreatePipeline(string root)
+        {
+            var vfs = new VirtualFileSystem();
+            vfs.Mount("Core", root);
+            var modLoader = new ModLoader(vfs, new FunctionRegistry(), new TriggerManager());
+            return new ConfigPipeline(vfs, modLoader);
+        }
+
+        private static string CreateTempRoot(string prefix)
+        {
+            string root = Path.Combine(Path.GetTempPath(), prefix, Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(root);
+            return root;
+        }
+
+        private static void TryDeleteDirectory(string path)
+        {
+            try
+            {
+                if (Directory.Exists(path))
+                {
+                    Directory.Delete(path, recursive: true);
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private sealed class CapturingSpatialQueryService : ISpatialQueryService
+        {
+            private readonly Entity[] _hits;
+
+            public CapturingSpatialQueryService(params Entity[] hits)
+            {
+                _hits = hits;
+            }
+
+            public int LastConeDirectionDeg { get; private set; } = int.MinValue;
+            public int LastLineDirectionDeg { get; private set; } = int.MinValue;
+
+            public SpatialQueryResult QueryAabb(in WorldAabbCm bounds, Span<Entity> buffer) => Write(buffer);
+
+            public SpatialQueryResult QueryRadius(WorldCmInt2 center, int radiusCm, Span<Entity> buffer) => Write(buffer);
+
+            public SpatialQueryResult QueryCone(WorldCmInt2 origin, int directionDeg, int halfAngleDeg, int rangeCm, Span<Entity> buffer)
+            {
+                LastConeDirectionDeg = directionDeg;
+                return Write(buffer);
+            }
+
+            public SpatialQueryResult QueryRectangle(WorldCmInt2 center, int halfWidthCm, int halfHeightCm, int rotationDeg, Span<Entity> buffer) => Write(buffer);
+
+            public SpatialQueryResult QueryLine(WorldCmInt2 origin, int directionDeg, int lengthCm, int halfWidthCm, Span<Entity> buffer)
+            {
+                LastLineDirectionDeg = directionDeg;
+                return Write(buffer);
+            }
+
+            public SpatialQueryResult QueryHexRange(HexCoordinates center, int hexRadius, Span<Entity> buffer) => Write(buffer);
+
+            public SpatialQueryResult QueryHexRing(HexCoordinates center, int hexRadius, Span<Entity> buffer) => Write(buffer);
+
+            private SpatialQueryResult Write(Span<Entity> buffer)
+            {
+                int count = Math.Min(buffer.Length, _hits.Length);
+                for (int i = 0; i < count; i++)
+                {
+                    buffer[i] = _hits[i];
+                }
+
+                return new SpatialQueryResult(count, _hits.Length - count);
+            }
+        }
+    }
+}

--- a/src/Tests/GasTests/PresetTypePerformanceTests.cs
+++ b/src/Tests/GasTests/PresetTypePerformanceTests.cs
@@ -4,6 +4,7 @@ using Arch.Core;
 using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Components;
 using Ludots.Core.Gameplay.GAS.Config;
+using Ludots.Core.NodeLibraries.GASGraph.Host;
 using NUnit.Framework;
 using static NUnit.Framework.Assert;
 
@@ -260,6 +261,8 @@ namespace Ludots.Tests.GAS
         {
             string json = System.IO.File.ReadAllText(
                 System.IO.Path.Combine(FindRepoRoot(), "assets", "Configs", "GAS", "preset_types.json"));
+            GraphIdRegistry.Clear();
+            GraphIdRegistry.Register("Graph.Lifecycle.DeployConsumeSource");
 
             // Warm up
             for (int i = 0; i < 10; i++)
@@ -292,11 +295,11 @@ namespace Ludots.Tests.GAS
             string dir = AppDomain.CurrentDomain.BaseDirectory;
             while (dir != null)
             {
-                if (System.IO.Directory.Exists(System.IO.Path.Combine(dir, "assets")))
+                if (System.IO.File.Exists(System.IO.Path.Combine(dir, "assets", "Configs", "GAS", "preset_types.json")))
                     return dir;
                 dir = System.IO.Directory.GetParent(dir)?.FullName;
             }
-            throw new InvalidOperationException("Cannot find repo root.");
+            throw new InvalidOperationException("Cannot find repo root (looking for assets/Configs/GAS/preset_types.json).");
         }
     }
 }

--- a/src/Tests/GasTests/PresetTypeSystemTests.cs
+++ b/src/Tests/GasTests/PresetTypeSystemTests.cs
@@ -661,6 +661,8 @@ namespace Ludots.Tests.GAS
         {
             string json = System.IO.File.ReadAllText(
                 System.IO.Path.Combine(FindRepoRoot(), "assets", "Configs", "GAS", "preset_types.json"));
+            GraphIdRegistry.Clear();
+            int lifecycleGraphId = GraphIdRegistry.Register("Graph.Lifecycle.DeployConsumeSource");
 
             var reg = new PresetTypeRegistry();
             PresetTypeLoader.LoadFromJson(reg, json);
@@ -682,6 +684,8 @@ namespace Ludots.Tests.GAS
             That(reg.IsRegistered(EffectPresetType.Displacement), Is.True);
             That(reg.IsRegistered(EffectPresetType.Relation), Is.True);
             That(reg.IsRegistered(EffectPresetType.Exchange), Is.True);
+            That(reg.IsRegistered(EffectPresetType.DeployConsumeSource), Is.True);
+            That(reg.IsRegistered(EffectPresetType.RevealArea), Is.True);
 
             // Spot-check ApplyForce2D builtin handler
             ref readonly var af = ref reg.Get(EffectPresetType.ApplyForce2D);
@@ -703,6 +707,19 @@ namespace Ludots.Tests.GAS
             ref readonly var exchange = ref reg.Get(EffectPresetType.Exchange);
             That(exchange.DefaultPhaseHandlers[EffectPhaseId.OnApply].HandlerId,
                 Is.EqualTo((int)BuiltinHandlerId.ExecuteExchange));
+
+            ref readonly var deploy = ref reg.Get(EffectPresetType.DeployConsumeSource);
+            That(deploy.DefaultPhaseHandlers[EffectPhaseId.OnApply].Kind, Is.EqualTo(PhaseHandlerKind.Graph));
+            That(deploy.DefaultPhaseHandlers[EffectPhaseId.OnApply].HandlerId, Is.EqualTo(lifecycleGraphId));
+
+            ref readonly var reveal = ref reg.Get(EffectPresetType.RevealArea);
+            That(reveal.HasComponent(ComponentFlags.RevealAreaParams), Is.True);
+            That(reveal.DefaultPhaseHandlers[EffectPhaseId.OnApply].HandlerId,
+                Is.EqualTo((int)BuiltinHandlerId.RevealArea));
+            That(reveal.DefaultPhaseHandlers[EffectPhaseId.OnPeriod].HandlerId,
+                Is.EqualTo((int)BuiltinHandlerId.RevealArea));
+            That(reveal.DefaultPhaseHandlers[EffectPhaseId.OnRemove].HandlerId,
+                Is.EqualTo((int)BuiltinHandlerId.DecayRevealArea));
         }
 
         // ════════════════════════════════════════════════════════════════════
@@ -714,11 +731,11 @@ namespace Ludots.Tests.GAS
             string dir = AppDomain.CurrentDomain.BaseDirectory;
             while (dir != null)
             {
-                if (System.IO.Directory.Exists(System.IO.Path.Combine(dir, "assets")))
+                if (System.IO.File.Exists(System.IO.Path.Combine(dir, "assets", "Configs", "GAS", "preset_types.json")))
                     return dir;
                 dir = System.IO.Directory.GetParent(dir)?.FullName;
             }
-            throw new InvalidOperationException("Cannot find repo root (looking for assets/ directory).");
+            throw new InvalidOperationException("Cannot find repo root (looking for assets/Configs/GAS/preset_types.json).");
         }
     }
 }


### PR DESCRIPTION
Refs #590

Summary:
- Add RevealArea preset, Vision fog layer config catalog, and KnowledgeAreaRevealRuntime.
- Wire Cast/FacingSector, Relation EnsureLink, search dispatch fixture, and GAS lifecycle presentation projection.
- Keep #589 Performer paths on existing Core performer pipeline and cover them with targeted regression tests.

GAS composition gate:
- PASS: this extends existing effect/template/registry/phase/presentation pipelines.
- New Vision/fog_layers.json is a formal infra catalog, not a parallel gameplay profile DSL.
- No fallback/backcompat path or parallel runtime pipeline added.

Validation:
- dotnet build src/Tests/GasTests/GasTests.csproj --no-restore
- dotnet test src/Tests/GasTests/GasTests.csproj --no-build --filter CoreHeroSkillInfraTests|KnowledgeProjectionRelationGrantTests|KnowledgeProjectionResolverTests|MinimapKnowledgeProjectionTests|SelectionKnowledgeProjectionTests|VisionResolverTests|RelationshipCoreTests|NewGraphOpsTests|EffectTemplateLoaderTests|TagEffectArchitectureTests|PresetTypeSystemTests|PresetTypePerformanceTests
- dotnet test src/Tests/PresentationTests/PresentationTests.csproj --no-build --filter FullyQualifiedName~PerformerBehaviorKindTests|FullyQualifiedName~PerformerAssetKindTests
- dotnet test src/Tests/GasTests/GasTests.csproj --no-build --filter FullyQualifiedName~AbilityAimPresentationRuntimeTests|FullyQualifiedName~CoreHeroSkillInfraTests
- git diff --check