### PR TITLE
feat(lsw): debug patch layer and edit session (#617)

### DIFF
--- a/src/Core/Gameplay/GAS/LiveSkillWorkbench/LiveDebugPatch.cs
+++ b/src/Core/Gameplay/GAS/LiveSkillWorkbench/LiveDebugPatch.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Ludots.Core.Gameplay.GAS.LiveSkillWorkbench
 {
@@ -161,12 +162,21 @@ namespace Ludots.Core.Gameplay.GAS.LiveSkillWorkbench
     public sealed class LiveDebugPatch
     {
         private readonly List<LiveDebugPatchOperation> _operations = new();
+        private readonly ReadOnlyCollection<LiveDebugPatchOperation> _operationsView;
+
+        public LiveDebugPatch()
+        {
+            _operationsView = _operations.AsReadOnly();
+        }
 
         public int Count => _operations.Count;
 
         public bool IsEmpty => _operations.Count == 0;
 
-        public IReadOnlyList<LiveDebugPatchOperation> Operations => _operations;
+        /// <summary>
+        /// Read-only view of staged operations. Not castable to the internal mutable list.
+        /// </summary>
+        public IReadOnlyList<LiveDebugPatchOperation> Operations => _operationsView;
 
         internal void Add(in LiveDebugPatchOperation operation)
         {

--- a/src/Core/Gameplay/GAS/LiveSkillWorkbench/LiveDebugPatch.cs
+++ b/src/Core/Gameplay/GAS/LiveSkillWorkbench/LiveDebugPatch.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ludots.Core.Gameplay.GAS.LiveSkillWorkbench
+{
+    public enum LiveDebugPatchOperationKind : byte
+    {
+        SkillEffectNumeric = 1,
+        SelectedActorAttribute = 2
+    }
+
+    public enum ActorAttributeMutationKind : byte
+    {
+        Set = 1,
+        Add = 2
+    }
+
+    /// <summary>
+    /// Provenance retained so accepted edits can later be saved as Mod config (#624).
+    /// This slice records provenance only; it does not persist files.
+    /// </summary>
+    public readonly struct LiveEditProvenance
+    {
+        public LiveEditProvenance(
+            LiveEditSource source,
+            string sourceUri,
+            string? authorNote = null,
+            string? configRelativePath = null)
+        {
+            Source = source;
+            SourceUri = sourceUri ?? string.Empty;
+            AuthorNote = authorNote;
+            ConfigRelativePath = configRelativePath;
+        }
+
+        public LiveEditSource Source { get; }
+
+        /// <summary>
+        /// Stable origin locator (UI control path, watched file URI, or AI draft id).
+        /// </summary>
+        public string SourceUri { get; }
+
+        public string? AuthorNote { get; }
+
+        /// <summary>
+        /// Optional Mod-relative config path hint for later save (#624).
+        /// </summary>
+        public string? ConfigRelativePath { get; }
+    }
+
+    /// <summary>
+    /// Selected actor target for an ImmediateCommand-style attribute edit.
+    /// Either a selection descriptor, an entity id surrogate, or both may be provided.
+    /// </summary>
+    public readonly struct ActorTargetSelection
+    {
+        public ActorTargetSelection(string? selectionDescriptor, int? entityIdSurrogate)
+        {
+            SelectionDescriptor = selectionDescriptor;
+            EntityIdSurrogate = entityIdSurrogate;
+        }
+
+        public static ActorTargetSelection FromDescriptor(string selectionDescriptor)
+        {
+            return new ActorTargetSelection(selectionDescriptor, entityIdSurrogate: null);
+        }
+
+        public static ActorTargetSelection FromEntityIdSurrogate(int entityIdSurrogate)
+        {
+            return new ActorTargetSelection(selectionDescriptor: null, entityIdSurrogate);
+        }
+
+        public string? SelectionDescriptor { get; }
+
+        public int? EntityIdSurrogate { get; }
+
+        public bool HasTarget =>
+            !string.IsNullOrWhiteSpace(SelectionDescriptor) || EntityIdSurrogate.HasValue;
+    }
+
+    /// <summary>
+    /// Structured debug patch operation. ManualWorkbench and FileChange share this model.
+    /// </summary>
+    public readonly struct LiveDebugPatchOperation
+    {
+        private LiveDebugPatchOperation(
+            LiveDebugPatchOperationKind kind,
+            LiveEditProvenance provenance,
+            string? definitionId,
+            string? fieldPath,
+            double numericValue,
+            ActorTargetSelection actorTarget,
+            string? attributeName,
+            ActorAttributeMutationKind attributeMutation)
+        {
+            Kind = kind;
+            Provenance = provenance;
+            DefinitionId = definitionId;
+            FieldPath = fieldPath;
+            NumericValue = numericValue;
+            ActorTarget = actorTarget;
+            AttributeName = attributeName;
+            AttributeMutation = attributeMutation;
+        }
+
+        public LiveDebugPatchOperationKind Kind { get; }
+
+        public LiveEditProvenance Provenance { get; }
+
+        public string? DefinitionId { get; }
+
+        public string? FieldPath { get; }
+
+        public double NumericValue { get; }
+
+        public ActorTargetSelection ActorTarget { get; }
+
+        public string? AttributeName { get; }
+
+        public ActorAttributeMutationKind AttributeMutation { get; }
+
+        public static LiveDebugPatchOperation SkillEffectNumeric(
+            string definitionId,
+            string fieldPath,
+            double numericValue,
+            in LiveEditProvenance provenance)
+        {
+            return new LiveDebugPatchOperation(
+                LiveDebugPatchOperationKind.SkillEffectNumeric,
+                provenance,
+                definitionId,
+                fieldPath,
+                numericValue,
+                default,
+                attributeName: null,
+                attributeMutation: default);
+        }
+
+        public static LiveDebugPatchOperation SelectedActorAttribute(
+            in ActorTargetSelection actorTarget,
+            string attributeName,
+            ActorAttributeMutationKind mutation,
+            double numericValue,
+            in LiveEditProvenance provenance)
+        {
+            return new LiveDebugPatchOperation(
+                LiveDebugPatchOperationKind.SelectedActorAttribute,
+                provenance,
+                definitionId: null,
+                fieldPath: null,
+                numericValue,
+                actorTarget,
+                attributeName,
+                mutation);
+        }
+    }
+
+    /// <summary>
+    /// Staged edit collection. Expresses intent only; never writes live registries.
+    /// </summary>
+    public sealed class LiveDebugPatch
+    {
+        private readonly List<LiveDebugPatchOperation> _operations = new();
+
+        public int Count => _operations.Count;
+
+        public bool IsEmpty => _operations.Count == 0;
+
+        public IReadOnlyList<LiveDebugPatchOperation> Operations => _operations;
+
+        internal void Add(in LiveDebugPatchOperation operation)
+        {
+            _operations.Add(operation);
+        }
+
+        internal void Clear()
+        {
+            _operations.Clear();
+        }
+    }
+}

--- a/src/Core/Gameplay/GAS/LiveSkillWorkbench/LiveEditDiagnostics.cs
+++ b/src/Core/Gameplay/GAS/LiveSkillWorkbench/LiveEditDiagnostics.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ludots.Core.Gameplay.GAS.LiveSkillWorkbench
+{
+    public enum LiveEditDiagnosticSeverity : byte
+    {
+        Error = 1,
+        Warning = 2
+    }
+
+    public static class LiveEditDiagnosticCodes
+    {
+        public const string MissingDefinitionId = "LSW0001";
+        public const string MissingFieldPath = "LSW0002";
+        public const string NonFiniteNumericValue = "LSW0003";
+        public const string MissingAttributeName = "LSW0004";
+        public const string MissingActorTarget = "LSW0005";
+        public const string UnsupportedAttributeMutation = "LSW0006";
+        public const string UnsupportedOperationKind = "LSW0007";
+        public const string MissingProvenanceSourceUri = "LSW0008";
+    }
+
+    public readonly record struct LiveEditDiagnostic(
+        LiveEditDiagnosticSeverity Severity,
+        string Code,
+        string Message,
+        string? TargetId = null);
+
+    public readonly struct LiveEditStageResult
+    {
+        private static readonly LiveEditDiagnostic[] EmptyDiagnostics = Array.Empty<LiveEditDiagnostic>();
+
+        private LiveEditStageResult(
+            bool succeeded,
+            ulong revision,
+            bool isDirty,
+            IReadOnlyList<LiveEditDiagnostic> diagnostics)
+        {
+            Succeeded = succeeded;
+            Revision = revision;
+            IsDirty = isDirty;
+            Diagnostics = diagnostics ?? EmptyDiagnostics;
+        }
+
+        public bool Succeeded { get; }
+
+        public ulong Revision { get; }
+
+        public bool IsDirty { get; }
+
+        public IReadOnlyList<LiveEditDiagnostic> Diagnostics { get; }
+
+        public static LiveEditStageResult Success(ulong revision, bool isDirty)
+        {
+            return new LiveEditStageResult(true, revision, isDirty, EmptyDiagnostics);
+        }
+
+        public static LiveEditStageResult Failure(
+            ulong revision,
+            bool isDirty,
+            params LiveEditDiagnostic[] diagnostics)
+        {
+            if (diagnostics == null || diagnostics.Length == 0)
+            {
+                throw new ArgumentException("Failure results require at least one diagnostic.", nameof(diagnostics));
+            }
+
+            return new LiveEditStageResult(false, revision, isDirty, diagnostics);
+        }
+
+        public static LiveEditStageResult Failure(
+            ulong revision,
+            bool isDirty,
+            IReadOnlyList<LiveEditDiagnostic> diagnostics)
+        {
+            if (diagnostics == null || diagnostics.Count == 0)
+            {
+                throw new ArgumentException("Failure results require at least one diagnostic.", nameof(diagnostics));
+            }
+
+            return new LiveEditStageResult(false, revision, isDirty, diagnostics);
+        }
+    }
+}

--- a/src/Core/Gameplay/GAS/LiveSkillWorkbench/LiveEditDiagnostics.cs
+++ b/src/Core/Gameplay/GAS/LiveSkillWorkbench/LiveEditDiagnostics.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Ludots.Core.Gameplay.GAS.LiveSkillWorkbench
 {
@@ -49,6 +50,9 @@ namespace Ludots.Core.Gameplay.GAS.LiveSkillWorkbench
 
         public bool IsDirty { get; }
 
+        /// <summary>
+        /// Read-only diagnostics. Failure results snapshot input and cannot be cast back to the caller-owned mutable source.
+        /// </summary>
         public IReadOnlyList<LiveEditDiagnostic> Diagnostics { get; }
 
         public static LiveEditStageResult Success(ulong revision, bool isDirty)
@@ -66,7 +70,7 @@ namespace Ludots.Core.Gameplay.GAS.LiveSkillWorkbench
                 throw new ArgumentException("Failure results require at least one diagnostic.", nameof(diagnostics));
             }
 
-            return new LiveEditStageResult(false, revision, isDirty, diagnostics);
+            return new LiveEditStageResult(false, revision, isDirty, SnapshotDiagnostics(diagnostics));
         }
 
         public static LiveEditStageResult Failure(
@@ -79,7 +83,19 @@ namespace Ludots.Core.Gameplay.GAS.LiveSkillWorkbench
                 throw new ArgumentException("Failure results require at least one diagnostic.", nameof(diagnostics));
             }
 
-            return new LiveEditStageResult(false, revision, isDirty, diagnostics);
+            return new LiveEditStageResult(false, revision, isDirty, SnapshotDiagnostics(diagnostics));
+        }
+
+        private static IReadOnlyList<LiveEditDiagnostic> SnapshotDiagnostics(
+            IReadOnlyList<LiveEditDiagnostic> diagnostics)
+        {
+            var copy = new LiveEditDiagnostic[diagnostics.Count];
+            for (int i = 0; i < diagnostics.Count; i++)
+            {
+                copy[i] = diagnostics[i];
+            }
+
+            return new ReadOnlyCollection<LiveEditDiagnostic>(copy);
         }
     }
 }

--- a/src/Core/Gameplay/GAS/LiveSkillWorkbench/LiveEditSession.cs
+++ b/src/Core/Gameplay/GAS/LiveSkillWorkbench/LiveEditSession.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ludots.Core.Gameplay.GAS.LiveSkillWorkbench
+{
+    /// <summary>
+    /// Runtime edit session for the Real-time Skill Workbench.
+    /// Stages structured debug patches without mutating live Ability/Effect/Graph registries.
+    /// </summary>
+    public sealed class LiveEditSession
+    {
+        private readonly LiveDebugPatch _patch = new();
+        private readonly List<LiveEditDiagnostic> _scratchDiagnostics = new(4);
+
+        private LiveEditSession(Guid sessionId, LiveEditSource source, DateTime createdUtc)
+        {
+            SessionId = sessionId;
+            Source = source;
+            CreatedUtc = createdUtc;
+            UpdatedUtc = createdUtc;
+            Revision = 0;
+        }
+
+        public Guid SessionId { get; }
+
+        public LiveEditSource Source { get; }
+
+        public ulong Revision { get; private set; }
+
+        public bool IsDirty => !_patch.IsEmpty;
+
+        public DateTime CreatedUtc { get; }
+
+        public DateTime UpdatedUtc { get; private set; }
+
+        public LiveDebugPatch Patch => _patch;
+
+        public static LiveEditSession Start(LiveEditSource source, DateTime? createdUtc = null)
+        {
+            if (!IsKnownSource(source))
+            {
+                throw new ArgumentOutOfRangeException(nameof(source), source, "Unknown live edit source.");
+            }
+
+            return new LiveEditSession(Guid.NewGuid(), source, createdUtc ?? DateTime.UtcNow);
+        }
+
+        public static LiveEditSession Start(LiveEditSource source, Guid sessionId, DateTime? createdUtc = null)
+        {
+            if (!IsKnownSource(source))
+            {
+                throw new ArgumentOutOfRangeException(nameof(source), source, "Unknown live edit source.");
+            }
+
+            if (sessionId == Guid.Empty)
+            {
+                throw new ArgumentException("Session id must be a non-empty Guid.", nameof(sessionId));
+            }
+
+            return new LiveEditSession(sessionId, source, createdUtc ?? DateTime.UtcNow);
+        }
+
+        /// <summary>
+        /// Stages a structured operation into the debug patch.
+        /// Invalid edits are rejected with diagnostics and do not mutate the patch.
+        /// </summary>
+        public LiveEditStageResult TryStage(in LiveDebugPatchOperation operation, DateTime? updatedUtc = null)
+        {
+            _scratchDiagnostics.Clear();
+            Validate(in operation, _scratchDiagnostics);
+            if (_scratchDiagnostics.Count > 0)
+            {
+                return LiveEditStageResult.Failure(Revision, IsDirty, _scratchDiagnostics.ToArray());
+            }
+
+            _patch.Add(in operation);
+            Revision++;
+            UpdatedUtc = updatedUtc ?? DateTime.UtcNow;
+            return LiveEditStageResult.Success(Revision, IsDirty);
+        }
+
+        /// <summary>
+        /// Discards all staged edits and returns the session to a clean state.
+        /// Revision advances so observers can detect the rollback coherently.
+        /// </summary>
+        public LiveEditStageResult Discard(DateTime? updatedUtc = null)
+        {
+            _patch.Clear();
+            Revision++;
+            UpdatedUtc = updatedUtc ?? DateTime.UtcNow;
+            return LiveEditStageResult.Success(Revision, isDirty: false);
+        }
+
+        private static void Validate(in LiveDebugPatchOperation operation, List<LiveEditDiagnostic> diagnostics)
+        {
+            if (string.IsNullOrWhiteSpace(operation.Provenance.SourceUri))
+            {
+                diagnostics.Add(new LiveEditDiagnostic(
+                    LiveEditDiagnosticSeverity.Error,
+                    LiveEditDiagnosticCodes.MissingProvenanceSourceUri,
+                    "Edit provenance sourceUri is required so accepted drafts can later be saved."));
+            }
+
+            switch (operation.Kind)
+            {
+                case LiveDebugPatchOperationKind.SkillEffectNumeric:
+                    ValidateSkillEffectNumeric(in operation, diagnostics);
+                    break;
+                case LiveDebugPatchOperationKind.SelectedActorAttribute:
+                    ValidateSelectedActorAttribute(in operation, diagnostics);
+                    break;
+                default:
+                    diagnostics.Add(new LiveEditDiagnostic(
+                        LiveEditDiagnosticSeverity.Error,
+                        LiveEditDiagnosticCodes.UnsupportedOperationKind,
+                        $"Unsupported debug patch operation kind '{operation.Kind}'."));
+                    break;
+            }
+        }
+
+        private static void ValidateSkillEffectNumeric(
+            in LiveDebugPatchOperation operation,
+            List<LiveEditDiagnostic> diagnostics)
+        {
+            if (string.IsNullOrWhiteSpace(operation.DefinitionId))
+            {
+                diagnostics.Add(new LiveEditDiagnostic(
+                    LiveEditDiagnosticSeverity.Error,
+                    LiveEditDiagnosticCodes.MissingDefinitionId,
+                    "Skill/effect numeric edits require a target definition id.",
+                    operation.DefinitionId));
+            }
+
+            if (string.IsNullOrWhiteSpace(operation.FieldPath))
+            {
+                diagnostics.Add(new LiveEditDiagnostic(
+                    LiveEditDiagnosticSeverity.Error,
+                    LiveEditDiagnosticCodes.MissingFieldPath,
+                    "Skill/effect numeric edits require a field path/key.",
+                    operation.DefinitionId));
+            }
+
+            if (!IsFinite(operation.NumericValue))
+            {
+                diagnostics.Add(new LiveEditDiagnostic(
+                    LiveEditDiagnosticSeverity.Error,
+                    LiveEditDiagnosticCodes.NonFiniteNumericValue,
+                    "Skill/effect numeric edits require a finite numeric value.",
+                    operation.DefinitionId));
+            }
+        }
+
+        private static void ValidateSelectedActorAttribute(
+            in LiveDebugPatchOperation operation,
+            List<LiveEditDiagnostic> diagnostics)
+        {
+            if (!operation.ActorTarget.HasTarget)
+            {
+                diagnostics.Add(new LiveEditDiagnostic(
+                    LiveEditDiagnosticSeverity.Error,
+                    LiveEditDiagnosticCodes.MissingActorTarget,
+                    "Selected actor attribute edits require a selection descriptor or entity id surrogate."));
+            }
+
+            if (string.IsNullOrWhiteSpace(operation.AttributeName))
+            {
+                diagnostics.Add(new LiveEditDiagnostic(
+                    LiveEditDiagnosticSeverity.Error,
+                    LiveEditDiagnosticCodes.MissingAttributeName,
+                    "Selected actor attribute edits require an attribute name/id.",
+                    operation.AttributeName));
+            }
+
+            if (operation.AttributeMutation is not (ActorAttributeMutationKind.Set or ActorAttributeMutationKind.Add))
+            {
+                diagnostics.Add(new LiveEditDiagnostic(
+                    LiveEditDiagnosticSeverity.Error,
+                    LiveEditDiagnosticCodes.UnsupportedAttributeMutation,
+                    $"Unsupported attribute mutation '{operation.AttributeMutation}'.",
+                    operation.AttributeName));
+            }
+
+            if (!IsFinite(operation.NumericValue))
+            {
+                diagnostics.Add(new LiveEditDiagnostic(
+                    LiveEditDiagnosticSeverity.Error,
+                    LiveEditDiagnosticCodes.NonFiniteNumericValue,
+                    "Selected actor attribute edits require a finite numeric value.",
+                    operation.AttributeName));
+            }
+        }
+
+        private static bool IsFinite(double value)
+        {
+            return !double.IsNaN(value) && !double.IsInfinity(value);
+        }
+
+        private static bool IsKnownSource(LiveEditSource source)
+        {
+            return source is LiveEditSource.ManualWorkbench
+                or LiveEditSource.FileChange
+                or LiveEditSource.AiGeneratedDraft;
+        }
+    }
+}

--- a/src/Core/Gameplay/GAS/LiveSkillWorkbench/LiveEditSession.cs
+++ b/src/Core/Gameplay/GAS/LiveSkillWorkbench/LiveEditSession.cs
@@ -70,7 +70,7 @@ namespace Ludots.Core.Gameplay.GAS.LiveSkillWorkbench
             Validate(in operation, _scratchDiagnostics);
             if (_scratchDiagnostics.Count > 0)
             {
-                return LiveEditStageResult.Failure(Revision, IsDirty, _scratchDiagnostics.ToArray());
+                return LiveEditStageResult.Failure(Revision, IsDirty, _scratchDiagnostics);
             }
 
             _patch.Add(in operation);

--- a/src/Core/Gameplay/GAS/LiveSkillWorkbench/LiveEditSource.cs
+++ b/src/Core/Gameplay/GAS/LiveSkillWorkbench/LiveEditSource.cs
@@ -1,0 +1,13 @@
+namespace Ludots.Core.Gameplay.GAS.LiveSkillWorkbench
+{
+    /// <summary>
+    /// Entry channel for a live skill workbench edit session.
+    /// All sources stage into the same debug patch model.
+    /// </summary>
+    public enum LiveEditSource : byte
+    {
+        ManualWorkbench = 1,
+        FileChange = 2,
+        AiGeneratedDraft = 3
+    }
+}

--- a/src/Tests/GasTests/LiveEditSessionTests.cs
+++ b/src/Tests/GasTests/LiveEditSessionTests.cs
@@ -1,0 +1,264 @@
+using System;
+using Ludots.Core.Gameplay.GAS.LiveSkillWorkbench;
+using NUnit.Framework;
+using static NUnit.Framework.Assert;
+
+namespace Ludots.Tests.GAS
+{
+    [TestFixture]
+    public sealed class LiveEditSessionTests
+    {
+        private static readonly DateTime T0 = new(2026, 7, 10, 8, 0, 0, DateTimeKind.Utc);
+        private static readonly DateTime T1 = new(2026, 7, 10, 8, 0, 1, DateTimeKind.Utc);
+        private static readonly DateTime T2 = new(2026, 7, 10, 8, 0, 2, DateTimeKind.Utc);
+
+        [Test]
+        public void Start_CreatesStableSessionWithCleanPatch()
+        {
+            Guid sessionId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+            LiveEditSession session = LiveEditSession.Start(
+                LiveEditSource.ManualWorkbench,
+                sessionId,
+                createdUtc: T0);
+
+            That(session.SessionId, Is.EqualTo(sessionId));
+            That(session.Source, Is.EqualTo(LiveEditSource.ManualWorkbench));
+            That(session.Revision, Is.EqualTo(0u));
+            That(session.IsDirty, Is.False);
+            That(session.CreatedUtc, Is.EqualTo(T0));
+            That(session.UpdatedUtc, Is.EqualTo(T0));
+            That(session.Patch.IsEmpty, Is.True);
+            That(session.Patch.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Start_AcceptsAllDocumentedSources()
+        {
+            That(LiveEditSession.Start(LiveEditSource.ManualWorkbench, createdUtc: T0).Source,
+                Is.EqualTo(LiveEditSource.ManualWorkbench));
+            That(LiveEditSession.Start(LiveEditSource.FileChange, createdUtc: T0).Source,
+                Is.EqualTo(LiveEditSource.FileChange));
+            That(LiveEditSession.Start(LiveEditSource.AiGeneratedDraft, createdUtc: T0).Source,
+                Is.EqualTo(LiveEditSource.AiGeneratedDraft));
+        }
+
+        [Test]
+        public void TryStage_SkillEffectNumeric_StagesStructuredEditAndMarksDirty()
+        {
+            LiveEditSession session = LiveEditSession.Start(LiveEditSource.ManualWorkbench, createdUtc: T0);
+            var provenance = new LiveEditProvenance(
+                LiveEditSource.ManualWorkbench,
+                sourceUri: "workbench://ability/Fireball/damage",
+                authorNote: "raise fireball damage",
+                configRelativePath: "gas/abilities.json");
+
+            LiveEditStageResult result = session.TryStage(
+                LiveDebugPatchOperation.SkillEffectNumeric(
+                    definitionId: "Fireball",
+                    fieldPath: "damage",
+                    numericValue: 80d,
+                    provenance),
+                updatedUtc: T1);
+
+            That(result.Succeeded, Is.True);
+            That(result.Revision, Is.EqualTo(1u));
+            That(result.IsDirty, Is.True);
+            That(result.Diagnostics, Is.Empty);
+            That(session.Revision, Is.EqualTo(1u));
+            That(session.IsDirty, Is.True);
+            That(session.UpdatedUtc, Is.EqualTo(T1));
+            That(session.Patch.Count, Is.EqualTo(1));
+
+            LiveDebugPatchOperation staged = session.Patch.Operations[0];
+            That(staged.Kind, Is.EqualTo(LiveDebugPatchOperationKind.SkillEffectNumeric));
+            That(staged.DefinitionId, Is.EqualTo("Fireball"));
+            That(staged.FieldPath, Is.EqualTo("damage"));
+            That(staged.NumericValue, Is.EqualTo(80d));
+            That(staged.Provenance.Source, Is.EqualTo(LiveEditSource.ManualWorkbench));
+            That(staged.Provenance.SourceUri, Is.EqualTo("workbench://ability/Fireball/damage"));
+            That(staged.Provenance.ConfigRelativePath, Is.EqualTo("gas/abilities.json"));
+        }
+
+        [Test]
+        public void TryStage_SelectedActorAttribute_StagesSetAndAddCommands()
+        {
+            LiveEditSession session = LiveEditSession.Start(LiveEditSource.ManualWorkbench, createdUtc: T0);
+            var provenance = new LiveEditProvenance(
+                LiveEditSource.ManualWorkbench,
+                sourceUri: "workbench://actor/selected/Health");
+
+            LiveEditStageResult setResult = session.TryStage(
+                LiveDebugPatchOperation.SelectedActorAttribute(
+                    ActorTargetSelection.FromDescriptor("selected"),
+                    attributeName: "Health",
+                    ActorAttributeMutationKind.Set,
+                    numericValue: 100d,
+                    provenance),
+                updatedUtc: T1);
+
+            LiveEditStageResult addResult = session.TryStage(
+                LiveDebugPatchOperation.SelectedActorAttribute(
+                    ActorTargetSelection.FromEntityIdSurrogate(42),
+                    attributeName: "Mana",
+                    ActorAttributeMutationKind.Add,
+                    numericValue: 15d,
+                    provenance),
+                updatedUtc: T2);
+
+            That(setResult.Succeeded, Is.True);
+            That(addResult.Succeeded, Is.True);
+            That(session.Revision, Is.EqualTo(2u));
+            That(session.Patch.Count, Is.EqualTo(2));
+
+            LiveDebugPatchOperation setOp = session.Patch.Operations[0];
+            That(setOp.Kind, Is.EqualTo(LiveDebugPatchOperationKind.SelectedActorAttribute));
+            That(setOp.ActorTarget.SelectionDescriptor, Is.EqualTo("selected"));
+            That(setOp.AttributeName, Is.EqualTo("Health"));
+            That(setOp.AttributeMutation, Is.EqualTo(ActorAttributeMutationKind.Set));
+            That(setOp.NumericValue, Is.EqualTo(100d));
+
+            LiveDebugPatchOperation addOp = session.Patch.Operations[1];
+            That(addOp.ActorTarget.EntityIdSurrogate, Is.EqualTo(42));
+            That(addOp.AttributeName, Is.EqualTo("Mana"));
+            That(addOp.AttributeMutation, Is.EqualTo(ActorAttributeMutationKind.Add));
+            That(addOp.NumericValue, Is.EqualTo(15d));
+        }
+
+        [Test]
+        public void TryStage_InvalidSkillEffectNumeric_RejectsWithoutMutatingPatch()
+        {
+            LiveEditSession session = LiveEditSession.Start(LiveEditSource.ManualWorkbench, createdUtc: T0);
+            var provenance = new LiveEditProvenance(
+                LiveEditSource.ManualWorkbench,
+                sourceUri: "workbench://ability/Fireball/damage");
+
+            LiveEditStageResult result = session.TryStage(
+                LiveDebugPatchOperation.SkillEffectNumeric(
+                    definitionId: " ",
+                    fieldPath: "",
+                    numericValue: double.NaN,
+                    provenance),
+                updatedUtc: T1);
+
+            That(result.Succeeded, Is.False);
+            That(result.Revision, Is.EqualTo(0u));
+            That(result.IsDirty, Is.False);
+            That(result.Diagnostics.Count, Is.EqualTo(3));
+            That(result.Diagnostics[0].Code, Is.EqualTo(LiveEditDiagnosticCodes.MissingDefinitionId));
+            That(result.Diagnostics[1].Code, Is.EqualTo(LiveEditDiagnosticCodes.MissingFieldPath));
+            That(result.Diagnostics[2].Code, Is.EqualTo(LiveEditDiagnosticCodes.NonFiniteNumericValue));
+            That(session.Revision, Is.EqualTo(0u));
+            That(session.IsDirty, Is.False);
+            That(session.Patch.IsEmpty, Is.True);
+            That(session.UpdatedUtc, Is.EqualTo(T0), "Rejected edits must not bump UpdatedUtc.");
+        }
+
+        [Test]
+        public void TryStage_InvalidSelectedActorAttribute_RejectsWithoutMutatingPatch()
+        {
+            LiveEditSession session = LiveEditSession.Start(LiveEditSource.ManualWorkbench, createdUtc: T0);
+            var provenance = new LiveEditProvenance(
+                LiveEditSource.ManualWorkbench,
+                sourceUri: "workbench://actor/selected/Health");
+
+            LiveEditStageResult result = session.TryStage(
+                LiveDebugPatchOperation.SelectedActorAttribute(
+                    new ActorTargetSelection(selectionDescriptor: " ", entityIdSurrogate: null),
+                    attributeName: null!,
+                    mutation: (ActorAttributeMutationKind)255,
+                    numericValue: double.PositiveInfinity,
+                    provenance));
+
+            That(result.Succeeded, Is.False);
+            That(session.Patch.IsEmpty, Is.True);
+            That(session.IsDirty, Is.False);
+            That(result.Diagnostics, Has.Some.Matches<LiveEditDiagnostic>(
+                d => d.Code == LiveEditDiagnosticCodes.MissingActorTarget));
+            That(result.Diagnostics, Has.Some.Matches<LiveEditDiagnostic>(
+                d => d.Code == LiveEditDiagnosticCodes.MissingAttributeName));
+            That(result.Diagnostics, Has.Some.Matches<LiveEditDiagnostic>(
+                d => d.Code == LiveEditDiagnosticCodes.UnsupportedAttributeMutation));
+            That(result.Diagnostics, Has.Some.Matches<LiveEditDiagnostic>(
+                d => d.Code == LiveEditDiagnosticCodes.NonFiniteNumericValue));
+        }
+
+        [Test]
+        public void Discard_ClearsStagedEditsAndAdvancesRevision()
+        {
+            LiveEditSession session = LiveEditSession.Start(LiveEditSource.ManualWorkbench, createdUtc: T0);
+            var provenance = new LiveEditProvenance(
+                LiveEditSource.ManualWorkbench,
+                sourceUri: "workbench://ability/Fireball/damage");
+
+            That(session.TryStage(
+                LiveDebugPatchOperation.SkillEffectNumeric("Fireball", "damage", 80d, provenance),
+                updatedUtc: T1).Succeeded,
+                Is.True);
+
+            LiveEditStageResult discard = session.Discard(updatedUtc: T2);
+
+            That(discard.Succeeded, Is.True);
+            That(discard.Revision, Is.EqualTo(2u));
+            That(discard.IsDirty, Is.False);
+            That(session.Revision, Is.EqualTo(2u));
+            That(session.IsDirty, Is.False);
+            That(session.Patch.IsEmpty, Is.True);
+            That(session.UpdatedUtc, Is.EqualTo(T2));
+        }
+
+        [Test]
+        public void ManualAndFileChange_ProduceSamePatchOperationShape()
+        {
+            LiveEditSession manual = LiveEditSession.Start(LiveEditSource.ManualWorkbench, createdUtc: T0);
+            LiveEditSession fileChange = LiveEditSession.Start(LiveEditSource.FileChange, createdUtc: T0);
+
+            var manualProvenance = new LiveEditProvenance(
+                LiveEditSource.ManualWorkbench,
+                sourceUri: "workbench://ability/Fireball/damage",
+                configRelativePath: "gas/abilities.json");
+            var fileProvenance = new LiveEditProvenance(
+                LiveEditSource.FileChange,
+                sourceUri: "file://mods/Demo/gas/abilities.json#Fireball.damage",
+                configRelativePath: "gas/abilities.json");
+
+            LiveDebugPatchOperation manualOp = LiveDebugPatchOperation.SkillEffectNumeric(
+                "Fireball",
+                "damage",
+                80d,
+                manualProvenance);
+            LiveDebugPatchOperation fileOp = LiveDebugPatchOperation.SkillEffectNumeric(
+                "Fireball",
+                "damage",
+                80d,
+                fileProvenance);
+
+            That(manual.TryStage(manualOp, updatedUtc: T1).Succeeded, Is.True);
+            That(fileChange.TryStage(fileOp, updatedUtc: T1).Succeeded, Is.True);
+
+            LiveDebugPatchOperation stagedManual = manual.Patch.Operations[0];
+            LiveDebugPatchOperation stagedFile = fileChange.Patch.Operations[0];
+
+            That(stagedManual.Kind, Is.EqualTo(stagedFile.Kind));
+            That(stagedManual.DefinitionId, Is.EqualTo(stagedFile.DefinitionId));
+            That(stagedManual.FieldPath, Is.EqualTo(stagedFile.FieldPath));
+            That(stagedManual.NumericValue, Is.EqualTo(stagedFile.NumericValue));
+            That(stagedManual.Provenance.ConfigRelativePath, Is.EqualTo(stagedFile.Provenance.ConfigRelativePath));
+            That(stagedManual.Provenance.Source, Is.Not.EqualTo(stagedFile.Provenance.Source));
+            That(stagedManual.Provenance.SourceUri, Is.Not.EqualTo(stagedFile.Provenance.SourceUri));
+        }
+
+        [Test]
+        public void TryStage_MissingProvenanceSourceUri_IsRejected()
+        {
+            LiveEditSession session = LiveEditSession.Start(LiveEditSource.AiGeneratedDraft, createdUtc: T0);
+            var provenance = new LiveEditProvenance(LiveEditSource.AiGeneratedDraft, sourceUri: " ");
+
+            LiveEditStageResult result = session.TryStage(
+                LiveDebugPatchOperation.SkillEffectNumeric("IceNova", "radius", 3.5d, provenance));
+
+            That(result.Succeeded, Is.False);
+            That(result.Diagnostics[0].Code, Is.EqualTo(LiveEditDiagnosticCodes.MissingProvenanceSourceUri));
+            That(session.Patch.IsEmpty, Is.True);
+        }
+    }
+}

--- a/src/Tests/GasTests/LiveEditSessionTests.cs
+++ b/src/Tests/GasTests/LiveEditSessionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Ludots.Core.Gameplay.GAS.LiveSkillWorkbench;
 using NUnit.Framework;
 using static NUnit.Framework.Assert;
@@ -259,6 +260,31 @@ namespace Ludots.Tests.GAS
             That(result.Succeeded, Is.False);
             That(result.Diagnostics[0].Code, Is.EqualTo(LiveEditDiagnosticCodes.MissingProvenanceSourceUri));
             That(session.Patch.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void Operations_CannotBeCastToMutableListAndMutated()
+        {
+            LiveEditSession session = LiveEditSession.Start(LiveEditSource.ManualWorkbench, createdUtc: T0);
+            var provenance = new LiveEditProvenance(
+                LiveEditSource.ManualWorkbench,
+                sourceUri: "workbench://ability/Fireball/damage");
+
+            That(session.TryStage(
+                LiveDebugPatchOperation.SkillEffectNumeric("Fireball", "damage", 80d, provenance),
+                updatedUtc: T1).Succeeded,
+                Is.True);
+
+            IReadOnlyList<LiveDebugPatchOperation> operations = session.Patch.Operations;
+
+            That(operations, Is.Not.InstanceOf<List<LiveDebugPatchOperation>>());
+            That(operations as List<LiveDebugPatchOperation>, Is.Null,
+                "Exposed Operations must not be the internal List; cast-and-mutate would bypass TryStage.");
+
+            That(operations.Count, Is.EqualTo(1));
+            That(operations[0].DefinitionId, Is.EqualTo("Fireball"));
+            That(session.Patch.Count, Is.EqualTo(1));
+            That(session.Revision, Is.EqualTo(1u));
         }
     }
 }

--- a/src/Tests/GasTests/LiveEditSessionTests.cs
+++ b/src/Tests/GasTests/LiveEditSessionTests.cs
@@ -281,10 +281,149 @@ namespace Ludots.Tests.GAS
             That(operations as List<LiveDebugPatchOperation>, Is.Null,
                 "Exposed Operations must not be the internal List; cast-and-mutate would bypass TryStage.");
 
+            var forged = LiveDebugPatchOperation.SkillEffectNumeric(
+                "IceNova",
+                "radius",
+                3.5d,
+                provenance);
+
+            IList<LiveDebugPatchOperation>? asIList = operations as IList<LiveDebugPatchOperation>;
+            That(asIList, Is.Not.Null, "ReadOnlyCollection exposes IList but must reject mutation.");
+            Throws<NotSupportedException>(() => asIList!.Add(forged));
+            Throws<NotSupportedException>(() => asIList!.Insert(0, forged));
+            Throws<NotSupportedException>(() => asIList!.RemoveAt(0));
+            Throws<NotSupportedException>(() => asIList!.Clear());
+
+            ICollection<LiveDebugPatchOperation>? asCollection = operations as ICollection<LiveDebugPatchOperation>;
+            That(asCollection, Is.Not.Null);
+            Throws<NotSupportedException>(() => asCollection!.Add(forged));
+            Throws<NotSupportedException>(() => asCollection!.Clear());
+
             That(operations.Count, Is.EqualTo(1));
             That(operations[0].DefinitionId, Is.EqualTo("Fireball"));
             That(session.Patch.Count, Is.EqualTo(1));
             That(session.Revision, Is.EqualTo(1u));
+        }
+
+        [Test]
+        public void FailureDiagnostics_CallerOwnedArrayCannotMutateResultOrCastBack()
+        {
+            var owned = new[]
+            {
+                new LiveEditDiagnostic(
+                    LiveEditDiagnosticSeverity.Error,
+                    LiveEditDiagnosticCodes.MissingDefinitionId,
+                    "definition id is required")
+            };
+
+            LiveEditStageResult result = LiveEditStageResult.Failure(
+                revision: 0,
+                isDirty: false,
+                owned);
+
+            That(result.Succeeded, Is.False);
+            That(result.Diagnostics.Count, Is.EqualTo(1));
+            That(result.Diagnostics[0].Code, Is.EqualTo(LiveEditDiagnosticCodes.MissingDefinitionId));
+
+            owned[0] = new LiveEditDiagnostic(
+                LiveEditDiagnosticSeverity.Warning,
+                LiveEditDiagnosticCodes.MissingFieldPath,
+                "mutated after Failure");
+
+            That(result.Diagnostics[0].Code, Is.EqualTo(LiveEditDiagnosticCodes.MissingDefinitionId),
+                "Caller-owned array mutation must not alter the staged failure report.");
+            That(result.Diagnostics as LiveEditDiagnostic[], Is.Null,
+                "Diagnostics must not expose the caller-owned array.");
+            That(result.Diagnostics as List<LiveEditDiagnostic>, Is.Null);
+
+            IList<LiveEditDiagnostic>? asIList = result.Diagnostics as IList<LiveEditDiagnostic>;
+            That(asIList, Is.Not.Null);
+            Throws<NotSupportedException>(() => asIList!.Clear());
+            That(result.Diagnostics.Count, Is.EqualTo(1));
+            That(result.Diagnostics[0].Code, Is.EqualTo(LiveEditDiagnosticCodes.MissingDefinitionId));
+        }
+
+        [Test]
+        public void FailureDiagnostics_CallerOwnedListCannotMutateResultOrCastBack()
+        {
+            var owned = new List<LiveEditDiagnostic>
+            {
+                new(
+                    LiveEditDiagnosticSeverity.Error,
+                    LiveEditDiagnosticCodes.MissingFieldPath,
+                    "field path is required")
+            };
+
+            LiveEditStageResult result = LiveEditStageResult.Failure(
+                revision: 3,
+                isDirty: true,
+                owned);
+
+            That(result.Diagnostics.Count, Is.EqualTo(1));
+            That(result.Diagnostics[0].Code, Is.EqualTo(LiveEditDiagnosticCodes.MissingFieldPath));
+
+            owned[0] = new LiveEditDiagnostic(
+                LiveEditDiagnosticSeverity.Warning,
+                LiveEditDiagnosticCodes.NonFiniteNumericValue,
+                "mutated after Failure");
+            owned.Add(new LiveEditDiagnostic(
+                LiveEditDiagnosticSeverity.Error,
+                LiveEditDiagnosticCodes.MissingAttributeName,
+                "extra"));
+
+            That(result.Diagnostics.Count, Is.EqualTo(1));
+            That(result.Diagnostics[0].Code, Is.EqualTo(LiveEditDiagnosticCodes.MissingFieldPath));
+            That(result.Diagnostics as List<LiveEditDiagnostic>, Is.Null,
+                "Diagnostics must not expose the caller-owned list.");
+            That(result.Diagnostics as LiveEditDiagnostic[], Is.Null);
+
+            ICollection<LiveEditDiagnostic>? asCollection = result.Diagnostics as ICollection<LiveEditDiagnostic>;
+            That(asCollection, Is.Not.Null);
+            Throws<NotSupportedException>(() => asCollection!.Add(owned[0]));
+            That(result.Diagnostics.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TryStage_FailureDiagnostics_RemainImmutableAfterScratchReuse()
+        {
+            LiveEditSession session = LiveEditSession.Start(LiveEditSource.ManualWorkbench, createdUtc: T0);
+            var provenance = new LiveEditProvenance(
+                LiveEditSource.ManualWorkbench,
+                sourceUri: "workbench://ability/Fireball/damage");
+
+            LiveEditStageResult firstFailure = session.TryStage(
+                LiveDebugPatchOperation.SkillEffectNumeric(
+                    definitionId: " ",
+                    fieldPath: "",
+                    numericValue: double.NaN,
+                    provenance),
+                updatedUtc: T1);
+
+            That(firstFailure.Succeeded, Is.False);
+            That(firstFailure.Diagnostics.Count, Is.EqualTo(3));
+            string firstCode = firstFailure.Diagnostics[0].Code;
+            string secondCode = firstFailure.Diagnostics[1].Code;
+            string thirdCode = firstFailure.Diagnostics[2].Code;
+
+            LiveEditStageResult secondFailure = session.TryStage(
+                LiveDebugPatchOperation.SelectedActorAttribute(
+                    new ActorTargetSelection(selectionDescriptor: " ", entityIdSurrogate: null),
+                    attributeName: null!,
+                    mutation: (ActorAttributeMutationKind)255,
+                    numericValue: double.PositiveInfinity,
+                    provenance));
+
+            That(secondFailure.Succeeded, Is.False);
+            That(session.Patch.IsEmpty, Is.True);
+            That(session.Revision, Is.EqualTo(0u));
+
+            That(firstFailure.Diagnostics.Count, Is.EqualTo(3),
+                "A later TryStage must not mutate a prior failure diagnostics snapshot.");
+            That(firstFailure.Diagnostics[0].Code, Is.EqualTo(firstCode));
+            That(firstFailure.Diagnostics[1].Code, Is.EqualTo(secondCode));
+            That(firstFailure.Diagnostics[2].Code, Is.EqualTo(thirdCode));
+            That(firstFailure.Diagnostics as LiveEditDiagnostic[], Is.Null);
+            That(firstFailure.Diagnostics as List<LiveEditDiagnostic>, Is.Null);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `LiveSkillWorkbench` domain session with stable id, monotonic revision, source, dirty state, and discard/rollback.
- Stage structured skill/effect numeric edits and selected-actor attribute Set/Add commands in one debug patch model shared by ManualWorkbench and FileChange (plus AiGeneratedDraft source).
- Reject invalid edits with explicit diagnostics without mutating the patch or live registries; record provenance for later Mod save (#624) without persisting files.

## Test plan
- [x] `dotnet build src/Core/Ludots.Core.csproj`
- [x] `dotnet build src/Tests/GasTests/GasTests.csproj`
- [x] `dotnet test src/Tests/GasTests/GasTests.csproj --filter FullyQualifiedName~LiveEditSessionTests --no-build`
- [x] `git diff --check`
- [ ] Confirm PR stacks cleanly on `codex/lsw-1-architecture-contract` (#616)

Closes #617

Made with [Cursor](https://cursor.com)