### PR TITLE
[WPK-8] Add Web minimap shell showcase

### DIFF
--- a/launcher.config.json
+++ b/launcher.config.json
@@ -202,6 +202,14 @@
       }
     },
     {
+      "name": "browser_minimap_composited_overlay_showcase",
+      "target": {
+        "type": "path",
+        "value": "mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod",
+        "projectPath": "BrowserMinimapCompositedOverlayShowcaseMod.csproj"
+      }
+    },
+    {
       "name": "utility_autocast_showcase",
       "target": {
         "type": "path",

--- a/launcher.presets.json
+++ b/launcher.presets.json
@@ -192,6 +192,21 @@
       }
     },
     {
+      "id": "browser_minimap_composited_overlay_cef_raylib",
+      "name": "Browser Minimap Composited Overlay CEF Raylib",
+      "selectors": [
+        "$performer_blacksmith_large_world_nohud",
+        "$browser_minimap_composited_overlay_showcase"
+      ],
+      "adapterId": "raylib",
+      "buildMode": "auto",
+      "browserRuntime": {
+        "enabled": true,
+        "required": true,
+        "provider": "cef"
+      }
+    },
+    {
       "id": "utility_autocast_showcase_raylib",
       "name": "Utility Autocast Showcase Raylib",
       "selectors": [

--- a/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/Assets/Maps/performer_blacksmith_minimap_marker_large_world_showcase.json
+++ b/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/Assets/Maps/performer_blacksmith_minimap_marker_large_world_showcase.json
@@ -1,0 +1,18 @@
+{
+  "Id": "performer_blacksmith_minimap_marker_large_world_showcase",
+  "Metadata": {
+    "performerBlacksmith": {
+      "minimapMarkerShowcaseTotal": 30000,
+      "minimapMarkerScatterPaddingCm": 64000.0,
+      "minimapMarkerScatterJitterCm": 4200.0,
+      "minimapMarkerVisibleClusterCount": 300,
+      "minimapMarkerVisibleClusterCenterXCm": -2099200.0,
+      "minimapMarkerVisibleClusterCenterYCm": 2508800.0,
+      "minimapMarkerVisibleClusterRadiusCm": 9000.0,
+      "minimapMarkerScatterSeed": 129135,
+      "minimapMarkerMovementPaddingCm": 64000.0,
+      "minimapMarkerMovementSpeedCmPerSecond": 120000.0,
+      "minimapMarkerMovementTurnPeriodSeconds": 3.0
+    }
+  }
+}

--- a/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/Assets/Presentation/performers.json
+++ b/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/Assets/Presentation/performers.json
@@ -1,0 +1,81 @@
+[
+  {
+    "id": "blacksmith_minimap_marker_ball",
+    "defaultColor": [
+      1,
+      0.24,
+      0.06,
+      1
+    ],
+    "children": [],
+    "behaviors": [
+      {
+        "slot": "body",
+        "kind": "AssetBinding",
+        "activeByDefault": true,
+        "assetBinding": {
+          "assetKind": "SkinnedMesh",
+          "assetId": "blacksmith.worker.knight",
+          "materialId": "default_surface",
+          "renderPath": "GpuSkinnedInstance",
+          "mobility": "Movable",
+          "localScale": [
+            0.45,
+            0.45,
+            0.45
+          ]
+        }
+      },
+      {
+        "slot": "animator",
+        "kind": "Animator",
+        "activeByDefault": true,
+        "animator": {
+          "animatorControllerId": "blacksmith.worker.locomotion",
+          "animationProfileId": "blacksmith.worker.profile",
+          "speedParamKey": "blacksmith.worker.locomotion.speed",
+          "stateParamKey": "none"
+        }
+      },
+      {
+        "slot": "grounding",
+        "kind": "Grounding",
+        "activeByDefault": true,
+        "grounding": {
+          "mode": "SnapToGround",
+          "offset": 5.6,
+          "updatePolicy": "EveryFrame"
+        }
+      },
+      {
+        "slot": "minimap",
+        "kind": "MinimapMarker",
+        "activeByDefault": true,
+        "minimapMarker": {
+          "shape": "Circle",
+          "color": [
+            0.98,
+            0.82,
+            0.32,
+            0.72
+          ],
+          "sizePx": 2,
+          "colorParamKey": "none",
+          "sizeParamKey": "none",
+          "visibilityParamKey": "none",
+          "orientationMode": "None",
+          "orientationParamKey": "none",
+          "orientationOffsetRad": 0,
+          "orientationLengthPx": 0
+        }
+      }
+    ],
+    "paramDefaults": [
+      {
+        "paramKey": "blacksmith.worker.locomotion.speed",
+        "lane": "Float",
+        "floatValue": 1
+      }
+    ]
+  }
+]

--- a/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/Assets/game.json
+++ b/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/Assets/game.json
@@ -1,0 +1,16 @@
+{
+  "startupMapId": "performer_blacksmith_minimap_marker_large_world_showcase",
+  "windowTitle": "Ludots Engine - Browser Minimap Composited Overlay",
+  "windowWidth": 1440,
+  "windowHeight": 900,
+  "windowResizable": true,
+  "targetFps": 60,
+  "presentation": {
+    "minimap": {
+      "zoomSliderEnabled": false,
+      "modeToggleEnabled": false,
+      "rotateToggleEnabled": false,
+      "debugMarkerSampleCapacity": 0
+    }
+  }
+}

--- a/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/Assets/overlay-app/index.html
+++ b/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/Assets/overlay-app/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ludots Composited Minimap Overlay</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <section id="minimap-widget" class="minimap-widget" aria-label="Minimap">
+      <div id="minimap-viewport" class="minimap-viewport" aria-hidden="true"></div>
+    </section>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/Assets/overlay-app/main.js
+++ b/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/Assets/overlay-app/main.js
@@ -1,0 +1,164 @@
+const refs = {
+  widget: document.getElementById('minimap-widget'),
+  viewport: document.getElementById('minimap-viewport')
+};
+
+const NATIVE_CLIP_KIND = 'circle';
+let sequence = 0;
+let dragging = false;
+let lastPointerX = 0;
+let lastPointerY = 0;
+let rectPostQueued = false;
+let rectPostHandle = 0;
+
+function postHostMessage(payload) {
+  if (window.ludotsDataplane && typeof window.ludotsDataplane.postMessage === 'function') {
+    window.ludotsDataplane.postMessage(payload);
+    return true;
+  }
+
+  if (window.ludotsBrowser && typeof window.ludotsBrowser.postMessage === 'function') {
+    window.ludotsBrowser.postMessage(payload);
+    return true;
+  }
+
+  return false;
+}
+
+function resolvePointerX(event) {
+  return Number.isFinite(event.clientX) ? event.clientX : 0;
+}
+
+function resolvePointerY(event) {
+  return Number.isFinite(event.clientY) ? event.clientY : 0;
+}
+
+function resolvePointerDelta(event, pointerX, pointerY) {
+  return {
+    x: pointerX - lastPointerX,
+    y: pointerY - lastPointerY
+  };
+}
+
+function browserCoordinateSpacePayload() {
+  const root = document.documentElement;
+  return {
+    kind: 'browser-css-px',
+    width: root.clientWidth || window.innerWidth || refs.widget.getBoundingClientRect().width,
+    height: root.clientHeight || window.innerHeight || refs.widget.getBoundingClientRect().height,
+    devicePixelRatio: window.devicePixelRatio || 1
+  };
+}
+
+function viewportRectPayload(dragDelta = null) {
+  const rect = refs.viewport.getBoundingClientRect();
+  const payload = {
+    type: 'ludots.minimapOverlay.rect',
+    sequence: ++sequence,
+    coordinateSpace: browserCoordinateSpacePayload(),
+    rect: {
+      x: rect.left,
+      y: rect.top,
+      width: rect.width,
+      height: rect.height
+    },
+    clip: {
+      kind: NATIVE_CLIP_KIND
+    }
+  };
+
+  if (dragDelta) {
+    payload.dragDelta = dragDelta;
+  }
+
+  return payload;
+}
+
+function postViewportRect() {
+  rectPostQueued = false;
+  rectPostHandle = 0;
+  postHostMessage(viewportRectPayload());
+}
+
+function queueViewportRect() {
+  if (rectPostQueued) {
+    return;
+  }
+
+  rectPostQueued = true;
+  rectPostHandle = requestAnimationFrame(postViewportRect);
+}
+
+function postViewportRectImmediately() {
+  if (rectPostHandle !== 0) {
+    cancelAnimationFrame(rectPostHandle);
+  }
+
+  rectPostQueued = false;
+  rectPostHandle = 0;
+  postViewportRect();
+}
+
+function postDragDelta(deltaX, deltaY) {
+  if (deltaX === 0 && deltaY === 0) {
+    return;
+  }
+
+  if (rectPostHandle !== 0) {
+    cancelAnimationFrame(rectPostHandle);
+  }
+
+  rectPostQueued = false;
+  rectPostHandle = 0;
+  postHostMessage(viewportRectPayload({
+    x: deltaX,
+    y: deltaY
+  }));
+}
+
+refs.widget.addEventListener('pointerdown', (event) => {
+  if (event.button !== 0) {
+    return;
+  }
+
+  dragging = true;
+  lastPointerX = resolvePointerX(event);
+  lastPointerY = resolvePointerY(event);
+  refs.widget.classList.add('is-dragging');
+  refs.widget.setPointerCapture(event.pointerId);
+  event.preventDefault();
+});
+
+refs.widget.addEventListener('pointermove', (event) => {
+  if (!dragging) {
+    return;
+  }
+
+  const pointerX = resolvePointerX(event);
+  const pointerY = resolvePointerY(event);
+  const delta = resolvePointerDelta(event, pointerX, pointerY);
+  lastPointerX = pointerX;
+  lastPointerY = pointerY;
+  postDragDelta(delta.x, delta.y);
+  event.preventDefault();
+});
+
+function stopDrag(event) {
+  if (!dragging) {
+    return;
+  }
+
+  dragging = false;
+  refs.widget.classList.remove('is-dragging');
+  if (refs.widget.hasPointerCapture(event.pointerId)) {
+    refs.widget.releasePointerCapture(event.pointerId);
+  }
+  postViewportRectImmediately();
+}
+
+refs.widget.addEventListener('pointerup', stopDrag);
+refs.widget.addEventListener('pointercancel', stopDrag);
+window.addEventListener('resize', queueViewportRect);
+
+window.__LUDOTS_MINIMAP_COMPOSITED_OVERLAY_READY__ = true;
+queueViewportRect();

--- a/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/Assets/overlay-app/styles.css
+++ b/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/Assets/overlay-app/styles.css
@@ -1,0 +1,74 @@
+:root {
+  color-scheme: dark;
+  --chrome-inset: 10px;
+  --chrome-fill: rgba(7, 13, 16, 0.42);
+  --chrome-stroke: rgba(227, 242, 232, 0.68);
+  --chrome-shadow: rgba(0, 0, 0, 0.42);
+  --ring: rgba(232, 247, 238, 0.74);
+  --ring-soft: rgba(105, 213, 170, 0.5);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: transparent;
+  font-family: "Segoe UI", system-ui, sans-serif;
+  pointer-events: none;
+  user-select: none;
+}
+
+.minimap-widget {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  border: 1px solid var(--chrome-stroke);
+  background: var(--chrome-fill);
+  box-shadow:
+    0 10px 24px var(--chrome-shadow),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  cursor: grab;
+  pointer-events: auto;
+  touch-action: none;
+}
+
+.minimap-widget.is-dragging {
+  cursor: grabbing;
+  border-color: rgba(240, 255, 247, 0.88);
+  box-shadow:
+    0 14px 30px rgba(0, 0, 0, 0.5),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.14);
+}
+
+.minimap-widget::before {
+  content: "";
+  position: absolute;
+  top: 5px;
+  left: 50%;
+  width: 34px;
+  height: 3px;
+  border-radius: 999px;
+  background: rgba(235, 248, 239, 0.64);
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.minimap-viewport {
+  position: absolute;
+  inset: var(--chrome-inset);
+  border: 1px solid var(--ring);
+  border-radius: 999px;
+  background: transparent;
+  box-shadow:
+    0 0 0 2px rgba(0, 0, 0, 0.28),
+    inset 0 0 0 1px var(--ring-soft);
+  clip-path: circle(50% at 50% 50%);
+  overflow: hidden;
+  pointer-events: none;
+}

--- a/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/BrowserMinimapCompositedOverlayBrowserCanvasContent.cs
+++ b/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/BrowserMinimapCompositedOverlayBrowserCanvasContent.cs
@@ -1,0 +1,24 @@
+using Ludots.UI.Browser;
+using Ludots.UI.Runtime;
+
+namespace BrowserMinimapCompositedOverlayShowcaseMod;
+
+internal sealed class BrowserMinimapCompositedOverlayBrowserCanvasContent : BrowserSurfaceCanvasContent
+{
+	private readonly BrowserMinimapCompositedOverlayLayoutState _layoutState;
+
+	public BrowserMinimapCompositedOverlayBrowserCanvasContent(
+		IBrowserSurface surface,
+		BrowserMinimapCompositedOverlayLayoutState layoutState,
+		BrowserSurfaceHitTestOptions? hitTestOptions = null)
+		: base(surface, hitTestOptions)
+	{
+		_layoutState = layoutState ?? throw new ArgumentNullException(nameof(layoutState));
+	}
+
+	public override UiRect GetContentRect(UiNode node)
+	{
+		BrowserMinimapCompositedOverlayCanvasRect rect = _layoutState.GetCanvasRect();
+		return new UiRect(rect.X, rect.Y, rect.Width, rect.Height);
+	}
+}

--- a/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/BrowserMinimapCompositedOverlayLayoutState.cs
+++ b/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/BrowserMinimapCompositedOverlayLayoutState.cs
@@ -1,0 +1,156 @@
+using Ludots.Core.Presentation;
+
+namespace BrowserMinimapCompositedOverlayShowcaseMod;
+
+internal readonly record struct BrowserMinimapCompositedOverlayRect(
+	int X,
+	int Y,
+	int Width,
+	int Height,
+	PresentationClipShapeKind ClipKind,
+	long Sequence);
+
+internal readonly record struct BrowserMinimapCompositedOverlayCanvasRect(
+	int X,
+	int Y,
+	int Width,
+	int Height);
+
+internal sealed class BrowserMinimapCompositedOverlayLayoutState
+{
+	private readonly object _sync = new();
+	private BrowserMinimapCompositedOverlayRect _rect;
+	private BrowserMinimapCompositedOverlayCanvasRect _canvasRect;
+	private int _screenWidth;
+	private int _screenHeight;
+	private bool _hasRect;
+
+	public void ConfigureCanvas(int x, int y, int width, int height, int screenWidth, int screenHeight)
+	{
+		if (width <= 0 || height <= 0)
+		{
+			throw new ArgumentOutOfRangeException(nameof(width), "Canvas size must be positive.");
+		}
+
+		lock (_sync)
+		{
+			_canvasRect = new BrowserMinimapCompositedOverlayCanvasRect(x, y, width, height);
+			_screenWidth = Math.Max(width, screenWidth);
+			_screenHeight = Math.Max(height, screenHeight);
+		}
+	}
+
+	public BrowserMinimapCompositedOverlayCanvasRect GetCanvasRect()
+	{
+		lock (_sync)
+		{
+			return _canvasRect;
+		}
+	}
+
+	public void UpdateScreenBounds(int screenWidth, int screenHeight)
+	{
+		lock (_sync)
+		{
+			_screenWidth = Math.Max(_canvasRect.Width, screenWidth);
+			_screenHeight = Math.Max(_canvasRect.Height, screenHeight);
+			_canvasRect = ClampCanvasRect(_canvasRect);
+		}
+	}
+
+	public bool ApplyViewportMessage(
+		float localX,
+		float localY,
+		float width,
+		float height,
+		float coordinateSpaceWidth,
+		float coordinateSpaceHeight,
+		PresentationClipShapeKind clipKind,
+		long sequence,
+		float dragDeltaX,
+		float dragDeltaY)
+	{
+		if (width <= 0 || height <= 0)
+		{
+			return false;
+		}
+
+		lock (_sync)
+		{
+			if (_hasRect && sequence < _rect.Sequence)
+			{
+				return false;
+			}
+
+			float scaleX = ResolveCoordinateSpaceScale(_canvasRect.Width, coordinateSpaceWidth);
+			float scaleY = ResolveCoordinateSpaceScale(_canvasRect.Height, coordinateSpaceHeight);
+			int dragDeltaUiX = ScaleToUiPixels(dragDeltaX, scaleX);
+			int dragDeltaUiY = ScaleToUiPixels(dragDeltaY, scaleY);
+			bool canvasMoved = false;
+			if (dragDeltaUiX != 0 || dragDeltaUiY != 0)
+			{
+				BrowserMinimapCompositedOverlayCanvasRect previous = _canvasRect;
+				BrowserMinimapCompositedOverlayCanvasRect next = ClampCanvasRect(previous with
+				{
+					X = previous.X + dragDeltaUiX,
+					Y = previous.Y + dragDeltaUiY
+				});
+				int nextX = next.X;
+				int nextY = next.Y;
+				if (nextX != previous.X || nextY != previous.Y)
+				{
+					_canvasRect = next;
+					canvasMoved = true;
+				}
+			}
+
+			_rect = new BrowserMinimapCompositedOverlayRect(
+				_canvasRect.X + ScaleToUiPixels(localX, scaleX),
+				_canvasRect.Y + ScaleToUiPixels(localY, scaleY),
+				Math.Max(1, ScaleToUiPixels(width, scaleX)),
+				Math.Max(1, ScaleToUiPixels(height, scaleY)),
+				clipKind,
+				sequence);
+			_hasRect = true;
+			return canvasMoved;
+		}
+	}
+
+	private static float ResolveCoordinateSpaceScale(int uiPixels, float coordinateSpacePixels)
+	{
+		return coordinateSpacePixels > 0.001f && float.IsFinite(coordinateSpacePixels)
+			? uiPixels / coordinateSpacePixels
+			: 1f;
+	}
+
+	private static int ScaleToUiPixels(float value, float scale)
+	{
+		if (!float.IsFinite(value) || !float.IsFinite(scale))
+		{
+			return 0;
+		}
+
+		return (int)MathF.Round(value * scale);
+	}
+
+	private BrowserMinimapCompositedOverlayCanvasRect ClampCanvasRect(BrowserMinimapCompositedOverlayCanvasRect rect)
+	{
+		const int Margin = 8;
+		int maxX = Math.Max(Margin, _screenWidth - rect.Width - Margin);
+		int maxY = Math.Max(Margin, _screenHeight - rect.Height - Margin);
+		return rect with
+		{
+			X = Math.Clamp(rect.X, Margin, maxX),
+			Y = Math.Clamp(rect.Y, Margin, maxY)
+		};
+	}
+
+	public bool TryGetRect(out BrowserMinimapCompositedOverlayRect rect)
+	{
+		lock (_sync)
+		{
+			rect = _rect;
+			return _hasRect;
+		}
+	}
+}

--- a/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/BrowserMinimapCompositedOverlayNativeMarkerBridgeSystem.cs
+++ b/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/BrowserMinimapCompositedOverlayNativeMarkerBridgeSystem.cs
@@ -1,0 +1,247 @@
+using Arch.Core;
+using Arch.System;
+using Ludots.Core.Engine;
+using Ludots.Core.Knowledge;
+using Ludots.Core.Presentation.ChunkDebug;
+using Ludots.Core.Presentation.Hud;
+using Ludots.Core.Presentation.Minimap;
+using Ludots.Core.Scripting;
+using Ludots.UI;
+
+namespace BrowserMinimapCompositedOverlayShowcaseMod;
+
+internal sealed class BrowserMinimapCompositedOverlayNativeMarkerBridgeSystem : ISystem<float>
+{
+	private readonly GameEngine _engine;
+	private readonly BrowserMinimapCompositedOverlayLayoutState _layoutState;
+	private readonly HashSet<Entity> _disclosedOwners = new();
+	private MinimapKnowledgeViewerProvider? _previousKnowledgeViewerProvider;
+	private Entity _viewer = Entity.Null;
+	private string _mapId = string.Empty;
+	private bool _knowledgeViewerProviderInstalled;
+	private bool _hasPreviousKnowledgeViewerProvider;
+	private bool _disposed;
+
+	public BrowserMinimapCompositedOverlayNativeMarkerBridgeSystem(
+		GameEngine engine,
+		BrowserMinimapCompositedOverlayLayoutState layoutState)
+	{
+		_engine = engine ?? throw new ArgumentNullException(nameof(engine));
+		_layoutState = layoutState ?? throw new ArgumentNullException(nameof(layoutState));
+	}
+
+	public void Initialize()
+	{
+		_viewer = _engine.World.Create();
+		InstallMinimapKnowledgeViewerProvider();
+	}
+
+	public void BeforeUpdate(in float dt)
+	{
+	}
+
+	public void Update(in float dt)
+	{
+		if (_disposed)
+		{
+			return;
+		}
+
+		SuppressShowcaseNoise();
+		ApplyWebOwnedMinimapViewport();
+		EnsureNativeMinimapMarkerKnowledge();
+	}
+
+	public void AfterUpdate(in float dt)
+	{
+	}
+
+	public void Dispose()
+	{
+		_disposed = true;
+		RestoreMinimapKnowledgeViewerProvider();
+		if (_engine.GetService(CoreServiceKeys.MinimapRuntime) is MinimapRuntime runtime)
+		{
+			runtime.NativeChromeVisible = true;
+			runtime.ClearExternalFieldRect();
+			runtime.ClearFieldClipShape();
+		}
+	}
+
+	private void SuppressShowcaseNoise()
+	{
+		_engine.GetService(CoreServiceKeys.PresentationWorldHudBuffer)?.Clear();
+		_engine.GetService(CoreServiceKeys.PresentationScreenHudBuffer)?.Clear();
+		if (_engine.GetService(CoreServiceKeys.ChunkDebugPanelRuntime) is ChunkDebugPanelRuntime chunkDebug)
+		{
+			chunkDebug.Visible = false;
+		}
+
+		if (_engine.GetService(CoreServiceKeys.RenderDebugState) is RenderDebugState renderDebug)
+		{
+			renderDebug.DrawWorldHudBars = false;
+			renderDebug.DrawWorldHudText = false;
+			renderDebug.DrawCombatText = false;
+			renderDebug.DrawDebugDraw = false;
+		}
+	}
+
+	private void EnsureNativeMinimapMarkerKnowledge()
+	{
+		if (_engine.GetService(CoreServiceKeys.MinimapRuntime) is not MinimapRuntime runtime ||
+			_engine.GetService(CoreServiceKeys.MinimapMarkerBuffer) is not MinimapMarkerBuffer markers ||
+			_engine.GetService(CoreServiceKeys.KnowledgeProjectionStore) is not KnowledgeProjectionStore store)
+		{
+			return;
+		}
+
+		ResetIfMapChanged();
+
+		int markerCount = markers.Count;
+		if (markerCount <= 0)
+		{
+			return;
+		}
+
+		Entity viewer = ResolveOrCreateViewer();
+		if (viewer == Entity.Null)
+		{
+			return;
+		}
+
+		ReadOnlySpan<Entity> owners = markers.Owners;
+		int currentTick = KnowledgeProjectionConsumer.ResolveCurrentTick(_engine.GlobalContext);
+		var record = new KnowledgeDisclosureRecord(
+			KnowledgePresence.LiveVisible,
+			KnowledgePositionAccess.Live,
+			KnowledgeIdMask256.Empty,
+			KnowledgeIdMask256.Empty,
+			KnowledgeIdMask256.Empty,
+			viewer,
+			currentTick,
+			expiryTick: 0,
+			confidencePermille: 1000,
+			revision: 0);
+
+		for (int i = 0; i < owners.Length; i++)
+		{
+			Entity owner = owners[i];
+			if (owner == Entity.Null ||
+				!_engine.World.IsAlive(owner) ||
+				!_disclosedOwners.Add(owner))
+			{
+				continue;
+			}
+
+			store.Upsert(viewer, owner, in record);
+		}
+	}
+
+	private void ApplyWebOwnedMinimapViewport()
+	{
+		if (_engine.GetService(CoreServiceKeys.MinimapRuntime) is not MinimapRuntime runtime)
+		{
+			return;
+		}
+
+		runtime.NativeChromeVisible = false;
+		SyncScreenBounds();
+		if (!_layoutState.TryGetRect(out BrowserMinimapCompositedOverlayRect rect))
+		{
+			runtime.Visible = false;
+			return;
+		}
+
+		runtime.SetExternalFieldRect(rect.X, rect.Y, rect.Width, rect.Height);
+		runtime.SetFieldClipShape(rect.ClipKind);
+		runtime.Visible = true;
+	}
+
+	private void SyncScreenBounds()
+	{
+		if (_engine.GetService(CoreServiceKeys.UIRoot) is not UIRoot root ||
+			root.Width <= 0f ||
+			root.Height <= 0f)
+		{
+			return;
+		}
+
+		_layoutState.UpdateScreenBounds(
+			Math.Max(1, (int)MathF.Ceiling(root.Width)),
+			Math.Max(1, (int)MathF.Ceiling(root.Height)));
+	}
+
+	private void ResetIfMapChanged()
+	{
+		string mapId = _engine.CurrentMapSession?.MapId.Value ?? string.Empty;
+		if (string.Equals(_mapId, mapId, StringComparison.Ordinal))
+		{
+			return;
+		}
+
+		_mapId = mapId;
+		_disclosedOwners.Clear();
+	}
+
+	private Entity ResolveOrCreateViewer()
+	{
+		if (TryResolveViewer(CoreServiceKeys.LocalPlayerEntity.Name, out Entity viewer))
+		{
+			_viewer = viewer;
+			return viewer;
+		}
+
+		if (_viewer == Entity.Null || !_engine.World.IsAlive(_viewer))
+		{
+			_viewer = _engine.World.Create();
+		}
+
+		return _viewer;
+	}
+
+	private void InstallMinimapKnowledgeViewerProvider()
+	{
+		_hasPreviousKnowledgeViewerProvider = _engine.TryGetService(
+			CoreServiceKeys.MinimapKnowledgeViewerProvider,
+			out _previousKnowledgeViewerProvider);
+		_engine.SetService(CoreServiceKeys.MinimapKnowledgeViewerProvider, TryResolveMinimapKnowledgeViewer);
+		_knowledgeViewerProviderInstalled = true;
+	}
+
+	private bool TryResolveMinimapKnowledgeViewer(GameEngine engine, out Entity viewer)
+	{
+		viewer = ResolveOrCreateViewer();
+		return viewer != Entity.Null && engine.World.IsAlive(viewer);
+	}
+
+	private void RestoreMinimapKnowledgeViewerProvider()
+	{
+		if (!_knowledgeViewerProviderInstalled)
+		{
+			return;
+		}
+
+		if (_hasPreviousKnowledgeViewerProvider && _previousKnowledgeViewerProvider != null)
+		{
+			_engine.SetService(CoreServiceKeys.MinimapKnowledgeViewerProvider, _previousKnowledgeViewerProvider);
+		}
+		else
+		{
+			_engine.RemoveService(CoreServiceKeys.MinimapKnowledgeViewerProvider);
+		}
+
+		_knowledgeViewerProviderInstalled = false;
+		_hasPreviousKnowledgeViewerProvider = false;
+		_previousKnowledgeViewerProvider = null;
+	}
+
+	private bool TryResolveViewer(string key, out Entity viewer)
+	{
+		viewer = Entity.Null;
+		return _engine.GlobalContext.TryGetValue(key, out object? value) &&
+			value is Entity candidate &&
+			candidate != Entity.Null &&
+			_engine.World.IsAlive(candidate) &&
+			(viewer = candidate) != Entity.Null;
+	}
+}

--- a/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/BrowserMinimapCompositedOverlayShowcaseMod.csproj
+++ b/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/BrowserMinimapCompositedOverlayShowcaseMod.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Core.csproj">
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\src\Libraries\Ludots.UI\Ludots.UI.csproj">
+      <Private>false</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\src\Libraries\Ludots.UI.Browser\Ludots.UI.Browser.csproj">
+      <Private>true</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\src\Libraries\Ludots.WebUI.Browser\Ludots.WebUI.Browser.csproj">
+      <Private>true</Private>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Assets\**\*.*" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/BrowserMinimapCompositedOverlayShowcaseModEntry.cs
+++ b/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/BrowserMinimapCompositedOverlayShowcaseModEntry.cs
@@ -1,0 +1,333 @@
+using System.Text.Json;
+using Ludots.Core.Engine;
+using Ludots.Core.Modding;
+using Ludots.Core.Presentation;
+using Ludots.Core.Presentation.Minimap;
+using Ludots.Core.Scripting;
+using Ludots.UI;
+using Ludots.UI.Browser;
+using Ludots.UI.Compose;
+using Ludots.UI.Runtime;
+using Ludots.UI.Surface;
+using Ludots.WebUI.Browser;
+
+namespace BrowserMinimapCompositedOverlayShowcaseMod;
+
+public sealed class BrowserMinimapCompositedOverlayShowcaseModEntry : IMod
+{
+	private const string AssetIndexPath = "BrowserMinimapCompositedOverlayShowcaseMod:Assets/overlay-app/index.html";
+	private const int BrowserCanvasSize = 288;
+	private const int BrowserCanvasMargin = 24;
+
+	private IBrowserSurface? _surface;
+	private BrowserMinimapCompositedOverlayBrowserCanvasContent? _browserContent;
+	private readonly BrowserMinimapCompositedOverlayLayoutState _layoutState = new();
+	private BrowserMinimapCompositedOverlayNativeMarkerBridgeSystem? _nativeMarkerBridgeSystem;
+	private IUiSurfaceHost? _surfaceHost;
+	private UiSurfaceLeaseHandle _lease;
+
+	public void OnLoad(IModContext context)
+	{
+		ArgumentNullException.ThrowIfNull(context);
+		context.Log("[BrowserMinimapCompositedOverlayShowcaseMod] Loaded.");
+		context.OnEvent(GameEvents.GameStart, OnGameStartAsync);
+	}
+
+	public void OnUnload()
+	{
+		_nativeMarkerBridgeSystem?.Dispose();
+		_nativeMarkerBridgeSystem = null;
+		if (_surface != null)
+		{
+			_surface.Messages.MessageReceived -= OnBrowserMessageReceived;
+		}
+
+		if (_lease.IsValid && _surfaceHost != null)
+		{
+			_surfaceHost.ReleaseLease(ref _lease);
+		}
+
+		_surfaceHost = null;
+		_browserContent?.Dispose();
+		_browserContent = null;
+		_surface?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+		_surface = null;
+	}
+
+	private async Task OnGameStartAsync(ScriptContext context)
+	{
+		GameEngine engine = context.Get(CoreServiceKeys.Engine)
+			?? throw new InvalidOperationException("GameEngine service is missing from ScriptContext.");
+		IUiSurfaceHost surfaceHost = context.Get(CoreServiceKeys.UiSurfaceHost) as IUiSurfaceHost
+			?? throw new InvalidOperationException("UiSurfaceHost service is missing from ScriptContext.");
+		UIRoot root = context.Get(CoreServiceKeys.UIRoot) as UIRoot
+			?? throw new InvalidOperationException("UIRoot service is missing from ScriptContext.");
+		_surfaceHost = surfaceHost;
+		_lease = surfaceHost.Acquire(new UiSurfaceLeaseRequest(
+			"BrowserMinimapCompositedOverlay.Showcase",
+			UiSurfaceSegment.Main,
+			priority: 12,
+			exclusive: true));
+
+		_nativeMarkerBridgeSystem = new BrowserMinimapCompositedOverlayNativeMarkerBridgeSystem(engine, _layoutState);
+		engine.InsertPresentationSystemBefore<MinimapPresentationSystem>(_nativeMarkerBridgeSystem);
+
+		if (!TryGetBrowserRuntime(context, out IBrowserRuntime runtime))
+		{
+			surfaceHost.Publish(_lease, UiSurfaceContribution.FromBuilder(BuildMissingRuntimeRoot));
+			return;
+		}
+
+		string assetRoot = ResolveAssetRoot(engine);
+		var resolver = new BrowserAppResourceResolver(assetRoot);
+		int screenWidth = Math.Max(BrowserCanvasSize + (BrowserCanvasMargin * 2), (int)MathF.Ceiling(root.Width));
+		int screenHeight = Math.Max(BrowserCanvasSize + (BrowserCanvasMargin * 2), (int)MathF.Ceiling(root.Height));
+		_layoutState.ConfigureCanvas(
+			Math.Max(BrowserCanvasMargin, screenWidth - BrowserCanvasSize - BrowserCanvasMargin),
+			BrowserCanvasMargin,
+			BrowserCanvasSize,
+			BrowserCanvasSize,
+			screenWidth,
+			screenHeight);
+		var viewport = new BrowserViewport(BrowserCanvasSize, BrowserCanvasSize);
+
+		_surface = await runtime.CreateSurfaceAsync(viewport, resolver).ConfigureAwait(false);
+		_surface.Messages.MessageReceived += OnBrowserMessageReceived;
+		_browserContent = new BrowserMinimapCompositedOverlayBrowserCanvasContent(
+			_surface,
+			_layoutState,
+			hitTestOptions: BrowserSurfaceHitTestOptions.Bounds);
+		surfaceHost.Publish(
+			_lease,
+			UiSurfaceContribution.FromBuilder(() => BuildBrowserRoot(_browserContent)));
+
+		await _surface.NavigateAsync(new BrowserNavigationRequest(BrowserLocalAppUri.Create("/", "route=composited-overlay"))).ConfigureAwait(false);
+	}
+
+	private UiElementBuilder BuildBrowserRoot(BrowserMinimapCompositedOverlayBrowserCanvasContent browserContent)
+	{
+		return Ui.Canvas(browserContent)
+			.Id("browser-minimap-composited-overlay-surface")
+			.WidthPercent(100f)
+			.HeightPercent(100f)
+			.Absolute(0f, 0f)
+			.ZIndex(24);
+	}
+
+	private static UiElementBuilder BuildMissingRuntimeRoot()
+	{
+		return Ui.Column(
+				Ui.Text("Browser runtime missing").FontSize(28f).Bold(),
+				Ui.Text("Run browser_minimap_composited_overlay_cef_raylib so the host can mount the transparent browser overlay."))
+			.WidthPercent(100f)
+			.HeightPercent(100f)
+			.Padding(32f)
+			.Gap(12f);
+	}
+
+	private static bool TryGetBrowserRuntime(ScriptContext context, out IBrowserRuntime runtime)
+	{
+		var key = new ServiceKey<IBrowserRuntime>(BrowserRuntimeServiceNames.BrowserRuntime);
+		if (context.TryGet(key, out runtime))
+		{
+			return true;
+		}
+
+		if (context.TryGet(CoreServiceKeys.Engine, out GameEngine? engine) &&
+			engine != null &&
+			engine.TryGetService(key, out runtime))
+		{
+			context.Set(key, runtime);
+			return true;
+		}
+
+		runtime = null!;
+		return false;
+	}
+
+	private static string ResolveAssetRoot(GameEngine engine)
+	{
+		if (engine.VFS != null &&
+			engine.VFS.TryResolveFullPath(AssetIndexPath, out string indexPath))
+		{
+			string? root = Path.GetDirectoryName(indexPath);
+			if (!string.IsNullOrWhiteSpace(root) && Directory.Exists(root))
+			{
+				return root;
+			}
+		}
+
+		throw new DirectoryNotFoundException($"Composited overlay browser app assets were not found: {AssetIndexPath}");
+	}
+
+	private void OnBrowserMessageReceived(object? sender, BrowserScriptMessage message)
+	{
+		if (!TryParseMinimapRectMessage(
+			message.Payload,
+			out float x,
+			out float y,
+			out float width,
+			out float height,
+			out float coordinateSpaceWidth,
+			out float coordinateSpaceHeight,
+			out PresentationClipShapeKind clipKind,
+			out long sequence,
+			out float dragDeltaX,
+			out float dragDeltaY))
+		{
+			return;
+		}
+
+		_layoutState.ApplyViewportMessage(
+			x,
+			y,
+			width,
+			height,
+			coordinateSpaceWidth,
+			coordinateSpaceHeight,
+			clipKind,
+			sequence,
+			dragDeltaX,
+			dragDeltaY);
+	}
+
+	private static bool TryParseMinimapRectMessage(
+		string payload,
+		out float x,
+		out float y,
+		out float width,
+		out float height,
+		out float coordinateSpaceWidth,
+		out float coordinateSpaceHeight,
+		out PresentationClipShapeKind clipKind,
+		out long sequence,
+		out float dragDeltaX,
+		out float dragDeltaY)
+	{
+		x = 0;
+		y = 0;
+		width = 0;
+		height = 0;
+		coordinateSpaceWidth = BrowserCanvasSize;
+		coordinateSpaceHeight = BrowserCanvasSize;
+		clipKind = PresentationClipShapeKind.None;
+		sequence = 0L;
+		dragDeltaX = 0;
+		dragDeltaY = 0;
+		if (string.IsNullOrWhiteSpace(payload))
+		{
+			return false;
+		}
+
+		try
+		{
+			using JsonDocument document = JsonDocument.Parse(payload);
+			JsonElement root = document.RootElement;
+			if (root.ValueKind != JsonValueKind.Object ||
+				!root.TryGetProperty("type", out JsonElement typeElement) ||
+				!string.Equals(typeElement.GetString(), "ludots.minimapOverlay.rect", StringComparison.Ordinal) ||
+				!root.TryGetProperty("rect", out JsonElement rectElement) ||
+				rectElement.ValueKind != JsonValueKind.Object)
+			{
+				return false;
+			}
+
+			if (!TryGetFiniteSingle(rectElement, "x", out float xf) ||
+				!TryGetFiniteSingle(rectElement, "y", out float yf) ||
+				!TryGetFiniteSingle(rectElement, "width", out float widthf) ||
+				!TryGetFiniteSingle(rectElement, "height", out float heightf))
+			{
+				return false;
+			}
+
+			if (root.TryGetProperty("sequence", out JsonElement sequenceElement) &&
+				sequenceElement.ValueKind == JsonValueKind.Number &&
+				sequenceElement.TryGetInt64(out long parsedSequence))
+			{
+				sequence = parsedSequence;
+			}
+
+			clipKind = TryGetClipKind(root, out PresentationClipShapeKind parsedClipKind)
+				? parsedClipKind
+				: PresentationClipShapeKind.None;
+			if (root.TryGetProperty("coordinateSpace", out JsonElement coordinateSpaceElement) &&
+				coordinateSpaceElement.ValueKind == JsonValueKind.Object)
+			{
+				if (TryGetFiniteSingle(coordinateSpaceElement, "width", out float coordinateSpaceWidthf) &&
+					coordinateSpaceWidthf > 0f)
+				{
+					coordinateSpaceWidth = Math.Clamp(coordinateSpaceWidthf, 1f, 4096f);
+				}
+
+				if (TryGetFiniteSingle(coordinateSpaceElement, "height", out float coordinateSpaceHeightf) &&
+					coordinateSpaceHeightf > 0f)
+				{
+					coordinateSpaceHeight = Math.Clamp(coordinateSpaceHeightf, 1f, 4096f);
+				}
+			}
+
+			if (root.TryGetProperty("dragDelta", out JsonElement dragDeltaElement) &&
+				dragDeltaElement.ValueKind == JsonValueKind.Object)
+			{
+				if (TryGetFiniteSingle(dragDeltaElement, "x", out float dragDeltaXf))
+				{
+					dragDeltaX = Math.Clamp(dragDeltaXf, -4096f, 4096f);
+				}
+
+				if (TryGetFiniteSingle(dragDeltaElement, "y", out float dragDeltaYf))
+				{
+					dragDeltaY = Math.Clamp(dragDeltaYf, -4096f, 4096f);
+				}
+			}
+
+			x = Math.Clamp(xf, -4096f, 4096f);
+			y = Math.Clamp(yf, -4096f, 4096f);
+			width = Math.Clamp(widthf, 1f, 4096f);
+			height = Math.Clamp(heightf, 1f, 4096f);
+			return true;
+		}
+		catch (JsonException)
+		{
+			return false;
+		}
+	}
+
+	private static bool TryGetFiniteSingle(JsonElement element, string propertyName, out float value)
+	{
+		value = 0f;
+		if (!element.TryGetProperty(propertyName, out JsonElement property) ||
+			property.ValueKind != JsonValueKind.Number ||
+			!property.TryGetSingle(out value))
+		{
+			return false;
+		}
+
+		return float.IsFinite(value);
+	}
+
+	private static bool TryGetClipKind(JsonElement root, out PresentationClipShapeKind clipKind)
+	{
+		clipKind = PresentationClipShapeKind.None;
+		if (!root.TryGetProperty("clip", out JsonElement clipElement) ||
+			clipElement.ValueKind != JsonValueKind.Object ||
+			!clipElement.TryGetProperty("kind", out JsonElement kindElement))
+		{
+			return false;
+		}
+
+		return kindElement.GetString()?.Trim().ToLowerInvariant() switch
+		{
+			"rect" => SetClipKind(PresentationClipShapeKind.Rect, out clipKind),
+			"circle" => SetClipKind(PresentationClipShapeKind.Circle, out clipKind),
+			"diamond" => SetClipKind(PresentationClipShapeKind.Diamond, out clipKind),
+			"none" => SetClipKind(PresentationClipShapeKind.None, out clipKind),
+			_ => false,
+		};
+	}
+
+	private static bool SetClipKind(PresentationClipShapeKind value, out PresentationClipShapeKind target)
+	{
+		target = value;
+		return true;
+	}
+}

--- a/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/mod.json
+++ b/mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod/mod.json
@@ -1,0 +1,12 @@
+{
+  "name": "BrowserMinimapCompositedOverlayShowcaseMod",
+  "version": "1.0.0",
+  "description": "Composited minimap showcase where native Skia renders the minimap markers and Web UI is only a transparent overlay.",
+  "main": "bin/net8.0/BrowserMinimapCompositedOverlayShowcaseMod.dll",
+  "priority": 192,
+  "dependencies": {
+    "LudotsCoreMod": "^1.0.0"
+  },
+  "author": "Ludots Team",
+  "tags": ["showcase", "browser-ui", "minimap", "overlay", "performance"]
+}

--- a/src/Core/Presentation/Hud/PresentationOverlayItem.cs
+++ b/src/Core/Presentation/Hud/PresentationOverlayItem.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Ludots.Core.Presentation;
 
 namespace Ludots.Core.Presentation.Hud
 {
@@ -19,5 +20,6 @@ namespace Ludots.Core.Presentation.Hud
         public float Value0;
         public float Value1;
         public float Value2;
+        public PresentationClipShape ClipShape;
     }
 }

--- a/src/Core/Presentation/Hud/PresentationOverlayScene.cs
+++ b/src/Core/Presentation/Hud/PresentationOverlayScene.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using Ludots.Core.Presentation;
 using Ludots.Core.Presentation.Minimap;
 
 namespace Ludots.Core.Presentation.Hud
@@ -533,7 +534,8 @@ namespace Ludots.Core.Presentation.Hud
             in Vector4 fill,
             in Vector4 border,
             int stableId = 0,
-            int dirtySerial = 0)
+            int dirtySerial = 0,
+            PresentationClipShape clipShape = default)
         {
             if (width <= 0f || height <= 0f)
             {
@@ -551,7 +553,8 @@ namespace Ludots.Core.Presentation.Hud
                 Width = width,
                 Height = height,
                 Color0 = fill,
-                Color1 = border
+                Color1 = border,
+                ClipShape = clipShape
             };
             return TryStore(in item);
         }
@@ -612,7 +615,8 @@ namespace Ludots.Core.Presentation.Hud
             float thickness,
             in Vector4 color,
             int stableId = 0,
-            int dirtySerial = 0)
+            int dirtySerial = 0,
+            PresentationClipShape clipShape = default)
         {
             if (thickness <= 0f || color.W <= 0f)
             {
@@ -630,7 +634,8 @@ namespace Ludots.Core.Presentation.Hud
                 Width = x1,
                 Height = y1,
                 Value0 = thickness,
-                Color0 = color
+                Color0 = color,
+                ClipShape = clipShape
             };
             return TryStore(in item);
         }
@@ -1498,7 +1503,8 @@ namespace Ludots.Core.Presentation.Hud
                 left.FontSize != right.FontSize ||
                 left.Value0 != right.Value0 ||
                 left.Value1 != right.Value1 ||
-                left.Value2 != right.Value2)
+                left.Value2 != right.Value2 ||
+                !left.ClipShape.Equals(right.ClipShape))
             {
                 return PresentationOverlayItemCompareResult.Content;
             }

--- a/src/Core/Presentation/Hud/PresentationOverlaySceneBuilder.cs
+++ b/src/Core/Presentation/Hud/PresentationOverlaySceneBuilder.cs
@@ -355,7 +355,8 @@ namespace Ludots.Core.Presentation.Hud
                                 item.BackgroundColor,
                                 item.Color,
                                 item.StableId,
-                                item.DirtySerial);
+                                item.DirtySerial,
+                                item.ClipShape);
                             break;
 
                         case ScreenOverlayItemKind.Line:
@@ -368,7 +369,8 @@ namespace Ludots.Core.Presentation.Hud
                                 item.Thickness,
                                 item.Color,
                                 item.StableId,
-                                item.DirtySerial);
+                                item.DirtySerial,
+                                item.ClipShape);
                             break;
                     }
                 }

--- a/src/Core/Presentation/Hud/ScreenOverlayBuffer.cs
+++ b/src/Core/Presentation/Hud/ScreenOverlayBuffer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Numerics;
+using Ludots.Core.Presentation;
 
 namespace Ludots.Core.Presentation.Hud
 {
@@ -25,6 +26,7 @@ namespace Ludots.Core.Presentation.Hud
         public Vector4 Color;
         public Vector4 BackgroundColor;
         public PresentationTextPacket Text;
+        public PresentationClipShape ClipShape;
     }
 
     /// <summary>
@@ -112,6 +114,20 @@ namespace Ludots.Core.Presentation.Hud
 
         public bool AddRect(int x, int y, int width, int height, Vector4 fill, Vector4 border, int stableId, int dirtySerial)
         {
+            return AddRect(x, y, width, height, fill, border, stableId, dirtySerial, PresentationClipShape.None);
+        }
+
+        public bool AddRect(
+            int x,
+            int y,
+            int width,
+            int height,
+            Vector4 fill,
+            Vector4 border,
+            int stableId,
+            int dirtySerial,
+            PresentationClipShape clipShape)
+        {
             if (_count >= MaxItems) return false;
 
             _items[_count++] = new ScreenOverlayItem
@@ -124,7 +140,8 @@ namespace Ludots.Core.Presentation.Hud
                 Width = width,
                 Height = height,
                 BackgroundColor = fill,
-                Color = border
+                Color = border,
+                ClipShape = clipShape
             };
             return true;
         }
@@ -135,6 +152,20 @@ namespace Ludots.Core.Presentation.Hud
         }
 
         public bool AddLine(int x0, int y0, int x1, int y1, int thickness, Vector4 color, int stableId, int dirtySerial)
+        {
+            return AddLine(x0, y0, x1, y1, thickness, color, stableId, dirtySerial, PresentationClipShape.None);
+        }
+
+        public bool AddLine(
+            int x0,
+            int y0,
+            int x1,
+            int y1,
+            int thickness,
+            Vector4 color,
+            int stableId,
+            int dirtySerial,
+            PresentationClipShape clipShape)
         {
             if (_count >= MaxItems) return false;
             if (thickness <= 0 || color.W <= 0f) return true;
@@ -149,7 +180,8 @@ namespace Ludots.Core.Presentation.Hud
                 Width = x1,
                 Height = y1,
                 Thickness = thickness,
-                Color = color
+                Color = color,
+                ClipShape = clipShape
             };
             return true;
         }

--- a/src/Core/Presentation/Minimap/MinimapRuntime.cs
+++ b/src/Core/Presentation/Minimap/MinimapRuntime.cs
@@ -170,6 +170,12 @@ namespace Ludots.Core.Presentation.Minimap
         private int _presetToggleY = 392;
         private int _rotateToggleX = 926;
         private int _rotateToggleY = 392;
+        private bool _externalFieldRectActive;
+        private int _externalFieldX;
+        private int _externalFieldY;
+        private int _externalFieldWidth;
+        private int _externalFieldHeight;
+        private PresentationClipShapeKind _fieldClipShapeKind;
         private int _markerCount;
         private int _visibleMarkerCount;
         private bool _cameraFrustumVisible;
@@ -199,6 +205,8 @@ namespace Ludots.Core.Presentation.Minimap
 
         public bool Visible { get; set; }
 
+        public bool NativeChromeVisible { get; set; } = true;
+
         public MinimapPreset Preset { get; private set; } = MinimapPreset.RtsFullMap;
 
         public Entity FollowEntity { get; private set; } = Entity.Null;
@@ -224,6 +232,8 @@ namespace Ludots.Core.Presentation.Minimap
         public bool ZoomSliderEnabled => _config.ZoomSliderEnabled;
 
         public string Diagnostic => _diagnostic;
+
+        public PresentationClipShapeKind FieldClipShapeKind => _fieldClipShapeKind;
 
         public int FieldX => _fieldX;
 
@@ -256,6 +266,42 @@ namespace Ludots.Core.Presentation.Minimap
         public int RotateToggleHeight => ToggleButtonHeight;
 
         public float MetricGridStepCm => _metricGridStepCm;
+
+        public void SetExternalFieldRect(int x, int y, int width, int height)
+        {
+            if (width <= 0 || height <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(width), "External minimap field rect must have positive width and height.");
+            }
+
+            _externalFieldX = x;
+            _externalFieldY = y;
+            _externalFieldWidth = width;
+            _externalFieldHeight = height;
+            _externalFieldRectActive = true;
+        }
+
+        public void ClearExternalFieldRect()
+        {
+            _externalFieldRectActive = false;
+        }
+
+        public void SetFieldClipShape(PresentationClipShapeKind kind)
+        {
+            _fieldClipShapeKind = kind switch
+            {
+                PresentationClipShapeKind.None => PresentationClipShapeKind.None,
+                PresentationClipShapeKind.Rect => PresentationClipShapeKind.Rect,
+                PresentationClipShapeKind.Circle => PresentationClipShapeKind.Circle,
+                PresentationClipShapeKind.Diamond => PresentationClipShapeKind.Diamond,
+                _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unsupported minimap field clip shape."),
+            };
+        }
+
+        public void ClearFieldClipShape()
+        {
+            _fieldClipShapeKind = PresentationClipShapeKind.None;
+        }
 
         public void SetRotateWithCamera(bool enabled)
         {
@@ -362,27 +408,52 @@ namespace Ludots.Core.Presentation.Minimap
                 return;
             }
 
-            overlay.AddRect(
-                _panelX,
-                _panelY,
-                _panelWidth,
-                _panelHeight,
-                new Vector4(0.02f, 0.05f, 0.07f, 1f),
-                new Vector4(0.48f, 0.70f, 0.86f, 1f));
-            overlay.AddRect(
-                _fieldX,
-                _fieldY,
-                _fieldSize,
-                _fieldSize,
-                new Vector4(0.01f, 0.04f, 0.06f, 1f),
-                new Vector4(0.42f, 0.65f, 0.80f, 1f));
-            overlay.AddText(_panelX + PanelInset + 6, _panelY + 13, "Minimap", 18, new Vector4(0.98f, 0.99f, 1f, 1f));
-            overlay.AddText(_panelX + _panelWidth - 118, _panelY + 14, BandLabels[(int)ZoomBand], 14, new Vector4(1f, 0.84f, 0.42f, 1f));
-            RenderGrid(overlay);
-            RenderCameraFrustum(overlay);
+            PresentationClipShape fieldClip = ResolveFieldClipShape();
+            if (NativeChromeVisible)
+            {
+                overlay.AddRect(
+                    _panelX,
+                    _panelY,
+                    _panelWidth,
+                    _panelHeight,
+                    new Vector4(0.02f, 0.05f, 0.07f, 1f),
+                    new Vector4(0.48f, 0.70f, 0.86f, 1f));
+                overlay.AddRect(
+                    _fieldX,
+                    _fieldY,
+                    _fieldSize,
+                    _fieldSize,
+                    new Vector4(0.01f, 0.04f, 0.06f, 1f),
+                    new Vector4(0.42f, 0.65f, 0.80f, 1f),
+                    stableId: 0,
+                    dirtySerial: 0,
+                    clipShape: fieldClip);
+                overlay.AddText(_panelX + PanelInset + 6, _panelY + 13, "Minimap", 18, new Vector4(0.98f, 0.99f, 1f, 1f));
+                overlay.AddText(_panelX + _panelWidth - 118, _panelY + 14, BandLabels[(int)ZoomBand], 14, new Vector4(1f, 0.84f, 0.42f, 1f));
+            }
+            else
+            {
+                overlay.AddRect(
+                    _fieldX,
+                    _fieldY,
+                    _fieldSize,
+                    _fieldSize,
+                    new Vector4(0.01f, 0.04f, 0.06f, 1f),
+                    Vector4.Zero,
+                    stableId: 0,
+                    dirtySerial: 0,
+                    clipShape: fieldClip);
+            }
+
+            RenderGrid(overlay, fieldClip);
+            RenderCameraFrustum(overlay, fieldClip);
+            if (!NativeChromeVisible)
+            {
+                return;
+            }
+
             RenderZoomSlider(overlay);
             RenderToggleButtons(overlay);
-
             if (!string.IsNullOrWhiteSpace(_diagnostic))
             {
                 overlay.AddText(_fieldX + 16, _fieldY + 28, _diagnostic, 14, new Vector4(1f, 0.72f, 0.48f, 1f));
@@ -691,6 +762,7 @@ namespace Ludots.Core.Presentation.Minimap
         {
             screenMarkers.BeginBucketedFrame();
             screenMarkers.SetFieldBounds(_fieldX, _fieldY, _fieldSize);
+            screenMarkers.SetClipShape(ResolveFieldClipShape());
             int count = markers.Count;
             float centerX = _centerXcm;
             float centerY = _centerYcm;
@@ -739,9 +811,9 @@ namespace Ludots.Core.Presentation.Minimap
                 Vector4 markerColor = colors[i];
                 float markerSizePx = sizesPx[i];
                 bool useAuthoredStyleBucket = true;
+                Entity owner = owners[i];
                 if (hasKnowledgeResolver)
                 {
-                    Entity owner = owners[i];
                     if (owner == Entity.Null ||
                         !KnowledgeProjectionConsumer.TryResolveForViewer(
                             engine.World,
@@ -1023,7 +1095,7 @@ namespace Ludots.Core.Presentation.Minimap
             return bounds;
         }
 
-        private void RenderGrid(ScreenOverlayBuffer overlay)
+        private void RenderGrid(ScreenOverlayBuffer overlay, PresentationClipShape clipShape)
         {
             _metricGridStepCm = ResolveMetricGridStepCm();
             ResolveViewportWorldAabb(out float minX, out float minY, out float maxX, out float maxY);
@@ -1037,7 +1109,7 @@ namespace Ludots.Core.Presentation.Minimap
             {
                 Vector4 color = IsMajorGridLine(x, step) ? major : minor;
                 int thickness = IsMajorGridLine(x, step) ? 2 : 1;
-                AddWorldLineClipped(overlay, x, minY, x, maxY, thickness, color);
+                AddWorldLineClipped(overlay, x, minY, x, maxY, thickness, color, clipShape);
             }
 
             float startY = MathF.Ceiling(minY / step) * step;
@@ -1046,7 +1118,7 @@ namespace Ludots.Core.Presentation.Minimap
             {
                 Vector4 color = IsMajorGridLine(y, step) ? major : minor;
                 int thickness = IsMajorGridLine(y, step) ? 2 : 1;
-                AddWorldLineClipped(overlay, minX, y, maxX, y, thickness, color);
+                AddWorldLineClipped(overlay, minX, y, maxX, y, thickness, color, clipShape);
             }
         }
 
@@ -1160,7 +1232,8 @@ namespace Ludots.Core.Presentation.Minimap
             float worldX1,
             float worldY1,
             int thickness,
-            Vector4 color)
+            Vector4 color,
+            PresentationClipShape clipShape)
         {
             ProjectWorldToScreenUnclipped(worldX0, worldY0, out float x0, out float y0);
             ProjectWorldToScreenUnclipped(worldX1, worldY1, out float x1, out float y1);
@@ -1175,7 +1248,10 @@ namespace Ludots.Core.Presentation.Minimap
                 (int)MathF.Round(x1),
                 (int)MathF.Round(y1),
                 thickness,
-                color);
+                color,
+                stableId: 0,
+                dirtySerial: 0,
+                clipShape: clipShape);
         }
 
         private bool TryClipScreenLineToField(ref float x0, ref float y0, ref float x1, ref float y1)
@@ -1284,7 +1360,7 @@ namespace Ludots.Core.Presentation.Minimap
             return code;
         }
 
-        private void RenderCameraFrustum(ScreenOverlayBuffer overlay)
+        private void RenderCameraFrustum(ScreenOverlayBuffer overlay, PresentationClipShape clipShape)
         {
             if (!_cameraFrustumVisible || _cameraFrustumPointCount < 4)
             {
@@ -1297,8 +1373,8 @@ namespace Ludots.Core.Presentation.Minimap
             {
                 Vector2 a = _cameraFrustumScreenPoints[i];
                 Vector2 b = _cameraFrustumScreenPoints[(i + 1) % _cameraFrustumPointCount];
-                AddScreenLine(overlay, a, b, CameraFrustumShadowThickness, shadow);
-                AddScreenLine(overlay, a, b, CameraFrustumLineThickness, frustumColor);
+                AddScreenLine(overlay, a, b, CameraFrustumShadowThickness, shadow, clipShape);
+                AddScreenLine(overlay, a, b, CameraFrustumLineThickness, frustumColor, clipShape);
             }
 
             if (TryWorldToScreen(_cameraTargetXcm, _cameraTargetYcm, out float targetX, out float targetY))
@@ -1306,14 +1382,14 @@ namespace Ludots.Core.Presentation.Minimap
                 Vector4 targetColor = new(1f, 0.95f, 0.55f, 1f);
                 int cx = (int)MathF.Round(targetX);
                 int cy = (int)MathF.Round(targetY);
-                overlay.AddRect(cx - CameraCenterCrossHalfExtent - 1, cy - 2, (CameraCenterCrossHalfExtent * 2) + 2, CameraCenterCrossThickness + 2, Vector4.Zero, shadow);
-                overlay.AddRect(cx - 2, cy - CameraCenterCrossHalfExtent - 1, CameraCenterCrossThickness + 2, (CameraCenterCrossHalfExtent * 2) + 2, Vector4.Zero, shadow);
-                overlay.AddRect(cx - CameraCenterCrossHalfExtent, cy - 1, CameraCenterCrossHalfExtent * 2, CameraCenterCrossThickness, Vector4.Zero, targetColor);
-                overlay.AddRect(cx - 1, cy - CameraCenterCrossHalfExtent, CameraCenterCrossThickness, CameraCenterCrossHalfExtent * 2, Vector4.Zero, targetColor);
+                overlay.AddRect(cx - CameraCenterCrossHalfExtent - 1, cy - 2, (CameraCenterCrossHalfExtent * 2) + 2, CameraCenterCrossThickness + 2, Vector4.Zero, shadow, stableId: 0, dirtySerial: 0, clipShape: clipShape);
+                overlay.AddRect(cx - 2, cy - CameraCenterCrossHalfExtent - 1, CameraCenterCrossThickness + 2, (CameraCenterCrossHalfExtent * 2) + 2, Vector4.Zero, shadow, stableId: 0, dirtySerial: 0, clipShape: clipShape);
+                overlay.AddRect(cx - CameraCenterCrossHalfExtent, cy - 1, CameraCenterCrossHalfExtent * 2, CameraCenterCrossThickness, Vector4.Zero, targetColor, stableId: 0, dirtySerial: 0, clipShape: clipShape);
+                overlay.AddRect(cx - 1, cy - CameraCenterCrossHalfExtent, CameraCenterCrossThickness, CameraCenterCrossHalfExtent * 2, Vector4.Zero, targetColor, stableId: 0, dirtySerial: 0, clipShape: clipShape);
             }
         }
 
-        private static void AddScreenLine(ScreenOverlayBuffer overlay, Vector2 a, Vector2 b, int thickness, Vector4 color)
+        private static void AddScreenLine(ScreenOverlayBuffer overlay, Vector2 a, Vector2 b, int thickness, Vector4 color, PresentationClipShape clipShape)
         {
             overlay.AddLine(
                 (int)MathF.Round(a.X),
@@ -1321,7 +1397,10 @@ namespace Ludots.Core.Presentation.Minimap
                 (int)MathF.Round(b.X),
                 (int)MathF.Round(b.Y),
                 thickness,
-                color);
+                color,
+                stableId: 0,
+                dirtySerial: 0,
+                clipShape: clipShape);
         }
 
         private bool TryProjectCameraCorner(
@@ -1493,6 +1572,25 @@ namespace Ludots.Core.Presentation.Minimap
 
         private void RefreshPanelLayout(GameEngine engine)
         {
+            if (_externalFieldRectActive)
+            {
+                _fieldSize = Math.Max(1, Math.Min(_externalFieldWidth, _externalFieldHeight));
+                _fieldX = _externalFieldX + Math.Max(0, (_externalFieldWidth - _fieldSize) / 2);
+                _fieldY = _externalFieldY + Math.Max(0, (_externalFieldHeight - _fieldSize) / 2);
+                _panelX = _externalFieldX;
+                _panelY = _externalFieldY;
+                _panelWidth = _externalFieldWidth;
+                _panelHeight = _externalFieldHeight;
+                _zoomSliderX = _fieldX;
+                _zoomSliderY = _fieldY + _fieldSize + 4;
+                _zoomSliderWidth = _fieldSize;
+                _presetToggleX = _panelX + _panelWidth - PanelInset - ToggleButtonWidth;
+                _rotateToggleX = _presetToggleX - ToggleButtonGap - ToggleButtonWidth;
+                _presetToggleY = _fieldY + _fieldSize + (_config.ZoomSliderEnabled ? ZoomSliderHeight : 0) + 8;
+                _rotateToggleY = _presetToggleY;
+                return;
+            }
+
             int screenWidth = engine.MergedConfig?.WindowWidth > 0 ? engine.MergedConfig.WindowWidth : 1280;
             int screenHeight = engine.MergedConfig?.WindowHeight > 0 ? engine.MergedConfig.WindowHeight : 720;
             _fieldSize = ResolveFieldSize(screenWidth, screenHeight, _config.ZoomSliderEnabled);
@@ -1509,6 +1607,17 @@ namespace Ludots.Core.Presentation.Minimap
             _rotateToggleX = _presetToggleX - ToggleButtonGap - ToggleButtonWidth;
             _presetToggleY = _fieldY + _fieldSize + (_config.ZoomSliderEnabled ? ZoomSliderHeight : 0) + 8;
             _rotateToggleY = _presetToggleY;
+        }
+
+        private PresentationClipShape ResolveFieldClipShape()
+        {
+            return _fieldClipShapeKind switch
+            {
+                PresentationClipShapeKind.Rect => PresentationClipShape.FromRect(_fieldX, _fieldY, _fieldSize, _fieldSize),
+                PresentationClipShapeKind.Circle => PresentationClipShape.FromCircle(_fieldX, _fieldY, _fieldSize, _fieldSize),
+                PresentationClipShapeKind.Diamond => PresentationClipShape.FromDiamond(_fieldX, _fieldY, _fieldSize, _fieldSize),
+                _ => PresentationClipShape.None,
+            };
         }
 
         private static int ResolveFieldSize(int screenWidth, int screenHeight, bool zoomSliderEnabled)

--- a/src/Core/Presentation/Minimap/MinimapScreenMarkerBuffer.cs
+++ b/src/Core/Presentation/Minimap/MinimapScreenMarkerBuffer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Numerics;
 using Ludots.Core.Mathematics;
+using Ludots.Core.Presentation;
 
 namespace Ludots.Core.Presentation.Minimap
 {
@@ -108,6 +109,8 @@ namespace Ludots.Core.Presentation.Minimap
 
         public int FieldSize => _fieldSize;
 
+        public PresentationClipShape ClipShape { get; private set; }
+
         public int DroppedSinceClear { get; private set; }
 
         public int DroppedTotal { get; private set; }
@@ -119,6 +122,7 @@ namespace Ludots.Core.Presentation.Minimap
             _bucketCount = 0;
             _bucketedReservedCount = 0;
             _bucketLayoutMaterialized = false;
+            ClipShape = PresentationClipShape.None;
             AdvanceLookupStamp();
             DroppedSinceClear = 0;
         }
@@ -133,6 +137,11 @@ namespace Ludots.Core.Presentation.Minimap
             _fieldX = x;
             _fieldY = y;
             _fieldSize = Math.Max(0, size);
+        }
+
+        public void SetClipShape(PresentationClipShape clipShape)
+        {
+            ClipShape = clipShape.IsActive ? clipShape : PresentationClipShape.None;
         }
 
         public bool TryAdd(

--- a/src/Core/Presentation/PresentationClipShape.cs
+++ b/src/Core/Presentation/PresentationClipShape.cs
@@ -1,0 +1,54 @@
+namespace Ludots.Core.Presentation
+{
+    public enum PresentationClipShapeKind : byte
+    {
+        None = 0,
+        Rect = 1,
+        Circle = 2,
+        Diamond = 3,
+    }
+
+    public readonly record struct PresentationClipShape(
+        PresentationClipShapeKind Kind,
+        float X,
+        float Y,
+        float Width,
+        float Height)
+    {
+        public static PresentationClipShape None => default;
+
+        public bool IsActive => Kind != PresentationClipShapeKind.None &&
+            Width > 0f &&
+            Height > 0f;
+
+        public static PresentationClipShape FromRect(float x, float y, float width, float height)
+        {
+            return Create(PresentationClipShapeKind.Rect, x, y, width, height);
+        }
+
+        public static PresentationClipShape FromCircle(float x, float y, float width, float height)
+        {
+            return Create(PresentationClipShapeKind.Circle, x, y, width, height);
+        }
+
+        public static PresentationClipShape FromDiamond(float x, float y, float width, float height)
+        {
+            return Create(PresentationClipShapeKind.Diamond, x, y, width, height);
+        }
+
+        public static PresentationClipShape Create(
+            PresentationClipShapeKind kind,
+            float x,
+            float y,
+            float width,
+            float height)
+        {
+            if (kind == PresentationClipShapeKind.None || width <= 0f || height <= 0f)
+            {
+                return None;
+            }
+
+            return new PresentationClipShape(kind, x, y, width, height);
+        }
+    }
+}

--- a/src/Libraries/Ludots.Presentation.Skia/SkiaOverlayRenderer.cs
+++ b/src/Libraries/Ludots.Presentation.Skia/SkiaOverlayRenderer.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 using Ludots.Core.Mathematics;
+using Ludots.Core.Presentation;
 using Ludots.Core.Presentation.Hud;
 using Ludots.Core.Presentation.Minimap;
 using Ludots.UI.Runtime;
@@ -191,6 +192,20 @@ namespace Ludots.Presentation.Skia
                 scene.TopMostMinimapMarkers is not MinimapScreenMarkerBuffer markers ||
                 markers.Count <= 0)
             {
+                return;
+            }
+
+            if (TrySaveClipShape(canvas, markers.ClipShape, out int saveCount))
+            {
+                try
+                {
+                    DrawMinimapMarkersBatched(canvas, markers);
+                }
+                finally
+                {
+                    canvas.RestoreToCount(saveCount);
+                }
+
                 return;
             }
 
@@ -438,6 +453,25 @@ namespace Ludots.Presentation.Skia
             }
         }
 
+        private void DrawRectWithClip(SKCanvas canvas, in PresentationOverlayItem item)
+        {
+            if (TrySaveClipShape(canvas, item.ClipShape, out int saveCount))
+            {
+                try
+                {
+                    DrawRect(canvas, item);
+                }
+                finally
+                {
+                    canvas.RestoreToCount(saveCount);
+                }
+
+                return;
+            }
+
+            DrawRect(canvas, item);
+        }
+
         private void DrawBar(SKCanvas canvas, in PresentationOverlayItem item)
         {
             CachedBarSprite sprite = GetBarSprite(item);
@@ -569,6 +603,25 @@ namespace Ludots.Presentation.Skia
             }
         }
 
+        private void DrawLineWithClip(SKCanvas canvas, in PresentationOverlayItem item)
+        {
+            if (TrySaveClipShape(canvas, item.ClipShape, out int saveCount))
+            {
+                try
+                {
+                    DrawLine(canvas, item);
+                }
+                finally
+                {
+                    canvas.RestoreToCount(saveCount);
+                }
+
+                return;
+            }
+
+            DrawLine(canvas, item);
+        }
+
         private void DrawLaneImmediate(SKCanvas canvas, PresentationOverlayItemKind kind, ReadOnlySpan<PresentationOverlayItem> span)
         {
             if (kind == PresentationOverlayItemKind.Bar)
@@ -589,11 +642,11 @@ namespace Ludots.Presentation.Skia
                 switch (kind)
                 {
                     case PresentationOverlayItemKind.Rect:
-                        DrawRect(canvas, item);
+                        DrawRectWithClip(canvas, item);
                         break;
 
                     case PresentationOverlayItemKind.Line:
-                        DrawLine(canvas, item);
+                        DrawLineWithClip(canvas, item);
                         break;
                 }
             }
@@ -1280,11 +1333,11 @@ namespace Ludots.Presentation.Skia
                     switch (kind)
                     {
                         case PresentationOverlayItemKind.Rect:
-                            DrawRect(pictureCanvas, item);
+                            DrawRectWithClip(pictureCanvas, item);
                             break;
 
                         case PresentationOverlayItemKind.Line:
-                            DrawLine(pictureCanvas, item);
+                            DrawLineWithClip(pictureCanvas, item);
                             break;
                     }
                 }
@@ -2237,6 +2290,55 @@ namespace Ludots.Presentation.Skia
             IntPtr sampling,
             IntPtr cullRect,
             IntPtr paint);
+
+        private static bool TrySaveClipShape(SKCanvas canvas, in PresentationClipShape clipShape, out int saveCount)
+        {
+            saveCount = -1;
+            if (!clipShape.IsActive)
+            {
+                return false;
+            }
+
+            saveCount = canvas.Save();
+            using SKPath path = CreateClipPath(in clipShape);
+            canvas.ClipPath(path, SKClipOperation.Intersect, antialias: true);
+            return true;
+        }
+
+        private static SKPath CreateClipPath(in PresentationClipShape clipShape)
+        {
+            var path = new SKPath();
+            SKRect rect = new(
+                clipShape.X,
+                clipShape.Y,
+                clipShape.X + clipShape.Width,
+                clipShape.Y + clipShape.Height);
+            switch (clipShape.Kind)
+            {
+                case PresentationClipShapeKind.Circle:
+                {
+                    float radius = MathF.Max(0f, MathF.Min(rect.Width, rect.Height) * 0.5f);
+                    path.AddCircle((rect.Left + rect.Right) * 0.5f, (rect.Top + rect.Bottom) * 0.5f, radius);
+                    return path;
+                }
+
+                case PresentationClipShapeKind.Diamond:
+                {
+                    float midX = (rect.Left + rect.Right) * 0.5f;
+                    float midY = (rect.Top + rect.Bottom) * 0.5f;
+                    path.MoveTo(midX, rect.Top);
+                    path.LineTo(rect.Right, midY);
+                    path.LineTo(midX, rect.Bottom);
+                    path.LineTo(rect.Left, midY);
+                    path.Close();
+                    return path;
+                }
+
+                default:
+                    path.AddRect(rect);
+                    return path;
+            }
+        }
 
         private static SKColor ToSkColor(in System.Numerics.Vector4 color)
         {

--- a/src/Libraries/Ludots.UI.Browser/BrowserSurfaceCanvasContent.cs
+++ b/src/Libraries/Ludots.UI.Browser/BrowserSurfaceCanvasContent.cs
@@ -16,6 +16,8 @@ public class BrowserSurfaceCanvasContent : IUiCanvasContent, IUiBrowserCanvasCon
 	private BrowserViewport _pointerMappingViewport;
 	private float _pointerMappingScaleX;
 	private float _pointerMappingScaleY;
+	private bool _hasActivePointerContentRect;
+	private UiRect _activePointerContentRect;
 
 	public BrowserSurfaceCanvasContent(
 		IBrowserSurface surface,
@@ -67,7 +69,12 @@ public class BrowserSurfaceCanvasContent : IUiCanvasContent, IUiBrowserCanvasCon
 		}
 		PointerButton? pointerButton = pointerEvent.Button;
 
-		UiRect contentRect = GetContentRect(node);
+		UiRect currentContentRect = GetContentRect(node);
+		UiRect contentRect = _activePointerButton.HasValue &&
+			pointerEvent.Action != PointerAction.Down &&
+			_hasActivePointerContentRect
+				? _activePointerContentRect
+				: currentContentRect;
 		if (!contentRect.Contains(pointerEvent.X, pointerEvent.Y) &&
 			pointerEvent.Action != PointerAction.Up &&
 			pointerEvent.Action != PointerAction.Cancel &&
@@ -77,11 +84,20 @@ public class BrowserSurfaceCanvasContent : IUiCanvasContent, IUiBrowserCanvasCon
 		}
 
 		BrowserPointerMapping pointerMapping = GetPointerMapping(contentRect);
-		float localX = Math.Clamp((pointerEvent.X - contentRect.X) * pointerMapping.ScaleX, 0f, pointerMapping.Viewport.Width - 1f);
-		float localY = Math.Clamp((pointerEvent.Y - contentRect.Y) * pointerMapping.ScaleY, 0f, pointerMapping.Viewport.Height - 1f);
+		bool preserveCapturedDragDelta = _activePointerButton.HasValue && pointerEvent.Action == PointerAction.Move;
+		float rawLocalX = (pointerEvent.X - contentRect.X) * pointerMapping.ScaleX;
+		float rawLocalY = (pointerEvent.Y - contentRect.Y) * pointerMapping.ScaleY;
+		float localX = preserveCapturedDragDelta
+			? rawLocalX
+			: Math.Clamp(rawLocalX, 0f, pointerMapping.Viewport.Width - 1f);
+		float localY = preserveCapturedDragDelta
+			? rawLocalY
+			: Math.Clamp(rawLocalY, 0f, pointerMapping.Viewport.Height - 1f);
 		if (pointerEvent.Action == PointerAction.Down)
 		{
 			_activePointerButton = pointerButton;
+			_activePointerContentRect = currentContentRect;
+			_hasActivePointerContentRect = true;
 			SetBrowserFocus(true);
 		}
 
@@ -120,6 +136,7 @@ public class BrowserSurfaceCanvasContent : IUiCanvasContent, IUiBrowserCanvasCon
 		if (pointerEvent.Action is PointerAction.Up or PointerAction.Cancel)
 		{
 			_activePointerButton = null;
+			_hasActivePointerContentRect = false;
 		}
 
 		return true;
@@ -187,7 +204,7 @@ public class BrowserSurfaceCanvasContent : IUiCanvasContent, IUiBrowserCanvasCon
 		_disposed = true;
 	}
 
-	public UiRect GetContentRect(UiNode node)
+	public virtual UiRect GetContentRect(UiNode node)
 	{
 		return ResolveContentRect(node);
 	}

--- a/src/Tests/GasTests/GasTests.csproj
+++ b/src/Tests/GasTests/GasTests.csproj
@@ -59,6 +59,7 @@
     <ProjectReference Include="..\..\..\mods\fixtures\camera\CameraAcceptanceMod\CameraAcceptanceMod.csproj" />
     <ProjectReference Include="..\..\..\mods\fixtures\camera\CameraAcceptanceHotpathEntryMod\CameraAcceptanceHotpathEntryMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\camera\CameraShowcaseMod\CameraShowcaseMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\browser_minimap_composited_overlay\BrowserMinimapCompositedOverlayShowcaseMod\BrowserMinimapCompositedOverlayShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\interaction\InteractionShowcaseMod\InteractionShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\entity_command_panel\EntityCommandPanelShowcaseMod\EntityCommandPanelShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\superweapon_context\SuperweaponContextShowcaseMod\SuperweaponContextShowcaseMod.csproj" />

--- a/src/Tests/GasTests/Production/BrowserMinimapWebShellShowcaseAcceptanceTests.cs
+++ b/src/Tests/GasTests/Production/BrowserMinimapWebShellShowcaseAcceptanceTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using NUnit.Framework;
+
+namespace Ludots.Tests.GAS.Production;
+
+[TestFixture]
+public sealed class BrowserMinimapWebShellShowcaseAcceptanceTests
+{
+    private const string BindingName = "browser_minimap_composited_overlay_showcase";
+    private const string PresetId = "browser_minimap_composited_overlay_cef_raylib";
+    private const string ShowcasePath = "mods/showcases/browser_minimap_composited_overlay/BrowserMinimapCompositedOverlayShowcaseMod";
+
+    [Test]
+    public void Launcher_ExposesOnlyThePlayableCompositedMinimapShowcaseForWpk8()
+    {
+        string repoRoot = FindRepoRoot();
+
+        using JsonDocument config = JsonDocument.Parse(File.ReadAllText(Path.Combine(repoRoot, "launcher.config.json")));
+        JsonElement binding = config.RootElement
+            .GetProperty("bindings")
+            .EnumerateArray()
+            .Single(item => string.Equals(item.GetProperty("name").GetString(), BindingName, StringComparison.Ordinal));
+        JsonElement target = binding.GetProperty("target");
+        Assert.That(target.GetProperty("type").GetString(), Is.EqualTo("path"));
+        Assert.That(target.GetProperty("value").GetString(), Is.EqualTo(ShowcasePath));
+        Assert.That(target.GetProperty("projectPath").GetString(), Is.EqualTo("BrowserMinimapCompositedOverlayShowcaseMod.csproj"));
+
+        using JsonDocument presets = JsonDocument.Parse(File.ReadAllText(Path.Combine(repoRoot, "launcher.presets.json")));
+        JsonElement preset = presets.RootElement
+            .GetProperty("presets")
+            .EnumerateArray()
+            .Single(item => string.Equals(item.GetProperty("id").GetString(), PresetId, StringComparison.Ordinal));
+        string[] selectors = preset.GetProperty("selectors").EnumerateArray().Select(item => item.GetString() ?? string.Empty).ToArray();
+        Assert.That(selectors, Is.EqualTo(new[] { "$performer_blacksmith_large_world_nohud", $"${BindingName}" }));
+        Assert.That(preset.GetProperty("adapterId").GetString(), Is.EqualTo("raylib"));
+        Assert.That(preset.GetProperty("browserRuntime").GetProperty("enabled").GetBoolean(), Is.True);
+        Assert.That(preset.GetProperty("browserRuntime").GetProperty("required").GetBoolean(), Is.True);
+        Assert.That(preset.GetProperty("browserRuntime").GetProperty("provider").GetString(), Is.EqualTo("cef"));
+
+        string configText = File.ReadAllText(Path.Combine(repoRoot, "launcher.config.json"));
+        string presetsText = File.ReadAllText(Path.Combine(repoRoot, "launcher.presets.json"));
+        Assert.That(configText + presetsText, Does.Not.Contain("browser_minimap_true_v8"));
+        Assert.That(configText + presetsText, Does.Not.Contain("browser_minimap_bridge_compare"));
+        Assert.That(configText + presetsText, Does.Not.Contain("browser_minimap_performance"));
+        Assert.That(configText + presetsText, Does.Not.Contain("browser_minimap_read_copy"));
+        Assert.That(configText + presetsText, Does.Not.Contain("browser_minimap_browser_arraybuffer"));
+    }
+
+    [Test]
+    public void WebShell_OwnsThePanelFrameButDoesNotRenderGameplayMarkers()
+    {
+        string modRoot = Path.Combine(FindRepoRoot(), ShowcasePath.Replace('/', Path.DirectorySeparatorChar));
+        string index = File.ReadAllText(Path.Combine(modRoot, "Assets", "overlay-app", "index.html"));
+        string script = File.ReadAllText(Path.Combine(modRoot, "Assets", "overlay-app", "main.js"));
+        string styles = File.ReadAllText(Path.Combine(modRoot, "Assets", "overlay-app", "styles.css"));
+        string entry = File.ReadAllText(Path.Combine(modRoot, "BrowserMinimapCompositedOverlayShowcaseModEntry.cs"));
+        string manifest = File.ReadAllText(Path.Combine(modRoot, "mod.json"));
+
+        Assert.That(index, Does.Contain("id=\"minimap-widget\""));
+        Assert.That(index, Does.Contain("id=\"minimap-viewport\""));
+        Assert.That(styles, Does.Contain("pointer-events: auto"));
+        Assert.That(styles, Does.Contain("clip-path: circle"));
+        Assert.That(script, Does.Contain("type: 'ludots.minimapOverlay.rect'"));
+        Assert.That(script, Does.Contain("clip"));
+        Assert.That(script, Does.Contain("kind: NATIVE_CLIP_KIND"));
+        Assert.That(script, Does.Contain("postDragDelta"));
+        Assert.That(script, Does.Contain("window.ludotsDataplane"));
+        Assert.That(script, Does.Contain("window.ludotsBrowser"));
+
+        Assert.That(script, Does.Not.Contain("CefSharp"));
+        Assert.That(script, Does.Not.Contain("acquireV8Buffer"));
+        Assert.That(script, Does.Not.Contain("readSharedBuffer"));
+        Assert.That(script, Does.Not.Contain("heatmap"));
+        Assert.That(script, Does.Not.Contain("markersJson"));
+        Assert.That(script, Does.Not.Contain("for (const marker"));
+        Assert.That(manifest, Does.Not.Contain("\"cef\""));
+        Assert.That(manifest, Does.Not.Contain("Cef"));
+        Assert.That(entry, Does.Contain("BrowserRuntimeServiceNames.BrowserRuntime"));
+        Assert.That(entry, Does.Not.Contain("Ludots.UI.Browser.Cef"));
+        Assert.That(entry, Does.Not.Contain("CefSharp"));
+    }
+
+    [Test]
+    public void NativePath_StillOwnsMarkerProjectionAndSkiaClipping()
+    {
+        string repoRoot = FindRepoRoot();
+        string modRoot = Path.Combine(repoRoot, ShowcasePath.Replace('/', Path.DirectorySeparatorChar));
+        string bridge = File.ReadAllText(Path.Combine(modRoot, "BrowserMinimapCompositedOverlayNativeMarkerBridgeSystem.cs"));
+        string layoutState = File.ReadAllText(Path.Combine(modRoot, "BrowserMinimapCompositedOverlayLayoutState.cs"));
+        string minimapRuntime = File.ReadAllText(Path.Combine(repoRoot, "src", "Core", "Presentation", "Minimap", "MinimapRuntime.cs"));
+        string screenMarkers = File.ReadAllText(Path.Combine(repoRoot, "src", "Core", "Presentation", "Minimap", "MinimapScreenMarkerBuffer.cs"));
+        string clipShape = File.ReadAllText(Path.Combine(repoRoot, "src", "Core", "Presentation", "PresentationClipShape.cs"));
+        string skiaRenderer = File.ReadAllText(Path.Combine(repoRoot, "src", "Libraries", "Ludots.Presentation.Skia", "SkiaOverlayRenderer.cs"));
+        string browserCanvas = File.ReadAllText(Path.Combine(repoRoot, "src", "Libraries", "Ludots.UI.Browser", "BrowserSurfaceCanvasContent.cs"));
+
+        Assert.That(bridge, Does.Contain("MinimapMarkerBuffer"));
+        Assert.That(bridge, Does.Contain("KnowledgeProjectionStore"));
+        Assert.That(bridge, Does.Contain("NativeChromeVisible = false"));
+        Assert.That(bridge, Does.Contain("SetExternalFieldRect"));
+        Assert.That(bridge, Does.Contain("SetFieldClipShape"));
+        Assert.That(bridge, Does.Not.Contain("acquireV8Buffer"));
+        Assert.That(bridge, Does.Not.Contain("BrowserSharedMemory"));
+
+        Assert.That(layoutState, Does.Contain("ClampCanvasRect"));
+        Assert.That(layoutState, Does.Contain("dragDeltaUiX"));
+        Assert.That(minimapRuntime, Does.Contain("public bool NativeChromeVisible"));
+        Assert.That(minimapRuntime, Does.Contain("SetExternalFieldRect"));
+        Assert.That(minimapRuntime, Does.Contain("ResolveFieldClipShape"));
+        Assert.That(minimapRuntime, Does.Contain("screenMarkers.SetClipShape"));
+        Assert.That(screenMarkers, Does.Contain("public PresentationClipShape ClipShape"));
+        Assert.That(screenMarkers, Does.Contain("SetClipShape"));
+        Assert.That(clipShape, Does.Contain("PresentationClipShapeKind.Circle"));
+        Assert.That(skiaRenderer, Does.Contain("TrySaveClipShape"));
+        Assert.That(skiaRenderer, Does.Contain("DrawMinimapMarkersBatched"));
+        Assert.That(browserCanvas, Does.Contain("public virtual UiRect GetContentRect"));
+        Assert.That(browserCanvas, Does.Contain("_activePointerContentRect"));
+    }
+
+    private static string FindRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "AGENTS.md")) &&
+                Directory.Exists(Path.Combine(current.FullName, "src")) &&
+                Directory.Exists(Path.Combine(current.FullName, "mods")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root from test output directory.");
+    }
+}


### PR DESCRIPTION
## 概述

从第一性角度看，这单只解决一个生产上最可能先落地的问题：Web 负责小地图外壳、拖拽和控件语义，30k marker 仍由 Core/Skia 原生路径渲染和裁剪。这样玩家看到的是一个可以像 Web UI 控件一样移动的小地图，但热路径不交给浏览器逐点绘制。

Closes #607.

## 这次提交

- 增加 Presentation clip shape，把小地图 marker、rect、line 的裁剪形状从 Core 传到 Skia。
- 扩展 MinimapRuntime，支持外部 Web 控件上报小地图区域，并隐藏原生 chrome。
- 增加 `browser_minimap_composited_overlay` showcase：Web 只画外壳和拖拽控件，原生桥负责 30k 动态 marker。
- 增加 launcher preset：`browser_minimap_composited_overlay_cef_raylib`。
- 增加边界测试，锁住这单范围：不引入 V8 buffer、shared memory、热力图、三方案对比面板，也不让 Web 自己循环渲染 marker。

## 刻意不放进这单

- 不做真 shared memory / V8 ArrayBuffer 实验。
- 不做三个方案对比 showcase。
- 不做性能报表页或热力图 UI。
- 不临时补 WPK manifest mount；这部分仍等 #600 / WPK-1 的主线基建。

## 验证

- `dotnet build mods\showcases\browser_minimap_composited_overlay\BrowserMinimapCompositedOverlayShowcaseMod\BrowserMinimapCompositedOverlayShowcaseMod.csproj -c Release --no-restore -m:1 /nr:false` passed
- `dotnet build src\Apps\Raylib\Ludots.App.Raylib\Ludots.App.Raylib.csproj -c Release --no-restore -m:1 /nr:false` passed
- `dotnet test src\Tests\GasTests\GasTests.csproj -c Release --filter BrowserMinimapWebShellShowcaseAcceptanceTests --no-restore -m:1 /nr:false` passed, 3/3
- `git diff --check origin/main...HEAD` passed

## 已知阻塞

启动命令 `scripts\run-mod-launcher.cmd cli launch preset:browser_minimap_composited_overlay_cef_raylib --adapter raylib` 目前被 launcher/evidence 的无关编译回归挡住，不在这单修改范围内：

- `MassNavigationAvoidanceAgentSnapshot` 缺少 `Selected`
- `MassNavigationSimulationRuntime` 缺少 `CommandSourceSyncMs`

这不是 web minimap 分支新增的代码路径；按工作区隔离原则，这个 PR 没有顺手改那部分。