### PR TITLE
Fix PR595 capability showcase architecture

### DIFF
--- a/mods/capabilities/navigation/MassNavigationMod/assets/Configs/config_catalog.json
+++ b/mods/capabilities/navigation/MassNavigationMod/assets/Configs/config_catalog.json
@@ -3,5 +3,6 @@
   { "Path": "Presentation/animator_controllers.json", "Policy": "ArrayById", "IdField": "id" },
   { "Path": "Presentation/animation_clips.json", "Policy": "ArrayById", "IdField": "id" },
   { "Path": "Presentation/animation_profiles.json", "Policy": "ArrayById", "IdField": "id" },
+  { "Path": "Presentation/host_assets.json", "Policy": "ArrayById", "IdField": "id" },
   { "Path": "Camera/virtual_cameras.json", "Policy": "ArrayById", "IdField": "id" }
 ]

--- a/mods/capabilities/navigation/MassNavigationMod/assets/Entities/templates.json
+++ b/mods/capabilities/navigation/MassNavigationMod/assets/Entities/templates.json
@@ -1,5 +1,13 @@
 [
   {
+    "id": "mass_navigation_player_team",
+    "components": {
+      "Name": {
+        "Value": "MassNavigation.PlayerTeam"
+      }
+    }
+  },
+  {
     "id": "mass_navigation_local_player",
     "components": {
       "Name": {

--- a/mods/capabilities/navigation/MassNavigationMod/assets/Maps/mass_navigation.json
+++ b/mods/capabilities/navigation/MassNavigationMod/assets/Maps/mass_navigation.json
@@ -25,6 +25,11 @@
   ],
   "Entities": [
     {
+      "InstanceId": "player_team",
+      "Template": "mass_navigation_player_team"
+    },
+    {
+      "InstanceId": "local_player",
       "Template": "mass_navigation_local_player"
     },
     {
@@ -131,6 +136,19 @@
           "localOffsetYCm": 0
         }
       }
+    }
+  ],
+  "Teams": [
+    {
+      "TeamId": 1,
+      "RepresentativeInstanceId": "player_team"
+    }
+  ],
+  "Players": [
+    {
+      "PlayerId": 1,
+      "TeamId": 1,
+      "RepresentativeInstanceId": "local_player"
     }
   ]
 }

--- a/mods/capabilities/navigation/MassNavigationMod/assets/MassNavigationConfig.json
+++ b/mods/capabilities/navigation/MassNavigationMod/assets/MassNavigationConfig.json
@@ -135,15 +135,15 @@
   },
   "scenarioRuntime": {
     "autoSpawnConfiguredScenario": true,
-    "initialSelectionScratchCapacity": 256,
-    "initialSelectedEntityCapacity": 128,
+    "initialSelectionScratchCapacity": 10000,
+    "initialSelectedEntityCapacity": 10000,
     "runtimeCapacity": {
       "navigationGroupCapacity": 256,
       "groupMembershipAgentCapacity": 160000,
-      "selectionMemberScratchCapacity": 256,
-      "groupMemberCapacity": 256,
+      "selectionMemberScratchCapacity": 10000,
+      "groupMemberCapacity": 10000,
       "orderIngestionTokenCapacity": 256,
-      "orderIngestionMemberCapacity": 256,
+      "orderIngestionMemberCapacity": 10000,
       "loadedChunkCapacity": 256,
       "metadataTeamCapacity": 4
     }

--- a/mods/capabilities/navigation/MassNavigationMod/assets/MassNavigationConfig.json
+++ b/mods/capabilities/navigation/MassNavigationMod/assets/MassNavigationConfig.json
@@ -313,6 +313,8 @@
       "flowObstacleNeighborRadiusCells": 4,
       "flowObstacleNeighborWeight": 5,
       "flowObstacleAvoidanceWeight": 1.5,
+      "crowdStampCenterCost": 8,
+      "crowdStampNeighborCost": 3,
       "coincidentPairHashBucketCount": 1024,
       "coincidentPairHashPrimeA": 73856093,
       "coincidentPairHashPrimeB": 19349663

--- a/mods/showcases/capability_standard/CapabilityStandardMassNavigationLargeWorld10kMod/CapabilityStandardMassNavigationLargeWorld10kMapFocus.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardMassNavigationLargeWorld10kMod/CapabilityStandardMassNavigationLargeWorld10kMapFocus.cs
@@ -1,0 +1,19 @@
+using System;
+using Ludots.Core.Engine;
+
+namespace CapabilityStandardMassNavigationLargeWorld10kMod;
+
+internal static class CapabilityStandardMassNavigationLargeWorld10kMapFocus
+{
+    public static bool IsStartupMapFocused(GameEngine engine)
+    {
+        ArgumentNullException.ThrowIfNull(engine);
+
+        string? startupMapId = engine.MergedConfig?.StartupMapId;
+        return !string.IsNullOrWhiteSpace(startupMapId) &&
+               string.Equals(
+                   engine.CurrentMapSession?.MapId.Value,
+                   startupMapId,
+                   StringComparison.Ordinal);
+    }
+}

--- a/mods/showcases/capability_standard/CapabilityStandardMassNavigationLargeWorld10kMod/CapabilityStandardMassNavigationLargeWorld10kModEntry.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardMassNavigationLargeWorld10kMod/CapabilityStandardMassNavigationLargeWorld10kModEntry.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using CapabilityStandardMassNavigationLargeWorld10kMod.Systems;
 using Ludots.Core.Engine;
 using Ludots.Core.Modding;
 using Ludots.Core.Presentation.Minimap;
@@ -9,22 +10,33 @@ namespace CapabilityStandardMassNavigationLargeWorld10kMod;
 
 public sealed class CapabilityStandardMassNavigationLargeWorld10kModEntry : IMod
 {
+    private const string ObserverVisibilitySystemInstalledKey =
+        "CapabilityStandardMassNavigationLargeWorld10k.ObserverVisibilitySystemInstalled";
+
     public void OnLoad(IModContext context)
     {
         context.Log("[CapabilityStandardMassNavigationLargeWorld10kMod] Loaded");
-        context.OnEvent(GameEvents.GameStart, ConfigureLargeWorldUatAsync);
-        context.OnEvent(GameEvents.MapLoaded, ConfigureLargeWorldUatAsync);
-        context.OnEvent(GameEvents.MapResumed, ConfigureLargeWorldUatAsync);
+        context.OnEvent(GameEvents.GameStart, ConfigureLargeWorldShowcaseAsync);
+        context.OnEvent(GameEvents.MapLoaded, ConfigureLargeWorldShowcaseAsync);
+        context.OnEvent(GameEvents.MapResumed, ConfigureLargeWorldShowcaseAsync);
     }
 
     public void OnUnload()
     {
     }
 
-    private static Task ConfigureLargeWorldUatAsync(ScriptContext context)
+    private static Task ConfigureLargeWorldShowcaseAsync(ScriptContext context)
     {
         GameEngine? engine = context.GetEngine();
-        if (engine == null || !IsStartupMapFocused(engine))
+        if (engine == null)
+        {
+            return Task.CompletedTask;
+        }
+
+        EnsureObserverVisibilitySystem(engine);
+        bool mapFocused = CapabilityStandardMassNavigationLargeWorld10kMapFocus.IsStartupMapFocused(engine);
+        engine.SetService(CoreServiceKeys.PresentationAudienceRevealHidden, mapFocused);
+        if (!mapFocused)
         {
             return Task.CompletedTask;
         }
@@ -40,13 +52,16 @@ public sealed class CapabilityStandardMassNavigationLargeWorld10kModEntry : IMod
         return Task.CompletedTask;
     }
 
-    private static bool IsStartupMapFocused(GameEngine engine)
+    private static void EnsureObserverVisibilitySystem(GameEngine engine)
     {
-        string? startupMapId = engine.MergedConfig?.StartupMapId;
-        return !string.IsNullOrWhiteSpace(startupMapId) &&
-               string.Equals(
-                   engine.CurrentMapSession?.MapId.Value,
-                   startupMapId,
-                   StringComparison.Ordinal);
+        if (engine.GlobalContext.ContainsKey(ObserverVisibilitySystemInstalledKey))
+        {
+            return;
+        }
+
+        engine.RegisterSystem(
+            new MassNavigationObserverVisibilityBindingSystem(engine),
+            SystemGroup.RuntimeEntityBinding);
+        engine.GlobalContext[ObserverVisibilitySystemInstalledKey] = true;
     }
 }

--- a/mods/showcases/capability_standard/CapabilityStandardMassNavigationLargeWorld10kMod/Systems/MassNavigationObserverVisibilityBindingSystem.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardMassNavigationLargeWorld10kMod/Systems/MassNavigationObserverVisibilityBindingSystem.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Runtime.CompilerServices;
+using Arch.Core;
+using Arch.System;
+using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.Components;
+using Ludots.Core.Knowledge;
+using Ludots.Core.MassNavigation;
+using Ludots.Core.MassNavigation.Runtime;
+using Ludots.Core.Presentation.Components;
+using Ludots.Core.Presentation.Performers;
+using Ludots.Core.Scripting;
+
+namespace CapabilityStandardMassNavigationLargeWorld10kMod.Systems;
+
+internal sealed class MassNavigationObserverVisibilityBindingSystem : BaseSystem<World, float>
+{
+    private const int LiveKnowledgeConfidencePermille = 1000;
+
+    private static readonly QueryDescription AgentQuery = new QueryDescription()
+        .WithAll<MassNavigationAgent, MassNavigationAgentIndex, Team>()
+        .WithNone<PresentationDestroyPending>();
+
+    private readonly GameEngine _engine;
+    private Entity _publishedViewer = Entity.Null;
+    private int _publishedStructuralRevision = -1;
+    private int _publishedPerformerDefinitionVersion = -1;
+    private KnowledgeIdMask256 _publishedAttributeMask;
+
+    public MassNavigationObserverVisibilityBindingSystem(GameEngine engine)
+        : base(engine?.World ?? throw new ArgumentNullException(nameof(engine)))
+    {
+        _engine = engine;
+    }
+
+    public override void Update(in float dt)
+    {
+        if (!CapabilityStandardMassNavigationLargeWorld10kMapFocus.IsStartupMapFocused(_engine) ||
+            !MassNavigationIds.IsCurrentNavigationRuntimeReady(_engine) ||
+            _engine.GetService(MassNavigationKeys.SimulationRuntime) is not MassNavigationSimulationRuntime simulation ||
+            _engine.GetService(CoreServiceKeys.KnowledgeProjectionStore) is not KnowledgeProjectionStore knowledge ||
+            _engine.GetService(CoreServiceKeys.PerformerDefinitionRegistry) is not PerformerDefinitionRegistry performers ||
+            !TryResolveViewer(out Entity viewer))
+        {
+            return;
+        }
+
+        int expectedAgentCount = ResolveExpectedAgentCount(simulation);
+        if (expectedAgentCount <= 0 || simulation.AgentState.TotalAgents < expectedAgentCount)
+        {
+            return;
+        }
+
+        KnowledgeIdMask256 attributeMask = ResolveHudAttributeMask(simulation, performers);
+        if (_publishedViewer == viewer &&
+            _publishedStructuralRevision == simulation.StructuralChangeRevision &&
+            _publishedPerformerDefinitionVersion == performers.Version &&
+            _publishedAttributeMask == attributeMask)
+        {
+            return;
+        }
+
+        int observedTick = KnowledgeProjectionConsumer.ResolveCurrentTick(_engine.GlobalContext);
+        var emptyMask = KnowledgeIdMask256.Empty;
+        var record = new KnowledgeDisclosureRecord(
+            KnowledgePresence.LiveVisible,
+            KnowledgePositionAccess.Live,
+            attributeMask,
+            emptyMask,
+            emptyMask,
+            viewer,
+            observedTick,
+            expiryTick: 0,
+            confidencePermille: LiveKnowledgeConfidencePermille,
+            revision: 0);
+
+        int published = PublishAgentKnowledge(knowledge, viewer, in record);
+        if (published < expectedAgentCount)
+        {
+            return;
+        }
+
+        _publishedViewer = viewer;
+        _publishedStructuralRevision = simulation.StructuralChangeRevision;
+        _publishedPerformerDefinitionVersion = performers.Version;
+        _publishedAttributeMask = attributeMask;
+    }
+
+    private bool TryResolveViewer(out Entity viewer)
+    {
+        Entity candidate = _engine.GetService(CoreServiceKeys.LocalPlayerEntity);
+        viewer = candidate;
+        return candidate != Entity.Null &&
+               World.IsAlive(candidate) &&
+               viewer != Entity.Null;
+    }
+
+    private static int ResolveExpectedAgentCount(MassNavigationSimulationRuntime simulation)
+    {
+        return checked(simulation.Config.Scenario.Teams.Length * simulation.Config.Scenario.AgentsPerTeam);
+    }
+
+    private static KnowledgeIdMask256 ResolveHudAttributeMask(
+        MassNavigationSimulationRuntime simulation,
+        PerformerDefinitionRegistry performers)
+    {
+        KnowledgeIdMask256 mask = KnowledgeIdMask256.Empty;
+        ReadOnlySpan<int> teamIds = simulation.TeamIds;
+        for (int i = 0; i < teamIds.Length; i++)
+        {
+            int teamId = teamIds[i];
+            mask = mask.Union(ResolveHudAttributeMask(
+                performers,
+                simulation.Config.Presentation.ResolveAgentPerformerId(teamId, heavy: false)));
+            mask = mask.Union(ResolveHudAttributeMask(
+                performers,
+                simulation.Config.Presentation.ResolveAgentPerformerId(teamId, heavy: true)));
+        }
+
+        return mask;
+    }
+
+    private static KnowledgeIdMask256 ResolveHudAttributeMask(
+        PerformerDefinitionRegistry performers,
+        string performerKey)
+    {
+        int definitionId = performers.GetId(performerKey);
+        if (definitionId <= 0 || !performers.TryGet(definitionId, out PerformerDefinition definition))
+        {
+            throw new InvalidOperationException(
+                $"MassNavigation observer visibility requires performer definition '{performerKey}'.");
+        }
+
+        return ResolveHudAttributeMask(performers, definition);
+    }
+
+    private static KnowledgeIdMask256 ResolveHudAttributeMask(
+        PerformerDefinitionRegistry performers,
+        PerformerDefinition definition)
+    {
+        KnowledgeIdMask256 mask = HasHudAssetBinding(definition)
+            ? BuildMask(definition.RequiredAttributeIds)
+            : KnowledgeIdMask256.Empty;
+
+        ChildPerformerRef[] children = definition.Children;
+        for (int i = 0; i < children.Length; i++)
+        {
+            int childDefinitionId = children[i].DefinitionId;
+            if (childDefinitionId <= 0 || !performers.TryGet(childDefinitionId, out PerformerDefinition child))
+            {
+                throw new InvalidOperationException(
+                    $"MassNavigation observer visibility requires child performer definition id {childDefinitionId}.");
+            }
+
+            mask = mask.Union(ResolveHudAttributeMask(performers, child));
+        }
+
+        return mask;
+    }
+
+    private static bool HasHudAssetBinding(PerformerDefinition definition)
+    {
+        BehaviorSlot[] behaviors = definition.Behaviors;
+        for (int i = 0; i < behaviors.Length; i++)
+        {
+            if (behaviors[i].Kind == BehaviorKind.AssetBinding &&
+                behaviors[i].AssetBinding.AssetKind is AssetKind.WorldHud or AssetKind.WorldText)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static KnowledgeIdMask256 BuildMask(ReadOnlySpan<int> attributeIds)
+    {
+        KnowledgeIdMask256 mask = KnowledgeIdMask256.Empty;
+        for (int i = 0; i < attributeIds.Length; i++)
+        {
+            mask = mask.WithId(attributeIds[i]);
+        }
+
+        return mask;
+    }
+
+    private int PublishAgentKnowledge(
+        KnowledgeProjectionStore knowledge,
+        Entity viewer,
+        in KnowledgeDisclosureRecord record)
+    {
+        int published = 0;
+        foreach (ref var chunk in World.Query(in AgentQuery))
+        {
+            ref Entity firstEntity = ref chunk.Entity(0);
+            foreach (int index in chunk)
+            {
+                Entity target = Unsafe.Add(ref firstEntity, index);
+                knowledge.Upsert(viewer, target, in record);
+                published++;
+            }
+        }
+
+        return published;
+    }
+}

--- a/mods/showcases/capability_standard/CapabilityStandardMassNavigationLargeWorld10kMod/assets/Configs/config_catalog.json
+++ b/mods/showcases/capability_standard/CapabilityStandardMassNavigationLargeWorld10kMod/assets/Configs/config_catalog.json
@@ -1,1 +1,3 @@
-[]
+[
+  { "Path": "Entities/templates.json", "Policy": "ArrayById", "IdField": "id" }
+]

--- a/mods/showcases/capability_standard/CapabilityStandardMassNavigationLargeWorld10kMod/assets/Entities/templates.json
+++ b/mods/showcases/capability_standard/CapabilityStandardMassNavigationLargeWorld10kMod/assets/Entities/templates.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "mass_navigation_agent_azure_light",
+    "onSpawnEffect": null
+  },
+  {
+    "id": "mass_navigation_agent_azure_heavy",
+    "onSpawnEffect": null
+  },
+  {
+    "id": "mass_navigation_agent_crimson_light",
+    "onSpawnEffect": null
+  },
+  {
+    "id": "mass_navigation_agent_crimson_heavy",
+    "onSpawnEffect": null
+  },
+  {
+    "id": "mass_navigation_agent_amber_light",
+    "onSpawnEffect": null
+  },
+  {
+    "id": "mass_navigation_agent_amber_heavy",
+    "onSpawnEffect": null
+  },
+  {
+    "id": "mass_navigation_agent_emerald_light",
+    "onSpawnEffect": null
+  },
+  {
+    "id": "mass_navigation_agent_emerald_heavy",
+    "onSpawnEffect": null
+  }
+]

--- a/mods/showcases/capability_standard/CapabilityStandardMassNavigationLargeWorld10kMod/assets/Maps/mass_navigation.json
+++ b/mods/showcases/capability_standard/CapabilityStandardMassNavigationLargeWorld10kMod/assets/Maps/mass_navigation.json
@@ -1,0 +1,12 @@
+{
+  "Id": "mass_navigation",
+  "DefaultCamera": {
+    "VirtualCameraId": "MassNavigation.Camera.LargeWorldHeightmap",
+    "TargetXCm": 0,
+    "TargetYCm": 0,
+    "Yaw": 45,
+    "Pitch": 42,
+    "DistanceCm": 14000,
+    "FovYDeg": 60
+  }
+}

--- a/mods/showcases/capability_standard/CapabilityStandardMassNavigationLargeWorld10kMod/assets/game.json
+++ b/mods/showcases/capability_standard/CapabilityStandardMassNavigationLargeWorld10kMod/assets/game.json
@@ -1,10 +1,12 @@
 {
   "startupMapId": "mass_navigation",
+  "startupSelectedPlayerId": 1,
   "windowTitle": "Ludots Engine - Capability Standard Mass Navigation Large World 10K",
   "targetFps": 0,
   "worldWidthInMacroTiles": 250,
   "worldHeightInMacroTiles": 250,
   "selection": {
+    "targetFilter": { "relationFilter": "Friendly" },
     "movePathPreviewOrderTypeKeys": [ "massNavigationMove" ]
   },
   "presentation": {
@@ -31,7 +33,7 @@
       "lowLodDistanceCm": 20000.0
     },
     "minimap": {
-      "initialZoomNormalized": 1.0,
+      "initialZoomNormalized": 0.12,
       "wheelZoomNormalizedStep": 0.08,
       "buttonZoomNormalizedStep": 0.18,
       "zoomSliderEnabled": true,

--- a/mods/showcases/capability_standard/CapabilityStandardParticipantViewsMod/assets/Maps/capability_standard_participant_views.json
+++ b/mods/showcases/capability_standard/CapabilityStandardParticipantViewsMod/assets/Maps/capability_standard_participant_views.json
@@ -5,6 +5,15 @@
     "capability_standard_participant_views",
     "capability.participant_view"
   ],
+  "DefaultCamera": {
+    "VirtualCameraId": "MassNavigation.Camera.LargeWorldHeightmap",
+    "TargetXCm": 250,
+    "TargetYCm": 350,
+    "Yaw": 45,
+    "Pitch": 42,
+    "DistanceCm": 12000,
+    "FovYDeg": 55
+  },
   "Metadata": {
     "participantViewKnowledge": {
       "Projections": [],

--- a/mods/showcases/formation_capability/FormationCapabilityShowcaseMod/assets/game.json
+++ b/mods/showcases/formation_capability/FormationCapabilityShowcaseMod/assets/game.json
@@ -32,6 +32,11 @@
     "minimapMarkerCapacity": 131072,
     "runtimeEntitySpawnQueueCapacity": 131072,
     "runtimeEntitySpawnReceiptQueueCapacity": 131072,
+    "runtimeEntityLifecycleQueueCapacity": 131072,
+    "runtimeEntityLifecycleReceiptQueueCapacity": 131072,
+    "globalFieldVisualRecordCapacity": 256,
+    "globalFieldVisualCellCapacity": 262144,
+    "globalFieldVisualDirtyRectCapacity": 4096,
     "minimap": {
       "initialZoomNormalized": 1.0,
       "wheelZoomNormalizedStep": 0.08,

--- a/mods/showcases/formation_capability/FormationCapabilityShowcaseMod/mod.json
+++ b/mods/showcases/formation_capability/FormationCapabilityShowcaseMod/mod.json
@@ -4,7 +4,11 @@
   "description": "Direct launcher entry for the Formation Capability Showcase movement showcase.",
   "main": "bin/net8.0/FormationCapabilityShowcaseMod.dll",
   "priority": -2000,
-  "dependencies": {},
+  "dependencies": {
+    "LudotsCoreMod": "^1.0.0",
+    "CoreInputMod": "^1.0.0",
+    "CameraProfilesMod": "^1.0.0"
+  },
   "author": "OpenAI Codex",
   "tags": ["navigation", "mass-navigation", "formation-capability", "showcase"]
 }

--- a/src/Adapters/Web/Ludots.Adapter.Web/WebHostComposer.cs
+++ b/src/Adapters/Web/Ludots.Adapter.Web/WebHostComposer.cs
@@ -24,7 +24,8 @@ namespace Ludots.Adapter.Web
         WebViewController ViewController,
         WebCameraAdapter CameraAdapter,
         WebUiRuntimeBridge UiBridge,
-        WebTransportLayer Transport
+        WebTransportLayer Transport,
+        WebHostLoopStatus LoopStatus
     );
 
     public static class WebHostComposer
@@ -83,6 +84,7 @@ namespace Ludots.Adapter.Web
             inputBackend.SyncNeutralViewport((int)viewController.Resolution.X, (int)viewController.Resolution.Y);
             var uiBridge = new WebUiRuntimeBridge(uiRoot, inputBackend, viewController);
             var transport = new WebTransportLayer(inputBackend, viewController);
+            var loopStatus = new WebHostLoopStatus();
 
             ValidateRequiredContextBeforeStart(engine);
 
@@ -94,7 +96,8 @@ namespace Ludots.Adapter.Web
                 viewController,
                 cameraAdapter,
                 uiBridge,
-                transport);
+                transport,
+                loopStatus);
         }
 
         private static void ValidateRequiredContextBeforeStart(GameEngine engine)

--- a/src/Adapters/Web/Ludots.Adapter.Web/WebHostLoop.cs
+++ b/src/Adapters/Web/Ludots.Adapter.Web/WebHostLoop.cs
@@ -93,6 +93,7 @@ namespace Ludots.Adapter.Web
 
             BuildAndSendMeshMap(engine, setup.Transport);
 
+            setup.LoopStatus.MarkStarted();
             Log.Info(in LogChannel, $"Web host loop started (target {targetFps} fps, map={config.StartupMapId})");
 
             var sw = Stopwatch.StartNew();
@@ -149,12 +150,19 @@ namespace Ludots.Adapter.Web
                     }
                     catch (Exception ex)
                     {
+                        setup.LoopStatus.MarkFaulted(ex);
                         Log.Error(in LogChannel, $"Unhandled exception in game loop: {ex}");
+                        throw;
                     }
                 }
             }
             finally
             {
+                if (!setup.LoopStatus.IsFaulted)
+                {
+                    setup.LoopStatus.MarkStopped();
+                }
+
                 engine.Stop();
                 setup.Transport.Dispose();
                 Log.Info(in LogChannel, "Web host loop stopped.");

--- a/src/Adapters/Web/Ludots.Adapter.Web/WebHostLoopStatus.cs
+++ b/src/Adapters/Web/Ludots.Adapter.Web/WebHostLoopStatus.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Threading;
+
+namespace Ludots.Adapter.Web
+{
+    public sealed class WebHostLoopStatus
+    {
+        public const string RunningStatus = "ok";
+        public const string FaultedStatus = "faulted";
+        public const string StoppedStatus = "stopped";
+
+        private Exception? _fault;
+        private long _running;
+
+        public bool IsRunning => Interlocked.Read(ref _running) != 0;
+        public Exception? Fault => Volatile.Read(ref _fault);
+        public bool IsFaulted => Fault != null;
+
+        public WebHostLoopHealthSnapshot CaptureHealthSnapshot()
+        {
+            Exception? fault = Fault;
+            bool running = IsRunning;
+            bool healthy = fault == null && running;
+            return new WebHostLoopHealthSnapshot(
+                Status: fault != null ? FaultedStatus : running ? RunningStatus : StoppedStatus,
+                Healthy: healthy,
+                Running: running,
+                Faulted: fault != null,
+                FaultType: fault?.GetType().FullName,
+                FaultMessage: fault?.Message);
+        }
+
+        public void MarkStarted()
+        {
+            Volatile.Write(ref _fault, null);
+            Interlocked.Exchange(ref _running, 1);
+        }
+
+        public void MarkFaulted(Exception exception)
+        {
+            ArgumentNullException.ThrowIfNull(exception);
+            Volatile.Write(ref _fault, exception);
+            Interlocked.Exchange(ref _running, 0);
+        }
+
+        public void MarkStopped()
+        {
+            Interlocked.Exchange(ref _running, 0);
+        }
+    }
+
+    public readonly record struct WebHostLoopHealthSnapshot(
+        string Status,
+        bool Healthy,
+        bool Running,
+        bool Faulted,
+        string? FaultType,
+        string? FaultMessage);
+}

--- a/src/Apps/Web/Ludots.App.Web/Program.cs
+++ b/src/Apps/Web/Ludots.App.Web/Program.cs
@@ -13,6 +13,10 @@ var setup = gameHost.Setup;
 
 var cts = new CancellationTokenSource();
 var gameLoopTask = Task.Run(() => gameHost.Run(cts.Token));
+// The web host keeps serving HTTP if the loop dies; without this the fault is silently swallowed.
+gameLoopTask.ContinueWith(
+    t => Console.Error.WriteLine($"[GameLoop FAULTED] {t.Exception}"),
+    TaskContinuationOptions.OnlyOnFaulted);
 
 app.UseWebSockets();
 

--- a/src/Apps/Web/Ludots.App.Web/Program.cs
+++ b/src/Apps/Web/Ludots.App.Web/Program.cs
@@ -13,10 +13,17 @@ var setup = gameHost.Setup;
 
 var cts = new CancellationTokenSource();
 var gameLoopTask = Task.Run(() => gameHost.Run(cts.Token));
-// The web host keeps serving HTTP if the loop dies; without this the fault is silently swallowed.
-gameLoopTask.ContinueWith(
-    t => Console.Error.WriteLine($"[GameLoop FAULTED] {t.Exception}"),
-    TaskContinuationOptions.OnlyOnFaulted);
+_ = gameLoopTask.ContinueWith(
+    t =>
+    {
+        Exception? taskFault = t.Exception?.GetBaseException() ?? t.Exception;
+        Exception fault = taskFault ?? new InvalidOperationException("Web game loop faulted without exception details.");
+        setup.LoopStatus.MarkFaulted(fault);
+        Console.Error.WriteLine($"[GameLoop FAULTED] {t.Exception}");
+    },
+    CancellationToken.None,
+    TaskContinuationOptions.OnlyOnFaulted,
+    TaskScheduler.Default);
 
 app.UseWebSockets();
 
@@ -30,13 +37,26 @@ if (Directory.Exists(clientPath))
 app.MapGet("/health", () =>
 {
     var sessions = setup.Transport.GetSessionInfo();
-    return Results.Json(new
+    WebHostLoopHealthSnapshot loop = setup.LoopStatus.CaptureHealthSnapshot();
+    var payload = new
     {
-        status = "ok",
+        status = loop.Status,
+        loop = new
+        {
+            loop.Healthy,
+            loop.Running,
+            loop.Faulted,
+            loop.FaultType,
+            loop.FaultMessage,
+        },
         clients = sessions.Count,
         tick = setup.Engine.GameSession?.CurrentTick ?? 0,
         sessions = sessions.Select(s => new { s.Id, s.FramesSent, s.BytesSent, s.FramesDropped }),
-    });
+    };
+
+    return Results.Json(
+        payload,
+        statusCode: loop.Healthy ? StatusCodes.Status200OK : StatusCodes.Status503ServiceUnavailable);
 });
 
 app.Map("/ws", async (HttpContext context) =>

--- a/src/Core/Engine/GameEngine.cs
+++ b/src/Core/Engine/GameEngine.cs
@@ -1314,6 +1314,7 @@ namespace Ludots.Core.Engine
             SetService(CoreServiceKeys.ChunkDebugPanelRuntime, chunkDebugPanelRuntime);
             SetService(CoreServiceKeys.InputFrameConsumers, inputFrameConsumers);
             SetService(CoreServiceKeys.RenderDebugState, new RenderDebugState());
+            SetService(CoreServiceKeys.PresentationAudienceRevealHidden, false);
             SetService(CoreServiceKeys.PresentationTimingDiagnostics, presentationTimingDiagnostics);
             SetService(CoreServiceKeys.TransientMarkerBuffer, transientMarkerBuffer);
             SetService(CoreServiceKeys.GasPresentationEventBuffer, gasPresentationEvents);

--- a/src/Core/MassNavigation/Runtime/MassNavigationConfig.cs
+++ b/src/Core/MassNavigation/Runtime/MassNavigationConfig.cs
@@ -529,6 +529,24 @@ public sealed class MassNavigationRuntimeCapacityConfig
                 $"MassNavigation scenarioRuntime.runtimeCapacity.groupMembershipAgentCapacity {GroupMembershipAgentCapacity} is smaller than authored scenario agent count {authoredAgentCount}.");
         }
 
+        if (authoredAgentCount > SelectionMemberScratchCapacity)
+        {
+            throw new InvalidOperationException(
+                $"MassNavigation scenarioRuntime.runtimeCapacity.selectionMemberScratchCapacity {SelectionMemberScratchCapacity} is smaller than authored scenario agent count {authoredAgentCount}.");
+        }
+
+        if (authoredAgentCount > GroupMemberCapacity)
+        {
+            throw new InvalidOperationException(
+                $"MassNavigation scenarioRuntime.runtimeCapacity.groupMemberCapacity {GroupMemberCapacity} is smaller than authored scenario agent count {authoredAgentCount}.");
+        }
+
+        if (authoredAgentCount > OrderIngestionMemberCapacity)
+        {
+            throw new InvalidOperationException(
+                $"MassNavigation scenarioRuntime.runtimeCapacity.orderIngestionMemberCapacity {OrderIngestionMemberCapacity} is smaller than authored scenario agent count {authoredAgentCount}.");
+        }
+
         if (teamCount > MetadataTeamCapacity)
         {
             throw new InvalidOperationException(
@@ -1146,6 +1164,19 @@ public sealed class MassNavigationScenarioConfig
         {
             throw new InvalidOperationException(
                 $"MassNavigation config InitialSelectedTeamId {InitialSelectedTeamId} is not present in Scenario.Teams.");
+        }
+
+        long authoredAgentCount = (long)Teams.Length * AgentsPerTeam;
+        if (authoredAgentCount > scenarioRuntime.InitialSelectionScratchCapacity)
+        {
+            throw new InvalidOperationException(
+                $"MassNavigation scenarioRuntime.initialSelectionScratchCapacity {scenarioRuntime.InitialSelectionScratchCapacity} is smaller than authored scenario agent count {authoredAgentCount}.");
+        }
+
+        if (authoredAgentCount > scenarioRuntime.InitialSelectedEntityCapacity)
+        {
+            throw new InvalidOperationException(
+                $"MassNavigation scenarioRuntime.initialSelectedEntityCapacity {scenarioRuntime.InitialSelectedEntityCapacity} is smaller than authored scenario agent count {authoredAgentCount}.");
         }
 
         scenarioRuntime.RuntimeCapacity.ValidateForScenario(Teams.Length, AgentsPerTeam);

--- a/src/Core/MassNavigation/Runtime/MassNavigationConfig.cs
+++ b/src/Core/MassNavigation/Runtime/MassNavigationConfig.cs
@@ -327,6 +327,8 @@ public sealed class MassNavigationConfig
             "flowObstacleNeighborRadiusCells",
             "flowObstacleNeighborWeight",
             "flowObstacleAvoidanceWeight",
+            "crowdStampCenterCost",
+            "crowdStampNeighborCost",
             "coincidentPairHashBucketCount",
             "coincidentPairHashPrimeA",
             "coincidentPairHashPrimeB");

--- a/src/Core/MassNavigation/Runtime/MassNavigationCrowdSemantics.cs
+++ b/src/Core/MassNavigation/Runtime/MassNavigationCrowdSemantics.cs
@@ -267,6 +267,8 @@ public sealed class MassNavigationSolverSemantics
     public int FlowObstacleNeighborRadiusCells { get; set; }
     public float FlowObstacleNeighborWeight { get; set; }
     public float FlowObstacleAvoidanceWeight { get; set; }
+    public float CrowdStampCenterCost { get; set; }
+    public float CrowdStampNeighborCost { get; set; }
     public int CoincidentPairHashBucketCount { get; set; }
     public int CoincidentPairHashPrimeA { get; set; }
     public int CoincidentPairHashPrimeB { get; set; }
@@ -290,6 +292,8 @@ public sealed class MassNavigationSolverSemantics
         FlowObstacleNeighborRadiusCells = source.FlowObstacleNeighborRadiusCells;
         FlowObstacleNeighborWeight = source.FlowObstacleNeighborWeight;
         FlowObstacleAvoidanceWeight = source.FlowObstacleAvoidanceWeight;
+        CrowdStampCenterCost = source.CrowdStampCenterCost;
+        CrowdStampNeighborCost = source.CrowdStampNeighborCost;
         CoincidentPairHashBucketCount = source.CoincidentPairHashBucketCount;
         CoincidentPairHashPrimeA = source.CoincidentPairHashPrimeA;
         CoincidentPairHashPrimeB = source.CoincidentPairHashPrimeB;
@@ -318,6 +322,8 @@ public sealed class MassNavigationSolverSemantics
         RequireNonNegative(FlowObstacleNeighborRadiusCells, nameof(FlowObstacleNeighborRadiusCells));
         RequireNonNegative(FlowObstacleNeighborWeight, nameof(FlowObstacleNeighborWeight));
         RequireNonNegative(FlowObstacleAvoidanceWeight, nameof(FlowObstacleAvoidanceWeight));
+        RequirePositive(CrowdStampCenterCost, nameof(CrowdStampCenterCost));
+        RequirePositive(CrowdStampNeighborCost, nameof(CrowdStampNeighborCost));
         RequirePowerOfTwo(CoincidentPairHashBucketCount, nameof(CoincidentPairHashBucketCount));
         RequirePositive(CoincidentPairHashPrimeA, nameof(CoincidentPairHashPrimeA));
         RequirePositive(CoincidentPairHashPrimeB, nameof(CoincidentPairHashPrimeB));

--- a/src/Core/MassNavigation/Runtime/MassNavigationFlowSolverArrivalRecovery.cs
+++ b/src/Core/MassNavigation/Runtime/MassNavigationFlowSolverArrivalRecovery.cs
@@ -41,6 +41,8 @@ public sealed partial class MassNavigationFlowSolverState
             : configuredStopThresholdSq;
     }
 
+    // Runs inside parallel step jobs: must only touch per-agent slots. Arrival events are
+    // enqueued later by the single-threaded post-step scan (EnqueuePendingArrivalEvents).
     private void EnterSettledState(int index, float px, float py)
     {
         int i2 = index << 1;
@@ -52,7 +54,6 @@ public sealed partial class MassNavigationFlowSolverState
         _unitStuckSeconds[index] = 0f;
         _velocitiesCm[i2] = 0f;
         _velocitiesCm[i2 + 1] = 0f;
-        EnqueueArrivalEvent(index);
     }
 
     private void ExitSettledState(int index, float px, float py)

--- a/src/Core/MassNavigation/Runtime/MassNavigationFlowSolverState.cs
+++ b/src/Core/MassNavigation/Runtime/MassNavigationFlowSolverState.cs
@@ -861,6 +861,7 @@ public sealed partial class MassNavigationFlowSolverState
         _unitRetryCounts[index] = 0;
         _arrivalEventEmittedFlags[index] = 0;
         EnterSettledState(index, x, y);
+        EnqueueArrivalEvent(index);
         MarkEntityDirty(index);
     }
 
@@ -1503,7 +1504,9 @@ public sealed partial class MassNavigationFlowSolverState
                     continue;
                 }
 
-                float penalty = (ox == 0 && oy == 0) ? 8f : 3f;
+                float penalty = (ox == 0 && oy == 0)
+                    ? Semantics.Solver.CrowdStampCenterCost
+                    : Semantics.Solver.CrowdStampNeighborCost;
                 _cost[idx] += penalty;
             }
         }
@@ -1655,7 +1658,7 @@ public sealed partial class MassNavigationFlowSolverState
                             float ovx = -offsetX;
                             float ovy = -offsetY;
                             float obstacleDistSq = (ovx * ovx) + (ovy * ovy);
-                            if (obstacleDistSq > Semantics.Solver.EntitySyncVelocityEpsilonSq)
+                            if (obstacleDistSq > Semantics.Solver.NormalizationEpsilonSq)
                             {
                                 float invObstacleDist = FastInvSqrt(obstacleDistSq);
                                 float obstacleDist = obstacleDistSq * invObstacleDist;
@@ -1947,15 +1950,6 @@ public sealed partial class MassNavigationFlowSolverState
                 }
             }
 
-            if (suppressTargetMotion)
-            {
-                _velocitiesCm[i2] = 0f;
-                _velocitiesCm[i2 + 1] = 0f;
-                _positionsCm[i2] = px;
-                _positionsCm[i2 + 1] = py;
-                continue;
-            }
-
             float directTargetX = hasGoalTarget ? targetX - px : 0f;
             float directTargetY = hasGoalTarget ? targetY - py : 0f;
             float directTargetSq = hasGoalTarget ? directTargetX * directTargetX + directTargetY * directTargetY : 0f;
@@ -2067,6 +2061,19 @@ public sealed partial class MassNavigationFlowSolverState
                     obstaclePushX += dx * invD * pushForce;
                     obstaclePushY += dy * invD * pushForce;
                 }
+            }
+
+            // Settled agents hold position and velocity to avoid post-arrival jitter, but only
+            // after the scans above have marked hard-resolve candidates: real body overlap must
+            // still be separated by ResolveHardPenetration, which can wake them via the
+            // arrival-recovery push threshold.
+            if (suppressTargetMotion)
+            {
+                _velocitiesCm[i2] = 0f;
+                _velocitiesCm[i2 + 1] = 0f;
+                _positionsCm[i2] = px;
+                _positionsCm[i2 + 1] = py;
+                continue;
             }
 
             float separationScale = (inFormation
@@ -2454,6 +2461,7 @@ public sealed partial class MassNavigationFlowSolverState
             if (_unitSettledFlags[i] != 0)
             {
                 settled++;
+                EnqueueArrivalEvent(i);
             }
         }
 

--- a/src/Core/MassNavigation/Runtime/MassNavigationSimulationRuntime.cs
+++ b/src/Core/MassNavigation/Runtime/MassNavigationSimulationRuntime.cs
@@ -29,6 +29,28 @@ public readonly struct MassNavigationObstacleSnapshot
     public float RadiusCm { get; }
 }
 
+public readonly record struct MassNavigationAvoidanceAgentSnapshot(
+    int AgentIndex,
+    float LocalXCm,
+    float LocalYCm,
+    float WorldXCm,
+    float WorldYCm,
+    int TeamId,
+    float BodyRadiusCm,
+    bool Selected,
+    bool HeavyProfile,
+    bool Settled,
+    bool InsidePlayArea);
+
+public readonly record struct MassNavigationAvoidanceSnapshot(
+    int UnitCount,
+    int ObstacleCount,
+    int SettledUnitCount,
+    float PlayAreaMinXCm,
+    float PlayAreaMaxXCm,
+    float PlayAreaMinYCm,
+    float PlayAreaMaxYCm);
+
 public readonly record struct MassNavigationArrivalEvent(
     int AgentIndex,
     Entity Agent,
@@ -192,6 +214,7 @@ public sealed class MassNavigationSimulationRuntime
 
     public int NavigationAgentCount => MassNavigationFlow.UnitCount;
     public int NavigationObstacleCount => MassNavigationFlow.ObstacleCount;
+    public int NavigationSettledAgentCount => MassNavigationFlow.SettledUnitCount;
     public int SelectedCount => _selectedCount;
     public uint SelectionRevision => _selectionRevision;
     public ReadOnlySpan<Entity> SelectedEntities => _selectedEntities.AsSpan(0, _selectedCount);
@@ -434,6 +457,63 @@ public sealed class MassNavigationSimulationRuntime
             HardResolveHashCellSizeCm: MassNavigationFlow.HardResolveHashCellSizeCm,
             PlayAreaMinXCm: MassNavigationFlow.PlayAreaMinXCm,
             PlayAreaMaxXCm: MassNavigationFlow.PlayAreaMaxXCm);
+    }
+
+    public MassNavigationAvoidanceSnapshot CaptureAvoidanceSnapshot(
+        Span<MassNavigationAvoidanceAgentSnapshot> agents,
+        Span<MassNavigationObstacleSnapshot> obstacles)
+    {
+        int unitCount = MassNavigationFlow.UnitCount;
+        if (agents.Length < unitCount)
+        {
+            throw new InvalidOperationException(
+                $"MassNavigation avoidance snapshot requires {unitCount} agent slots, received {agents.Length}.");
+        }
+
+        for (int i = 0; i < unitCount; i++)
+        {
+            float localX = MassNavigationFlow.GetPositionX(i);
+            float localY = MassNavigationFlow.GetPositionY(i);
+            agents[i] = new MassNavigationAvoidanceAgentSnapshot(
+                AgentIndex: i,
+                LocalXCm: localX,
+                LocalYCm: localY,
+                WorldXCm: ToWorldXCm(localX),
+                WorldYCm: ToWorldYCm(localY),
+                TeamId: MassNavigationFlow.GetTeam(i),
+                BodyRadiusCm: MassNavigationFlow.GetBodyRadiusCm(i),
+                Selected: MassNavigationFlow.IsSelected(i),
+                HeavyProfile: MassNavigationFlow.IsHeavyProfile(i),
+                Settled: MassNavigationFlow.IsUnitSettled(i),
+                InsidePlayArea: localX >= MassNavigationFlow.PlayAreaMinXCm &&
+                    localX <= MassNavigationFlow.PlayAreaMaxXCm &&
+                    localY >= MassNavigationFlow.PlayAreaMinYCm &&
+                    localY <= MassNavigationFlow.PlayAreaMaxYCm);
+        }
+
+        int obstacleCount = MassNavigationFlow.ObstacleCount;
+        if (obstacles.Length < obstacleCount)
+        {
+            throw new InvalidOperationException(
+                $"MassNavigation avoidance snapshot requires {obstacleCount} obstacle slots, received {obstacles.Length}.");
+        }
+
+        for (int i = 0; i < obstacleCount; i++)
+        {
+            obstacles[i] = new MassNavigationObstacleSnapshot(
+                MassNavigationFlow.GetObstacleWorldX(i),
+                MassNavigationFlow.GetObstacleWorldY(i),
+                MassNavigationFlow.GetObstacleRadius(i));
+        }
+
+        return new MassNavigationAvoidanceSnapshot(
+            UnitCount: unitCount,
+            ObstacleCount: obstacleCount,
+            SettledUnitCount: MassNavigationFlow.SettledUnitCount,
+            PlayAreaMinXCm: MassNavigationFlow.PlayAreaMinXCm,
+            PlayAreaMaxXCm: MassNavigationFlow.PlayAreaMaxXCm,
+            PlayAreaMinYCm: MassNavigationFlow.PlayAreaMinYCm,
+            PlayAreaMaxYCm: MassNavigationFlow.PlayAreaMaxYCm);
     }
 
     public void ObservePerformerCoverage(int crowdInViewCount, int crowdSubmittedCount, int obstacleSubmittedCount, int performerDroppedCount)

--- a/src/Core/MassNavigation/Systems/MassNavigationScenarioBootstrap.cs
+++ b/src/Core/MassNavigation/Systems/MassNavigationScenarioBootstrap.cs
@@ -1,12 +1,12 @@
 using Ludots.Core.Gameplay.Relationships;
 using Ludots.Core.Gameplay.Spawning;
 using Ludots.Core.Gameplay.Teams;
+using Ludots.Core.Config;
 using Ludots.Core.Engine;
 using Ludots.Core.Map;
 using Ludots.Core.Mathematics.FixedPoint;
 using Ludots.Core.Scripting;
 using Ludots.Core.MassNavigation.Runtime;
-using System.Text.Json.Nodes;
 
 namespace Ludots.Core.MassNavigation.Systems;
 
@@ -24,6 +24,8 @@ internal static class MassNavigationScenarioBootstrap
 
         simulation.AgentState.Reset();
         ReadOnlySpan<int> teamIds = simulation.TeamIds;
+        MapSession session = RequireCurrentMapSession(engine, simulation.Config.MapId);
+        int[] playerOwnerIdsByScenarioTeam = ResolveScenarioTeamPlayerOwners(session, teamIds);
         simulation.ConfigureScenarioTeams(teamIds);
         ConfigureRelationships(simulation.Config);
         MassNavigationAgentLayer scenarioAgentLayer = ResolveScenarioAgentLayer(authoring, simulation.Config);
@@ -48,7 +50,7 @@ internal static class MassNavigationScenarioBootstrap
                 $"MassNavigation runtime requires RuntimeEntitySpawnQueue free capacity {requested}, actual {spawnQueue.FreeCapacity}.");
         }
 
-        MapId mapId = RequireCurrentMapId(engine, simulation.Config.MapId);
+        MapId mapId = session.MapId;
         for (int i = 0; i < simulation.MassNavigationFlow.UnitCount; i++)
         {
             int teamId = simulation.MassNavigationFlow.GetTeam(i);
@@ -68,7 +70,8 @@ internal static class MassNavigationScenarioBootstrap
                 mapId,
                 templateId,
                 Fix64Vec2.FromInt((int)MathF.Round(worldXCm), (int)MathF.Round(worldYCm)),
-                teamIdOverride: teamId);
+                teamIdOverride: teamId,
+                playerOwnerIdOverride: ResolvePlayerOwnerId(teamIds, playerOwnerIdsByScenarioTeam, teamId));
         }
 
         string hotspotTemplateId = simulation.Config.Presentation.HotspotTemplateId;
@@ -134,24 +137,49 @@ internal static class MassNavigationScenarioBootstrap
             $"MassNavigation runtime scenario auto-spawn requires one explicit agent layer across generated agent templates; '{actualLabel}' differs from '{expectedLabel}'.");
     }
 
-    private static void ValidateTemplate(GameEngine engine, string templateId)
+    private static int[] ResolveScenarioTeamPlayerOwners(MapSession session, ReadOnlySpan<int> scenarioTeamIds)
     {
-        if (string.IsNullOrWhiteSpace(templateId))
+        MapConfig mapConfig = session.MapConfig
+            ?? throw new InvalidOperationException($"MassNavigation runtime map '{session.MapId.Value}' has no MapConfig.");
+        int[] playerOwnerIdsByScenarioTeam = new int[scenarioTeamIds.Length];
+        for (int i = 0; i < mapConfig.Players.Count; i++)
         {
-            throw new InvalidOperationException("MassNavigation runtime template id must be non-empty.");
+            PlayerBindingData binding = mapConfig.Players[i];
+            int teamIndex = IndexOfScenarioTeam(scenarioTeamIds, binding.TeamId);
+            if (teamIndex < 0)
+            {
+                continue;
+            }
+
+            if (playerOwnerIdsByScenarioTeam[teamIndex] > 0)
+            {
+                throw new InvalidOperationException(
+                    $"MassNavigation runtime map '{session.MapId.Value}' binds multiple players to scenario team {binding.TeamId}; generated agents require one PlayerOwner per team.");
+            }
+
+            playerOwnerIdsByScenarioTeam[teamIndex] = binding.PlayerId;
         }
 
-        if (!engine.MapLoader.TemplateRegistry.Contains(templateId))
+        return playerOwnerIdsByScenarioTeam;
+    }
+
+    private static int ResolvePlayerOwnerId(ReadOnlySpan<int> scenarioTeamIds, ReadOnlySpan<int> playerOwnerIdsByScenarioTeam, int teamId)
+    {
+        int teamIndex = IndexOfScenarioTeam(scenarioTeamIds, teamId);
+        return teamIndex >= 0 ? playerOwnerIdsByScenarioTeam[teamIndex] : 0;
+    }
+
+    private static int IndexOfScenarioTeam(ReadOnlySpan<int> scenarioTeamIds, int teamId)
+    {
+        for (int i = 0; i < scenarioTeamIds.Length; i++)
         {
-            throw new InvalidOperationException($"MassNavigation runtime requires configured entity template '{templateId}'.");
+            if (scenarioTeamIds[i] == teamId)
+            {
+                return i;
+            }
         }
 
-        EntityTemplateKeyRegistry templateKeys = engine.GetService(CoreServiceKeys.EntityTemplateKeyRegistry)
-            ?? throw new InvalidOperationException("MassNavigation runtime requires EntityTemplateKeyRegistry.");
-        if (!templateKeys.TryGetId(templateId, out int templateKeyId) || templateKeyId <= 0)
-        {
-            throw new InvalidOperationException($"MassNavigation runtime template '{templateId}' was not registered in EntityTemplateKeyRegistry.");
-        }
+        return -1;
     }
 
     private static void EnqueueSpawn(
@@ -160,6 +188,7 @@ internal static class MassNavigationScenarioBootstrap
         string templateId,
         Fix64Vec2 worldPosition,
         int teamIdOverride = 0,
+        int playerOwnerIdOverride = 0,
         RuntimeEntitySpawnComponentPatch[]? componentPatches = null)
     {
         var request = new RuntimeEntitySpawnRequest
@@ -170,6 +199,7 @@ internal static class MassNavigationScenarioBootstrap
             WorldPositionCm = worldPosition,
             HasWorldPosition = 1,
             TeamIdOverride = teamIdOverride,
+            PlayerOwnerIdOverride = playerOwnerIdOverride,
             ComponentPatches = componentPatches ?? Array.Empty<RuntimeEntitySpawnComponentPatch>(),
         };
 
@@ -179,7 +209,7 @@ internal static class MassNavigationScenarioBootstrap
         }
     }
 
-    private static MapId RequireCurrentMapId(GameEngine engine, string configuredMapId)
+    private static MapSession RequireCurrentMapSession(GameEngine engine, string configuredMapId)
     {
         MapSession session = engine.CurrentMapSession
             ?? throw new InvalidOperationException("MassNavigation runtime requires an active map session before scenario bootstrap.");
@@ -189,7 +219,7 @@ internal static class MassNavigationScenarioBootstrap
                 $"MassNavigation runtime scenario bootstrap requires active map '{configuredMapId}', got '{session.MapId.Value}'.");
         }
 
-        return session.MapId;
+        return session;
     }
 
 }

--- a/src/Core/Presentation/Performers/WorldHudPerformBehavior.cs
+++ b/src/Core/Presentation/Performers/WorldHudPerformBehavior.cs
@@ -100,10 +100,18 @@ namespace Ludots.Core.Presentation.Performers
                 viewerObj is Entity viewer &&
                 world.IsAlive(viewer))
             {
-                return _phaseResolver.CreateAudienceContext(world, viewer);
+                return _phaseResolver.CreateAudienceContext(world, viewer, ResolveRevealHidden(globals));
             }
 
             return PerformAudienceContext.Default;
+        }
+
+        private static bool ResolveRevealHidden(Dictionary<string, object> globals)
+        {
+            return globals != null &&
+                   globals.TryGetValue(CoreServiceKeys.PresentationAudienceRevealHidden.Name, out object value) &&
+                   value is bool revealHidden &&
+                   revealHidden;
         }
 
         private static PerformProjectionFacts ResolveProjectionFacts(

--- a/src/Core/Presentation/Systems/PerformerRuleSystem.cs
+++ b/src/Core/Presentation/Systems/PerformerRuleSystem.cs
@@ -374,12 +374,49 @@ namespace Ludots.Core.Presentation.Systems
 
                 if (CommandTargetsScopedPerformer(rule.Command.CommandKind))
                 {
+                    if (ScopedCommandRequiresOwnerDefinitionInstance(rule.OwnerDefinitionId))
+                    {
+                        EmitForMatchingInstances(rule.OwnerDefinitionId, in rule.Command, in evt);
+                        return;
+                    }
+
                     EmitCommand(in rule.Command, in evt, performerEntity: Entity.Null, ownerDefinitionId: rule.OwnerDefinitionId);
                     return;
                 }
             }
 
             EmitCommand(in rule.Command, in evt, performerEntity: Entity.Null, ownerDefinitionId: rule.OwnerDefinitionId);
+        }
+
+        private bool ScopedCommandRequiresOwnerDefinitionInstance(int ownerDefinitionId)
+        {
+            if (_runtime != null &&
+                _runtime.GetActiveByDefinition(ownerDefinitionId).Count != 0)
+            {
+                return true;
+            }
+
+            if (!_definitions.TryGet(ownerDefinitionId, out PerformerDefinition definition))
+            {
+                return false;
+            }
+
+            return DefinitionHasRuntimeInstanceAuthoring(definition);
+        }
+
+        private static bool DefinitionHasRuntimeInstanceAuthoring(PerformerDefinition definition)
+        {
+            return HasAny(definition.Behaviors) ||
+                   HasAny(definition.Children) ||
+                   HasAny(definition.Bindings) ||
+                   HasAny(definition.ParamDefaults) ||
+                   HasAny(definition.InstancedBatches) ||
+                   definition.Surface != null;
+        }
+
+        private static bool HasAny<T>(T[]? items)
+        {
+            return items != null && items.Length != 0;
         }
 
         private void EmitForMatchingInstances(int ownerDefinitionId, in PerformerCommand command, in PresentationEvent evt)

--- a/src/Core/Presentation/Systems/WorldHudToScreenSystem.cs
+++ b/src/Core/Presentation/Systems/WorldHudToScreenSystem.cs
@@ -28,11 +28,9 @@ namespace Ludots.Core.Presentation.Systems
         private int _lastWorldHudProjectionRevision = -1;
         private int _lastProjectionRevision = -1;
         private int _lastCullVisibilityRevision = -1;
-        private int _lastSelectedCount;
 
         private const int Margin = 200;
         private const float WorldHudCoarseMarginCm = 600f;
-        private SelectedHudProjection[] _selectedHudProjections = Array.Empty<SelectedHudProjection>();
         private OwnerVisibilityCacheEntry[] _ownerVisibilityCache = Array.Empty<OwnerVisibilityCacheEntry>();
         private OwnerProjectionCacheEntry[] _ownerProjectionCache = Array.Empty<OwnerProjectionCacheEntry>();
         private int _frameCacheStamp;
@@ -119,26 +117,6 @@ namespace Ludots.Core.Presentation.Systems
             float maxZ = useCoarseCull ? _cullingDebug!.MaxY + WorldHudCoarseMarginCm : 0f;
             int projectedItems = 0;
             int densitySkippedItems = 0;
-            bool canReplaySelection = projectionRevision >= 0 &&
-                                      worldHudProjectionRevision == _lastWorldHudProjectionRevision &&
-                                      projectionRevision == _lastProjectionRevision &&
-                                      cullVisibilityRevision == _lastCullVisibilityRevision &&
-                                      _lastSelectedCount > 0;
-            if (canReplaySelection)
-            {
-                ReplaySelectedHudItems(ref projectedItems);
-                _timingDiagnostics?.ObserveWorldHudProjection(
-                    (Stopwatch.GetTimestamp() - start) * 1000.0 / Stopwatch.Frequency,
-                    span.Length,
-                    projectedItems,
-                    0);
-                _screenHud.EndProjectedBuild(removeUnseenProjectedItems: false);
-                _lastWorldHudRevision = worldHudRevision;
-                _lastCullVisibilityRevision = cullVisibilityRevision;
-                return;
-            }
-
-            _lastSelectedCount = 0;
             int projectedBarIndex = 0;
             int projectedTextIndex = 0;
 
@@ -241,81 +219,6 @@ namespace Ludots.Core.Presentation.Systems
                 _screenHud.Count,
                 0);
             return true;
-        }
-
-        private void ReplaySelectedHudItems(ref int projectedItems)
-        {
-            for (int i = 0; i < _lastSelectedCount; i++)
-            {
-                ref readonly SelectedHudProjection selected = ref _selectedHudProjections[i];
-                if (!_worldHud.TryGetByStableId(selected.StableId, out WorldHudItem item))
-                {
-                    continue;
-                }
-
-                if (IsAssignedOwner(item.Owner) && !IsOwnerVisible(item.Owner))
-                {
-                    continue;
-                }
-
-                var screen = selected.ScreenPosition;
-                float x = MathF.Round(screen.X - item.Width * 0.5f);
-                float y = MathF.Round(screen.Y);
-                if (item.Kind == WorldHudItemKind.Bar)
-                {
-                    if (_screenHud.TryAddProjectedBar(new ScreenHudBarItem
-                    {
-                        StableId = item.StableId,
-                        DirtySerial = item.DirtySerial,
-                        ScreenX = x,
-                        ScreenY = y,
-                        Color0 = item.Color0,
-                        Color1 = item.Color1,
-                        Width = item.Width,
-                        Height = item.Height,
-                        Value0 = item.Value0,
-                    }))
-                    {
-                        projectedItems++;
-                    }
-                    continue;
-                }
-
-                if (item.Kind == WorldHudItemKind.Text &&
-                    _screenHud.TryAddProjectedText(new ScreenHudTextItem
-                    {
-                        StableId = item.StableId,
-                        DirtySerial = item.DirtySerial,
-                        ScreenX = x,
-                        ScreenY = y,
-                        Color0 = item.Color0,
-                        Value0 = item.Value0,
-                        Value1 = item.Value1,
-                        Id0 = item.Id0,
-                        Id1 = item.Id1,
-                        FontSize = item.FontSize,
-                        Text = item.Text,
-                    }))
-                {
-                    projectedItems++;
-                }
-            }
-        }
-
-        private void RememberSelectedHudProjection(int stableId, System.Numerics.Vector2 screen)
-        {
-            if (stableId <= 0)
-            {
-                return;
-            }
-
-            if (_lastSelectedCount >= _selectedHudProjections.Length)
-            {
-                int next = _selectedHudProjections.Length == 0 ? 256 : _selectedHudProjections.Length * 2;
-                Array.Resize(ref _selectedHudProjections, next);
-            }
-
-            _selectedHudProjections[_lastSelectedCount++] = new SelectedHudProjection(stableId, screen);
         }
 
         private void ProjectSingleItem(
@@ -637,8 +540,5 @@ namespace Ludots.Core.Presentation.Systems
             System.Numerics.Vector3 WorldPosition,
             System.Numerics.Vector2 ScreenPosition);
 
-        private readonly record struct SelectedHudProjection(
-            int StableId,
-            System.Numerics.Vector2 ScreenPosition);
     }
 }

--- a/src/Core/Scripting/CoreServiceKeys.cs
+++ b/src/Core/Scripting/CoreServiceKeys.cs
@@ -296,6 +296,7 @@ namespace Ludots.Core.Scripting
         public static readonly ServiceKey<MinimapScreenMarkerBuffer> MinimapScreenMarkerBuffer = new("MinimapScreenMarkerBuffer");
         public static readonly ServiceKey<ChunkDebugPanelRuntime> ChunkDebugPanelRuntime = new("ChunkDebugPanelRuntime");
         public static readonly ServiceKey<RenderDebugState> RenderDebugState = new("RenderDebugState");
+        public static readonly ServiceKey<bool> PresentationAudienceRevealHidden = new("PresentationAudienceRevealHidden");
         public static readonly ServiceKey<RenderCameraDebugState> RenderCameraDebugState = new("RenderCameraDebugState");
         public static readonly ServiceKey<CameraCullingDebugState> CameraCullingDebugState = new("CameraCullingDebugState");
         public static readonly ServiceKey<PresentationTimingDiagnostics> PresentationTimingDiagnostics = new("PresentationTimingDiagnostics");

--- a/src/Tests/ArchitectureTests/LauncherBootstrapContractTests.cs
+++ b/src/Tests/ArchitectureTests/LauncherBootstrapContractTests.cs
@@ -493,7 +493,14 @@ namespace Ludots.Tests.Architecture
                     LauncherBuildMode.Never).Plan,
                     expectedRootModId: "FormationCapabilityShowcaseMod",
                     expectedStartupMapId: "formation_capability_showcase",
-                    allowedModIds: new[] { "LudotsCoreMod", "CoreInputMod", "FormationCapabilityShowcaseMod" });
+                    allowedModIds: new[]
+                    {
+                        "LudotsCoreMod",
+                        "CoreInputMod",
+                        "CameraProfilesMod",
+                        "FormationCapabilityShowcaseMod"
+                    },
+                    requiredModIds: new[] { "LudotsCoreMod", "CoreInputMod", "CameraProfilesMod" });
 
                 AssertCapabilityStandardPlan(
                     launcher.Resolve(
@@ -508,7 +515,8 @@ namespace Ludots.Tests.Architecture
                         "CoreInputMod",
                         "ParticipantViewCapabilityMod",
                         "CapabilityStandardParticipantViewsMod"
-                    });
+                    },
+                    requiredModIds: new[] { "LudotsCoreMod", "CoreInputMod", "ParticipantViewCapabilityMod" });
 
                 AssertCapabilityStandardPlan(
                     launcher.Resolve(

--- a/src/Tests/GasTests/Physics2D/Physics2DPipelineTests.cs
+++ b/src/Tests/GasTests/Physics2D/Physics2DPipelineTests.cs
@@ -27,7 +27,6 @@ namespace Ludots.Tests.GAS.Physics2D
             Assert.That(pipeline.StepNames.ToArray(), Is.EqualTo(new[]
             {
                 "ForceInputWake",
-                "NavToPhysicsVelocitySync",
                 "BuildPhysicsWorld",
                 "SpatialBroadphase",
                 "NarrowPhase",
@@ -42,8 +41,8 @@ namespace Ludots.Tests.GAS.Physics2D
                 "Cleanup"
             }));
             Assert.That(pipeline.Systems.Length, Is.EqualTo(pipeline.StepNames.Length));
-            Assert.That(pipeline.Build, Is.SameAs(pipeline.Systems[2]));
-            Assert.That(pipeline.Spatial, Is.SameAs(pipeline.Systems[3]));
+            Assert.That(pipeline.Build, Is.SameAs(pipeline.Systems[1]));
+            Assert.That(pipeline.Spatial, Is.SameAs(pipeline.Systems[2]));
         }
     }
 }

--- a/src/Tests/GasTests/Production/ParticipantViewKnowledgeShowcaseAcceptanceTests.cs
+++ b/src/Tests/GasTests/Production/ParticipantViewKnowledgeShowcaseAcceptanceTests.cs
@@ -11,6 +11,9 @@ using Ludots.Core.Input.Runtime;
 using Ludots.Core.Knowledge;
 using Ludots.Core.Map;
 using Ludots.Core.Presentation.Camera;
+using Ludots.Core.Presentation.Components;
+using Ludots.Core.Presentation.Rendering;
+using Ludots.Core.Presentation.Terrain;
 using Ludots.Core.Scripting;
 using Ludots.Tests;
 using NUnit.Framework;
@@ -23,6 +26,7 @@ namespace Ludots.Tests.GAS.Production;
 public sealed class ParticipantViewKnowledgeShowcaseAcceptanceTests
 {
     private const string MapId = "capability_standard_participant_views";
+    private const string LargeWorldCameraId = "MassNavigation.Camera.LargeWorldHeightmap";
 
     private static readonly string[] AcceptanceMods =
     {
@@ -44,6 +48,8 @@ public sealed class ParticipantViewKnowledgeShowcaseAcceptanceTests
         MapSession session = engine.CurrentMapSession
             ?? throw new InvalidOperationException("Participant showcase map did not load.");
         Assert.That(session.MapId.Value, Is.EqualTo(MapId));
+        Assert.That(session.MapConfig.DefaultCamera, Is.Not.Null);
+        Assert.That(session.MapConfig.DefaultCamera.VirtualCameraId, Is.EqualTo(LargeWorldCameraId));
 
         KnowledgeProjectionResolver resolver = engine.GetService(CoreServiceKeys.KnowledgeProjectionResolver)
             ?? throw new InvalidOperationException("CapabilityStandardParticipantViewsMod did not install KnowledgeProjectionResolver.");
@@ -93,6 +99,35 @@ public sealed class ParticipantViewKnowledgeShowcaseAcceptanceTests
         Assert.That(teamNeutral.IsKnown, Is.False, "Team view should differ from Player 1 by not inheriting Player 1's NPC disclosure.");
     }
 
+    [Test]
+    public void ParticipantShowcaseLoadsRenderableFourTeamWorld()
+    {
+        using GameEngine engine = CreateEngine();
+        engine.Start();
+        engine.LoadMap(MapId);
+
+        for (int frame = 0; frame < 8; frame++)
+        {
+            engine.Tick(1f / 60f);
+        }
+
+        Assert.That(
+            engine.GetService(CoreServiceKeys.VisualHeightmap),
+            Is.AssignableTo<IVisualHeightmapRenderSource>(),
+            "The four-team participant view showcase must bind the MassNavigation visual heightmap through the formal map service.");
+        Assert.That(CountVisualTransforms(engine), Is.GreaterThan(0),
+            "The showcase world must contain visual transforms for its authored team members.");
+
+        PrimitiveDrawBuffer primitives = engine.GetService(CoreServiceKeys.PresentationPrimitiveDrawBuffer)
+            ?? throw new InvalidOperationException("PresentationPrimitiveDrawBuffer missing.");
+        SkinnedVisualBatchBuffer skinned = engine.GetService(CoreServiceKeys.PresentationSkinnedVisualBatchBuffer)
+            ?? throw new InvalidOperationException("PresentationSkinnedVisualBatchBuffer missing.");
+
+        int worldVisualCount = primitives.GetSpan().Length + skinned.Count;
+        Assert.That(worldVisualCount, Is.GreaterThan(0),
+            "The showcase must emit world visuals after startup; a UI-only participant panel is not a valid capability standard showcase.");
+    }
+
     private static ParticipantKnowledgeSnapshot Resolve(
         GameEngine engine,
         KnowledgeProjectionResolver resolver,
@@ -129,6 +164,14 @@ public sealed class ParticipantViewKnowledgeShowcaseAcceptanceTests
         }
 
         return entity;
+    }
+
+    private static int CountVisualTransforms(GameEngine engine)
+    {
+        int count = 0;
+        var query = new QueryDescription().WithAll<VisualTransform>();
+        engine.World.Query(in query, (Entity _) => count++);
+        return count;
     }
 
     private static GameEngine CreateEngine()

--- a/src/Tests/PresentationTests/CapabilityStandardMassNavigationLargeWorld10kProductionPathTests.cs
+++ b/src/Tests/PresentationTests/CapabilityStandardMassNavigationLargeWorld10kProductionPathTests.cs
@@ -1,0 +1,1156 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Numerics;
+using Arch.Core;
+using CapabilityStandardMassNavigationLargeWorld10kMod;
+using Ludots.Core.Config;
+using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.Components;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.Gameplay.Teams;
+using Ludots.Core.Input.Config;
+using Ludots.Core.Input.Runtime;
+using Ludots.Core.Input.Selection;
+using Ludots.Core.Knowledge;
+using Ludots.Core.Mathematics;
+using Ludots.Core.MassNavigation;
+using Ludots.Core.MassNavigation.Runtime;
+using Ludots.Core.Presentation.Camera;
+using Ludots.Core.Presentation.Components;
+using Ludots.Core.Presentation.Assets;
+using Ludots.Core.Presentation.Config;
+using Ludots.Core.Presentation.Hud;
+using Ludots.Core.Presentation.Minimap;
+using Ludots.Core.Presentation.Performers;
+using Ludots.Core.Presentation.Systems;
+using Ludots.Core.Scripting;
+using Ludots.Core.Spatial;
+using Ludots.Platform.Abstractions;
+using NUnit.Framework;
+
+namespace Ludots.Tests.Presentation
+{
+    [TestFixture]
+    public sealed class CapabilityStandardMassNavigationLargeWorld10kProductionPathTests
+    {
+        private const int ExpectedAgentCount = 10_000;
+        private const int ExpectedTeamCount = 4;
+        private const float FixedDeltaSeconds = 1f / 60f;
+        private const int MaxWarmupFrames = 240;
+        private const int MovementObservationFrames = 60;
+        private const int HealthStabilityObservationFrames = 75;
+        private const int HudStabilityObservationFrames = 12;
+        private const float CommandTargetOffsetWindowScale = 0.25f;
+        private const float MovementEpsilonCm = 1f;
+        private const string MouseLeftButtonPath = "<Mouse>/LeftButton";
+        private const string MouseRightButtonPath = "<Mouse>/RightButton";
+        private const string LightSelectionMarkerPerformerId = "mass_navigation_agent_selection_marker_light";
+        private const string HeavySelectionMarkerPerformerId = "mass_navigation_agent_selection_marker_heavy";
+
+        private static readonly string[] ShowcaseMods =
+        {
+            "LudotsCoreMod",
+            "CoreInputMod",
+            "MassNavigationMod",
+            "CapabilityStandardMassNavigationLargeWorld10kMod"
+        };
+
+        [SetUp]
+        public void SetUp()
+        {
+            AttributeRegistry.Clear();
+            TagRegistry.Clear();
+            PerformerScopeTagRegistry.Clear();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            AttributeRegistry.Clear();
+            TagRegistry.Clear();
+            PerformerScopeTagRegistry.Clear();
+        }
+
+        [Test]
+        public void Showcase_ProjectsFourTeamAgentsToMinimapAndScreenHud()
+        {
+            GC.KeepAlive(typeof(CapabilityStandardMassNavigationLargeWorld10kModEntry).Assembly);
+
+            using var engine = CreateEngine();
+            StartStartupMap(engine);
+
+            var simulation = RequireService(engine, MassNavigationKeys.SimulationRuntime);
+            int expectedAgents = checked(simulation.Config.Scenario.Teams.Length * simulation.Config.Scenario.AgentsPerTeam);
+            Assert.That(expectedAgents, Is.EqualTo(ExpectedAgentCount));
+            Assert.That(simulation.Config.Scenario.Teams.Length, Is.EqualTo(ExpectedTeamCount));
+
+            var hudProjection = CreateHudProjection(engine);
+            ProjectionSample sample = WaitForProductionProjection(engine, hudProjection, simulation, expectedAgents);
+
+            var minimapRuntime = RequireService(engine, CoreServiceKeys.MinimapRuntime);
+            var minimapMarkers = RequireService(engine, CoreServiceKeys.MinimapMarkerBuffer);
+            var minimapScreenMarkers = RequireService(engine, CoreServiceKeys.MinimapScreenMarkerBuffer);
+            var screenHud = RequireService(engine, CoreServiceKeys.PresentationScreenHudBuffer);
+            string diagnostics = sample.Diagnostics;
+
+            Assert.That(minimapRuntime.Visible, Is.True, diagnostics);
+            Assert.That(minimapRuntime.Preset, Is.EqualTo(MinimapPreset.RtsFullMap), diagnostics);
+            Assert.That(sample.MinimapSnapshot.ZoomBand, Is.EqualTo(MinimapZoomBand.Strategic), diagnostics);
+            Assert.That(minimapMarkers.Count, Is.GreaterThanOrEqualTo(expectedAgents), diagnostics);
+            Assert.That(minimapScreenMarkers.Count, Is.GreaterThanOrEqualTo(expectedAgents), diagnostics);
+            Assert.That(sample.MinimapSnapshot.VisibleMarkerCount, Is.GreaterThanOrEqualTo(expectedAgents), diagnostics);
+            Assert.That(sample.WorldHudBars, Is.GreaterThanOrEqualTo(expectedAgents), diagnostics);
+            Assert.That(sample.WorldHudText, Is.GreaterThanOrEqualTo(expectedAgents), diagnostics);
+            Assert.That(screenHud.BarCount, Is.GreaterThanOrEqualTo(expectedAgents), diagnostics);
+            Assert.That(screenHud.TextCount, Is.GreaterThanOrEqualTo(expectedAgents), diagnostics);
+        }
+
+        [Test]
+        public void Showcase_SelectionSyncCapacityCoversAuthoredAgentSet()
+        {
+            GC.KeepAlive(typeof(CapabilityStandardMassNavigationLargeWorld10kModEntry).Assembly);
+
+            using var engine = CreateEngine();
+            StartStartupMap(engine);
+
+            var simulation = RequireService(engine, MassNavigationKeys.SimulationRuntime);
+            int expectedAgents = checked(simulation.Config.Scenario.Teams.Length * simulation.Config.Scenario.AgentsPerTeam);
+            Assert.That(expectedAgents, Is.EqualTo(ExpectedAgentCount));
+            Assert.That(simulation.Config.ScenarioRuntime.InitialSelectionScratchCapacity, Is.GreaterThanOrEqualTo(expectedAgents));
+            Assert.That(simulation.Config.ScenarioRuntime.InitialSelectedEntityCapacity, Is.GreaterThanOrEqualTo(expectedAgents));
+            Assert.That(simulation.Config.ScenarioRuntime.RuntimeCapacity.SelectionMemberScratchCapacity, Is.GreaterThanOrEqualTo(expectedAgents));
+            Assert.That(simulation.Config.ScenarioRuntime.RuntimeCapacity.GroupMemberCapacity, Is.GreaterThanOrEqualTo(expectedAgents));
+            Assert.That(simulation.Config.ScenarioRuntime.RuntimeCapacity.OrderIngestionMemberCapacity, Is.GreaterThanOrEqualTo(expectedAgents));
+
+            var hudProjection = CreateHudProjection(engine);
+            _ = WaitForProductionProjection(engine, hudProjection, simulation, expectedAgents);
+
+            Entity[] agents = CollectMassNavigationAgents(engine, expectedAgents);
+            var selection = RequireService(engine, CoreServiceKeys.SelectionRuntime);
+            Entity localPlayer = RequireService(engine, CoreServiceKeys.LocalPlayerEntity);
+            Assert.That(selection.ReplaceSelection(localPlayer, SelectionSetKeys.LivePrimary, agents), Is.True);
+
+            Assert.DoesNotThrow(() => MassNavigationSelectionSync.SyncIfChanged(engine.World, engine.GlobalContext, selection, simulation));
+            Assert.That(simulation.SelectedCount, Is.EqualTo(expectedAgents));
+        }
+
+        [Test]
+        public void Showcase_AgentHealthHudInputsRemainStableAcrossHealthDriftPeriodWindow()
+        {
+            GC.KeepAlive(typeof(CapabilityStandardMassNavigationLargeWorld10kModEntry).Assembly);
+
+            using var engine = CreateEngine();
+            StartStartupMap(engine);
+
+            var simulation = RequireService(engine, MassNavigationKeys.SimulationRuntime);
+            int expectedAgents = checked(simulation.Config.Scenario.Teams.Length * simulation.Config.Scenario.AgentsPerTeam);
+            Assert.That(expectedAgents, Is.EqualTo(ExpectedAgentCount));
+            AssertScenarioAgentTemplatesDoNotDriveHealthPeriodically(engine, simulation);
+
+            var hudProjection = CreateHudProjection(engine);
+            _ = WaitForProductionProjection(engine, hudProjection, simulation, expectedAgents);
+            AssertScreenHudIdentityStableAcrossProjectionFrames(engine, hudProjection, HudStabilityObservationFrames);
+
+            Dictionary<int, AgentHealthSample> before = CaptureAgentHealth(engine, expectedAgents);
+            TickProjectionFrames(engine, hudProjection, HealthStabilityObservationFrames);
+            Dictionary<int, AgentHealthSample> after = CaptureAgentHealth(engine, expectedAgents);
+
+            AssertAgentHealthStable(before, after);
+        }
+
+        [Test]
+        public void Showcase_MouseBoxSelection_AcquiresVisibleMassNavigationAgents()
+        {
+            GC.KeepAlive(typeof(CapabilityStandardMassNavigationLargeWorld10kModEntry).Assembly);
+
+            using var engine = CreateEngine();
+            StartStartupMap(engine);
+
+            var simulation = RequireService(engine, MassNavigationKeys.SimulationRuntime);
+            int expectedAgents = checked(simulation.Config.Scenario.Teams.Length * simulation.Config.Scenario.AgentsPerTeam);
+            Assert.That(expectedAgents, Is.EqualTo(ExpectedAgentCount));
+
+            var hudProjection = CreateHudProjection(engine);
+            _ = WaitForProductionProjection(engine, hudProjection, simulation, expectedAgents);
+            AssertLocalScenarioAgentsAreCommandable(engine);
+
+            var backend = RequireMutableInputBackend(engine);
+            SelectionDragGesture gesture = ResolveVisibleAgentDragGesture(engine);
+            SelectionDiagnostics before = CaptureSelectionDiagnostics(engine, gesture.Marquee);
+            Assert.That(before.VisibleSelectable, Is.GreaterThan(0), before.ToString());
+            Assert.That(before.ScreenIntersecting, Is.GreaterThan(0), before.ToString());
+            Assert.That(before.EligibleIntersecting, Is.GreaterThan(0), before.ToString());
+
+            DriveBoxSelection(engine, hudProjection, backend, gesture);
+            TickProjectionFrames(engine, hudProjection, 2);
+
+            Entity[] selected = SelectionContextRuntime.SnapshotCurrentSelection(engine.World, engine.GlobalContext);
+            SelectionDiagnostics after = CaptureSelectionDiagnostics(engine, gesture.Marquee);
+            Assert.That(selected.Length, Is.GreaterThan(0), after.ToString());
+            Assert.That(simulation.SelectedCount, Is.GreaterThan(0), after.ToString());
+            Assert.That(CountActiveSelectionMarkers(engine), Is.EqualTo(selected.Length), after.ToString());
+        }
+
+        [Test]
+        public void Showcase_MouseBoxSelection_RightClickIssuesOrdersForCommandableAgents()
+        {
+            GC.KeepAlive(typeof(CapabilityStandardMassNavigationLargeWorld10kModEntry).Assembly);
+
+            using var engine = CreateEngine();
+            StartStartupMap(engine);
+
+            var simulation = RequireService(engine, MassNavigationKeys.SimulationRuntime);
+            int expectedAgents = checked(simulation.Config.Scenario.Teams.Length * simulation.Config.Scenario.AgentsPerTeam);
+            Assert.That(expectedAgents, Is.EqualTo(ExpectedAgentCount));
+
+            var hudProjection = CreateHudProjection(engine);
+            _ = WaitForProductionProjection(engine, hudProjection, simulation, expectedAgents);
+
+            var backend = RequireMutableInputBackend(engine);
+            SelectionDragGesture gesture = ResolveVisibleAgentDragGesture(engine);
+            DriveBoxSelection(engine, hudProjection, backend, gesture);
+            TickProjectionFrames(engine, hudProjection, 2);
+
+            Entity[] selected = SelectionContextRuntime.SnapshotCurrentSelection(engine.World, engine.GlobalContext);
+            SelectionDiagnostics selectionDiagnostics = CaptureSelectionDiagnostics(engine, gesture.Marquee);
+            Assert.That(selected.Length, Is.GreaterThan(0), selectionDiagnostics.ToString());
+            Assert.That(simulation.SelectedCount, Is.EqualTo(selected.Length), selectionDiagnostics.ToString());
+            AssertSelectedEntitiesAreCommandable(engine, selected);
+
+            int activeOrdersBefore = CountActiveMoveOrders(engine, selected);
+            int rejectsBefore = simulation.CommandRejectsTotal;
+            Vector2[] positionsBefore = CaptureSelectedWorldPositions(engine, simulation, selected);
+            Vector2 commandScreenPoint = ResolveCommandTargetScreenPoint(engine, simulation, selected);
+
+            DriveRightClickCommandFrame(engine, hudProjection, backend, commandScreenPoint);
+
+            Assert.That(simulation.CommandRejectsTotal, Is.EqualTo(rejectsBefore), selectionDiagnostics.ToString());
+            Assert.That(simulation.CommandCountFrame, Is.GreaterThan(0), selectionDiagnostics.ToString());
+            Assert.That(simulation.LastCommandSelectionCount, Is.EqualTo(selected.Length), selectionDiagnostics.ToString());
+            Assert.That(CountActiveMoveOrders(engine, selected), Is.GreaterThan(activeOrdersBefore), selectionDiagnostics.ToString());
+
+            TickProjectionFrames(engine, hudProjection, MovementObservationFrames);
+            Assert.That(
+                CountMovedSelectedAgents(engine, simulation, selected, positionsBefore),
+                Is.GreaterThan(0),
+                selectionDiagnostics.ToString());
+
+            backend.SetButton(MouseRightButtonPath, false);
+            TickProjectionFrames(engine, hudProjection, 2);
+        }
+
+        private static void StartStartupMap(GameEngine engine)
+        {
+            Assert.That(engine.MergedConfig.StartupMapId, Is.Not.Empty);
+            Assert.That(engine.MergedConfig.StartupSelectedPlayerId, Is.GreaterThan(0));
+
+            engine.Start();
+            engine.LoadStartupMap();
+            AssertStartupParticipantBindings(engine);
+        }
+
+        private static void AssertStartupParticipantBindings(GameEngine engine)
+        {
+            int playerId = engine.MergedConfig.StartupSelectedPlayerId;
+            Entity localPlayer = RequireService(engine, CoreServiceKeys.LocalPlayerEntity);
+            Assert.That(localPlayer, Is.Not.EqualTo(Entity.Null));
+            Assert.That(engine.World.IsAlive(localPlayer), Is.True);
+
+            var players = RequireService(engine, CoreServiceKeys.PlayerEntityLookup);
+            Assert.That(players.TryGet(playerId, out Entity playerEntity), Is.True);
+            Assert.That(playerEntity, Is.EqualTo(localPlayer));
+
+            var session = engine.CurrentMapSession
+                ?? throw new InvalidOperationException("Startup map session is missing.");
+            PlayerBindingData? playerBinding = null;
+            for (int i = 0; i < session.MapConfig.Players.Count; i++)
+            {
+                PlayerBindingData binding = session.MapConfig.Players[i];
+                if (binding.PlayerId == playerId)
+                {
+                    playerBinding = binding;
+                    break;
+                }
+            }
+
+            Assert.That(playerBinding, Is.Not.Null);
+
+            var teams = RequireService(engine, CoreServiceKeys.TeamEntityLookup);
+            Assert.That(teams.TryGet(playerBinding!.TeamId, out Entity teamEntity), Is.True);
+            Assert.That(engine.World.IsAlive(teamEntity), Is.True);
+            Assert.That(engine.World.TryGet(localPlayer, out PlayerIdentity identity), Is.True);
+            Assert.That(identity.PlayerId, Is.EqualTo(playerId));
+            Assert.That(engine.World.TryGet(localPlayer, out PlayerOwner owner), Is.True);
+            Assert.That(owner.PlayerId, Is.EqualTo(playerId));
+            Assert.That(engine.World.TryGet(localPlayer, out Team team), Is.True);
+            Assert.That(team.Id, Is.EqualTo(playerBinding.TeamId));
+        }
+
+        private static GameEngine CreateEngine()
+        {
+            string repoRoot = FindRepoRoot();
+            var engine = new GameEngine();
+            engine.InitializeWithConfigPipeline(
+                RepoModPaths.ResolveExplicit(repoRoot, ShowcaseMods),
+                Path.Combine(repoRoot, "assets"));
+            ApplyHostAssets(engine);
+            InstallInput(engine);
+            HeadlessPresentationTestHost.Install(engine);
+            return engine;
+        }
+
+        private static void ApplyHostAssets(GameEngine engine)
+        {
+            var meshAssets = RequireService(engine, CoreServiceKeys.PresentationMeshAssetRegistry);
+            var materialAssets = RequireService(engine, CoreServiceKeys.PresentationMaterialRegistry);
+            new PresentationHostAssetConfigLoader(engine.ConfigPipeline, meshAssets, materialAssets)
+                .Apply("raylib", engine.ConfigCatalog, engine.ConfigConflictReport);
+        }
+
+        private static void InstallInput(GameEngine engine)
+        {
+            var inputConfig = new InputConfigPipelineLoader(engine.ConfigPipeline).Load();
+            var backend = new MutableInputBackend();
+            var inputHandler = new PlayerInputHandler(backend, inputConfig);
+            for (int i = 0; i < engine.MergedConfig.StartupInputContexts.Count; i++)
+            {
+                inputHandler.PushContext(engine.MergedConfig.StartupInputContexts[i]);
+            }
+
+            engine.SetService(CoreServiceKeys.InputHandler, inputHandler);
+            engine.SetService(CoreServiceKeys.InputBackend, (IInputBackend)backend);
+            engine.SetService(CoreServiceKeys.UiCaptured, false);
+        }
+
+        private static MutableInputBackend RequireMutableInputBackend(GameEngine engine)
+        {
+            return RequireService(engine, CoreServiceKeys.InputBackend) as MutableInputBackend
+                ?? throw new InvalidOperationException("MassNavigation production path test requires the mutable input backend.");
+        }
+
+        private static WorldHudToScreenSystem CreateHudProjection(GameEngine engine)
+        {
+            return new WorldHudToScreenSystem(
+                engine.World,
+                RequireService(engine, CoreServiceKeys.PresentationWorldHudBuffer),
+                engine.GetService(CoreServiceKeys.PresentationWorldHudStrings),
+                RequireService(engine, CoreServiceKeys.ScreenProjector),
+                RequireService(engine, CoreServiceKeys.ViewController),
+                RequireService(engine, CoreServiceKeys.PresentationScreenHudBuffer),
+                engine.GetService(CoreServiceKeys.PresentationTimingDiagnostics),
+                engine.GetService(CoreServiceKeys.CameraCullingDebugState));
+        }
+
+        private static ProjectionSample WaitForProductionProjection(
+            GameEngine engine,
+            WorldHudToScreenSystem hudProjection,
+            MassNavigationSimulationRuntime simulation,
+            int expectedAgents)
+        {
+            ProjectionSample lastSample = default;
+            for (int frame = 0; frame < MaxWarmupFrames; frame++)
+            {
+                TickProjectionFrames(engine, hudProjection, 1);
+                lastSample = CaptureProjectionSample(engine, simulation);
+                if (simulation.AgentState.HasBoundAgents(expectedAgents) &&
+                    lastSample.MinimapSnapshot.ZoomBand == MinimapZoomBand.Strategic &&
+                    lastSample.MinimapScreenMarkers >= expectedAgents &&
+                    lastSample.MinimapSnapshot.VisibleMarkerCount >= expectedAgents &&
+                    lastSample.WorldHudBars >= expectedAgents &&
+                    lastSample.WorldHudText >= expectedAgents &&
+                    lastSample.ScreenHudBars >= expectedAgents &&
+                    lastSample.ScreenHudText >= expectedAgents)
+                {
+                    return lastSample;
+                }
+            }
+
+            Assert.Fail(
+                $"MassNavigation showcase did not project {expectedAgents} agents to minimap and HUD within {MaxWarmupFrames} frames; {lastSample.Diagnostics}");
+            return default;
+        }
+
+        private static ProjectionSample CaptureProjectionSample(GameEngine engine, MassNavigationSimulationRuntime simulation)
+        {
+            var minimapRuntime = RequireService(engine, CoreServiceKeys.MinimapRuntime);
+            var minimapMarkers = RequireService(engine, CoreServiceKeys.MinimapMarkerBuffer);
+            var minimapScreenMarkers = RequireService(engine, CoreServiceKeys.MinimapScreenMarkerBuffer);
+            var worldHud = RequireService(engine, CoreServiceKeys.PresentationWorldHudBuffer);
+            var screenHud = RequireService(engine, CoreServiceKeys.PresentationScreenHudBuffer);
+            MinimapDebugSnapshot minimapSnapshot = minimapRuntime.CaptureDebugSnapshot();
+            int worldHudBars = CountWorldHudItems(worldHud, WorldHudItemKind.Bar);
+            int worldHudText = CountWorldHudItems(worldHud, WorldHudItemKind.Text);
+            return new ProjectionSample(
+                minimapSnapshot,
+                minimapScreenMarkers.Count,
+                worldHudBars,
+                worldHudText,
+                screenHud.BarCount,
+                screenHud.TextCount,
+                BuildDiagnostics(
+                    simulation,
+                    minimapRuntime,
+                    minimapSnapshot,
+                    minimapMarkers,
+                    minimapScreenMarkers,
+                    worldHud,
+                    screenHud,
+                    worldHudBars,
+                    worldHudText));
+        }
+
+        private static void TickProjectionFrames(GameEngine engine, WorldHudToScreenSystem hudProjection, int frames)
+        {
+            for (int i = 0; i < frames; i++)
+            {
+                engine.SetService(CoreServiceKeys.UiCaptured, false);
+                engine.Tick(FixedDeltaSeconds);
+                HeadlessPresentationTestHost.UpdateCamera(engine);
+                if (engine.GetService(CoreServiceKeys.MinimapRuntime) is MinimapRuntime minimapRuntime &&
+                    engine.GetService(CoreServiceKeys.MinimapMarkerBuffer) is MinimapMarkerBuffer minimapMarkers &&
+                    engine.GetService(CoreServiceKeys.MinimapScreenMarkerBuffer) is MinimapScreenMarkerBuffer minimapScreenMarkers)
+                {
+                    minimapRuntime.Refresh(engine, minimapMarkers, minimapScreenMarkers);
+                }
+
+                hudProjection.Update(FixedDeltaSeconds);
+            }
+        }
+
+        private static void DriveBoxSelection(
+            GameEngine engine,
+            WorldHudToScreenSystem hudProjection,
+            MutableInputBackend backend,
+            in SelectionDragGesture gesture)
+        {
+            backend.SetMousePosition(gesture.Start);
+            backend.SetButton(MouseLeftButtonPath, false);
+            TickProjectionFrames(engine, hudProjection, 1);
+
+            backend.SetButton(MouseLeftButtonPath, true);
+            TickProjectionFrames(engine, hudProjection, 1);
+
+            backend.SetMousePosition(gesture.End);
+            TickProjectionFrames(engine, hudProjection, 1);
+
+            backend.SetButton(MouseLeftButtonPath, false);
+            TickProjectionFrames(engine, hudProjection, 1);
+        }
+
+        private static void DriveRightClickCommandFrame(
+            GameEngine engine,
+            WorldHudToScreenSystem hudProjection,
+            MutableInputBackend backend,
+            Vector2 position)
+        {
+            backend.SetMousePosition(position);
+            backend.SetButton(MouseRightButtonPath, false);
+            TickProjectionFrames(engine, hudProjection, 1);
+
+            backend.SetButton(MouseRightButtonPath, true);
+            TickProjectionFrames(engine, hudProjection, 1);
+
+            backend.SetButton(MouseRightButtonPath, false);
+            TickProjectionFrames(engine, hudProjection, 2);
+        }
+
+        private static Vector2 ResolveCommandTargetScreenPoint(
+            GameEngine engine,
+            MassNavigationSimulationRuntime simulation,
+            ReadOnlySpan<Entity> selected)
+        {
+            Vector2 targetWorldCm = ResolveCommandTargetWorldCm(engine, simulation, selected);
+            Vector2 candidate = WorldToScreen(engine, targetWorldCm);
+            if (AuthoritativeGroundPointerHelper.TryResolveFromScreen(
+                    engine.GlobalContext,
+                    candidate,
+                    out WorldCmInt2 worldCm) &&
+                simulation.ContainsWorldPoint(worldCm.X, worldCm.Y))
+            {
+                return candidate;
+            }
+
+            throw new InvalidOperationException("MassNavigation production path test could not resolve the command target to commandable ground.");
+        }
+
+        private static Vector2 ResolveCommandTargetWorldCm(
+            GameEngine engine,
+            MassNavigationSimulationRuntime simulation,
+            ReadOnlySpan<Entity> selected)
+        {
+            Vector2 center = ResolveSelectedCenterWorldCm(engine, simulation, selected);
+            float offsetCm = MathF.Min(simulation.SolverWindowWidthCm, simulation.SolverWindowHeightCm) * CommandTargetOffsetWindowScale;
+            ReadOnlySpan<Vector2> directions = stackalloc Vector2[]
+            {
+                new(1f, 0f),
+                new(0f, 1f),
+                new(-1f, 0f),
+                new(0f, -1f),
+                Vector2.Normalize(new Vector2(1f, 1f)),
+                Vector2.Normalize(new Vector2(1f, -1f)),
+                Vector2.Normalize(new Vector2(-1f, 1f)),
+                Vector2.Normalize(new Vector2(-1f, -1f))
+            };
+
+            for (int i = 0; i < directions.Length; i++)
+            {
+                Vector2 candidate = ClampWorldPoint(simulation.WorldBounds, center + (directions[i] * offsetCm));
+                if (Vector2.DistanceSquared(candidate, center) < offsetCm * offsetCm * 0.25f)
+                {
+                    continue;
+                }
+
+                Vector2 screen = WorldToScreen(engine, candidate);
+                if (!IsScreenPointInsideView(engine, screen) ||
+                    IsScreenPointInsideMinimap(engine, screen))
+                {
+                    continue;
+                }
+
+                if (AuthoritativeGroundPointerHelper.TryResolveFromScreen(
+                        engine.GlobalContext,
+                        screen,
+                        out WorldCmInt2 resolved) &&
+                    simulation.ContainsWorldPoint(resolved.X, resolved.Y))
+                {
+                    return candidate;
+                }
+            }
+
+            throw new InvalidOperationException("MassNavigation production path test could not find a visible off-center command target.");
+        }
+
+        private static Vector2 ResolveSelectedCenterWorldCm(
+            GameEngine engine,
+            MassNavigationSimulationRuntime simulation,
+            ReadOnlySpan<Entity> selected)
+        {
+            Vector2 sum = Vector2.Zero;
+            int count = 0;
+            for (int i = 0; i < selected.Length; i++)
+            {
+                if (simulation.TryGetAgentWorldPositionCm(engine.World, selected[i], out Vector2 worldCm))
+                {
+                    sum += worldCm;
+                    count++;
+                }
+            }
+
+            if (count <= 0)
+            {
+                throw new InvalidOperationException("MassNavigation production path test has no selected agent positions.");
+            }
+
+            return sum / count;
+        }
+
+        private static Vector2 ClampWorldPoint(WorldAabbCm bounds, Vector2 point)
+        {
+            return new Vector2(
+                Math.Clamp(point.X, bounds.Left, bounds.Right),
+                Math.Clamp(point.Y, bounds.Top, bounds.Bottom));
+        }
+
+        private static Vector2 WorldToScreen(GameEngine engine, Vector2 worldCm)
+        {
+            var projector = RequireService(engine, CoreServiceKeys.ScreenProjector);
+            return projector.WorldToScreen(new Vector3(worldCm.X / 100f, 0f, worldCm.Y / 100f));
+        }
+
+        private static bool IsScreenPointInsideView(GameEngine engine, Vector2 screen)
+        {
+            var view = RequireService(engine, CoreServiceKeys.ViewController);
+            return float.IsFinite(screen.X) &&
+                float.IsFinite(screen.Y) &&
+                screen.X >= 0f &&
+                screen.X <= view.Resolution.X &&
+                screen.Y >= 0f &&
+                screen.Y <= view.Resolution.Y;
+        }
+
+        private static bool IsScreenPointInsideMinimap(GameEngine engine, Vector2 screen)
+        {
+            return engine.GetService(CoreServiceKeys.MinimapRuntime) is MinimapRuntime minimapRuntime &&
+                (minimapRuntime.ContainsField(screen) ||
+                 minimapRuntime.ContainsZoomSlider(screen) ||
+                 minimapRuntime.ContainsPresetToggle(screen) ||
+                 minimapRuntime.ContainsRotateToggle(screen));
+        }
+
+        private static SelectionDragGesture ResolveVisibleAgentDragGesture(GameEngine engine)
+        {
+            var projector = RequireService(engine, CoreServiceKeys.ScreenProjector);
+            var view = RequireService(engine, CoreServiceKeys.ViewController);
+            var selection = RequireService(engine, CoreServiceKeys.SelectionRuntime);
+            Vector2 resolution = view.Resolution;
+            float padding = selection.Config.ClickPickRadiusPixels + selection.Config.DragThresholdPixels;
+            bool hasBounds = false;
+            ScreenRect bounds = default;
+
+            var query = new QueryDescription().WithAll<MassNavigationAgent, VisualTransform, CullState, SelectionSelectableTag>();
+            engine.World.Query(in query, (Entity entity, ref MassNavigationAgent _, ref VisualTransform _, ref CullState cull, ref SelectionSelectableTag _) =>
+            {
+                if (!cull.IsVisible ||
+                    !SpatialBoundsUtility.TryProjectScreenBounds(engine.World, entity, projector, out ScreenRect candidate))
+                {
+                    return;
+                }
+
+                if (!hasBounds)
+                {
+                    bounds = candidate;
+                    hasBounds = true;
+                    return;
+                }
+
+                bounds = new ScreenRect(
+                    MathF.Min(bounds.MinX, candidate.MinX),
+                    MathF.Min(bounds.MinY, candidate.MinY),
+                    MathF.Max(bounds.MaxX, candidate.MaxX),
+                    MathF.Max(bounds.MaxY, candidate.MaxY));
+            });
+
+            if (!hasBounds)
+            {
+                Assert.Fail("MassNavigation showcase has no projected selectable agents to drive a box selection gesture.");
+            }
+
+            Vector2 start = new(
+                Clamp(bounds.MinX - padding, 0f, resolution.X),
+                Clamp(bounds.MinY - padding, 0f, resolution.Y));
+            Vector2 end = new(
+                Clamp(bounds.MaxX + padding, 0f, resolution.X),
+                Clamp(bounds.MaxY + padding, 0f, resolution.Y));
+
+            float minExtent = selection.Config.DragThresholdPixels + padding;
+            if (MathF.Abs(end.X - start.X) <= selection.Config.DragThresholdPixels)
+            {
+                end.X = Clamp(start.X + minExtent, 0f, resolution.X);
+            }
+
+            if (MathF.Abs(end.Y - start.Y) <= selection.Config.DragThresholdPixels)
+            {
+                end.Y = Clamp(start.Y + minExtent, 0f, resolution.Y);
+            }
+
+            return new SelectionDragGesture(start, end, ScreenRect.FromPoints(start, end));
+        }
+
+        private static SelectionDiagnostics CaptureSelectionDiagnostics(GameEngine engine, in ScreenRect marquee)
+        {
+            var projector = RequireService(engine, CoreServiceKeys.ScreenProjector);
+            var selection = RequireService(engine, CoreServiceKeys.SelectionRuntime);
+            Entity localPlayer = engine.GlobalContext.TryGetValue(CoreServiceKeys.LocalPlayerEntity.Name, out object? localObj) &&
+                localObj is Entity local &&
+                engine.World.IsAlive(local)
+                    ? local
+                    : default;
+            bool hasCurrentView = SelectionContextRuntime.TryDescribeCurrentView(engine.World, engine.GlobalContext, out _);
+            bool hasKnowledgeResolver = KnowledgeProjectionConsumer.HasResolver(engine.GlobalContext);
+            bool localPlayerResolved = localPlayer != default && engine.World.IsAlive(localPlayer);
+            Team localTeam = default;
+            bool localHasTeam = localPlayerResolved && engine.World.TryGet(localPlayer, out localTeam);
+            int localTeamId = localHasTeam ? localTeam.Id : 0;
+            int selectedCount = SelectionContextRuntime.GetCurrentCount(engine.World, engine.GlobalContext);
+            int visibleSelectable = 0;
+            int projected = 0;
+            int screenIntersecting = 0;
+            int eligible = 0;
+            int eligibleIntersecting = 0;
+            int liveVisible = 0;
+            ScreenRect dragRect = marquee;
+
+            var query = new QueryDescription().WithAll<MassNavigationAgent, VisualTransform, CullState, SelectionSelectableTag>();
+            engine.World.Query(in query, (Entity entity, ref MassNavigationAgent _, ref VisualTransform _, ref CullState cull, ref SelectionSelectableTag _) =>
+            {
+                if (!cull.IsVisible)
+                {
+                    return;
+                }
+
+                visibleSelectable++;
+                bool hasProjectedBounds = SpatialBoundsUtility.TryProjectScreenBounds(engine.World, entity, projector, out ScreenRect bounds);
+                if (hasProjectedBounds)
+                {
+                    projected++;
+                }
+
+                bool intersects = hasProjectedBounds && bounds.Intersects(in dragRect);
+                if (intersects)
+                {
+                    screenIntersecting++;
+                }
+
+                if (hasKnowledgeResolver &&
+                    localPlayerResolved &&
+                    KnowledgeProjectionConsumer.CanReadPositionForViewer(
+                        engine.World,
+                        engine.GlobalContext,
+                        localPlayer,
+                        entity,
+                        KnowledgePositionAccess.Live,
+                        out KnowledgeProjection projection) &&
+                    projection.Presence == KnowledgePresence.LiveVisible)
+                {
+                    liveVisible++;
+                }
+
+                bool canAcquire = localPlayerResolved &&
+                    SelectionEligibility.CanAcquire(
+                        engine.World,
+                        engine.GlobalContext,
+                        localPlayer,
+                        entity,
+                        selection.TargetRelationFilter);
+                if (canAcquire)
+                {
+                    eligible++;
+                }
+
+                if (intersects && canAcquire)
+                {
+                    eligibleIntersecting++;
+                }
+            });
+
+            return new SelectionDiagnostics(
+                localPlayer,
+                localTeamId,
+                localHasTeam,
+                hasCurrentView,
+                hasKnowledgeResolver,
+                visibleSelectable,
+                projected,
+                screenIntersecting,
+                liveVisible,
+                eligible,
+                eligibleIntersecting,
+                selectedCount);
+        }
+
+        private static float Clamp(float value, float min, float max)
+        {
+            return MathF.Min(MathF.Max(value, min), max);
+        }
+
+        private static int CountActiveSelectionMarkers(GameEngine engine)
+        {
+            var performers = RequireService(engine, CoreServiceKeys.PerformerEntityRuntime);
+            var definitions = RequireService(engine, CoreServiceKeys.PerformerDefinitionRegistry);
+            int lightMarkerId = definitions.GetId(LightSelectionMarkerPerformerId);
+            int heavyMarkerId = definitions.GetId(HeavySelectionMarkerPerformerId);
+            if (lightMarkerId <= 0 || heavyMarkerId <= 0)
+            {
+                throw new InvalidOperationException("MassNavigation selection marker performer definitions are not registered.");
+            }
+
+            int count = 0;
+            var query = new QueryDescription().WithAll<PerformerState>();
+            engine.World.Query(in query, (ref PerformerState state) =>
+            {
+                if (state.DefId == lightMarkerId ||
+                    state.DefId == heavyMarkerId)
+                {
+                    count++;
+                }
+            });
+
+            return count;
+        }
+
+        private static Vector2[] CaptureSelectedWorldPositions(
+            GameEngine engine,
+            MassNavigationSimulationRuntime simulation,
+            ReadOnlySpan<Entity> selected)
+        {
+            var positions = new Vector2[selected.Length];
+            for (int i = 0; i < selected.Length; i++)
+            {
+                if (!simulation.TryGetAgentWorldPositionCm(engine.World, selected[i], out positions[i]))
+                {
+                    throw new InvalidOperationException(DescribeEntityCommandState(engine, selected[i]));
+                }
+            }
+
+            return positions;
+        }
+
+        private static int CountMovedSelectedAgents(
+            GameEngine engine,
+            MassNavigationSimulationRuntime simulation,
+            ReadOnlySpan<Entity> selected,
+            ReadOnlySpan<Vector2> positionsBefore)
+        {
+            if (positionsBefore.Length != selected.Length)
+            {
+                throw new InvalidOperationException("MassNavigation movement sample must match selected entity count.");
+            }
+
+            int moved = 0;
+            float epsilonSquared = MovementEpsilonCm * MovementEpsilonCm;
+            for (int i = 0; i < selected.Length; i++)
+            {
+                if (simulation.TryGetAgentWorldPositionCm(engine.World, selected[i], out Vector2 current) &&
+                    Vector2.DistanceSquared(current, positionsBefore[i]) > epsilonSquared)
+                {
+                    moved++;
+                }
+            }
+
+            return moved;
+        }
+
+        private static void AssertSelectedEntitiesAreCommandable(GameEngine engine, ReadOnlySpan<Entity> selected)
+        {
+            int playerId = engine.MergedConfig.StartupSelectedPlayerId;
+            for (int i = 0; i < selected.Length; i++)
+            {
+                Entity entity = selected[i];
+                string diagnostics = DescribeEntityCommandState(engine, entity);
+                Assert.That(engine.World.IsAlive(entity), Is.True, diagnostics);
+                Assert.That(engine.World.TryGet(entity, out PlayerOwner owner), Is.True, diagnostics);
+                Assert.That(owner.PlayerId, Is.EqualTo(playerId), diagnostics);
+            }
+        }
+
+        private static void AssertLocalScenarioAgentsAreCommandable(GameEngine engine)
+        {
+            int playerId = engine.MergedConfig.StartupSelectedPlayerId;
+            Entity localPlayer = RequireService(engine, CoreServiceKeys.LocalPlayerEntity);
+            Assert.That(engine.World.TryGet(localPlayer, out Team localTeam), Is.True, "Startup local player must have a Team.");
+
+            int localTeamAgents = 0;
+            int localOwnedAgents = 0;
+            var query = new QueryDescription().WithAll<MassNavigationAgent, Team>();
+            engine.World.Query(in query, (Entity entity, ref MassNavigationAgent _, ref Team team) =>
+            {
+                if (team.Id != localTeam.Id)
+                {
+                    return;
+                }
+
+                localTeamAgents++;
+                if (engine.World.TryGet(entity, out PlayerOwner owner) &&
+                    owner.PlayerId == playerId)
+                {
+                    localOwnedAgents++;
+                }
+            });
+
+            Assert.That(localTeamAgents, Is.GreaterThan(0), $"MassNavigation scenario should spawn agents for local team {localTeam.Id}.");
+            Assert.That(
+                localOwnedAgents,
+                Is.EqualTo(localTeamAgents),
+                $"MassNavigation scenario local team {localTeam.Id} agents must be owned by startup player {playerId}.");
+        }
+
+        private static string DescribeEntityCommandState(GameEngine engine, Entity entity)
+        {
+            string alive = engine.World.IsAlive(entity) ? "alive" : "dead";
+            string team = engine.World.TryGet(entity, out Team teamComponent)
+                ? teamComponent.Id.ToString()
+                : "none";
+            string owner = engine.World.TryGet(entity, out PlayerOwner ownerComponent)
+                ? ownerComponent.PlayerId.ToString()
+                : "none";
+            var selection = RequireService(engine, CoreServiceKeys.SelectionRuntime);
+            return $"selectedEntity={entity.Id}, state={alive}, team={team}, playerOwner={owner}, targetRelationFilter={selection.TargetRelationFilter}";
+        }
+
+        private static int CountActiveMoveOrders(GameEngine engine, ReadOnlySpan<Entity> selected)
+        {
+            int count = 0;
+            for (int i = 0; i < selected.Length; i++)
+            {
+                Entity entity = selected[i];
+                if (engine.World.IsAlive(entity) &&
+                    engine.World.TryGet(entity, out OrderBuffer orders) &&
+                    orders.HasActive)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        private static T RequireService<T>(GameEngine engine, ServiceKey<T> key)
+        {
+            T value = engine.GetService(key);
+            return value ?? throw new InvalidOperationException($"{key.Name} service is missing.");
+        }
+
+        private static int CountWorldHudItems(WorldHudBatchBuffer worldHud, WorldHudItemKind kind)
+        {
+            int count = 0;
+            ReadOnlySpan<WorldHudItem> span = worldHud.GetSpan();
+            for (int i = 0; i < span.Length; i++)
+            {
+                if (span[i].Kind == kind)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        private static Entity[] CollectMassNavigationAgents(GameEngine engine, int expectedAgents)
+        {
+            var agents = new Entity[expectedAgents];
+            int count = 0;
+            var query = new QueryDescription().WithAll<MassNavigationAgent, VisualTransform, CullState, SelectionSelectableTag>();
+            engine.World.Query(in query, (Entity entity, ref MassNavigationAgent _, ref VisualTransform _, ref CullState cull, ref SelectionSelectableTag _) =>
+            {
+                if (!cull.IsVisible)
+                {
+                    return;
+                }
+
+                Assert.That(count, Is.LessThan(agents.Length), "MassNavigation showcase authored more selectable visible agents than its scenario count.");
+                agents[count++] = entity;
+            });
+
+            Assert.That(count, Is.EqualTo(expectedAgents));
+            return agents;
+        }
+
+        private static void AssertScenarioAgentTemplatesDoNotDriveHealthPeriodically(
+            GameEngine engine,
+            MassNavigationSimulationRuntime simulation)
+        {
+            var checkedTemplateIds = new HashSet<string>(StringComparer.Ordinal);
+            for (int i = 0; i < simulation.Config.Presentation.Teams.Length; i++)
+            {
+                MassNavigationTeamPresentationConfig team = simulation.Config.Presentation.Teams[i];
+                AssertAgentTemplateDoesNotDriveHealthPeriodically(engine, team.LightTemplateId, checkedTemplateIds);
+                AssertAgentTemplateDoesNotDriveHealthPeriodically(engine, team.HeavyTemplateId, checkedTemplateIds);
+            }
+        }
+
+        private static void AssertAgentTemplateDoesNotDriveHealthPeriodically(
+            GameEngine engine,
+            string templateId,
+            HashSet<string> checkedTemplateIds)
+        {
+            Assert.That(templateId, Is.Not.Empty);
+            if (!checkedTemplateIds.Add(templateId))
+            {
+                return;
+            }
+
+            EntityTemplate template = engine.MapLoader.TemplateRegistry.Get(templateId)
+                ?? throw new InvalidOperationException($"MassNavigation showcase agent template '{templateId}' is not registered.");
+            Assert.That(
+                template.OnSpawnEffect,
+                Is.Null.Or.Empty,
+                $"MassNavigation 10k showcase template '{templateId}' must not attach periodic health effects; HUD text/bar inputs must stay stable unless gameplay changes Health.");
+        }
+
+        private static Dictionary<int, AgentHealthSample> CaptureAgentHealth(GameEngine engine, int expectedAgents)
+        {
+            int healthAttributeId = AttributeRegistry.GetId("Health");
+            Assert.That(healthAttributeId, Is.GreaterThanOrEqualTo(0), "MassNavigation HUD health stability requires the Health attribute id.");
+
+            var samples = new Dictionary<int, AgentHealthSample>(expectedAgents);
+            var query = new QueryDescription().WithAll<MassNavigationAgent, AttributeBuffer>();
+            engine.World.Query(in query, (Entity entity, ref MassNavigationAgent _, ref AttributeBuffer attributes) =>
+            {
+                samples.Add(
+                    entity.Id,
+                    new AgentHealthSample(
+                        attributes.GetCurrent(healthAttributeId),
+                        attributes.GetBase(healthAttributeId)));
+            });
+
+            Assert.That(samples.Count, Is.EqualTo(expectedAgents));
+            return samples;
+        }
+
+        private static void AssertAgentHealthStable(
+            IReadOnlyDictionary<int, AgentHealthSample> before,
+            IReadOnlyDictionary<int, AgentHealthSample> after)
+        {
+            Assert.That(after.Count, Is.EqualTo(before.Count));
+            foreach (KeyValuePair<int, AgentHealthSample> pair in before)
+            {
+                Assert.That(after.TryGetValue(pair.Key, out AgentHealthSample actual), Is.True);
+                Assert.That(actual.Current, Is.EqualTo(pair.Value.Current).Within(0.0001f), $"Agent {pair.Key} Health current changed.");
+                Assert.That(actual.Base, Is.EqualTo(pair.Value.Base).Within(0.0001f), $"Agent {pair.Key} Health base changed.");
+            }
+        }
+
+        private static void AssertScreenHudIdentityStableAcrossProjectionFrames(
+            GameEngine engine,
+            WorldHudToScreenSystem hudProjection,
+            int frames)
+        {
+            var screenHud = RequireService(engine, CoreServiceKeys.PresentationScreenHudBuffer);
+            ScreenHudIdentitySnapshot before = CaptureScreenHudIdentity(screenHud);
+            for (int i = 0; i < frames; i++)
+            {
+                TickProjectionFrames(engine, hudProjection, 1);
+                ScreenHudIdentitySnapshot after = CaptureScreenHudIdentity(screenHud);
+                Assert.That(after.BarCount, Is.EqualTo(before.BarCount), $"Screen HUD bar count changed on frame {i + 1}.");
+                Assert.That(after.TextCount, Is.EqualTo(before.TextCount), $"Screen HUD text count changed on frame {i + 1}.");
+                Assert.That(after.BarIdentities, Is.EqualTo(before.BarIdentities), $"Screen HUD bar identities changed on frame {i + 1}.");
+                Assert.That(after.TextIdentities, Is.EqualTo(before.TextIdentities), $"Screen HUD text identities changed on frame {i + 1}.");
+            }
+        }
+
+        private static ScreenHudIdentitySnapshot CaptureScreenHudIdentity(ScreenHudBatchBuffer screenHud)
+        {
+            ReadOnlySpan<ScreenHudBarItem> bars = screenHud.GetBarSpan();
+            ReadOnlySpan<ScreenHudTextItem> texts = screenHud.GetTextSpan();
+            long[] barIdentities = new long[bars.Length];
+            long[] textIdentities = new long[texts.Length];
+            for (int i = 0; i < bars.Length; i++)
+            {
+                barIdentities[i] = ComposeHudIdentity(bars[i].StableId, bars[i].DirtySerial);
+            }
+
+            for (int i = 0; i < texts.Length; i++)
+            {
+                textIdentities[i] = ComposeHudIdentity(texts[i].StableId, texts[i].DirtySerial);
+            }
+
+            Array.Sort(barIdentities);
+            Array.Sort(textIdentities);
+            return new ScreenHudIdentitySnapshot(bars.Length, texts.Length, barIdentities, textIdentities);
+        }
+
+        private static long ComposeHudIdentity(int stableId, int dirtySerial)
+        {
+            return ((long)stableId << 32) ^ (uint)dirtySerial;
+        }
+
+        private static string BuildDiagnostics(
+            MassNavigationSimulationRuntime simulation,
+            MinimapRuntime minimapRuntime,
+            MinimapDebugSnapshot minimapSnapshot,
+            MinimapMarkerBuffer minimapMarkers,
+            MinimapScreenMarkerBuffer minimapScreenMarkers,
+            WorldHudBatchBuffer worldHud,
+            ScreenHudBatchBuffer screenHud,
+            int worldHudBars,
+            int worldHudText)
+        {
+            return string.Join(
+                ", ",
+                $"agents={simulation.AgentState.TotalAgents}",
+                $"minimapVisible={minimapRuntime.Visible}",
+                $"minimapPreset={minimapRuntime.Preset}",
+                $"minimapBand={minimapSnapshot.ZoomBand}",
+                $"minimapHalfExtentCm={minimapSnapshot.HalfExtentCm:0.###}",
+                $"minimapMarkers={minimapMarkers.Count}",
+                $"minimapScreenMarkers={minimapScreenMarkers.Count}",
+                $"minimapVisibleMarkers={minimapSnapshot.VisibleMarkerCount}",
+                $"worldHud={worldHud.Count}",
+                $"worldHudBars={worldHudBars}",
+                $"worldHudText={worldHudText}",
+                $"screenHudBars={screenHud.BarCount}",
+                $"screenHudText={screenHud.TextCount}");
+        }
+
+        private static string FindRepoRoot()
+        {
+            string current = TestContext.CurrentContext.WorkDirectory;
+            while (!string.IsNullOrEmpty(current))
+            {
+                if (Directory.Exists(Path.Combine(current, "mods")) &&
+                    File.Exists(Path.Combine(current, "AGENTS.md")))
+                {
+                    return current;
+                }
+
+                current = Path.GetDirectoryName(current)!;
+            }
+
+            throw new DirectoryNotFoundException("Repository root not found from test work directory.");
+        }
+
+        private readonly record struct ProjectionSample(
+            MinimapDebugSnapshot MinimapSnapshot,
+            int MinimapScreenMarkers,
+            int WorldHudBars,
+            int WorldHudText,
+            int ScreenHudBars,
+            int ScreenHudText,
+            string Diagnostics);
+
+        private readonly record struct SelectionDragGesture(Vector2 Start, Vector2 End, ScreenRect Marquee);
+
+        private readonly record struct AgentHealthSample(float Current, float Base);
+
+        private readonly record struct ScreenHudIdentitySnapshot(
+            int BarCount,
+            int TextCount,
+            long[] BarIdentities,
+            long[] TextIdentities);
+
+        private readonly record struct SelectionDiagnostics(
+            Entity LocalPlayer,
+            int LocalTeamId,
+            bool LocalHasTeam,
+            bool HasCurrentView,
+            bool HasKnowledgeResolver,
+            int VisibleSelectable,
+            int Projected,
+            int ScreenIntersecting,
+            int LiveVisible,
+            int Eligible,
+            int EligibleIntersecting,
+            int CurrentSelectionCount)
+        {
+            public override string ToString()
+            {
+                return string.Join(
+                    ", ",
+                    $"localPlayer={LocalPlayer}",
+                    $"localHasTeam={LocalHasTeam}",
+                    $"localTeamId={LocalTeamId}",
+                    $"hasCurrentView={HasCurrentView}",
+                    $"hasKnowledgeResolver={HasKnowledgeResolver}",
+                    $"visibleSelectable={VisibleSelectable}",
+                    $"projected={Projected}",
+                    $"screenIntersecting={ScreenIntersecting}",
+                    $"liveVisible={LiveVisible}",
+                    $"eligible={Eligible}",
+                    $"eligibleIntersecting={EligibleIntersecting}",
+                    $"currentSelectionCount={CurrentSelectionCount}");
+            }
+        }
+
+        private sealed class MutableInputBackend : IInputBackend
+        {
+            private readonly HashSet<string> _pressedButtons = new(StringComparer.Ordinal);
+            private Vector2 _mousePosition;
+
+            public float GetAxis(string devicePath) => 0f;
+            public bool GetButton(string devicePath) => _pressedButtons.Contains(devicePath);
+            public Vector2 GetMousePosition() => _mousePosition;
+            public float GetMouseWheel() => 0f;
+            public void EnableIME(bool enable) { }
+            public void SetIMECandidatePosition(int x, int y) { }
+            public string GetCharBuffer() => string.Empty;
+
+            public void SetMousePosition(Vector2 mousePosition)
+            {
+                _mousePosition = mousePosition;
+            }
+
+            public void SetButton(string devicePath, bool pressed)
+            {
+                if (pressed)
+                {
+                    _pressedButtons.Add(devicePath);
+                    return;
+                }
+
+                _pressedButtons.Remove(devicePath);
+            }
+        }
+    }
+}

--- a/src/Tests/PresentationTests/FormationCapabilityShowcaseContractTests.cs
+++ b/src/Tests/PresentationTests/FormationCapabilityShowcaseContractTests.cs
@@ -107,7 +107,7 @@ namespace Ludots.Tests.Presentation
             Assert.That(components.ContainsKey("MassNavigationFormationAnchor"), Is.False,
                 "Formation identity is per spawned formation and must be applied by runtime component patch, not an empty template placeholder.");
             Assert.That(components.ContainsKey("MassNavigationFollowerLocomotion"), Is.True,
-                "Follower sync tuning belongs to component authoring, not a showcase-only runtime config block.");
+                "Follower sync tuning belongs to component authoring, not a runtime config block.");
 
             JsonArray formations = config["formations"]?.AsArray()
                 ?? throw new InvalidOperationException("FormationCapability config must author formations.");
@@ -2615,18 +2615,22 @@ namespace Ludots.Tests.Presentation
                 "capability_standard",
                 "CapabilityStandardMassNavigationLargeWorld10kMod");
             string entrySource = File.ReadAllText(Path.Combine(modRoot, "CapabilityStandardMassNavigationLargeWorld10kModEntry.cs"));
+            string mapFocusSource = File.ReadAllText(Path.Combine(modRoot, "CapabilityStandardMassNavigationLargeWorld10kMapFocus.cs"));
+            string runtimeSource = entrySource + mapFocusSource;
 
-            Assert.That(entrySource, Does.Contain("context.OnEvent(GameEvents.GameStart, ConfigureLargeWorldUatAsync);"));
-            Assert.That(entrySource, Does.Contain("context.OnEvent(GameEvents.MapLoaded, ConfigureLargeWorldUatAsync);"));
-            Assert.That(entrySource, Does.Contain("context.OnEvent(GameEvents.MapResumed, ConfigureLargeWorldUatAsync);"));
-            Assert.That(entrySource, Does.Contain("engine.MergedConfig?.StartupMapId"));
+            Assert.That(entrySource, Does.Contain("context.OnEvent(GameEvents.GameStart, ConfigureLargeWorldShowcaseAsync);"));
+            Assert.That(entrySource, Does.Contain("context.OnEvent(GameEvents.MapLoaded, ConfigureLargeWorldShowcaseAsync);"));
+            Assert.That(entrySource, Does.Contain("context.OnEvent(GameEvents.MapResumed, ConfigureLargeWorldShowcaseAsync);"));
+            Assert.That(entrySource, Does.Contain("MassNavigationObserverVisibilityBindingSystem"));
+            Assert.That(entrySource, Does.Contain("SystemGroup.RuntimeEntityBinding"));
+            Assert.That(runtimeSource, Does.Contain("engine.MergedConfig?.StartupMapId"));
             Assert.That(entrySource, Does.Contain("CoreServiceKeys.MinimapRuntime"));
             Assert.That(entrySource, Does.Contain("runtime.Visible = true;"));
             Assert.That(entrySource, Does.Contain("runtime.SetRotateWithCamera(false);"));
             Assert.That(entrySource, Does.Contain("runtime.UseRtsFullMapPreset();"));
-            Assert.That(entrySource, Does.Not.Contain("\"mass_navigation\""),
-                "The capability entry must use authored startupMapId instead of a code-level map-id duplicate.");
-            Assert.That(entrySource, Does.Not.Contain("Environment.GetEnvironmentVariable"),
+            Assert.That(runtimeSource, Does.Not.Contain("\"mass_navigation\""),
+                "The capability runtime must use authored startupMapId instead of a code-level map-id duplicate.");
+            Assert.That(runtimeSource, Does.Not.Contain("Environment.GetEnvironmentVariable"),
                 "Capability-standard MassNavigation acceptance must not depend on env fallback toggles.");
         }
 

--- a/src/Tests/PresentationTests/MassNavigationFlowSolverStateConfigurationTests.cs
+++ b/src/Tests/PresentationTests/MassNavigationFlowSolverStateConfigurationTests.cs
@@ -137,6 +137,60 @@ namespace Ludots.Tests.Presentation
         }
 
         [Test]
+        public void ParallelStep_EmitsExactlyOneArrivalEventPerSettledAgent()
+        {
+            World.SharedJobScheduler ??= new JobScheduler(new JobScheduler.Config
+            {
+                ThreadPrefixName = "MassNavArrivalTests",
+                ThreadCount = 0,
+                MaxExpectedConcurrentJobs = 64,
+                StrictAllocationMode = false
+            });
+
+            const int agentCount = 16;
+            var flow = CreateConfiguredFlow(parallelWorkerCount: 4);
+            flow.Semantics.Solver.ParallelStepMinAgents = 2;
+            var layer = new MassNavigationAgentLayer(categoryMask: 1u, interactionMask: 1u);
+            var seeds = new MassNavigationAgentSeed[agentCount];
+            for (int i = 0; i < agentCount; i++)
+            {
+                seeds[i] = new MassNavigationAgentSeed(
+                    teamId: 1,
+                    localPositionXCm: 1_000f + ((i % 4) * 800f),
+                    localPositionYCm: 1_000f + ((i / 4) * 800f),
+                    heavy: false,
+                    navMass: 1f,
+                    visualScale: 1f,
+                    bodyRadiusCm: 20f,
+                    speedCmPerSecond: 800f,
+                    layer);
+            }
+
+            TeamManager.LoadConfig(new TeamConfig
+            {
+                DefaultRelationship = "Friendly",
+                Relationships = new List<RelationshipEntry>(),
+            });
+            flow.ResetAuthoredAgents(seeds);
+            for (int i = 0; i < agentCount; i++)
+            {
+                flow.SetUnitTarget(i, flow.GetPositionX(i), flow.GetPositionY(i), resetRecovery: true);
+            }
+
+            using var world = World.Create();
+            var navGroups = new MassNavigationGroupRuntime(
+                new MassNavigationFormationRuntime(LoadBaseMassNavigationConfig().Semantics.Group),
+                CreateRuntimeCapacity(agentCapacity: agentCount, groupMemberCapacity: agentCount));
+
+            flow.Step(dt: 0.016f, world, navGroups, runHardResolve: false, hardResolveCandidateThresholdAgents: 1);
+            Assert.That(flow.SettledUnitCount, Is.EqualTo(agentCount));
+            Assert.That(flow.PendingArrivalEventCount, Is.EqualTo(agentCount));
+
+            flow.Step(dt: 0.016f, world, navGroups, runHardResolve: false, hardResolveCandidateThresholdAgents: 1);
+            Assert.That(flow.PendingArrivalEventCount, Is.EqualTo(agentCount));
+        }
+
+        [Test]
         public void SpawnJitter_UsesConfiguredSeedDeterministically()
         {
             var first = CreateSpawnedFlow(randomSeed: 1234);

--- a/src/Tests/PresentationTests/MassNavigationFlowSolverStateConfigurationTests.cs
+++ b/src/Tests/PresentationTests/MassNavigationFlowSolverStateConfigurationTests.cs
@@ -5,8 +5,16 @@ using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Arch.Core;
+using Ludots.Core.Components;
+using Ludots.Core.Gameplay.Components;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Orders;
+using Ludots.Core.Layers;
 using Ludots.Core.MassNavigation.Runtime;
+using Ludots.Core.MassNavigation;
+using Ludots.Core.Mathematics;
 using Ludots.Core.Navigation.AgentProfiles;
+using Ludots.Core.Spatial;
 using NUnit.Framework;
 using Schedulers;
 using Ludots.Core.Gameplay.Teams;
@@ -48,6 +56,30 @@ namespace Ludots.Tests.Presentation
 
             InvalidOperationException missing = Assert.Throws<InvalidOperationException>(() => MassNavigationConfig.Load(config))!;
             Assert.That(missing.Message, Does.Contain("randomSeed"));
+        }
+
+        [Test]
+        public void MassNavigationConfig_SelectionCapacityMustCoverAuthoredScenarioAgents()
+        {
+            JsonObject initialScratchConfig = ReadObject(Path.Combine(MassNavigationModRoot(), "assets", "MassNavigationConfig.json"));
+            int authoredAgentCount = ResolveAuthoredAgentCount(initialScratchConfig);
+            JsonObject scenarioRuntime = initialScratchConfig["scenarioRuntime"]?.AsObject()
+                ?? throw new InvalidOperationException("MassNavigationConfig.scenarioRuntime must be authored.");
+            scenarioRuntime["initialSelectionScratchCapacity"] = authoredAgentCount - 1;
+
+            InvalidOperationException initialScratch = Assert.Throws<InvalidOperationException>(() => MassNavigationConfig.Load(initialScratchConfig))!;
+            Assert.That(initialScratch.Message, Does.Contain("scenarioRuntime.initialSelectionScratchCapacity"));
+            Assert.That(initialScratch.Message, Does.Contain("authored scenario agent count"));
+
+            JsonObject runtimeScratchConfig = ReadObject(Path.Combine(MassNavigationModRoot(), "assets", "MassNavigationConfig.json"));
+            authoredAgentCount = ResolveAuthoredAgentCount(runtimeScratchConfig);
+            JsonObject runtimeCapacity = runtimeScratchConfig["scenarioRuntime"]?["runtimeCapacity"]?.AsObject()
+                ?? throw new InvalidOperationException("MassNavigationConfig.scenarioRuntime.runtimeCapacity must be authored.");
+            runtimeCapacity["selectionMemberScratchCapacity"] = authoredAgentCount - 1;
+
+            InvalidOperationException runtimeScratch = Assert.Throws<InvalidOperationException>(() => MassNavigationConfig.Load(runtimeScratchConfig))!;
+            Assert.That(runtimeScratch.Message, Does.Contain("scenarioRuntime.runtimeCapacity.selectionMemberScratchCapacity"));
+            Assert.That(runtimeScratch.Message, Does.Contain("scenarioRuntime.initialSelectedEntityCapacity"));
         }
 
         [Test]
@@ -249,6 +281,78 @@ namespace Ludots.Tests.Presentation
             AssertWritableLeavesEqual(config.Semantics, flow.Semantics, "semantics");
         }
 
+        [Test]
+        public void SimulationRuntime_CapturesReadOnlyAvoidanceSnapshot()
+        {
+            using var world = World.Create();
+            MassNavigationConfig config = LoadBaseMassNavigationConfig();
+            config.Solver.FieldWidthCm = 10_000;
+            config.Solver.FieldHeightCm = 10_000;
+            config.Solver.PlayAreaMinXCm = 50f;
+            config.Solver.PlayAreaMaxXCm = 9_950f;
+            config.Solver.PlayAreaMinYCm = 50f;
+            config.Solver.PlayAreaMaxYCm = 9_950f;
+            config.Solver.MaxObstacleCount = 8;
+            config.ScenarioRuntime.InitialSelectedEntityCapacity = 4;
+            config.ScenarioRuntime.InitialSelectionScratchCapacity = 4;
+            config.ScenarioRuntime.RuntimeCapacity.GroupMembershipAgentCapacity = 4;
+            config.ScenarioRuntime.RuntimeCapacity.SelectionMemberScratchCapacity = 4;
+            config.ScenarioRuntime.RuntimeCapacity.GroupMemberCapacity = 4;
+            config.ScenarioRuntime.RuntimeCapacity.OrderIngestionMemberCapacity = 4;
+            var runtime = new MassNavigationSimulationRuntime(config);
+            runtime.BindBoardWorld(new WorldSizeSpec(new WorldAabbCm(-5_000, -5_000, 10_000, 10_000), 100));
+
+            MassNavigationAgentLayer layer = CreateAgentLayer();
+            Entity light = CreateAuthoredAgentEntity(world, localX: 1000f, localY: 1200f, layer);
+            Entity heavy = CreateAuthoredAgentEntity(world, localX: 1400f, localY: 1200f, layer);
+            MassNavigationAgentSeed[] seeds =
+            {
+                CreateAvoidanceSeed(teamId: 1, localX: 1000f, localY: 1200f, heavy: false, layer),
+                CreateAvoidanceSeed(teamId: 2, localX: 1400f, localY: 1200f, heavy: true, layer),
+            };
+            runtime.RebuildFromAuthoredAgents(world, new[] { light, heavy }, seeds, new[] { true, true });
+            runtime.SetSelection(new[] { light }, revision: 1);
+            runtime.RebuildRuntimeObstacles(new[]
+            {
+                new MassNavigationObstacleSnapshot(worldXCm: 2200f, worldYCm: 2300f, radiusCm: 150f),
+            });
+
+            var agents = new MassNavigationAvoidanceAgentSnapshot[runtime.NavigationAgentCount];
+            var obstacles = new MassNavigationObstacleSnapshot[runtime.NavigationObstacleCount];
+            MassNavigationAvoidanceSnapshot snapshot = runtime.CaptureAvoidanceSnapshot(agents, obstacles);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(snapshot.UnitCount, Is.EqualTo(2));
+                Assert.That(snapshot.ObstacleCount, Is.EqualTo(1));
+                Assert.That(snapshot.PlayAreaMinXCm, Is.EqualTo(50f));
+                Assert.That(snapshot.PlayAreaMaxXCm, Is.EqualTo(9_950f));
+                Assert.That(agents, Has.Length.EqualTo(2));
+                Assert.That(obstacles, Has.Length.EqualTo(1));
+            });
+
+            MassNavigationAvoidanceAgentSnapshot selectedAgent = agents.Single(agent => agent.AgentIndex == 0);
+            MassNavigationAvoidanceAgentSnapshot heavyAgent = agents.Single(agent => agent.AgentIndex == 1);
+            Assert.Multiple(() =>
+            {
+                Assert.That(selectedAgent.LocalXCm, Is.EqualTo(1000f).Within(0.001f));
+                Assert.That(selectedAgent.LocalYCm, Is.EqualTo(1200f).Within(0.001f));
+                Assert.That(selectedAgent.WorldXCm, Is.EqualTo(-4000f).Within(0.001f));
+                Assert.That(selectedAgent.WorldYCm, Is.EqualTo(-3800f).Within(0.001f));
+                Assert.That(selectedAgent.Selected, Is.True);
+                Assert.That(selectedAgent.InsidePlayArea, Is.True);
+                Assert.That(heavyAgent.TeamId, Is.EqualTo(2));
+                Assert.That(heavyAgent.HeavyProfile, Is.True);
+                Assert.That(heavyAgent.BodyRadiusCm, Is.EqualTo(20f));
+                Assert.That(obstacles[0].WorldXCm, Is.EqualTo(2200f).Within(0.001f));
+                Assert.That(obstacles[0].RadiusCm, Is.EqualTo(150f));
+            });
+
+            Assert.That(
+                () => runtime.CaptureAvoidanceSnapshot(agents.AsSpan(0, 1), obstacles),
+                Throws.InvalidOperationException.With.Message.Contains("agent slots"));
+        }
+
         private static MassNavigationFlowSolverState CreateSpawnedFlow(int randomSeed)
         {
             var flow = CreateConfiguredFlow(parallelWorkerCount: 1);
@@ -366,6 +470,44 @@ namespace Ludots.Tests.Presentation
             });
         }
 
+        private static MassNavigationAgentLayer CreateAgentLayer()
+        {
+            int layerIndex = LayerRegistry.Register(MassNavigationLayerNames.Agent);
+            uint mask = 1u << layerIndex;
+            return new MassNavigationAgentLayer(mask, mask);
+        }
+
+        private static MassNavigationAgentSeed CreateAvoidanceSeed(
+            int teamId,
+            float localX,
+            float localY,
+            bool heavy,
+            MassNavigationAgentLayer layer)
+        {
+            return new MassNavigationAgentSeed(
+                teamId,
+                localX,
+                localY,
+                heavy,
+                navMass: heavy ? 4f : 1f,
+                visualScale: heavy ? 1.5f : 1f,
+                bodyRadiusCm: 20f,
+                speedCmPerSecond: 800f,
+                layer);
+        }
+
+        private static Entity CreateAuthoredAgentEntity(World world, float localX, float localY, MassNavigationAgentLayer layer)
+        {
+            int profileId = MassNavigationProfileRegistry.Register("light");
+            return world.Create(
+                new MassNavigationAgent { ProfileId = profileId },
+                new Team { Id = 1 },
+                WorldPositionCm.FromCmFloat(localX, localY),
+                new EntityLayer(layer.CategoryMask, layer.InteractionMask),
+                new FacingDirection { AngleRad = 0f },
+                OrderBuffer.CreateEmpty());
+        }
+
         private static JsonObject ReadObject(string path)
         {
             return JsonNode.Parse(File.ReadAllText(path))?.AsObject()
@@ -439,6 +581,17 @@ namespace Ludots.Tests.Presentation
             return property.CanRead &&
                 property.CanWrite &&
                 property.GetIndexParameters().Length == 0;
+        }
+
+        private static int ResolveAuthoredAgentCount(JsonObject config)
+        {
+            JsonObject scenario = config["scenario"]?.AsObject()
+                ?? throw new InvalidOperationException("MassNavigationConfig.scenario must be authored.");
+            JsonArray teams = scenario["teams"]?.AsArray()
+                ?? throw new InvalidOperationException("MassNavigationConfig.scenario.teams must be authored.");
+            int agentsPerTeam = scenario["agentsPerTeam"]?.GetValue<int>()
+                ?? throw new InvalidOperationException("MassNavigationConfig.scenario.agentsPerTeam must be authored.");
+            return checked(teams.Count * agentsPerTeam);
         }
 
         private static string MassNavigationModRoot()

--- a/src/Tests/PresentationTests/MassNavigationPerformerContractTests.cs
+++ b/src/Tests/PresentationTests/MassNavigationPerformerContractTests.cs
@@ -25,7 +25,6 @@ namespace Ludots.Tests.Presentation
         private const string HealthCurrentParamKey = "massNavigation.agent.health.current";
         private const string HealthBaseParamKey = "massNavigation.agent.health.base";
         private const string LargeWorldCameraId = "MassNavigation.Camera.LargeWorldHeightmap";
-        private const int LargeWorldEvidenceSelectionSampleCount = 128;
 
         [Test]
         public void AgentPerformers_UseMassNavigationOwnedGpuSkinnedAsset()
@@ -280,9 +279,15 @@ namespace Ludots.Tests.Presentation
         }
 
         [Test]
-        public void ScenarioRuntimeCapacity_CoversLargeWorldEvidenceSelectionSample()
+        public void ScenarioRuntimeCapacity_CoversAuthoredScenarioSelection()
         {
             JsonObject config = ReadObject(Path.Combine(MassNavigationModRoot(), "assets", "MassNavigationConfig.json"));
+            JsonObject scenario = config["scenario"]?.AsObject()
+                ?? throw new InvalidOperationException("MassNavigationConfig.scenario missing.");
+            JsonArray teams = scenario["teams"]?.AsArray()
+                ?? throw new InvalidOperationException("MassNavigationConfig.scenario.teams missing.");
+            int authoredAgentCount = checked(teams.Count * (scenario["agentsPerTeam"]?.GetValue<int>()
+                ?? throw new InvalidOperationException("MassNavigationConfig.scenario.agentsPerTeam missing.")));
             JsonObject scenarioRuntime = config["scenarioRuntime"]?.AsObject()
                 ?? throw new InvalidOperationException("MassNavigationConfig.scenarioRuntime missing.");
             JsonObject runtimeCapacity = scenarioRuntime["runtimeCapacity"]?.AsObject()
@@ -290,19 +295,19 @@ namespace Ludots.Tests.Presentation
 
             Assert.That(
                 scenarioRuntime["initialSelectedEntityCapacity"]?.GetValue<int>(),
-                Is.GreaterThanOrEqualTo(LargeWorldEvidenceSelectionSampleCount));
+                Is.EqualTo(authoredAgentCount));
             Assert.That(
                 scenarioRuntime["initialSelectionScratchCapacity"]?.GetValue<int>(),
-                Is.GreaterThanOrEqualTo(LargeWorldEvidenceSelectionSampleCount));
+                Is.EqualTo(authoredAgentCount));
             Assert.That(
                 runtimeCapacity["selectionMemberScratchCapacity"]?.GetValue<int>(),
-                Is.GreaterThanOrEqualTo(LargeWorldEvidenceSelectionSampleCount));
+                Is.EqualTo(authoredAgentCount));
             Assert.That(
                 runtimeCapacity["groupMemberCapacity"]?.GetValue<int>(),
-                Is.GreaterThanOrEqualTo(LargeWorldEvidenceSelectionSampleCount));
+                Is.EqualTo(authoredAgentCount));
             Assert.That(
                 runtimeCapacity["orderIngestionMemberCapacity"]?.GetValue<int>(),
-                Is.GreaterThanOrEqualTo(LargeWorldEvidenceSelectionSampleCount));
+                Is.EqualTo(authoredAgentCount));
         }
 
         [Test]

--- a/src/Tests/PresentationTests/PerformerTreeLifecycleTests.cs
+++ b/src/Tests/PresentationTests/PerformerTreeLifecycleTests.cs
@@ -79,6 +79,8 @@ namespace Ludots.Tests.Presentation
             int childAId = fixture.Definitions.GetId("child_a");
             int childBId = fixture.Definitions.GetId("child_b");
             int rootId = fixture.Definitions.GetId("root");
+            int childAScopeId = PerformerScopeTagRegistry.GetId("childA");
+            int childBScopeId = PerformerScopeTagRegistry.GetId("childB");
 
             Entity rootEntity = fixture.CreateRoot(rootId, scopeTag: 100);
             fixture.TickRuleThenRuntime();
@@ -97,7 +99,7 @@ namespace Ludots.Tests.Presentation
                 ref readonly PerformerParent childParent = ref fixture.World.Get<PerformerParent>(childEntity);
                 Assert.That(childParent.Parent, Is.EqualTo(rootEntity));
                 Assert.That(childState.DefId, Is.EqualTo(childAId).Or.EqualTo(childBId));
-                Assert.That(childState.ScopeId, Is.EqualTo(101).Or.EqualTo(102));
+                Assert.That(childState.ScopeId, Is.EqualTo(childAScopeId).Or.EqualTo(childBScopeId));
             }
 
             Assert.That(childCount, Is.EqualTo(2));
@@ -176,6 +178,127 @@ namespace Ludots.Tests.Presentation
             Assert.That(childParent.Parent, Is.EqualTo(rootEntity));
             Assert.That(childState.ScopeId, Is.EqualTo(500));
             Assert.That(childState.DefId, Is.EqualTo(childId));
+        }
+
+        [Test]
+        public void RuleCarrierScopedCreate_EmitsWithoutOwnerInstance()
+        {
+            using var fixture = PerformerTreeFixture.Create();
+            int markerId = fixture.Definitions.Register("carrier_marker", new PerformerDefinition());
+            _ = fixture.Definitions.Register("carrier_rules", new PerformerDefinition
+            {
+                Rules =
+                [
+                    new PerformerRule
+                    {
+                        Event = new EventFilter
+                        {
+                            Kind = PresentationEventKind.TagEffectiveChanged,
+                            KeyId = 91,
+                        },
+                        Condition = ConditionRef.AlwaysTrue,
+                        Command = new PerformerCommand
+                        {
+                            CommandKind = PerformerCommandKind.CreatePerformer,
+                            PerformerDefinitionId = markerId,
+                            ScopeTag = 700,
+                        },
+                    },
+                ],
+            });
+
+            Assert.That(fixture.Events.TryAdd(new PresentationEvent
+            {
+                Kind = PresentationEventKind.TagEffectiveChanged,
+                KeyId = 91,
+                Source = fixture.Owner,
+                Target = fixture.Owner,
+                Magnitude = 1f,
+            }), Is.True);
+
+            fixture.Rules.Update(0.016f);
+
+            Assert.That(fixture.Commands.Count, Is.EqualTo(1));
+            ref readonly PerformerCommand command = ref fixture.Commands.GetSpan()[0];
+            Assert.That(command.CommandKind, Is.EqualTo(PerformerCommandKind.CreatePerformer));
+            Assert.That(command.PerformerDefinitionId, Is.EqualTo(markerId));
+            Assert.That(command.Source, Is.EqualTo(fixture.Owner));
+            Assert.That(command.ScopeTag, Is.EqualTo(700));
+        }
+
+        [Test]
+        public void ScopedCreateRules_EmitOnlyForMatchingOwnerDefinitionInstance()
+        {
+            using var fixture = PerformerTreeFixture.Create();
+            int markerAId = fixture.Definitions.Register("marker_a", new PerformerDefinition());
+            int markerBId = fixture.Definitions.Register("marker_b", new PerformerDefinition());
+            int rootAId = fixture.Definitions.Register("root_a", new PerformerDefinition
+            {
+                Children = [new ChildPerformerRef { DefinitionId = markerAId, ScopeTag = 1 }],
+                Rules =
+                [
+                    new PerformerRule
+                    {
+                        Event = new EventFilter
+                        {
+                            Kind = PresentationEventKind.TagEffectiveChanged,
+                            KeyId = 92,
+                        },
+                        Condition = ConditionRef.AlwaysTrue,
+                        Command = new PerformerCommand
+                        {
+                            CommandKind = PerformerCommandKind.CreatePerformer,
+                            PerformerDefinitionId = markerAId,
+                            ScopeTag = 800,
+                        },
+                    },
+                ],
+            });
+            int rootBId = fixture.Definitions.Register("root_b", new PerformerDefinition
+            {
+                Children = [new ChildPerformerRef { DefinitionId = markerBId, ScopeTag = 1 }],
+                Rules =
+                [
+                    new PerformerRule
+                    {
+                        Event = new EventFilter
+                        {
+                            Kind = PresentationEventKind.TagEffectiveChanged,
+                            KeyId = 92,
+                        },
+                        Condition = ConditionRef.AlwaysTrue,
+                        Command = new PerformerCommand
+                        {
+                            CommandKind = PerformerCommandKind.CreatePerformer,
+                            PerformerDefinitionId = markerBId,
+                            ScopeTag = 800,
+                        },
+                    },
+                ],
+            });
+
+            Entity rootA = fixture.CreateRoot(rootAId, scopeTag: 101);
+            Entity otherOwner = fixture.World.Create();
+            _ = fixture.Create(rootBId, otherOwner, scopeTag: 202);
+            fixture.Events.Clear();
+
+            Assert.That(fixture.Events.TryAdd(new PresentationEvent
+            {
+                Kind = PresentationEventKind.TagEffectiveChanged,
+                KeyId = 92,
+                Source = fixture.Owner,
+                Target = fixture.Owner,
+                Magnitude = 1f,
+            }), Is.True);
+
+            fixture.Rules.Update(0.016f);
+
+            Assert.That(fixture.Commands.Count, Is.EqualTo(1));
+            ref readonly PerformerCommand command = ref fixture.Commands.GetSpan()[0];
+            Assert.That(command.CommandKind, Is.EqualTo(PerformerCommandKind.CreatePerformer));
+            Assert.That(command.PerformerDefinitionId, Is.EqualTo(markerAId));
+            Assert.That(command.ParentEntity, Is.EqualTo(rootA));
+            Assert.That(command.ScopeTag, Is.EqualTo(800));
         }
 
         [Test]
@@ -352,10 +475,8 @@ namespace Ludots.Tests.Presentation
             var registry = new PerformerDefinitionRegistry();
             var loader = new PerformerDefinitionConfigLoader(pipeline, registry);
 
-            Assert.DoesNotThrow(() => loader.Load(catalog));
-            Assert.That(registry.TryGet(registry.GetId("a"), out _), Is.False);
-            Assert.That(registry.TryGet(registry.GetId("b"), out _), Is.False);
-            Assert.That(registry.TryGet(registry.GetId("ok_root"), out _), Is.True);
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => loader.Load(catalog))!;
+            Assert.That(ex.Message, Does.Contain("Circular child reference"));
         }
 
         [Test]
@@ -411,9 +532,8 @@ namespace Ludots.Tests.Presentation
             var registry = new PerformerDefinitionRegistry();
             var loader = new PerformerDefinitionConfigLoader(pipeline, registry);
 
-            Assert.DoesNotThrow(() => loader.Load(catalog));
-            Assert.That(registry.TryGet(registry.GetId("too_many_behaviors"), out _), Is.False);
-            Assert.That(registry.TryGet(registry.GetId("ok_root"), out _), Is.True);
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => loader.Load(catalog))!;
+            Assert.That(ex.Message, Does.Contain("exceeds the max 32 behaviors"));
         }
 
         private (VirtualFileSystem Vfs, ModLoader ModLoader, ConfigPipeline Pipeline, ConfigCatalog Catalog) BuildPipeline()

--- a/src/Tests/PresentationTests/PresentationTests.csproj
+++ b/src/Tests/PresentationTests/PresentationTests.csproj
@@ -43,6 +43,7 @@
     <ProjectReference Include="..\..\..\mods\showcases\info_panels\GenreInfoShowcaseMod\GenreInfoShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\performer_blacksmith\PerformerBlacksmithShowcaseMod\PerformerBlacksmithShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\capabilities\navigation\MassNavigationMod\MassNavigationMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\capability_standard\CapabilityStandardMassNavigationLargeWorld10kMod\CapabilityStandardMassNavigationLargeWorld10kMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\formation_capability\FormationCapabilityShowcaseMod\FormationCapabilityShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\raylib_ism_benchmark\RaylibIsmBenchmarkShowcaseMod\RaylibIsmBenchmarkShowcaseMod.csproj" />
   </ItemGroup>

--- a/src/Tests/ThreeCTests/WebHostLoopStatusTests.cs
+++ b/src/Tests/ThreeCTests/WebHostLoopStatusTests.cs
@@ -1,0 +1,68 @@
+using System;
+using Ludots.Adapter.Web;
+using NUnit.Framework;
+
+namespace Ludots.Tests.ThreeC
+{
+    [TestFixture]
+    public sealed class WebHostLoopStatusTests
+    {
+        [Test]
+        public void CaptureHealthSnapshot_WhenRunningWithoutFault_IsOk()
+        {
+            var status = new WebHostLoopStatus();
+            status.MarkStarted();
+
+            WebHostLoopHealthSnapshot snapshot = status.CaptureHealthSnapshot();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(snapshot.Status, Is.EqualTo(WebHostLoopStatus.RunningStatus));
+                Assert.That(snapshot.Healthy, Is.True);
+                Assert.That(snapshot.Running, Is.True);
+                Assert.That(snapshot.Faulted, Is.False);
+                Assert.That(snapshot.FaultType, Is.Null);
+                Assert.That(snapshot.FaultMessage, Is.Null);
+            });
+        }
+
+        [Test]
+        public void CaptureHealthSnapshot_WhenFaulted_IsUnhealthyAndExposesFault()
+        {
+            var status = new WebHostLoopStatus();
+            status.MarkStarted();
+            var fault = new InvalidOperationException("frame failed");
+
+            status.MarkFaulted(fault);
+            WebHostLoopHealthSnapshot snapshot = status.CaptureHealthSnapshot();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(snapshot.Status, Is.EqualTo(WebHostLoopStatus.FaultedStatus));
+                Assert.That(snapshot.Healthy, Is.False);
+                Assert.That(snapshot.Running, Is.False);
+                Assert.That(snapshot.Faulted, Is.True);
+                Assert.That(snapshot.FaultType, Is.EqualTo(typeof(InvalidOperationException).FullName));
+                Assert.That(snapshot.FaultMessage, Is.EqualTo("frame failed"));
+            });
+        }
+
+        [Test]
+        public void CaptureHealthSnapshot_WhenStoppedWithoutFault_IsUnhealthy()
+        {
+            var status = new WebHostLoopStatus();
+
+            WebHostLoopHealthSnapshot snapshot = status.CaptureHealthSnapshot();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(snapshot.Status, Is.EqualTo(WebHostLoopStatus.StoppedStatus));
+                Assert.That(snapshot.Healthy, Is.False);
+                Assert.That(snapshot.Running, Is.False);
+                Assert.That(snapshot.Faulted, Is.False);
+                Assert.That(snapshot.FaultType, Is.Null);
+                Assert.That(snapshot.FaultMessage, Is.Null);
+            });
+        }
+    }
+}

--- a/src/Tools/Ludots.Launcher.Evidence/LauncherEvidenceRecorder.cs
+++ b/src/Tools/Ludots.Launcher.Evidence/LauncherEvidenceRecorder.cs
@@ -100,8 +100,16 @@ public static class LauncherEvidenceRecorder
     private const int MassNavigationAvoidanceFrameIntervalTicks = 4;
     private const int MassNavigationAvoidanceExtraOrderTicks = 210;
     private const int MassNavigationAvoidanceCrossingTicks = 420;
+    private const int MassNavigationAvoidanceCrowdSettleTicks = 1800;
+    private const int MassNavigationAvoidanceImageWidth = 1280;
+    private const int MassNavigationAvoidanceImageHeight = 720;
     private const float MassNavigationAvoidanceZoomWidthCm = 4000f;
+    private const float MassNavigationAvoidanceZoomAspectWidth = 16f;
+    private const float MassNavigationAvoidanceZoomAspectHeight = 9f;
     private const float MassNavigationAvoidanceCrossingScale = 0.2f;
+    private const float MassNavigationAvoidanceCrowdSettleFraction = 0.8f;
+    private const float MassNavigationAvoidanceDeepOverlapRatio = 0.10f;
+    private const float MassNavigationAvoidanceFinalMaxPenetrationRatio = 0.10f;
     private static readonly Vector2 CameraProjectionClickWorldCm = new(3200f, 2000f);
     private static readonly Vector2 RoadSelectionWorldCm = new(-9800f, 0f);
     private static readonly Vector2 RoadCommandWorldCm = new(0f, 0f);
@@ -1948,6 +1956,10 @@ public static class LauncherEvidenceRecorder
         MassNavigationSimulationRuntime simulation = runtime.Engine.GetService(MassNavigationKeys.SimulationRuntime)
             ?? throw new InvalidOperationException("MassNavigation UAT requires MassNavigationSimulationRuntime.");
         WaitForMassNavigationScenario(runtime, simulation, frameTimesMs, maxTicks: 240);
+        MassNavigationSolverRuntimeConfigSnapshot solverSnapshot = simulation.CaptureSolverRuntimeConfig();
+        var avoidanceScratch = new MassNavigationAvoidanceScratch(
+            simulation.Config.ScenarioRuntime.RuntimeCapacity.GroupMembershipAgentCapacity,
+            solverSnapshot.MaxObstacleCount);
         CaptureMassNavigationSnapshot(runtime, simulation, screensDir, frameTimesMs, timeline, captureFrames, 0, "000_boot", captureImage: true);
 
         Entity[] selected = SelectFirstOrderableMassNavigationAgents(runtime.Engine, simulation, MassNavigationSelectionSampleCount);
@@ -1962,18 +1974,18 @@ public static class LauncherEvidenceRecorder
         string avoidanceDir = Path.Combine(screensDir, "avoidance");
         Directory.CreateDirectory(avoidanceDir);
         var avoidanceMetrics = new List<MassNavigationAvoidanceFrameMetrics>();
-        CaptureMassNavigationAvoidanceSequence(runtime, simulation, commandTarget, avoidanceDir, frameTimesMs, avoidanceMetrics, MassNavigationCommandSettleTicks);
+        CaptureMassNavigationAvoidanceSequence(runtime, simulation, avoidanceScratch, commandTarget, avoidanceDir, frameTimesMs, avoidanceMetrics, MassNavigationCommandSettleTicks);
         CaptureMassNavigationSnapshot(runtime, simulation, screensDir, frameTimesMs, timeline, captureFrames, MassNavigationCommandSettleTicks, "001_selection_order", captureImage: true);
-        CaptureMassNavigationAvoidanceSequence(runtime, simulation, commandTarget, avoidanceDir, frameTimesMs, avoidanceMetrics, MassNavigationAvoidanceExtraOrderTicks);
+        CaptureMassNavigationAvoidanceSequence(runtime, simulation, avoidanceScratch, commandTarget, avoidanceDir, frameTimesMs, avoidanceMetrics, MassNavigationAvoidanceExtraOrderTicks);
 
-        WaitForMassNavigationCrowdSettle(runtime, simulation, frameTimesMs, minSettledFraction: 0.8f, maxTicks: 1800);
+        WaitForMassNavigationCrowdSettle(runtime, simulation, frameTimesMs, MassNavigationAvoidanceCrowdSettleFraction, MassNavigationAvoidanceCrowdSettleTicks);
         // March the commanded group back across the settled central crowd. The crossing target
         // mirrors the first order target through the pre-command work-area center, scaled down so
         // the destination-following solver window keeps the whole march inside the active play
         // area (hard resolve is intentionally skipped outside it).
         Vector2 crossingTarget = initialWorkAreaCenter - ((commandTarget - initialWorkAreaCenter) * MassNavigationAvoidanceCrossingScale);
         SubmitMassNavigationMoveOrder(runtime.Engine, simulation, selected, crossingTarget);
-        CaptureMassNavigationAvoidanceSequence(runtime, simulation, crossingTarget, avoidanceDir, frameTimesMs, avoidanceMetrics, MassNavigationAvoidanceCrossingTicks);
+        CaptureMassNavigationAvoidanceSequence(runtime, simulation, avoidanceScratch, crossingTarget, avoidanceDir, frameTimesMs, avoidanceMetrics, MassNavigationAvoidanceCrossingTicks);
         WriteMassNavigationAvoidanceMetrics(Path.Combine(request.OutputDirectory, "avoidance-metrics.jsonl"), avoidanceMetrics);
 
         Vector2 originalCameraTarget = runtime.Engine.GameSession.Camera.State.TargetCm;
@@ -1990,18 +2002,18 @@ public static class LauncherEvidenceRecorder
 
         WriteTimelineSheet("MassNavigation performer + minimap large-world UAT", captureFrames, screensDir, Path.Combine(screensDir, "timeline.png"));
 
-        MassNavigationAcceptanceResult acceptance = EvaluateMassNavigationAcceptance(timeline, simulation);
+        MassNavigationAcceptanceResult acceptance = EvaluateMassNavigationAcceptance(timeline, simulation, avoidanceMetrics);
         string battleReportPath = Path.Combine(request.OutputDirectory, "battle-report.md");
         string tracePath = Path.Combine(request.OutputDirectory, "trace.jsonl");
         string pathPath = Path.Combine(request.OutputDirectory, "path.mmd");
         string visibleChecklistPath = Path.Combine(request.OutputDirectory, "visible-checklist.md");
         string summaryPath = Path.Combine(request.OutputDirectory, "summary.json");
 
-        File.WriteAllText(battleReportPath, BuildMassNavigationBattleReport(request, timeline, captureFrames, frameTimesMs, acceptance));
+        File.WriteAllText(battleReportPath, BuildMassNavigationBattleReport(request, timeline, captureFrames, frameTimesMs, avoidanceMetrics, acceptance));
         File.WriteAllText(tracePath, BuildMassNavigationTraceJsonl(request.Plan.AdapterId, timeline));
         File.WriteAllText(pathPath, BuildMassNavigationPathMermaid());
         File.WriteAllText(visibleChecklistPath, BuildMassNavigationVisibleChecklist(captureFrames));
-        File.WriteAllText(summaryPath, BuildMassNavigationSummaryJson(request, acceptance, timeline));
+        File.WriteAllText(summaryPath, BuildMassNavigationSummaryJson(request, acceptance, timeline, avoidanceMetrics));
 
         if (!acceptance.Success)
         {
@@ -2025,7 +2037,7 @@ public static class LauncherEvidenceRecorder
         List<double> frameTimesMs,
         int maxTicks)
     {
-        int expectedAgents = checked(simulation.AgentsPerTeam * simulation.TeamCount);
+        int expectedAgents = ExpectedMassNavigationScenarioAgentCount(simulation);
         int expectedBlockers = simulation.NavigationObstacleCount;
         int expectedMarkers = simulation.HotZones.Length;
         for (int i = 0; i < maxTicks; i++)
@@ -2042,6 +2054,11 @@ public static class LauncherEvidenceRecorder
 
         throw new InvalidOperationException(
             $"MassNavigation scenario did not finish core-authored MassNavigation binding: agents={simulation.AgentState.TotalAgents}/{expectedAgents}, blockers={simulation.AgentState.BlockerCount}/{expectedBlockers}, markers={simulation.AgentState.WorldMarkerCount}/{expectedMarkers}.");
+    }
+
+    private static int ExpectedMassNavigationScenarioAgentCount(MassNavigationSimulationRuntime simulation)
+    {
+        return checked(simulation.AgentsPerTeam * simulation.TeamCount);
     }
 
     private static Entity[] SelectFirstOrderableMassNavigationAgents(GameEngine engine, MassNavigationSimulationRuntime simulation, int requestedCount)
@@ -2159,10 +2176,10 @@ public static class LauncherEvidenceRecorder
         float minSettledFraction,
         int maxTicks)
     {
-        MassNavigationFlowSolverState flow = simulation.GetFlowSolverForTests();
         for (int i = 0; i < maxTicks; i++)
         {
-            if (flow.UnitCount > 0 && flow.SettledUnitCount >= flow.UnitCount * minSettledFraction)
+            int unitCount = simulation.NavigationAgentCount;
+            if (unitCount > 0 && simulation.NavigationSettledAgentCount >= unitCount * minSettledFraction)
             {
                 return;
             }
@@ -2174,6 +2191,7 @@ public static class LauncherEvidenceRecorder
     private static void CaptureMassNavigationAvoidanceSequence(
         RecordingRuntime runtime,
         MassNavigationSimulationRuntime simulation,
+        MassNavigationAvoidanceScratch scratch,
         Vector2 commandTargetCm,
         string framesDir,
         List<double> frameTimesMs,
@@ -2188,35 +2206,37 @@ public static class LauncherEvidenceRecorder
                 continue;
             }
 
-            CaptureMassNavigationAvoidanceZoomFrame(simulation, commandTargetCm, framesDir, metrics);
+            CaptureMassNavigationAvoidanceZoomFrame(simulation, scratch, commandTargetCm, framesDir, metrics);
         }
     }
 
     private static void CaptureMassNavigationAvoidanceZoomFrame(
         MassNavigationSimulationRuntime simulation,
+        MassNavigationAvoidanceScratch scratch,
         Vector2 commandTargetCm,
         string framesDir,
         List<MassNavigationAvoidanceFrameMetrics> metrics)
     {
-        MassNavigationFlowSolverState flow = simulation.GetFlowSolverForTests();
-        int unitCount = flow.UnitCount;
-        if (unitCount <= 0)
+        MassNavigationAvoidanceSnapshot snapshot = scratch.Capture(simulation);
+        if (snapshot.UnitCount <= 0)
         {
             return;
         }
 
+        ReadOnlySpan<MassNavigationAvoidanceAgentSnapshot> agents = scratch.Agents(snapshot.UnitCount);
+        ReadOnlySpan<MassNavigationObstacleSnapshot> obstacles = scratch.Obstacles(snapshot.ObstacleCount);
         float centroidX = 0f;
         float centroidY = 0f;
         int selectedCount = 0;
-        for (int i = 0; i < unitCount; i++)
+        foreach (MassNavigationAvoidanceAgentSnapshot agent in agents)
         {
-            if (!flow.IsSelected(i))
+            if (!agent.Selected)
             {
                 continue;
             }
 
-            centroidX += simulation.ToWorldXCm(flow.GetPositionX(i));
-            centroidY += simulation.ToWorldYCm(flow.GetPositionY(i));
+            centroidX += agent.WorldXCm;
+            centroidY += agent.WorldYCm;
             selectedCount++;
         }
 
@@ -2229,58 +2249,45 @@ public static class LauncherEvidenceRecorder
         centroidY /= selectedCount;
 
         float zoomWidthCm = MassNavigationAvoidanceZoomWidthCm;
-        float zoomHeightCm = zoomWidthCm * 9f / 16f;
+        float zoomHeightCm = zoomWidthCm * MassNavigationAvoidanceZoomAspectHeight / MassNavigationAvoidanceZoomAspectWidth;
         float minXCm = centroidX - (zoomWidthCm * 0.5f);
         float maxXCm = centroidX + (zoomWidthCm * 0.5f);
         float minYCm = centroidY - (zoomHeightCm * 0.5f);
         float maxYCm = centroidY + (zoomHeightCm * 0.5f);
 
-        const int imageWidth = 1280;
-        const int imageHeight = 720;
-        float pxPerCm = imageWidth / zoomWidthCm;
+        float pxPerCm = MassNavigationAvoidanceImageWidth / zoomWidthCm;
 
-        bool IsInsideActiveField(int agentIndex)
+        Span<MassNavigationAvoidanceAgentSnapshot> visibleAgents = scratch.VisibleAgents(snapshot.UnitCount);
+        Span<MassNavigationAvoidanceAgentSnapshot> playAreaAgents = scratch.PlayAreaAgents(snapshot.UnitCount);
+        int visibleAgentCount = 0;
+        int playAreaAgentCount = 0;
+        foreach (MassNavigationAvoidanceAgentSnapshot agent in agents)
         {
-            float localX = flow.GetPositionX(agentIndex);
-            float localY = flow.GetPositionY(agentIndex);
-            return localX >= flow.PlayAreaMinXCm && localX <= flow.PlayAreaMaxXCm &&
-                localY >= flow.PlayAreaMinYCm && localY <= flow.PlayAreaMaxYCm;
-        }
-
-        var visibleAgents = new List<int>(512);
-        var inFieldAgents = new List<int>(512);
-        for (int i = 0; i < unitCount; i++)
-        {
-            float worldX = simulation.ToWorldXCm(flow.GetPositionX(i));
-            float worldY = simulation.ToWorldYCm(flow.GetPositionY(i));
-            if (worldX >= minXCm && worldX <= maxXCm && worldY >= minYCm && worldY <= maxYCm)
+            if (agent.WorldXCm >= minXCm && agent.WorldXCm <= maxXCm && agent.WorldYCm >= minYCm && agent.WorldYCm <= maxYCm)
             {
-                visibleAgents.Add(i);
-                if (IsInsideActiveField(i))
+                visibleAgents[visibleAgentCount++] = agent;
+                if (agent.InsidePlayArea)
                 {
-                    inFieldAgents.Add(i);
+                    playAreaAgents[playAreaAgentCount++] = agent;
                 }
             }
         }
 
         // Hard resolve intentionally skips agents outside the solver play area
-        // (IsInsideTacticalField), so overlap metrics only cover in-field agents;
-        // out-of-field agents are drawn dimmed to keep the evidence honest.
+        // (IsInsideTacticalField), so overlap metrics only cover play-area agents;
+        // outside-play-area agents are drawn dimmed so frame review preserves that distinction.
         float maxPenetrationCm = 0f;
         float maxPenetrationRatio = 0f;
         int deepOverlapPairs = 0;
-        for (int a = 0; a < inFieldAgents.Count; a++)
+        for (int a = 0; a < playAreaAgentCount; a++)
         {
-            int i = inFieldAgents[a];
-            float xi = flow.GetPositionX(i);
-            float yi = flow.GetPositionY(i);
-            float ri = flow.GetBodyRadiusCm(i);
-            for (int b = a + 1; b < inFieldAgents.Count; b++)
+            MassNavigationAvoidanceAgentSnapshot first = playAreaAgents[a];
+            for (int b = a + 1; b < playAreaAgentCount; b++)
             {
-                int j = inFieldAgents[b];
-                float dx = xi - flow.GetPositionX(j);
-                float dy = yi - flow.GetPositionY(j);
-                float minDistance = ri + flow.GetBodyRadiusCm(j);
+                MassNavigationAvoidanceAgentSnapshot second = playAreaAgents[b];
+                float dx = first.LocalXCm - second.LocalXCm;
+                float dy = first.LocalYCm - second.LocalYCm;
+                float minDistance = first.BodyRadiusCm + second.BodyRadiusCm;
                 float distanceSq = (dx * dx) + (dy * dy);
                 if (distanceSq >= minDistance * minDistance)
                 {
@@ -2291,7 +2298,7 @@ public static class LauncherEvidenceRecorder
                 float ratio = penetration / minDistance;
                 maxPenetrationCm = MathF.Max(maxPenetrationCm, penetration);
                 maxPenetrationRatio = MathF.Max(maxPenetrationRatio, ratio);
-                if (ratio > 0.10f)
+                if (ratio > MassNavigationAvoidanceDeepOverlapRatio)
                 {
                     deepOverlapPairs++;
                 }
@@ -2300,17 +2307,23 @@ public static class LauncherEvidenceRecorder
 
         int settledCount = 0;
         int heavyCount = 0;
-        for (int a = 0; a < inFieldAgents.Count; a++)
+        int selectedVisibleCount = 0;
+        for (int a = 0; a < playAreaAgentCount; a++)
         {
-            int i = inFieldAgents[a];
-            if (flow.IsUnitSettled(i))
+            MassNavigationAvoidanceAgentSnapshot agent = playAreaAgents[a];
+            if (agent.Settled)
             {
                 settledCount++;
             }
 
-            if (flow.IsHeavyProfile(i))
+            if (agent.HeavyProfile)
             {
                 heavyCount++;
+            }
+
+            if (agent.Selected)
+            {
+                selectedVisibleCount++;
             }
         }
 
@@ -2319,52 +2332,53 @@ public static class LauncherEvidenceRecorder
             frameIndex,
             centroidX,
             centroidY,
-            visibleAgents.Count,
+            snapshot.UnitCount,
+            visibleAgentCount,
+            playAreaAgentCount,
+            selectedVisibleCount,
             heavyCount,
             settledCount,
             maxPenetrationCm,
             maxPenetrationRatio,
             deepOverlapPairs));
 
-        using var surface = SKSurface.Create(new SKImageInfo(imageWidth, imageHeight));
+        using var surface = SKSurface.Create(new SKImageInfo(MassNavigationAvoidanceImageWidth, MassNavigationAvoidanceImageHeight));
         SKCanvas canvas = surface.Canvas;
         canvas.Clear(new SKColor(8, 12, 18));
 
         using var obstaclePaint = new SKPaint { Color = new SKColor(120, 128, 138, 210), IsAntialias = true, Style = SKPaintStyle.Fill };
         using var heavyRingPaint = new SKPaint { Color = SKColors.White, IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = 2f };
         using var targetPaint = new SKPaint { Color = new SKColor(255, 92, 92), IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = 3f };
-        using var textPaint = new SKPaint { Color = SKColors.White, IsAntialias = true, TextSize = 22f };
-        using var minorTextPaint = new SKPaint { Color = new SKColor(190, 205, 216), IsAntialias = true, TextSize = 17f };
+        using var textPaint = new SKPaint { Color = SKColors.White, IsAntialias = true };
+        using var minorTextPaint = new SKPaint { Color = new SKColor(190, 205, 216), IsAntialias = true };
+        using var textFont = new SKFont { Size = 22f };
+        using var minorTextFont = new SKFont { Size = 17f };
 
         float ToScreenX(float worldXCm) => (worldXCm - minXCm) * pxPerCm;
-        float ToScreenY(float worldYCm) => imageHeight - ((worldYCm - minYCm) * pxPerCm);
+        float ToScreenY(float worldYCm) => MassNavigationAvoidanceImageHeight - ((worldYCm - minYCm) * pxPerCm);
 
-        for (int i = 0; i < flow.ObstacleCount; i++)
+        foreach (MassNavigationObstacleSnapshot obstacle in obstacles)
         {
-            float ox = flow.GetObstacleWorldX(i);
-            float oy = flow.GetObstacleWorldY(i);
-            float radius = flow.GetObstacleRadius(i);
-            if (ox + radius < minXCm || ox - radius > maxXCm || oy + radius < minYCm || oy - radius > maxYCm)
+            if (obstacle.WorldXCm + obstacle.RadiusCm < minXCm ||
+                obstacle.WorldXCm - obstacle.RadiusCm > maxXCm ||
+                obstacle.WorldYCm + obstacle.RadiusCm < minYCm ||
+                obstacle.WorldYCm - obstacle.RadiusCm > maxYCm)
             {
                 continue;
             }
 
-            canvas.DrawCircle(ToScreenX(ox), ToScreenY(oy), radius * pxPerCm, obstaclePaint);
+            canvas.DrawCircle(ToScreenX(obstacle.WorldXCm), ToScreenY(obstacle.WorldYCm), obstacle.RadiusCm * pxPerCm, obstaclePaint);
         }
 
-        for (int a = 0; a < visibleAgents.Count; a++)
+        foreach (MassNavigationAvoidanceAgentSnapshot agent in visibleAgents[..visibleAgentCount])
         {
-            int i = visibleAgents[a];
-            float worldX = simulation.ToWorldXCm(flow.GetPositionX(i));
-            float worldY = simulation.ToWorldYCm(flow.GetPositionY(i));
-            float radiusPx = MathF.Max(1.5f, flow.GetBodyRadiusCm(i) * pxPerCm);
-            bool inField = IsInsideActiveField(i);
-            SKColor teamColor = ResolveMassNavigationTeamColor(flow.GetTeam(i));
-            using var agentPaint = new SKPaint { Color = teamColor.WithAlpha(inField ? (byte)220 : (byte)70), IsAntialias = true, Style = SKPaintStyle.Fill };
-            float screenX = ToScreenX(worldX);
-            float screenY = ToScreenY(worldY);
+            float radiusPx = MathF.Max(1.5f, agent.BodyRadiusCm * pxPerCm);
+            SKColor teamColor = ResolveMassNavigationTeamColor(agent.TeamId);
+            using var agentPaint = new SKPaint { Color = teamColor.WithAlpha(agent.InsidePlayArea ? (byte)220 : (byte)70), IsAntialias = true, Style = SKPaintStyle.Fill };
+            float screenX = ToScreenX(agent.WorldXCm);
+            float screenY = ToScreenY(agent.WorldYCm);
             canvas.DrawCircle(screenX, screenY, radiusPx, agentPaint);
-            if (inField && flow.IsHeavyProfile(i))
+            if (agent.InsidePlayArea && agent.HeavyProfile)
             {
                 canvas.DrawCircle(screenX, screenY, radiusPx + 1.5f, heavyRingPaint);
             }
@@ -2375,9 +2389,9 @@ public static class LauncherEvidenceRecorder
             DrawCrosshair(canvas, new SKPoint(ToScreenX(commandTargetCm.X), ToScreenY(commandTargetCm.Y)), 14f, targetPaint);
         }
 
-        canvas.DrawText($"MassNavigation avoidance zoom | frame={frameIndex:D4} | window {zoomWidthCm:F0}x{zoomHeightCm:F0} cm @ ({centroidX:F0}, {centroidY:F0})", 24, 34, textPaint);
-        canvas.DrawText($"Agents={visibleAgents.Count} heavy(ringed)={heavyCount} settled={settledCount} | circles are true bodyRadiusCm", 24, 62, minorTextPaint);
-        canvas.DrawText($"maxPenetration={maxPenetrationCm:F1}cm ({maxPenetrationRatio:P1} of pair radius) deepOverlapPairs(>10%)={deepOverlapPairs}", 24, 86, minorTextPaint);
+        canvas.DrawText($"MassNavigation avoidance zoom | frame={frameIndex:D4} | window {zoomWidthCm:F0}x{zoomHeightCm:F0} cm @ ({centroidX:F0}, {centroidY:F0})", 24, 34, SKTextAlign.Left, textFont, textPaint);
+        canvas.DrawText($"Agents={visibleAgentCount}/{snapshot.UnitCount} playArea={playAreaAgentCount} selected={selectedVisibleCount} heavyProfile(ringed)={heavyCount} settled={settledCount}", 24, 62, SKTextAlign.Left, minorTextFont, minorTextPaint);
+        canvas.DrawText($"maxPenetration={maxPenetrationCm:F1}cm ({maxPenetrationRatio:P1} of pair radius) deepOverlapPairs(>{MassNavigationAvoidanceDeepOverlapRatio:P0})={deepOverlapPairs}", 24, 86, SKTextAlign.Left, minorTextFont, minorTextPaint);
 
         using SKImage image = surface.Snapshot();
         using SKData data = image.Encode(SKEncodedImageFormat.Png, 100);
@@ -2394,6 +2408,52 @@ public static class LauncherEvidenceRecorder
         }
 
         File.WriteAllText(path, sb.ToString());
+    }
+
+    private static MassNavigationAvoidanceSummary SummarizeMassNavigationAvoidance(IReadOnlyList<MassNavigationAvoidanceFrameMetrics> metrics)
+    {
+        if (metrics.Count == 0)
+        {
+            return new MassNavigationAvoidanceSummary(
+                FrameCount: 0,
+                MaxVisibleAgentCount: 0,
+                MaxPlayAreaAgentCount: 0,
+                MaxSelectedVisibleAgentCount: 0,
+                MaxHeavyAgentCount: 0,
+                PeakDeepOverlapPairCount: 0,
+                FinalDeepOverlapPairCount: 0,
+                PeakMaxPenetrationRatio: 0f,
+                FinalMaxPenetrationRatio: 0f);
+        }
+
+        MassNavigationAvoidanceFrameMetrics final = metrics[^1];
+        int maxVisible = 0;
+        int maxPlayArea = 0;
+        int maxSelected = 0;
+        int maxHeavy = 0;
+        int peakDeepOverlap = 0;
+        float peakPenetrationRatio = 0f;
+        for (int i = 0; i < metrics.Count; i++)
+        {
+            MassNavigationAvoidanceFrameMetrics metric = metrics[i];
+            maxVisible = Math.Max(maxVisible, metric.VisibleAgentCount);
+            maxPlayArea = Math.Max(maxPlayArea, metric.PlayAreaAgentCount);
+            maxSelected = Math.Max(maxSelected, metric.SelectedVisibleAgentCount);
+            maxHeavy = Math.Max(maxHeavy, metric.HeavyAgentCount);
+            peakDeepOverlap = Math.Max(peakDeepOverlap, metric.DeepOverlapPairCount);
+            peakPenetrationRatio = MathF.Max(peakPenetrationRatio, metric.MaxPenetrationRatio);
+        }
+
+        return new MassNavigationAvoidanceSummary(
+            FrameCount: metrics.Count,
+            MaxVisibleAgentCount: maxVisible,
+            MaxPlayAreaAgentCount: maxPlayArea,
+            MaxSelectedVisibleAgentCount: maxSelected,
+            MaxHeavyAgentCount: maxHeavy,
+            PeakDeepOverlapPairCount: peakDeepOverlap,
+            FinalDeepOverlapPairCount: final.DeepOverlapPairCount,
+            PeakMaxPenetrationRatio: peakPenetrationRatio,
+            FinalMaxPenetrationRatio: final.MaxPenetrationRatio);
     }
 
     private static MassNavigationHotZoneConfig ResolveRemoteHotZone(MassNavigationSimulationRuntime simulation)
@@ -2561,7 +2621,10 @@ public static class LauncherEvidenceRecorder
             SamplePositions: samplePositions);
     }
 
-    private static MassNavigationAcceptanceResult EvaluateMassNavigationAcceptance(IReadOnlyList<MassNavigationSnapshot> timeline, MassNavigationSimulationRuntime simulation)
+    private static MassNavigationAcceptanceResult EvaluateMassNavigationAcceptance(
+        IReadOnlyList<MassNavigationSnapshot> timeline,
+        MassNavigationSimulationRuntime simulation,
+        IReadOnlyList<MassNavigationAvoidanceFrameMetrics> avoidanceMetrics)
     {
         var failures = new List<string>();
         MassNavigationSnapshot boot = timeline.First(snapshot => snapshot.Step == "000_boot");
@@ -2573,7 +2636,8 @@ public static class LauncherEvidenceRecorder
         AddAcceptanceCheck(boot.ActiveMapId == expectedMapId, $"Expected MassNavigation map '{expectedMapId}', got '{boot.ActiveMapId}'.", failures);
         AddAcceptanceCheck(boot.WorldWidthCm == 6_400_000 && boot.WorldHeightCm == 6_400_000, $"Expected 64km x 64km config, got {boot.WorldWidthCm}x{boot.WorldHeightCm} cm.", failures);
         AddAcceptanceCheck(boot.TeamCount >= 4, $"Expected at least 4 configured teams, got {boot.TeamCount}.", failures);
-        AddAcceptanceCheck(boot.AgentCount == simulation.AgentsPerTeam * simulation.TeamCount, $"Agent state count mismatch: {boot.AgentCount} vs configured {simulation.AgentsPerTeam * simulation.TeamCount}.", failures);
+        int expectedAgentCount = ExpectedMassNavigationScenarioAgentCount(simulation);
+        AddAcceptanceCheck(boot.AgentCount == expectedAgentCount, $"Agent state count mismatch: {boot.AgentCount} vs configured {expectedAgentCount}.", failures);
         AddAcceptanceCheck(boot.EcsAgentCount == boot.AgentCount, $"ECS controllable agent count mismatch: {boot.EcsAgentCount} vs runtime {boot.AgentCount}.", failures);
         AddAcceptanceCheck(boot.BlockerCount == simulation.NavigationObstacleCount, $"Blocker count mismatch: {boot.BlockerCount} vs solver {simulation.NavigationObstacleCount}.", failures);
         AddAcceptanceCheck(boot.HotspotMarkerCount == simulation.HotZones.Length, $"Hotspot marker count mismatch: {boot.HotspotMarkerCount} vs config {simulation.HotZones.Length}.", failures);
@@ -2591,6 +2655,25 @@ public static class LauncherEvidenceRecorder
         AddAcceptanceCheck(returned.ScenarioSpawnCount == boot.ScenarioSpawnCount, $"Returning to original area re-ran scenario spawn: {boot.ScenarioSpawnCount} -> {returned.ScenarioSpawnCount}.", failures);
         AddAcceptanceCheck(returned.SceneResetCount == boot.SceneResetCount, $"Returning to original area reset the scene: {boot.SceneResetCount} -> {returned.SceneResetCount}.", failures);
 
+        MassNavigationAvoidanceSummary avoidance = SummarizeMassNavigationAvoidance(avoidanceMetrics);
+        AddAcceptanceCheck(avoidance.FrameCount > 0, "MassNavigation avoidance evidence captured zero metric frames.", failures);
+        AddAcceptanceCheck(avoidance.MaxVisibleAgentCount > 0, "MassNavigation avoidance evidence never observed visible agents.", failures);
+        AddAcceptanceCheck(avoidance.MaxSelectedVisibleAgentCount > 0, "MassNavigation avoidance evidence never observed selected agents in the zoom window.", failures);
+        AddAcceptanceCheck(avoidance.MaxHeavyAgentCount > 0, "MassNavigation avoidance evidence never observed heavy-profile agents in the solver play area.", failures);
+        AddAcceptanceCheck(avoidance.MaxPlayAreaAgentCount > 1, "MassNavigation avoidance evidence did not observe enough play-area agents to validate overlap resolution.", failures);
+        AddAcceptanceCheck(avoidance.FinalDeepOverlapPairCount == 0, $"MassNavigation avoidance ended with {avoidance.FinalDeepOverlapPairCount} deep overlap pairs.", failures);
+        AddAcceptanceCheck(
+            avoidance.FinalMaxPenetrationRatio <= MassNavigationAvoidanceFinalMaxPenetrationRatio,
+            $"MassNavigation avoidance final penetration ratio {avoidance.FinalMaxPenetrationRatio:P2} exceeded {MassNavigationAvoidanceFinalMaxPenetrationRatio:P2}.",
+            failures);
+        if (avoidance.FrameCount >= 2 && avoidance.PeakDeepOverlapPairCount > 0)
+        {
+            AddAcceptanceCheck(
+                avoidance.FinalDeepOverlapPairCount < avoidance.PeakDeepOverlapPairCount,
+                $"MassNavigation avoidance deep overlaps did not reduce from peak {avoidance.PeakDeepOverlapPairCount} to final {avoidance.FinalDeepOverlapPairCount}.",
+                failures);
+        }
+
         string normalizedSignature = string.Join("|", new[]
         {
             "mass_navigation_large_world",
@@ -2600,11 +2683,12 @@ public static class LauncherEvidenceRecorder
             $"markers:{boot.MinimapBufferCount}/{boot.MinimapDroppedTotal}",
             $"remote:{MathF.Round(remote.CameraTargetCm.X):F0},{MathF.Round(remote.CameraTargetCm.Y):F0}",
             $"spawns:{boot.ScenarioSpawnCount}->{returned.ScenarioSpawnCount}",
-            $"resets:{boot.SceneResetCount}->{returned.SceneResetCount}"
+            $"resets:{boot.SceneResetCount}->{returned.SceneResetCount}",
+            $"avoidance:{avoidance.FrameCount}/{avoidance.MaxVisibleAgentCount}/{avoidance.MaxHeavyAgentCount}/{avoidance.FinalDeepOverlapPairCount}/{avoidance.FinalMaxPenetrationRatio:0.0000}"
         });
 
         string verdict = failures.Count == 0
-            ? $"MassNavigation passes large-world performer/minimap UAT with {boot.AgentCount} agents, {boot.PerformerActiveCount} performers and {boot.MinimapBufferCount} minimap markers."
+            ? $"MassNavigation passes large-world performer/minimap/avoidance UAT with {boot.AgentCount} agents, {boot.PerformerActiveCount} performers, {boot.MinimapBufferCount} minimap markers and {avoidance.FrameCount} avoidance frames."
             : "MassNavigation large-world performer/minimap UAT failed.";
 
         return new MassNavigationAcceptanceResult(
@@ -2620,10 +2704,12 @@ public static class LauncherEvidenceRecorder
         IReadOnlyList<MassNavigationSnapshot> timeline,
         IReadOnlyList<CaptureFrame> captureFrames,
         IReadOnlyList<double> frameTimesMs,
+        IReadOnlyList<MassNavigationAvoidanceFrameMetrics> avoidanceMetrics,
         MassNavigationAcceptanceResult acceptance)
     {
         MassNavigationSnapshot boot = timeline[0];
         MassNavigationSnapshot final = timeline[^1];
+        MassNavigationAvoidanceSummary avoidance = SummarizeMassNavigationAvoidance(avoidanceMetrics);
         double medianTickMs = Median(frameTimesMs.ToArray());
         double maxTickMs = frameTimesMs.Count == 0 ? 0d : frameTimesMs.Max();
         string evidenceImages = string.Join(", ", captureFrames.Select(frame => $"`screens/{frame.FileName}`").Append("`screens/timeline.png`"));
@@ -2672,6 +2758,10 @@ public static class LauncherEvidenceRecorder
         sb.AppendLine($"- minimap markers at boot: `{boot.MinimapBufferCount}` droppedTotal=`{boot.MinimapDroppedTotal}`");
         sb.AppendLine($"- scenario spawn count boot/final: `{boot.ScenarioSpawnCount}` / `{final.ScenarioSpawnCount}`");
         sb.AppendLine($"- scene reset count boot/final: `{boot.SceneResetCount}` / `{final.SceneResetCount}`");
+        sb.AppendLine($"- avoidance frames: `{avoidance.FrameCount}`");
+        sb.AppendLine($"- avoidance max visible/play-area/selected/heavy-profile agents: `{avoidance.MaxVisibleAgentCount}` / `{avoidance.MaxPlayAreaAgentCount}` / `{avoidance.MaxSelectedVisibleAgentCount}` / `{avoidance.MaxHeavyAgentCount}`");
+        sb.AppendLine($"- avoidance peak/final deep overlap pairs: `{avoidance.PeakDeepOverlapPairCount}` / `{avoidance.FinalDeepOverlapPairCount}`");
+        sb.AppendLine($"- avoidance peak/final max penetration ratio: `{avoidance.PeakMaxPenetrationRatio:P2}` / `{avoidance.FinalMaxPenetrationRatio:P2}`");
         sb.AppendLine($"- median headless tick: `{medianTickMs:F3}ms`");
         sb.AppendLine($"- max headless tick: `{maxTickMs:F3}ms`");
         sb.AppendLine($"- normalized signature: `{acceptance.NormalizedSignature}`");
@@ -2765,10 +2855,15 @@ public static class LauncherEvidenceRecorder
         return sb.ToString();
     }
 
-    private static string BuildMassNavigationSummaryJson(LauncherRecordingRequest request, MassNavigationAcceptanceResult acceptance, IReadOnlyList<MassNavigationSnapshot> timeline)
+    private static string BuildMassNavigationSummaryJson(
+        LauncherRecordingRequest request,
+        MassNavigationAcceptanceResult acceptance,
+        IReadOnlyList<MassNavigationSnapshot> timeline,
+        IReadOnlyList<MassNavigationAvoidanceFrameMetrics> avoidanceMetrics)
     {
         MassNavigationSnapshot boot = timeline[0];
         MassNavigationSnapshot final = timeline[^1];
+        MassNavigationAvoidanceSummary avoidance = SummarizeMassNavigationAvoidance(avoidanceMetrics);
         return JsonSerializer.Serialize(new
         {
             scenario = "mass_navigation_large_world",
@@ -2790,6 +2885,15 @@ public static class LauncherEvidenceRecorder
             final_scenario_spawn_count = final.ScenarioSpawnCount,
             boot_scene_reset_count = boot.SceneResetCount,
             final_scene_reset_count = final.SceneResetCount,
+            avoidance_frame_count = avoidance.FrameCount,
+            avoidance_max_visible_agent_count = avoidance.MaxVisibleAgentCount,
+            avoidance_max_play_area_agent_count = avoidance.MaxPlayAreaAgentCount,
+            avoidance_max_selected_visible_agent_count = avoidance.MaxSelectedVisibleAgentCount,
+            avoidance_max_heavy_agent_count = avoidance.MaxHeavyAgentCount,
+            avoidance_peak_deep_overlap_pair_count = avoidance.PeakDeepOverlapPairCount,
+            avoidance_final_deep_overlap_pair_count = avoidance.FinalDeepOverlapPairCount,
+            avoidance_peak_max_penetration_ratio = avoidance.PeakMaxPenetrationRatio,
+            avoidance_final_max_penetration_ratio = avoidance.FinalMaxPenetrationRatio,
             failed_checks = acceptance.FailedChecks
         }, new JsonSerializerOptions { WriteIndented = true });
     }
@@ -3266,12 +3370,67 @@ public static class LauncherEvidenceRecorder
         int FrameIndex,
         float WindowCenterXCm,
         float WindowCenterYCm,
+        int UnitCount,
         int VisibleAgentCount,
+        int PlayAreaAgentCount,
+        int SelectedVisibleAgentCount,
         int HeavyAgentCount,
         int SettledAgentCount,
         float MaxPenetrationCm,
         float MaxPenetrationRatio,
         int DeepOverlapPairCount);
+
+    private readonly record struct MassNavigationAvoidanceSummary(
+        int FrameCount,
+        int MaxVisibleAgentCount,
+        int MaxPlayAreaAgentCount,
+        int MaxSelectedVisibleAgentCount,
+        int MaxHeavyAgentCount,
+        int PeakDeepOverlapPairCount,
+        int FinalDeepOverlapPairCount,
+        float PeakMaxPenetrationRatio,
+        float FinalMaxPenetrationRatio);
+
+    private sealed class MassNavigationAvoidanceScratch
+    {
+        private readonly MassNavigationAvoidanceAgentSnapshot[] _agents;
+        private readonly MassNavigationObstacleSnapshot[] _obstacles;
+        private readonly MassNavigationAvoidanceAgentSnapshot[] _visibleAgents;
+        private readonly MassNavigationAvoidanceAgentSnapshot[] _playAreaAgents;
+
+        public MassNavigationAvoidanceScratch(int agentCapacity, int obstacleCapacity)
+        {
+            _agents = new MassNavigationAvoidanceAgentSnapshot[agentCapacity];
+            _obstacles = new MassNavigationObstacleSnapshot[obstacleCapacity];
+            _visibleAgents = new MassNavigationAvoidanceAgentSnapshot[agentCapacity];
+            _playAreaAgents = new MassNavigationAvoidanceAgentSnapshot[agentCapacity];
+        }
+
+        public MassNavigationAvoidanceSnapshot Capture(MassNavigationSimulationRuntime simulation)
+        {
+            return simulation.CaptureAvoidanceSnapshot(_agents, _obstacles);
+        }
+
+        public ReadOnlySpan<MassNavigationAvoidanceAgentSnapshot> Agents(int count)
+        {
+            return _agents.AsSpan(0, count);
+        }
+
+        public ReadOnlySpan<MassNavigationObstacleSnapshot> Obstacles(int count)
+        {
+            return _obstacles.AsSpan(0, count);
+        }
+
+        public Span<MassNavigationAvoidanceAgentSnapshot> VisibleAgents(int count)
+        {
+            return _visibleAgents.AsSpan(0, count);
+        }
+
+        public Span<MassNavigationAvoidanceAgentSnapshot> PlayAreaAgents(int count)
+        {
+            return _playAreaAgents.AsSpan(0, count);
+        }
+    }
 
     private readonly record struct MassNavigationSnapshot(
         int Tick,

--- a/src/Tools/Ludots.Launcher.Evidence/LauncherEvidenceRecorder.cs
+++ b/src/Tools/Ludots.Launcher.Evidence/LauncherEvidenceRecorder.cs
@@ -97,6 +97,11 @@ public static class LauncherEvidenceRecorder
     private const int MassNavigationRemoteSettleTicks = 20;
     private const int MassNavigationReturnSettleTicks = 20;
     private const int MassNavigationSelectionSampleCount = 128;
+    private const int MassNavigationAvoidanceFrameIntervalTicks = 4;
+    private const int MassNavigationAvoidanceExtraOrderTicks = 210;
+    private const int MassNavigationAvoidanceCrossingTicks = 420;
+    private const float MassNavigationAvoidanceZoomWidthCm = 4000f;
+    private const float MassNavigationAvoidanceCrossingScale = 0.2f;
     private static readonly Vector2 CameraProjectionClickWorldCm = new(3200f, 2000f);
     private static readonly Vector2 RoadSelectionWorldCm = new(-9800f, 0f);
     private static readonly Vector2 RoadCommandWorldCm = new(0f, 0f);
@@ -1947,12 +1952,29 @@ public static class LauncherEvidenceRecorder
 
         Entity[] selected = SelectFirstOrderableMassNavigationAgents(runtime.Engine, simulation, MassNavigationSelectionSampleCount);
         Tick(runtime, 3, frameTimesMs);
+        // The flow work area follows command focus, so capture the pre-command center now:
+        // the later crossing order mirrors the first target through this fixed point.
+        Vector2 initialWorkAreaCenter = new(simulation.FlowWorkAreaCenterXCm, simulation.FlowWorkAreaCenterYCm);
         Vector2 commandTarget = new(
-            simulation.FlowWorkAreaCenterXCm + (simulation.SolverWindowWidthCm * 0.34f),
-            simulation.FlowWorkAreaCenterYCm + (simulation.SolverWindowHeightCm * 0.18f));
+            initialWorkAreaCenter.X + (simulation.SolverWindowWidthCm * 0.34f),
+            initialWorkAreaCenter.Y + (simulation.SolverWindowHeightCm * 0.18f));
         SubmitMassNavigationMoveOrder(runtime.Engine, simulation, selected, commandTarget);
-        Tick(runtime, MassNavigationCommandSettleTicks, frameTimesMs);
+        string avoidanceDir = Path.Combine(screensDir, "avoidance");
+        Directory.CreateDirectory(avoidanceDir);
+        var avoidanceMetrics = new List<MassNavigationAvoidanceFrameMetrics>();
+        CaptureMassNavigationAvoidanceSequence(runtime, simulation, commandTarget, avoidanceDir, frameTimesMs, avoidanceMetrics, MassNavigationCommandSettleTicks);
         CaptureMassNavigationSnapshot(runtime, simulation, screensDir, frameTimesMs, timeline, captureFrames, MassNavigationCommandSettleTicks, "001_selection_order", captureImage: true);
+        CaptureMassNavigationAvoidanceSequence(runtime, simulation, commandTarget, avoidanceDir, frameTimesMs, avoidanceMetrics, MassNavigationAvoidanceExtraOrderTicks);
+
+        WaitForMassNavigationCrowdSettle(runtime, simulation, frameTimesMs, minSettledFraction: 0.8f, maxTicks: 1800);
+        // March the commanded group back across the settled central crowd. The crossing target
+        // mirrors the first order target through the pre-command work-area center, scaled down so
+        // the destination-following solver window keeps the whole march inside the active play
+        // area (hard resolve is intentionally skipped outside it).
+        Vector2 crossingTarget = initialWorkAreaCenter - ((commandTarget - initialWorkAreaCenter) * MassNavigationAvoidanceCrossingScale);
+        SubmitMassNavigationMoveOrder(runtime.Engine, simulation, selected, crossingTarget);
+        CaptureMassNavigationAvoidanceSequence(runtime, simulation, crossingTarget, avoidanceDir, frameTimesMs, avoidanceMetrics, MassNavigationAvoidanceCrossingTicks);
+        WriteMassNavigationAvoidanceMetrics(Path.Combine(request.OutputDirectory, "avoidance-metrics.jsonl"), avoidanceMetrics);
 
         Vector2 originalCameraTarget = runtime.Engine.GameSession.Camera.State.TargetCm;
         MassNavigationHotZoneConfig remoteZone = ResolveRemoteHotZone(simulation);
@@ -2128,6 +2150,250 @@ public static class LauncherEvidenceRecorder
         }
 
         simulation.FocusCommandTarget(targetCm, selected);
+    }
+
+    private static void WaitForMassNavigationCrowdSettle(
+        RecordingRuntime runtime,
+        MassNavigationSimulationRuntime simulation,
+        List<double> frameTimesMs,
+        float minSettledFraction,
+        int maxTicks)
+    {
+        MassNavigationFlowSolverState flow = simulation.GetFlowSolverForTests();
+        for (int i = 0; i < maxTicks; i++)
+        {
+            if (flow.UnitCount > 0 && flow.SettledUnitCount >= flow.UnitCount * minSettledFraction)
+            {
+                return;
+            }
+
+            Tick(runtime, 1, frameTimesMs);
+        }
+    }
+
+    private static void CaptureMassNavigationAvoidanceSequence(
+        RecordingRuntime runtime,
+        MassNavigationSimulationRuntime simulation,
+        Vector2 commandTargetCm,
+        string framesDir,
+        List<double> frameTimesMs,
+        List<MassNavigationAvoidanceFrameMetrics> metrics,
+        int tickCount)
+    {
+        for (int i = 0; i < tickCount; i++)
+        {
+            Tick(runtime, 1, frameTimesMs);
+            if (i % MassNavigationAvoidanceFrameIntervalTicks != 0)
+            {
+                continue;
+            }
+
+            CaptureMassNavigationAvoidanceZoomFrame(simulation, commandTargetCm, framesDir, metrics);
+        }
+    }
+
+    private static void CaptureMassNavigationAvoidanceZoomFrame(
+        MassNavigationSimulationRuntime simulation,
+        Vector2 commandTargetCm,
+        string framesDir,
+        List<MassNavigationAvoidanceFrameMetrics> metrics)
+    {
+        MassNavigationFlowSolverState flow = simulation.GetFlowSolverForTests();
+        int unitCount = flow.UnitCount;
+        if (unitCount <= 0)
+        {
+            return;
+        }
+
+        float centroidX = 0f;
+        float centroidY = 0f;
+        int selectedCount = 0;
+        for (int i = 0; i < unitCount; i++)
+        {
+            if (!flow.IsSelected(i))
+            {
+                continue;
+            }
+
+            centroidX += simulation.ToWorldXCm(flow.GetPositionX(i));
+            centroidY += simulation.ToWorldYCm(flow.GetPositionY(i));
+            selectedCount++;
+        }
+
+        if (selectedCount <= 0)
+        {
+            return;
+        }
+
+        centroidX /= selectedCount;
+        centroidY /= selectedCount;
+
+        float zoomWidthCm = MassNavigationAvoidanceZoomWidthCm;
+        float zoomHeightCm = zoomWidthCm * 9f / 16f;
+        float minXCm = centroidX - (zoomWidthCm * 0.5f);
+        float maxXCm = centroidX + (zoomWidthCm * 0.5f);
+        float minYCm = centroidY - (zoomHeightCm * 0.5f);
+        float maxYCm = centroidY + (zoomHeightCm * 0.5f);
+
+        const int imageWidth = 1280;
+        const int imageHeight = 720;
+        float pxPerCm = imageWidth / zoomWidthCm;
+
+        bool IsInsideActiveField(int agentIndex)
+        {
+            float localX = flow.GetPositionX(agentIndex);
+            float localY = flow.GetPositionY(agentIndex);
+            return localX >= flow.PlayAreaMinXCm && localX <= flow.PlayAreaMaxXCm &&
+                localY >= flow.PlayAreaMinYCm && localY <= flow.PlayAreaMaxYCm;
+        }
+
+        var visibleAgents = new List<int>(512);
+        var inFieldAgents = new List<int>(512);
+        for (int i = 0; i < unitCount; i++)
+        {
+            float worldX = simulation.ToWorldXCm(flow.GetPositionX(i));
+            float worldY = simulation.ToWorldYCm(flow.GetPositionY(i));
+            if (worldX >= minXCm && worldX <= maxXCm && worldY >= minYCm && worldY <= maxYCm)
+            {
+                visibleAgents.Add(i);
+                if (IsInsideActiveField(i))
+                {
+                    inFieldAgents.Add(i);
+                }
+            }
+        }
+
+        // Hard resolve intentionally skips agents outside the solver play area
+        // (IsInsideTacticalField), so overlap metrics only cover in-field agents;
+        // out-of-field agents are drawn dimmed to keep the evidence honest.
+        float maxPenetrationCm = 0f;
+        float maxPenetrationRatio = 0f;
+        int deepOverlapPairs = 0;
+        for (int a = 0; a < inFieldAgents.Count; a++)
+        {
+            int i = inFieldAgents[a];
+            float xi = flow.GetPositionX(i);
+            float yi = flow.GetPositionY(i);
+            float ri = flow.GetBodyRadiusCm(i);
+            for (int b = a + 1; b < inFieldAgents.Count; b++)
+            {
+                int j = inFieldAgents[b];
+                float dx = xi - flow.GetPositionX(j);
+                float dy = yi - flow.GetPositionY(j);
+                float minDistance = ri + flow.GetBodyRadiusCm(j);
+                float distanceSq = (dx * dx) + (dy * dy);
+                if (distanceSq >= minDistance * minDistance)
+                {
+                    continue;
+                }
+
+                float penetration = minDistance - MathF.Sqrt(distanceSq);
+                float ratio = penetration / minDistance;
+                maxPenetrationCm = MathF.Max(maxPenetrationCm, penetration);
+                maxPenetrationRatio = MathF.Max(maxPenetrationRatio, ratio);
+                if (ratio > 0.10f)
+                {
+                    deepOverlapPairs++;
+                }
+            }
+        }
+
+        int settledCount = 0;
+        int heavyCount = 0;
+        for (int a = 0; a < inFieldAgents.Count; a++)
+        {
+            int i = inFieldAgents[a];
+            if (flow.IsUnitSettled(i))
+            {
+                settledCount++;
+            }
+
+            if (flow.IsHeavyProfile(i))
+            {
+                heavyCount++;
+            }
+        }
+
+        int frameIndex = metrics.Count;
+        metrics.Add(new MassNavigationAvoidanceFrameMetrics(
+            frameIndex,
+            centroidX,
+            centroidY,
+            visibleAgents.Count,
+            heavyCount,
+            settledCount,
+            maxPenetrationCm,
+            maxPenetrationRatio,
+            deepOverlapPairs));
+
+        using var surface = SKSurface.Create(new SKImageInfo(imageWidth, imageHeight));
+        SKCanvas canvas = surface.Canvas;
+        canvas.Clear(new SKColor(8, 12, 18));
+
+        using var obstaclePaint = new SKPaint { Color = new SKColor(120, 128, 138, 210), IsAntialias = true, Style = SKPaintStyle.Fill };
+        using var heavyRingPaint = new SKPaint { Color = SKColors.White, IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = 2f };
+        using var targetPaint = new SKPaint { Color = new SKColor(255, 92, 92), IsAntialias = true, Style = SKPaintStyle.Stroke, StrokeWidth = 3f };
+        using var textPaint = new SKPaint { Color = SKColors.White, IsAntialias = true, TextSize = 22f };
+        using var minorTextPaint = new SKPaint { Color = new SKColor(190, 205, 216), IsAntialias = true, TextSize = 17f };
+
+        float ToScreenX(float worldXCm) => (worldXCm - minXCm) * pxPerCm;
+        float ToScreenY(float worldYCm) => imageHeight - ((worldYCm - minYCm) * pxPerCm);
+
+        for (int i = 0; i < flow.ObstacleCount; i++)
+        {
+            float ox = flow.GetObstacleWorldX(i);
+            float oy = flow.GetObstacleWorldY(i);
+            float radius = flow.GetObstacleRadius(i);
+            if (ox + radius < minXCm || ox - radius > maxXCm || oy + radius < minYCm || oy - radius > maxYCm)
+            {
+                continue;
+            }
+
+            canvas.DrawCircle(ToScreenX(ox), ToScreenY(oy), radius * pxPerCm, obstaclePaint);
+        }
+
+        for (int a = 0; a < visibleAgents.Count; a++)
+        {
+            int i = visibleAgents[a];
+            float worldX = simulation.ToWorldXCm(flow.GetPositionX(i));
+            float worldY = simulation.ToWorldYCm(flow.GetPositionY(i));
+            float radiusPx = MathF.Max(1.5f, flow.GetBodyRadiusCm(i) * pxPerCm);
+            bool inField = IsInsideActiveField(i);
+            SKColor teamColor = ResolveMassNavigationTeamColor(flow.GetTeam(i));
+            using var agentPaint = new SKPaint { Color = teamColor.WithAlpha(inField ? (byte)220 : (byte)70), IsAntialias = true, Style = SKPaintStyle.Fill };
+            float screenX = ToScreenX(worldX);
+            float screenY = ToScreenY(worldY);
+            canvas.DrawCircle(screenX, screenY, radiusPx, agentPaint);
+            if (inField && flow.IsHeavyProfile(i))
+            {
+                canvas.DrawCircle(screenX, screenY, radiusPx + 1.5f, heavyRingPaint);
+            }
+        }
+
+        if (commandTargetCm.X >= minXCm && commandTargetCm.X <= maxXCm && commandTargetCm.Y >= minYCm && commandTargetCm.Y <= maxYCm)
+        {
+            DrawCrosshair(canvas, new SKPoint(ToScreenX(commandTargetCm.X), ToScreenY(commandTargetCm.Y)), 14f, targetPaint);
+        }
+
+        canvas.DrawText($"MassNavigation avoidance zoom | frame={frameIndex:D4} | window {zoomWidthCm:F0}x{zoomHeightCm:F0} cm @ ({centroidX:F0}, {centroidY:F0})", 24, 34, textPaint);
+        canvas.DrawText($"Agents={visibleAgents.Count} heavy(ringed)={heavyCount} settled={settledCount} | circles are true bodyRadiusCm", 24, 62, minorTextPaint);
+        canvas.DrawText($"maxPenetration={maxPenetrationCm:F1}cm ({maxPenetrationRatio:P1} of pair radius) deepOverlapPairs(>10%)={deepOverlapPairs}", 24, 86, minorTextPaint);
+
+        using SKImage image = surface.Snapshot();
+        using SKData data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using FileStream stream = File.Open(Path.Combine(framesDir, $"frame_{frameIndex:D4}.png"), FileMode.Create, FileAccess.Write, FileShare.None);
+        data.SaveTo(stream);
+    }
+
+    private static void WriteMassNavigationAvoidanceMetrics(string path, IReadOnlyList<MassNavigationAvoidanceFrameMetrics> metrics)
+    {
+        var sb = new StringBuilder();
+        for (int i = 0; i < metrics.Count; i++)
+        {
+            sb.AppendLine(JsonSerializer.Serialize(metrics[i]));
+        }
+
+        File.WriteAllText(path, sb.ToString());
     }
 
     private static MassNavigationHotZoneConfig ResolveRemoteHotZone(MassNavigationSimulationRuntime simulation)
@@ -2995,6 +3261,17 @@ public static class LauncherEvidenceRecorder
     private readonly record struct MassNavigationAgentSample(
         int TeamId,
         Vector2 WorldCm);
+
+    private readonly record struct MassNavigationAvoidanceFrameMetrics(
+        int FrameIndex,
+        float WindowCenterXCm,
+        float WindowCenterYCm,
+        int VisibleAgentCount,
+        int HeavyAgentCount,
+        int SettledAgentCount,
+        float MaxPenetrationCm,
+        float MaxPenetrationRatio,
+        int DeepOverlapPairCount);
 
     private readonly record struct MassNavigationSnapshot(
         int Tick,


### PR DESCRIPTION
## Summary
- stabilizes the MassNavigation 10k capability showcase HUD by removing showcase health drift from agent templates and framing the full 10k agent set in the showcase map camera
- restores commandable local-player ownership/selection coverage and participant visibility needed for the four-team 10k scenario
- cleans capability showcase dependencies and related launcher/web-host contracts, with regression coverage for HUD identity stability and WebHostLoop health

## Verification
- dotnet test src\Tests\PresentationTests\PresentationTests.csproj --filter FullyQualifiedName~CapabilityStandardMassNavigationLargeWorld10kProductionPathTests
- dotnet test src\Tests\PresentationTests\PresentationTests.csproj --filter FullyQualifiedName~NativeSkiaOverlayTests|FullyQualifiedName~PresentationTextContractTests
- dotnet test src\Tests\PresentationTests\PresentationTests.csproj --filter FullyQualifiedName~MassNavigationPerformerContractTests|FullyQualifiedName~MassNavigationFlowSolverStateConfigurationTests
- dotnet test src\Tests\PresentationTests\PresentationTests.csproj --filter FullyQualifiedName~FormationCapabilityShowcaseContractTests|FullyQualifiedName~PerformerTreeLifecycleTests
- dotnet test src\Tests\ArchitectureTests\ArchitectureTests.csproj --filter FullyQualifiedName~LauncherBootstrapContractTests
- dotnet test src\Tests\GasTests\GasTests.csproj --filter FullyQualifiedName~ParticipantViewKnowledgeShowcaseAcceptanceTests
- dotnet test src\Tests\ThreeCTests\ThreeCTests.csproj --filter FullyQualifiedName~WebHostLoopStatusTests
- git diff --check
- changed JSON parsed with ConvertFrom-Json
- scanned for DEBUG markers and odd diagnostic/evidence spellings