### PR TITLE
fix(mass-navigation): restore settled-agent avoidance, de-race arrival events, add size-avoidance evidence

### DIFF
--- a/mods/capabilities/navigation/MassNavigationMod/assets/MassNavigationConfig.json
+++ b/mods/capabilities/navigation/MassNavigationMod/assets/MassNavigationConfig.json
@@ -313,6 +313,8 @@
       "flowObstacleNeighborRadiusCells": 4,
       "flowObstacleNeighborWeight": 5,
       "flowObstacleAvoidanceWeight": 1.5,
+      "crowdStampCenterCost": 8,
+      "crowdStampNeighborCost": 3,
       "coincidentPairHashBucketCount": 1024,
       "coincidentPairHashPrimeA": 73856093,
       "coincidentPairHashPrimeB": 19349663

--- a/src/Apps/Web/Ludots.App.Web/Program.cs
+++ b/src/Apps/Web/Ludots.App.Web/Program.cs
@@ -13,6 +13,10 @@ var setup = gameHost.Setup;
 
 var cts = new CancellationTokenSource();
 var gameLoopTask = Task.Run(() => gameHost.Run(cts.Token));
+// The web host keeps serving HTTP if the loop dies; without this the fault is silently swallowed.
+gameLoopTask.ContinueWith(
+    t => Console.Error.WriteLine($"[GameLoop FAULTED] {t.Exception}"),
+    TaskContinuationOptions.OnlyOnFaulted);
 
 app.UseWebSockets();
 

--- a/src/Core/MassNavigation/Runtime/MassNavigationConfig.cs
+++ b/src/Core/MassNavigation/Runtime/MassNavigationConfig.cs
@@ -327,6 +327,8 @@ public sealed class MassNavigationConfig
             "flowObstacleNeighborRadiusCells",
             "flowObstacleNeighborWeight",
             "flowObstacleAvoidanceWeight",
+            "crowdStampCenterCost",
+            "crowdStampNeighborCost",
             "coincidentPairHashBucketCount",
             "coincidentPairHashPrimeA",
             "coincidentPairHashPrimeB");

--- a/src/Core/MassNavigation/Runtime/MassNavigationCrowdSemantics.cs
+++ b/src/Core/MassNavigation/Runtime/MassNavigationCrowdSemantics.cs
@@ -267,6 +267,8 @@ public sealed class MassNavigationSolverSemantics
     public int FlowObstacleNeighborRadiusCells { get; set; }
     public float FlowObstacleNeighborWeight { get; set; }
     public float FlowObstacleAvoidanceWeight { get; set; }
+    public float CrowdStampCenterCost { get; set; }
+    public float CrowdStampNeighborCost { get; set; }
     public int CoincidentPairHashBucketCount { get; set; }
     public int CoincidentPairHashPrimeA { get; set; }
     public int CoincidentPairHashPrimeB { get; set; }
@@ -290,6 +292,8 @@ public sealed class MassNavigationSolverSemantics
         FlowObstacleNeighborRadiusCells = source.FlowObstacleNeighborRadiusCells;
         FlowObstacleNeighborWeight = source.FlowObstacleNeighborWeight;
         FlowObstacleAvoidanceWeight = source.FlowObstacleAvoidanceWeight;
+        CrowdStampCenterCost = source.CrowdStampCenterCost;
+        CrowdStampNeighborCost = source.CrowdStampNeighborCost;
         CoincidentPairHashBucketCount = source.CoincidentPairHashBucketCount;
         CoincidentPairHashPrimeA = source.CoincidentPairHashPrimeA;
         CoincidentPairHashPrimeB = source.CoincidentPairHashPrimeB;
@@ -318,6 +322,8 @@ public sealed class MassNavigationSolverSemantics
         RequireNonNegative(FlowObstacleNeighborRadiusCells, nameof(FlowObstacleNeighborRadiusCells));
         RequireNonNegative(FlowObstacleNeighborWeight, nameof(FlowObstacleNeighborWeight));
         RequireNonNegative(FlowObstacleAvoidanceWeight, nameof(FlowObstacleAvoidanceWeight));
+        RequirePositive(CrowdStampCenterCost, nameof(CrowdStampCenterCost));
+        RequirePositive(CrowdStampNeighborCost, nameof(CrowdStampNeighborCost));
         RequirePowerOfTwo(CoincidentPairHashBucketCount, nameof(CoincidentPairHashBucketCount));
         RequirePositive(CoincidentPairHashPrimeA, nameof(CoincidentPairHashPrimeA));
         RequirePositive(CoincidentPairHashPrimeB, nameof(CoincidentPairHashPrimeB));

--- a/src/Core/MassNavigation/Runtime/MassNavigationFlowSolverArrivalRecovery.cs
+++ b/src/Core/MassNavigation/Runtime/MassNavigationFlowSolverArrivalRecovery.cs
@@ -41,6 +41,8 @@ public sealed partial class MassNavigationFlowSolverState
             : configuredStopThresholdSq;
     }
 
+    // Runs inside parallel step jobs: must only touch per-agent slots. Arrival events are
+    // enqueued later by the single-threaded post-step scan (EnqueuePendingArrivalEvents).
     private void EnterSettledState(int index, float px, float py)
     {
         int i2 = index << 1;
@@ -52,7 +54,6 @@ public sealed partial class MassNavigationFlowSolverState
         _unitStuckSeconds[index] = 0f;
         _velocitiesCm[i2] = 0f;
         _velocitiesCm[i2 + 1] = 0f;
-        EnqueueArrivalEvent(index);
     }
 
     private void ExitSettledState(int index, float px, float py)

--- a/src/Core/MassNavigation/Runtime/MassNavigationFlowSolverState.cs
+++ b/src/Core/MassNavigation/Runtime/MassNavigationFlowSolverState.cs
@@ -861,6 +861,7 @@ public sealed partial class MassNavigationFlowSolverState
         _unitRetryCounts[index] = 0;
         _arrivalEventEmittedFlags[index] = 0;
         EnterSettledState(index, x, y);
+        EnqueueArrivalEvent(index);
         MarkEntityDirty(index);
     }
 
@@ -1503,7 +1504,9 @@ public sealed partial class MassNavigationFlowSolverState
                     continue;
                 }
 
-                float penalty = (ox == 0 && oy == 0) ? 8f : 3f;
+                float penalty = (ox == 0 && oy == 0)
+                    ? Semantics.Solver.CrowdStampCenterCost
+                    : Semantics.Solver.CrowdStampNeighborCost;
                 _cost[idx] += penalty;
             }
         }
@@ -1655,7 +1658,7 @@ public sealed partial class MassNavigationFlowSolverState
                             float ovx = -offsetX;
                             float ovy = -offsetY;
                             float obstacleDistSq = (ovx * ovx) + (ovy * ovy);
-                            if (obstacleDistSq > Semantics.Solver.EntitySyncVelocityEpsilonSq)
+                            if (obstacleDistSq > Semantics.Solver.NormalizationEpsilonSq)
                             {
                                 float invObstacleDist = FastInvSqrt(obstacleDistSq);
                                 float obstacleDist = obstacleDistSq * invObstacleDist;
@@ -1947,15 +1950,6 @@ public sealed partial class MassNavigationFlowSolverState
                 }
             }
 
-            if (suppressTargetMotion)
-            {
-                _velocitiesCm[i2] = 0f;
-                _velocitiesCm[i2 + 1] = 0f;
-                _positionsCm[i2] = px;
-                _positionsCm[i2 + 1] = py;
-                continue;
-            }
-
             float directTargetX = hasGoalTarget ? targetX - px : 0f;
             float directTargetY = hasGoalTarget ? targetY - py : 0f;
             float directTargetSq = hasGoalTarget ? directTargetX * directTargetX + directTargetY * directTargetY : 0f;
@@ -2067,6 +2061,19 @@ public sealed partial class MassNavigationFlowSolverState
                     obstaclePushX += dx * invD * pushForce;
                     obstaclePushY += dy * invD * pushForce;
                 }
+            }
+
+            // Settled agents hold position and velocity to avoid post-arrival jitter, but only
+            // after the scans above have marked hard-resolve candidates: real body overlap must
+            // still be separated by ResolveHardPenetration, which can wake them via the
+            // arrival-recovery push threshold.
+            if (suppressTargetMotion)
+            {
+                _velocitiesCm[i2] = 0f;
+                _velocitiesCm[i2 + 1] = 0f;
+                _positionsCm[i2] = px;
+                _positionsCm[i2 + 1] = py;
+                continue;
             }
 
             float separationScale = (inFormation
@@ -2454,6 +2461,7 @@ public sealed partial class MassNavigationFlowSolverState
             if (_unitSettledFlags[i] != 0)
             {
                 settled++;
+                EnqueueArrivalEvent(i);
             }
         }
 

--- a/src/Tests/GasTests/Physics2D/Physics2DPipelineTests.cs
+++ b/src/Tests/GasTests/Physics2D/Physics2DPipelineTests.cs
@@ -27,7 +27,6 @@ namespace Ludots.Tests.GAS.Physics2D
             Assert.That(pipeline.StepNames.ToArray(), Is.EqualTo(new[]
             {
                 "ForceInputWake",
-                "NavToPhysicsVelocitySync",
                 "BuildPhysicsWorld",
                 "SpatialBroadphase",
                 "NarrowPhase",
@@ -42,8 +41,8 @@ namespace Ludots.Tests.GAS.Physics2D
                 "Cleanup"
             }));
             Assert.That(pipeline.Systems.Length, Is.EqualTo(pipeline.StepNames.Length));
-            Assert.That(pipeline.Build, Is.SameAs(pipeline.Systems[2]));
-            Assert.That(pipeline.Spatial, Is.SameAs(pipeline.Systems[3]));
+            Assert.That(pipeline.Build, Is.SameAs(pipeline.Systems[1]));
+            Assert.That(pipeline.Spatial, Is.SameAs(pipeline.Systems[2]));
         }
     }
 }

--- a/src/Tests/PresentationTests/MassNavigationFlowSolverStateConfigurationTests.cs
+++ b/src/Tests/PresentationTests/MassNavigationFlowSolverStateConfigurationTests.cs
@@ -137,6 +137,60 @@ namespace Ludots.Tests.Presentation
         }
 
         [Test]
+        public void ParallelStep_EmitsExactlyOneArrivalEventPerSettledAgent()
+        {
+            World.SharedJobScheduler ??= new JobScheduler(new JobScheduler.Config
+            {
+                ThreadPrefixName = "MassNavArrivalTests",
+                ThreadCount = 0,
+                MaxExpectedConcurrentJobs = 64,
+                StrictAllocationMode = false
+            });
+
+            const int agentCount = 16;
+            var flow = CreateConfiguredFlow(parallelWorkerCount: 4);
+            flow.Semantics.Solver.ParallelStepMinAgents = 2;
+            var layer = new MassNavigationAgentLayer(categoryMask: 1u, interactionMask: 1u);
+            var seeds = new MassNavigationAgentSeed[agentCount];
+            for (int i = 0; i < agentCount; i++)
+            {
+                seeds[i] = new MassNavigationAgentSeed(
+                    teamId: 1,
+                    localPositionXCm: 1_000f + ((i % 4) * 800f),
+                    localPositionYCm: 1_000f + ((i / 4) * 800f),
+                    heavy: false,
+                    navMass: 1f,
+                    visualScale: 1f,
+                    bodyRadiusCm: 20f,
+                    speedCmPerSecond: 800f,
+                    layer);
+            }
+
+            TeamManager.LoadConfig(new TeamConfig
+            {
+                DefaultRelationship = "Friendly",
+                Relationships = new List<RelationshipEntry>(),
+            });
+            flow.ResetAuthoredAgents(seeds);
+            for (int i = 0; i < agentCount; i++)
+            {
+                flow.SetUnitTarget(i, flow.GetPositionX(i), flow.GetPositionY(i), resetRecovery: true);
+            }
+
+            using var world = World.Create();
+            var navGroups = new MassNavigationGroupRuntime(
+                new MassNavigationFormationRuntime(LoadBaseMassNavigationConfig().Semantics.Group),
+                CreateRuntimeCapacity(agentCapacity: agentCount, groupMemberCapacity: agentCount));
+
+            flow.Step(dt: 0.016f, world, navGroups, runHardResolve: false, hardResolveCandidateThresholdAgents: 1);
+            Assert.That(flow.SettledUnitCount, Is.EqualTo(agentCount));
+            Assert.That(flow.PendingArrivalEventCount, Is.EqualTo(agentCount));
+
+            flow.Step(dt: 0.016f, world, navGroups, runHardResolve: false, hardResolveCandidateThresholdAgents: 1);
+            Assert.That(flow.PendingArrivalEventCount, Is.EqualTo(agentCount));
+        }
+
+        [Test]
         public void SpawnJitter_UsesConfiguredSeedDeterministically()
         {
             var first = CreateSpawnedFlow(randomSeed: 1234);

--- a/src/Tools/Ludots.Launcher.Evidence/LauncherEvidenceRecorder.cs
+++ b/src/Tools/Ludots.Launcher.Evidence/LauncherEvidenceRecorder.cs
@@ -97,6 +97,11 @@ public static class LauncherEvidenceRecorder
     private const int MassNavigationRemoteSettleTicks = 20;
     private const int MassNavigationReturnSettleTicks = 20;
     private const int MassNavigationSelectionSampleCount = 128;
+    private const int MassNavigationAvoidanceFrameIntervalTicks = 4;
+    private const int MassNavigationAvoidanceExtraOrderTicks = 210;
+    private const int MassNavigationAvoidanceCrossingTicks = 420;
+    private const float MassNavigationAvoidanceZoomWidthCm = 4000f;
+    private const float MassNavigationAvoidanceCrossingScale = 0.2f;
     private static readonly Vector2 CameraProjectionClickWorldCm = new(3200f, 2000f);
     private static readonly Vector2 RoadSelectionWorldCm = new(-9800f, 0f);
     private static readonly Vector2 RoadCommandWorldCm = new(0f, 0f);
@@ -1947,12 +1952,29 @@ public static class LauncherEvidenceRecorder
 
         Entity[] selected = SelectFirstOrderableMassNavigationAgents(runtime.Engine, simulation, MassNavigationSelectionSampleCount);
         Tick(runtime, 3, frameTimesMs);
+        // The flow work area follows command focus, so capture the pre-command center now:
+        // the later crossing order mirrors the first target through this fixed point.
+        Vector2 initialWorkAreaCenter = new(simulation.FlowWorkAreaCenterXCm, simulation.FlowWorkAreaCenterYCm);
         Vector2 commandTarget = new(
-            simulation.FlowWorkAreaCenterXCm + (simulation.SolverWindowWidthCm * 0.34f),
-            simulation.FlowWorkAreaCenterYCm + (simulation.SolverWindowHeightCm * 0.18f));
+            initialWorkAreaCenter.X + (simulation.SolverWindowWidthCm * 0.34f),
+            initialWorkAreaCenter.Y + (simulation.SolverWindowHeightCm * 0.18f));
         SubmitMassNavigationMoveOrder(runtime.Engine, simulation, selected, commandTarget);
-        Tick(runtime, MassNavigationCommandSettleTicks, frameTimesMs);
+        string avoidanceDir = Path.Combine(screensDir, "avoidance");
+        Directory.CreateDirectory(avoidanceDir);
+        var avoidanceMetrics = new List<MassNavigationAvoidanceFrameMetrics>();
+        CaptureMassNavigationAvoidanceSequence(runtime, simulation, commandTarget, avoidanceDir, frameTimesMs, avoidanceMetrics, MassNavigationCommandSettleTicks);
         CaptureMassNavigationSnapshot(runtime, simulation, screensDir, frameTimesMs, timeline, captureFrames, MassNavigationCommandSettleTicks, "001_selection_order", captureImage: true);
+        CaptureMassNavigationAvoidanceSequence(runtime, simulation, commandTarget, avoidanceDir, frameTimesMs, avoidanceMetrics, MassNavigationAvoidanceExtraOrderTicks);
+
+        WaitForMassNavigationCrowdSettle(runtime, simulation, frameTimesMs, minSettledFraction: 0.8f, maxTicks: 1800);
+        // March the commanded group back across the settled central crowd. The crossing target
+        // mirrors the first order target through the pre-command work-area center, scaled down so
+        // the destination-following solver window keeps the whole march inside the active play
+        // area (hard resolve is intentionally skipped outside it).
+        Vector2 crossingTarget = initialWorkAreaCenter - ((commandTarget - initialWorkAreaCenter) * MassNavigationAvoidanceCrossingScale);
+        SubmitMassNavigationMoveOrder(runtime.Engine, simulation, selected, crossingTarget);
+        CaptureMassNavigationAvoidanceSequence(runtime, simulation, crossingTarget, avoidanceDir, frameTimesMs, avoidanceMetrics, MassNavigationAvoidanceCrossingTicks);
+        WriteMassNavigationAvoidanceMetrics(Path.Combine(request.OutputDirectory, "avoidance-metrics.jsonl"), avoidanceMetrics);
 
         Vector2 originalCameraTarget = runtime.Engine.GameSession.Camera.State.TargetCm;
         MassNavigationHotZoneConfig remoteZone = ResolveRemoteHotZone(simulation);
@@ -2128,6 +2150,250 @@ public static class LauncherEvidenceRecorder
         }
 
         simulation.FocusCommandTarget(targetCm, selected);
+    }
+
+    private static void WaitForMassNavigationCrowdSettle(
+        RecordingRuntime runtime,
+        MassNavigationSimulationRuntime simulation,
+        List<double> frameTimesMs,
+        float minSettledFraction,
+        int maxTicks)
+    {
+        MassNavigationFlowSolverState flow = simulation.GetFlowSolverForTests();
+        for (int i = 0; i < maxTicks; i++)
+        {
+            if (flow.UnitCount > 0 && flow.SettledUnitCount >= flow.UnitCount * minSettledFraction)
+            {
+                return;
+            }
+
+            Tick(runtime, 1, frameTimesMs);
+        }
+    }
+
+    private static void CaptureMassNavigationAvoidanceSequence(
+        RecordingRuntime runtime,
+        MassNavigationSimulationRuntime simulation,
+        Vector2 commandTargetCm,
+        string framesDir,
+        List<double> frameTimesMs,
+        List<MassNavigationAvoidanceFrameMetrics> metrics,
+        int tickCount)
+    {
+        for (int i = 0; i < tickCount; i++)
+        {
+            Tick(runtime, 1, frameTimesMs);
+            if (i % MassNavigationAvoidanceFrameIntervalTicks != 0)
+            {
+                continue;
+            }
+
+            CaptureMassNavigationAvoidanceZoomFrame(simulation, commandTargetCm, framesDir, metrics);
+        }
+    }
+
+    private static void CaptureMassNavigationAvoidanceZoomFrame(
+        MassNavigationSimulationRuntime simulation,
+        Vector2 commandTargetCm,
+        string framesDir,
+        List<MassNavigationAvoidanceFrameMetrics> metrics)
+    {
+        MassNavigationFlowSolverState flow = simulation.GetFlowSolverForTests();
+        int unitCount = flow.UnitCount;
+        if (unitCount <= 0)
+        {
+            return;
+        }
+
+        float centroidX = 0f;
+        float centroidY = 0f;
+        int selectedCount = 0;
+        for (int i = 0; i < unitCount; i++)
+        {
+            if (!flow.IsSelected(i))
+            {
+                continue;
+            }
+
+            centroidX += simulation.ToWorldXCm(flow.GetPositionX(i));
+            centroidY += simulation.ToWorldYCm(flow.GetPositionY(i));
+            selectedCount++;
+        }
+
+        if (selectedCount <= 0)
+        {
+            return;
+        }
+
+        centroidX /= selectedCount;
+        centroidY /= selectedCount;
+
+        float zoomWidthCm = MassNavigationAvoidanceZoomWidthCm;
+        float zoomHeightCm = zoomWidthCm * 9f / 16f;
+        float minXCm = centroidX - (zoomWidthCm * 0.5f);
+        float maxXCm = centroidX + (zoomWidthCm * 0.5f);
+        float minYCm = centroidY - (zoomHeightCm * 0.5f);
+        float maxYCm = centroidY + (zoomHeightCm * 0.5f);
+
+        const int imageWidth = 1280;
+        const int imageHeight = 720;
+        float pxPerCm = imageWidth / zoomWidthCm;
+
+        bool IsInsideActiveField(int agentIndex)
+        {
+            float localX = flow.GetPositionX(agentIndex);
+            float localY = flow.GetPositionY(agentIndex);
+            return localX >= flow.PlayAreaMinXCm && localX <= flow.PlayAreaMaxXCm &&
+                localY >= flow.PlayAreaMinYCm && localY <= flow.PlayAreaMaxYCm;
+        }
+
+        var visibleAgents = new List<int>(512);
+        var inFieldAgents = new List<int>(512);
+        for (int i = 0; i < unitCount; i++)
+        {
+            float worldX = simulation.ToWorldXCm(flow.GetPositionX(i));
+            float worldY = simulation.ToWorldYCm(flow.GetPositionY(i));
+            if (worldX >= minXCm && worldX <= maxXCm && worldY >= minYCm && worldY <= maxYCm)
+            {
+                visibleAgents.Add(i);
+                if (IsInsideActiveField(i))
+                {
+                    inFieldAgents.Add(i);
+                }
+            }
+        }
+
+        // Hard resolve intentionally skips agents outside the solver play area
+        // (IsInsideTacticalField), so overlap metrics only cover in-field agents;
+        // out-of-field agents are drawn dimmed to keep the evidence honest.
+        float maxPenetrationCm = 0f;
+        float maxPenetrationRatio = 0f;
+        int deepOverlapPairs = 0;
+        for (int a = 0; a < inFieldAgents.Count; a++)
+        {
+            int i = inFieldAgents[a];
+            float xi = flow.GetPositionX(i);
+            float yi = flow.GetPositionY(i);
+            float ri = flow.GetBodyRadiusCm(i);
+            for (int b = a + 1; b < inFieldAgents.Count; b++)
+            {
+                int j = inFieldAgents[b];
+                float dx = xi - flow.GetPositionX(j);
+                float dy = yi - flow.GetPositionY(j);
+                float minDistance = ri + flow.GetBodyRadiusCm(j);
+                float distanceSq = (dx * dx) + (dy * dy);
+                if (distanceSq >= minDistance * minDistance)
+                {
+                    continue;
+                }
+
+                float penetration = minDistance - MathF.Sqrt(distanceSq);
+                float ratio = penetration / minDistance;
+                maxPenetrationCm = MathF.Max(maxPenetrationCm, penetration);
+                maxPenetrationRatio = MathF.Max(maxPenetrationRatio, ratio);
+                if (ratio > 0.10f)
+                {
+                    deepOverlapPairs++;
+                }
+            }
+        }
+
+        int settledCount = 0;
+        int heavyCount = 0;
+        for (int a = 0; a < inFieldAgents.Count; a++)
+        {
+            int i = inFieldAgents[a];
+            if (flow.IsUnitSettled(i))
+            {
+                settledCount++;
+            }
+
+            if (flow.IsHeavyProfile(i))
+            {
+                heavyCount++;
+            }
+        }
+
+        int frameIndex = metrics.Count;
+        metrics.Add(new MassNavigationAvoidanceFrameMetrics(
+            frameIndex,
+            centroidX,
+            centroidY,
+            visibleAgents.Count,
+            heavyCount,
+            settledCount,
+            maxPenetrationCm,
+            maxPenetrationRatio,
+            deepOverlapPairs));
+
+        using var surface = SKSurface.Create(new SKImageInfo(imageWidth, imageHeight));
+        SKCanvas canvas = surface.Canvas;
+        canvas.Clear(new SKColor(8, 12, 18));
+
+        using var obstaclePaint = new SKPaint { Color = new SKColor(120, 128, 138, 210), IsAntialias = true, Style = SKPaintStyle.Fill };
+        using var heavyRingPaint = new SKPaint { Color = SKColors.White, IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = 2f };
+        using var targetPaint = new SKPaint { Color = new SKColor(255, 92, 92), IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = 3f };
+        using var textPaint = new SKPaint { Color = SKColors.White, IsAntialias = true, TextSize = 22f };
+        using var minorTextPaint = new SKPaint { Color = new SKColor(190, 205, 216), IsAntialias = true, TextSize = 17f };
+
+        float ToScreenX(float worldXCm) => (worldXCm - minXCm) * pxPerCm;
+        float ToScreenY(float worldYCm) => imageHeight - ((worldYCm - minYCm) * pxPerCm);
+
+        for (int i = 0; i < flow.ObstacleCount; i++)
+        {
+            float ox = flow.GetObstacleWorldX(i);
+            float oy = flow.GetObstacleWorldY(i);
+            float radius = flow.GetObstacleRadius(i);
+            if (ox + radius < minXCm || ox - radius > maxXCm || oy + radius < minYCm || oy - radius > maxYCm)
+            {
+                continue;
+            }
+
+            canvas.DrawCircle(ToScreenX(ox), ToScreenY(oy), radius * pxPerCm, obstaclePaint);
+        }
+
+        for (int a = 0; a < visibleAgents.Count; a++)
+        {
+            int i = visibleAgents[a];
+            float worldX = simulation.ToWorldXCm(flow.GetPositionX(i));
+            float worldY = simulation.ToWorldYCm(flow.GetPositionY(i));
+            float radiusPx = MathF.Max(1.5f, flow.GetBodyRadiusCm(i) * pxPerCm);
+            bool inField = IsInsideActiveField(i);
+            SKColor teamColor = ResolveMassNavigationTeamColor(flow.GetTeam(i));
+            using var agentPaint = new SKPaint { Color = teamColor.WithAlpha(inField ? (byte)220 : (byte)70), IsAntialias = true, Style = SKPaintStyle.Fill };
+            float screenX = ToScreenX(worldX);
+            float screenY = ToScreenY(worldY);
+            canvas.DrawCircle(screenX, screenY, radiusPx, agentPaint);
+            if (inField && flow.IsHeavyProfile(i))
+            {
+                canvas.DrawCircle(screenX, screenY, radiusPx + 1.5f, heavyRingPaint);
+            }
+        }
+
+        if (commandTargetCm.X >= minXCm && commandTargetCm.X <= maxXCm && commandTargetCm.Y >= minYCm && commandTargetCm.Y <= maxYCm)
+        {
+            DrawCrosshair(canvas, new SKPoint(ToScreenX(commandTargetCm.X), ToScreenY(commandTargetCm.Y)), 14f, targetPaint);
+        }
+
+        canvas.DrawText($"MassNavigation avoidance zoom | frame={frameIndex:D4} | window {zoomWidthCm:F0}x{zoomHeightCm:F0} cm @ ({centroidX:F0}, {centroidY:F0})", 24, 34, textPaint);
+        canvas.DrawText($"Agents={visibleAgents.Count} heavy(ringed)={heavyCount} settled={settledCount} | circles are true bodyRadiusCm", 24, 62, minorTextPaint);
+        canvas.DrawText($"maxPenetration={maxPenetrationCm:F1}cm ({maxPenetrationRatio:P1} of pair radius) deepOverlapPairs(>10%)={deepOverlapPairs}", 24, 86, minorTextPaint);
+
+        using SKImage image = surface.Snapshot();
+        using SKData data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using FileStream stream = File.Open(Path.Combine(framesDir, $"frame_{frameIndex:D4}.png"), FileMode.Create, FileAccess.Write, FileShare.None);
+        data.SaveTo(stream);
+    }
+
+    private static void WriteMassNavigationAvoidanceMetrics(string path, IReadOnlyList<MassNavigationAvoidanceFrameMetrics> metrics)
+    {
+        var sb = new StringBuilder();
+        for (int i = 0; i < metrics.Count; i++)
+        {
+            sb.AppendLine(JsonSerializer.Serialize(metrics[i]));
+        }
+
+        File.WriteAllText(path, sb.ToString());
     }
 
     private static MassNavigationHotZoneConfig ResolveRemoteHotZone(MassNavigationSimulationRuntime simulation)
@@ -2995,6 +3261,17 @@ public static class LauncherEvidenceRecorder
     private readonly record struct MassNavigationAgentSample(
         int TeamId,
         Vector2 WorldCm);
+
+    private readonly record struct MassNavigationAvoidanceFrameMetrics(
+        int FrameIndex,
+        float WindowCenterXCm,
+        float WindowCenterYCm,
+        int VisibleAgentCount,
+        int HeavyAgentCount,
+        int SettledAgentCount,
+        float MaxPenetrationCm,
+        float MaxPenetrationRatio,
+        int DeepOverlapPairCount);
 
     private readonly record struct MassNavigationSnapshot(
         int Tick,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# MassNav 审计修复 + 不同 size 避障证据链路

## 背景

审计发现 `8ecf927f1`（fix(core): preserve relationship state and arrival stops）为了解决"agent 到位后抖动"在 `StepRange` 中给定居 agent 加了提前 `continue`，副作用是定居 agent 同时跳过了 hard-resolve 候选标记——重叠的定居 agent 再也不会被硬解算分开（避让失效）。两个既有契约测试在该提交处由绿转红（已双向 bisect 验证）。

## 修复内容

### P0 回归修复（`MassNavigationFlowSolverState`）
- 定居 agent 的"钉位"逻辑移到分离扫描/障碍扫描**之后**：保留到位后不抖动的效果，同时保留 hard-resolve 候选标记，身体重叠仍会被 `ResolveHardPenetration` 分开，并可通过 arrival-recovery 唤醒阈值重新激活。
- `MassNavigationFlowCrowdCost_UsesAgentLayerWorldsInsteadOfTeamWideLayerUnion` 与 `MassNavigationFlowHardResolve_SeparatesLargeAgentsByConfiguredBodyRadius` 恢复通过；该提交新增的 `Runtime_PerAgentWorldTargetLocksVelocityAfterArrival`（锁定不抖动行为）同样保持通过。

### P0 并行数据竞争修复（`MassNavigationFlowSolverArrivalRecovery`）
- `EnterSettledState → EnqueueArrivalEvent` 曾在并行 step job 内对共享 `_arrivalEventCount++` 做非原子写（出厂配置 8 worker / 10k agents 实际走并行路径）。事件入队移至 join 后单线程的 `UpdateSettledUnitCount` 扫描；`EnterSettledState` 只写 per-agent 槽位。新增并行步进到达事件回归测试。

### P1 陈旧测试修复
- `Physics2DPipelineTests`：nav 域统一已移除 `NavToPhysicsVelocitySync`，断言未同步更新导致 main 上必失败（CI 未跑全量 GasTests 所以没人发现）。已更新步骤清单与索引。

### P2 SSOT / 硬编码
- `StampCrowdCost` 的 `8f/3f` 魔数提升为 `semantics.solver.crowdStampCenterCost/crowdStampNeighborCost` 配置（含校验与 JSON schema 必填项）。
- `ComputeFlow` 不再挪用 `entitySyncVelocityEpsilonSq` 做障碍物距离 epsilon，改用 `normalizationEpsilonSq`。

### 证据链路增强（`LauncherEvidenceRecorder`）
- MassNavigation 大世界 UAT 增加"避障 zoom"帧序列：按真实 bodyRadiusCm 绘制 agent（heavy 白圈标注、活跃场外 agent 降透明度），指令组到达并等待全场定居后，再下发一道穿越已定居人群的指令，逐帧输出 PNG + 每帧重叠穿透指标（`avoidance-metrics.jsonl`，只统计 hard-resolve 覆盖的场内 agent）。
- Web 宿主：游戏循环 Task 异常不再被静默吞掉（此前 massnav 在 web adapter 下循环崩溃但 HTTP 照常服务，客户端只看到 Entities: 0）。

## 证据

[massnav_mixed_size_group_crossing_settled_crowd.mp4](https://cursor.com/agents/bc-d3a1eded-f374-4079-bd90-eddccd0c7f6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmassnav_mixed_size_group_crossing_settled_crowd.mp4)

128 个混合 size（heavy 28cm 白圈 / light 20cm）指令组穿越已定居的敌方点阵：双方互相让行、瞬时接触逐帧消解（deepOverlapPairs 91→0），最终在目标点整齐停驻。视频审查确认"运动平滑、尺寸可辨、无堆叠"。

[massnav_10k_march_arrival_and_crossing.mp4](https://cursor.com/agents/bc-d3a1eded-f374-4079-bd90-eddccd0c7f6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmassnav_10k_march_arrival_and_crossing.mp4)

全程：10k agents 四队行军（瞬时拥挤 7000 对重叠随硬解算衰减至 ~160）→ 指令组到达 → 全场定居 → 穿越演示。

[混合 size 编队穿越定居点阵](https://cursor.com/agents/bc-d3a1eded-f374-4079-bd90-eddccd0c7f6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmassnav_crossing_weaving_through_settled_lattice.png)
[官方 UAT 时间线（10k agents，验收通过）](https://cursor.com/agents/bc-d3a1eded-f374-4079-bd90-eddccd0c7f6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmassnav_uat_timeline_final.png)

官方 UAT 验收签名：`mass_navigation_large_world|agents:10000|teams:4|performers:30009|markers:10009/0`（`launch $capability_standard_mass_navigation_large_world_10k --record` 全绿退出）。

## 测试

- ✅ `dotnet test PresentationTests --filter FullyQualifiedName~MassNavigation`（111/111，含 2 个回归恢复 + 1 个新并行到达事件测试）
- ✅ `dotnet test PresentationTests --filter FullyQualifiedName~FormationCapabilityShowcaseContractTests`（72/72）
- ✅ `dotnet test GasTests --filter Physics2DPipelineTests|Physics2DIntegrationTests`（15/15）
- ✅ `dotnet test GasTests --filter ArchitectureGuardTests`（35/35，CI 门禁切片）
- ✅ `dotnet test ArchitectureTests --filter LauncherBootstrapContractTests|NavigationObstacleAuthoringContractTests`
- ✅ PresentationTests 全量对比：分支 37 失败 == main 39 失败去掉本 PR 修复的 2 个，无新增失败
- ✅ 证据录制端到端跑通（headless raylib runtime，云 VM）

## 遗留发现（未在本 PR 处理）

- 大世界活跃场边界处会形成场外 agent 堆（hard resolve 按设计跳过场外 agent + 队伍 slot 网格被边界裁剪），建议后续 issue 跟进 slot 分布应约束在活跃场内。
- main 全量 GasTests/PresentationTests 仍红、CI 仅守护切片、`FogBenchmarkTests` 性能阈值在共享 runner 上 flaky。
- #522–#525 的输入/选择镜像整改分支仍未合入 main。

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3a1eded-f374-4079-bd90-eddccd0c7f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3a1eded-f374-4079-bd90-eddccd0c7f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

