### PR TITLE
feat(governance): Phase 2 收尾——注册表完备化、验收 CI 化、文档校验稀疏容错

### DIFF
--- a/.github/workflows/ci-acceptance.yml
+++ b/.github/workflows/ci-acceptance.yml
@@ -1,0 +1,202 @@
+name: ci-acceptance
+
+on:
+  schedule:
+    # 每天 UTC 17:23（非整点非半点，避开队列高峰）
+    - cron: '23 17 * * *'
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/ci-acceptance.yml'
+      - 'scripts/build-acceptance-index.py'
+      - 'scripts/acceptance/**'
+      - 'showcase.registry.json'
+
+jobs:
+  acceptance:
+    runs-on: windows-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+
+      - name: Pin acceptance SDK
+        shell: pwsh
+        run: dotnet new globaljson --sdk-version 9.0.100 --roll-forward latestFeature --force
+
+      - name: Check acceptance index is in sync with registry
+        shell: pwsh
+        run: |
+          python scripts/build-acceptance-index.py --check
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+      - name: Build acceptance test projects
+        shell: pwsh
+        run: |
+          $projects = @(
+            'src/Tests/GasTests/GasTests.csproj',
+            'src/Tests/PresentationTests/PresentationTests.csproj',
+            'src/Tests/UiShowcaseTests/UiShowcaseTests.csproj'
+          )
+
+          foreach ($project in $projects) {
+            Write-Host "Building $project ..."
+            dotnet build $project -c Debug -v minimal
+            if ($LASTEXITCODE -ne 0) {
+              exit $LASTEXITCODE
+            }
+          }
+
+      # 单条失败/超时不阻断后续条目；结果写入 ci-acceptance-results.json，最后由 Gate 步骤统一判定。
+      - name: Run runnable acceptance entries
+        shell: pwsh
+        run: |
+          $index = Get-Content 'scripts/acceptance/acceptance.index.json' -Raw -Encoding UTF8 | ConvertFrom-Json
+          $results = New-Object System.Collections.Generic.List[object]
+          $timeoutSeconds = 600
+
+          foreach ($entry in @($index.runnable)) {
+            $startedAt = Get-Date
+            $artifactDir = $entry.artifactDir
+            if ([string]::IsNullOrWhiteSpace($artifactDir)) {
+              $artifactDir = "artifacts/acceptance/ci/$($entry.id)"
+            }
+            New-Item -ItemType Directory -Force -Path $artifactDir | Out-Null
+
+            $selector = $entry.binding
+            if ([string]::IsNullOrWhiteSpace($selector)) {
+              $selector = $entry.preset
+            }
+
+            Write-Host "=== [$($entry.id)] cli launch $selector --adapter raylib --record $artifactDir"
+            $outLog = Join-Path $artifactDir 'ci-launch.out.log'
+            $errLog = Join-Path $artifactDir 'ci-launch.err.log'
+
+            $proc = Start-Process -FilePath 'cmd.exe' `
+              -ArgumentList @('/c', 'scripts\run-mod-launcher.cmd', 'cli', 'launch', $selector, '--adapter', 'raylib', '--record', $artifactDir) `
+              -WorkingDirectory (Get-Location).Path `
+              -NoNewWindow -PassThru `
+              -RedirectStandardOutput $outLog `
+              -RedirectStandardError $errLog
+
+            $status = 'ok'
+            $exitCode = $null
+            $exited = $proc.WaitForExit($timeoutSeconds * 1000)
+            if (-not $exited) {
+              try { $proc.Kill() } catch {}
+              $proc.WaitForExit()
+              $status = "timeout(>${timeoutSeconds}s)"
+            }
+            else {
+              $exitCode = $proc.ExitCode
+              if ($exitCode -ne 0) {
+                $status = "fail(exit $exitCode)"
+              }
+            }
+            $proc.Dispose()
+
+            # 录制产物带 summary.json 时，success=false 同样判失败
+            $summaryPath = Join-Path $artifactDir 'summary.json'
+            if ($status -eq 'ok' -and (Test-Path $summaryPath)) {
+              try {
+                $runSummary = Get-Content $summaryPath -Raw -Encoding UTF8 | ConvertFrom-Json
+                if (($runSummary.PSObject.Properties.Name -contains 'success') -and (-not $runSummary.success)) {
+                  $status = 'fail(summary.success=false)'
+                }
+              }
+              catch {
+              }
+            }
+
+            $elapsed = [int]((Get-Date) - $startedAt).TotalSeconds
+            Write-Host "=== [$($entry.id)] $status (${elapsed}s)"
+            $results.Add([pscustomobject]@{
+              id              = $entry.id
+              binding         = $selector
+              artifactDir     = $artifactDir
+              status          = $status
+              exitCode        = $exitCode
+              durationSeconds = $elapsed
+            })
+          }
+
+          New-Item -ItemType Directory -Force -Path 'artifacts/acceptance' | Out-Null
+          $results | ConvertTo-Json | Set-Content 'artifacts/acceptance/ci-acceptance-results.json' -Encoding UTF8
+          if ($results.Count -eq 0) {
+            Write-Host 'acceptance.index.json 中没有 runnable 条目。'
+          }
+
+      - name: Upload acceptance artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: acceptance-artifacts
+          path: artifacts/acceptance/
+          if-no-files-found: warn
+
+      - name: Write job summary
+        if: always()
+        shell: pwsh
+        run: |
+          $lines = New-Object System.Collections.Generic.List[string]
+          $lines.Add('# 验收套件运行结果')
+          $lines.Add('')
+
+          $indexPath = 'scripts/acceptance/acceptance.index.json'
+          if (Test-Path $indexPath) {
+            $index = Get-Content $indexPath -Raw -Encoding UTF8 | ConvertFrom-Json
+            $lines.Add("- runnable 条目: $($index.counts.runnable)；test-only 条目: $($index.counts.testOnly)")
+            $lines.Add('')
+          }
+
+          $resultsPath = 'artifacts/acceptance/ci-acceptance-results.json'
+          if (Test-Path $resultsPath) {
+            $results = @(Get-Content $resultsPath -Raw -Encoding UTF8 | ConvertFrom-Json)
+            $lines.Add('| 条目 | binding | 状态 | 耗时 | 产物目录 |')
+            $lines.Add('|---|---|---|---|---|')
+            foreach ($r in $results) {
+              $lines.Add("| $($r.id) | $($r.binding) | $($r.status) | $($r.durationSeconds)s | $($r.artifactDir) |")
+            }
+            $okCount = @($results | Where-Object { $_.status -eq 'ok' }).Count
+            $lines.Add('')
+            $lines.Add("通过 $okCount / $($results.Count)")
+          }
+          else {
+            $lines.Add('> 未生成 ci-acceptance-results.json（运行步骤可能在执行条目前失败）。')
+          }
+
+          $lines | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
+      - name: Gate on runnable results
+        if: always()
+        shell: pwsh
+        run: |
+          $resultsPath = 'artifacts/acceptance/ci-acceptance-results.json'
+          if (-not (Test-Path $resultsPath)) {
+            Write-Host '[FAIL] ci-acceptance-results.json 不存在，运行步骤未完成。'
+            exit 1
+          }
+
+          $results = @(Get-Content $resultsPath -Raw -Encoding UTF8 | ConvertFrom-Json)
+          $failed = @($results | Where-Object { $_.status -ne 'ok' })
+          if ($failed.Count -gt 0) {
+            Write-Host "[FAIL] $($failed.Count) 条 runnable 验收未通过:"
+            foreach ($f in $failed) {
+              Write-Host " - $($f.id): $($f.status)"
+            }
+            exit 1
+          }
+
+          Write-Host "[OK] 全部 $($results.Count) 条 runnable 验收通过。"

--- a/gitbook/reference/cli-runbook.md
+++ b/gitbook/reference/cli-runbook.md
@@ -41,6 +41,61 @@
 - `launcher.runtime.json`
 - `artifacts/launcher/<adapter>.launch.graph.json`
 
-## 5 深度材料
+## 5 产物录制与验收联动
+
+### --record 录制
+
+- 命令形式：`.\scripts\run-mod-launcher.cmd cli launch <binding> --adapter raylib --record <目录>`
+- 用途：把一次启动的验收证据固化到指定目录，供人工审查、soak 循环与 CI 断言复用
+- 实例：`scripts/acceptance/run-mass-navigation-large-world-uat.ps1` 每轮运行落一个 `run-NNNN` 目录并校验六件套齐全，缺任何一件即判该轮失败；`-Iterations 0 -UntilLocalTime <时间>` 即过夜 soak 模式
+
+产物六件套：
+
+| 产物 | 说明 |
+| --- | --- |
+| `battle-report.md` | 人类可读的战报，汇总本次运行的场景、关键断言与结论 |
+| `summary.json` | 机器可读的运行摘要；`success` 字段是总判定，`failed_checks` 列出未过检查，另含归一化签名与各项度量 |
+| `trace.jsonl` | 逐行 JSON 事件轨迹，按时间顺序记录运行期关键事件，供回放与排查 |
+| `path.mmd` | Mermaid 图源文件，描述本次运行的流程路径，可在支持 Mermaid 的工具中直接渲染 |
+| `visible-checklist.md` | 可见性检查清单，逐项核对"玩家应当看到什么" |
+| `screens/*.png` | 截图组；含按步骤编号的过程截图与 `screens/timeline.png` 时间线拼图 |
+
+### 无头截图环境变量
+
+照 `scripts/acceptance/run-item-system-showcase-raylib.ps1` 实例：
+
+```powershell
+$env:LUDOTS_TAKE_SCREENSHOT_PATH = "artifacts\acceptance\item-system-showcase\item-system-showcase-raylib.png"
+$env:LUDOTS_TAKE_SCREENSHOT_FRAME = "120"
+.\scripts\run-mod-launcher.cmd cli launch mod:ItemSystemShowcaseMod --adapter raylib
+```
+
+- `LUDOTS_TAKE_SCREENSHOT_PATH`：渲染到指定帧后把画面写入该 PNG 路径
+- `LUDOTS_TAKE_SCREENSHOT_FRAME`：触发截图的帧号（示例取 120，验收脚本默认 180）
+- 配套 `LUDOTS_RAYLIB_DIAGNOSTIC_PATH` 可额外落一份 Raylib 诊断日志
+- 脚本在截图文件出现且写入时间戳更新后主动结束 launcher，适合无头与 CI 环境
+
+### 与 dotnet test 的联动断言
+
+照 `scripts/acceptance/run-item-system-showcase-acceptance.ps1` 实例：先跑截图脚本，再设环境变量跑测试：
+
+```powershell
+$env:LUDOTS_ACCEPTANCE_REQUIRE_RAYLIB_EVIDENCE = "1"
+$env:LUDOTS_ACCEPTANCE_SCREENSHOT_PATH = "<截图路径>"
+$env:LUDOTS_ACCEPTANCE_DIAGNOSTIC_PATH = "<诊断日志路径>"
+$env:LUDOTS_ACCEPTANCE_SCREENSHOT_NOT_BEFORE_UTC = "<UTC 时间戳>"
+dotnet test src\Tests\GasTests\GasTests.csproj -c Release --no-build --filter ItemSystemShowcase
+```
+
+- `LUDOTS_ACCEPTANCE_REQUIRE_RAYLIB_EVIDENCE=1` 把 Raylib 证据从可选升级为必须：测试断言截图与诊断文件存在、且写入时间晚于 `LUDOTS_ACCEPTANCE_SCREENSHOT_NOT_BEFORE_UTC`，证据缺失或过期即断言失败
+- 不设该变量时同一测试按无证据路径放行，便于本地快速跑
+- 验收脚本在 finally 中统一清理这四个环境变量，避免污染后续测试进程
+
+### 进一步阅读
+
+- 门户 tests.html 证据查看器：<https://mightybubble.github.io/Ludots/tests.html>，在线浏览各验收用例的报告与截图
+- `scripts/acceptance/` 目录下的 `run-*` 脚本即本节用法的可执行实例
+
+## 6 深度材料
 
 - 仓库深度版：`docs/reference/cli_runbook.md`

--- a/launcher.config.json
+++ b/launcher.config.json
@@ -248,6 +248,85 @@
         "value": "mods/showcases/capability_standard/CapabilityStandardTransportNetworkMod",
         "projectPath": "CapabilityStandardTransportNetworkMod.csproj"
       }
+    },
+    {
+      "name": "capability_standard_virtual_camera_showcase",
+      "target": {
+        "type": "path",
+        "value": "mods/showcases/capability_standard/CapabilityStandardVirtualCameraShowcaseMod",
+        "projectPath": "CapabilityStandardVirtualCameraShowcaseMod.csproj"
+      }
+    },
+    {
+      "name": "animation_acceptance",
+      "target": {
+        "type": "path",
+        "value": "mods/fixtures/animation/AnimationAcceptanceMod",
+        "projectPath": "AnimationAcceptanceMod.csproj"
+      }
+    },
+    {
+      "name": "blacksmith_test",
+      "target": {
+        "type": "path",
+        "value": "mods/fixtures/blacksmith/BlacksmithTestMod"
+      }
+    },
+    {
+      "name": "fog_of_war",
+      "target": {
+        "type": "path",
+        "value": "mods/showcases/fog_of_war/FogOfWarShowcaseMod",
+        "projectPath": "FogOfWarShowcaseMod.csproj"
+      }
+    },
+    {
+      "name": "fog_vision_decay",
+      "target": {
+        "type": "path",
+        "value": "mods/showcases/fog_vision_decay/FogVisionDecayShowcaseMod",
+        "projectPath": "FogVisionDecayShowcaseMod.csproj"
+      }
+    },
+    {
+      "name": "item_system",
+      "target": {
+        "type": "path",
+        "value": "mods/showcases/item_system/ItemSystemShowcaseMod",
+        "projectPath": "ItemSystemShowcaseMod.csproj"
+      }
+    },
+    {
+      "name": "forge_socket",
+      "target": {
+        "type": "path",
+        "value": "mods/showcases/item_system/ForgeSocketShowcaseMod",
+        "projectPath": "ForgeSocketShowcaseMod.csproj"
+      }
+    },
+    {
+      "name": "item_loadout",
+      "target": {
+        "type": "path",
+        "value": "mods/showcases/item_system/ItemLoadoutShowcaseMod",
+        "projectPath": "ItemLoadoutShowcaseMod.csproj"
+      }
+    },
+    {
+      "name": "raid_loop",
+      "target": {
+        "type": "path",
+        "value": "mods/showcases/item_system/RaidLoopShowcaseMod",
+        "projectPath": "RaidLoopShowcaseMod.csproj"
+      }
+    },
+    {
+      "name": "weapon_bench",
+      "target": {
+        "type": "path",
+        "value": "mods/showcases/item_system/WeaponBenchShowcaseMod",
+        "projectPath": "WeaponBenchShowcaseMod.csproj"
+      }
     }
   ],
   "adapters": {

--- a/launcher.presets.json
+++ b/launcher.presets.json
@@ -250,6 +250,132 @@
       ],
       "adapterId": "raylib",
       "buildMode": "auto"
+    },
+    {
+      "id": "capability_standard_virtual_camera_showcase_raylib",
+      "name": "Capability Standard Virtual Camera Raylib",
+      "selectors": [
+        "$capability_standard_virtual_camera_showcase"
+      ],
+      "adapterId": "raylib",
+      "buildMode": "auto"
+    },
+    {
+      "id": "animation_acceptance_raylib",
+      "name": "Animation Acceptance Raylib",
+      "selectors": [
+        "$animation_acceptance"
+      ],
+      "adapterId": "raylib",
+      "buildMode": "auto"
+    },
+    {
+      "id": "blacksmith_test_raylib",
+      "name": "Blacksmith Test Raylib",
+      "selectors": [
+        "$blacksmith_test"
+      ],
+      "adapterId": "raylib",
+      "buildMode": "auto"
+    },
+    {
+      "id": "fog_of_war_raylib",
+      "name": "Fog Of War Raylib",
+      "selectors": [
+        "$fog_of_war"
+      ],
+      "adapterId": "raylib",
+      "buildMode": "auto"
+    },
+    {
+      "id": "fog_vision_decay_raylib",
+      "name": "Fog Vision Decay Raylib",
+      "selectors": [
+        "$fog_vision_decay"
+      ],
+      "adapterId": "raylib",
+      "buildMode": "auto"
+    },
+    {
+      "id": "item_system_raylib",
+      "name": "Item System Raylib",
+      "selectors": [
+        "$item_system"
+      ],
+      "adapterId": "raylib",
+      "buildMode": "auto"
+    },
+    {
+      "id": "forge_socket_raylib",
+      "name": "Forge Socket Raylib",
+      "selectors": [
+        "$forge_socket"
+      ],
+      "adapterId": "raylib",
+      "buildMode": "auto"
+    },
+    {
+      "id": "item_loadout_raylib",
+      "name": "Item Loadout Raylib",
+      "selectors": [
+        "$item_loadout"
+      ],
+      "adapterId": "raylib",
+      "buildMode": "auto"
+    },
+    {
+      "id": "raid_loop_raylib",
+      "name": "Raid Loop Raylib",
+      "selectors": [
+        "$raid_loop"
+      ],
+      "adapterId": "raylib",
+      "buildMode": "auto"
+    },
+    {
+      "id": "weapon_bench_raylib",
+      "name": "Weapon Bench Raylib",
+      "selectors": [
+        "$weapon_bench"
+      ],
+      "adapterId": "raylib",
+      "buildMode": "auto"
+    },
+    {
+      "id": "entity_command_panel_raylib",
+      "name": "Entity Command Panel Raylib",
+      "selectors": [
+        "$entity_command_panel_showcase"
+      ],
+      "adapterId": "raylib",
+      "buildMode": "auto"
+    },
+    {
+      "id": "interaction_raylib",
+      "name": "Interaction Raylib",
+      "selectors": [
+        "$interaction_showcase"
+      ],
+      "adapterId": "raylib",
+      "buildMode": "auto"
+    },
+    {
+      "id": "superweapon_context_raylib",
+      "name": "Superweapon Context Raylib",
+      "selectors": [
+        "$superweapon_context_showcase"
+      ],
+      "adapterId": "raylib",
+      "buildMode": "auto"
+    },
+    {
+      "id": "control_plane_projection_raylib",
+      "name": "Control Plane Projection Raylib",
+      "selectors": [
+        "$control_plane_projection_showcase"
+      ],
+      "adapterId": "raylib",
+      "buildMode": "auto"
     }
   ]
 }

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -1,0 +1,103 @@
+# 验收套件（Acceptance Suite）
+
+本目录是 Ludots showcase 验收的统一入口。验收清单不在这里手工维护，而是由
+`scripts/build-acceptance-index.py` 从仓库根部的 `showcase.registry.json` 自动生成为
+`acceptance.index.json`：
+
+- **选取范围**：注册表中 `tier = T1` 且 `status = active` 的条目。
+- **runnable**（`preset` 非空）：可通过 launcher 实跑录制，CI 逐条执行
+  `scripts/run-mod-launcher.cmd cli launch <binding> --adapter raylib --record <artifactDir>`。
+- **test-only**（`preset` 为空但有 `acceptanceTest`）：无 launcher 预设，仅通过
+  `dotnet test --filter FullyQualifiedName~<testFilter>` 覆盖（见各测试项目与 solution-verify 流水线）。
+
+当前索引统计：**runnable 9 条 / test-only 14 条 / 共 23 条**（以 `acceptance.index.json` 的
+`counts` 字段为准）。
+
+## 索引条目结构
+
+`acceptance.index.json` 中每条形如：
+
+```json
+{
+  "id": "camera_acceptance",
+  "preset": "camera_acceptance_raylib",
+  "binding": "camera_acceptance",
+  "testFilter": "CameraAcceptanceModTests",
+  "artifactDir": "artifacts/acceptance/launcher-camera-acceptance-raylib",
+  "hasScreenshotEvidence": true
+}
+```
+
+- `testFilter`：即注册表 `acceptanceTest`，对应 `dotnet test --filter FullyQualifiedName~<值>`。
+- `artifactDir`：录制产物目录；为空时 CI 落盘到 `artifacts/acceptance/ci/<id>/`。
+- `hasScreenshotEvidence`：注册表 `screenshot` 字段非空即为 `true`。
+
+## 录制产物"六件套"
+
+runnable 条目经 `--record` 录制后，产物目录下标准产出六件证据：
+
+| 产物 | 说明 |
+|---|---|
+| `summary.json` | 运行摘要与成功判定（`success` 字段，CI 据此二次校验退出码） |
+| `trace.jsonl` | 逐 tick 事件轨迹 |
+| `screens/` | 截图序列（如 `000_start.png`、操作后截图） |
+| `battle-report.md` | 战报 / 结果报告 |
+| `visible-checklist.md` | 可见性核对清单 |
+| `path.mmd` | Mermaid 路径 / 流程图 |
+
+## 目录内脚本清单（11 个）
+
+| 脚本 | 用途 |
+|---|---|
+| `capture-item-system-showcase-rooms.ps1` | 批量截取物品系统 showcase 各房间截图到 `artifacts/acceptance/item-system-showcase/room-screenshots` |
+| `run-forge-socket-showcase-acceptance.ps1` | 锻造插槽 showcase 验收：Raylib 截图 + 诊断日志 |
+| `run-item-loadout-showcase-acceptance.ps1` | 物品配装 showcase 验收：Raylib 截图 + 诊断日志 |
+| `run-item-system-showcase-acceptance.ps1` | 物品系统 showcase 验收：Raylib 截图 + 诊断日志 |
+| `run-item-system-showcase-raylib.ps1` | 物品系统 showcase 通用截图脚本（支持启动地图覆盖 mod） |
+| `run-mass-navigation-large-world-uat.ps1` | 大世界万人导航 UAT：launcher `--record` 循环录制并汇总成功率 |
+| `run-raid-loop-showcase-acceptance.ps1` | 突袭循环 showcase 验收：Raylib 截图 + 诊断日志 |
+| `run-relationship-showcase-raylib.ps1` | 关系系统 showcase Raylib 截图验收 |
+| `run-save-system-uat.ps1` | 存档系统 UAT（Debug 配置，纯测试驱动） |
+| `run-uxprototype-raylib.ps1` | UX 原型 showcase Raylib 截图验收 |
+| `run-weapon-bench-showcase-acceptance.ps1` | 武器工作台 showcase 验收：Raylib 截图 + 诊断日志 |
+
+## 如何新增一条验收
+
+只需改注册表，索引自动生成：
+
+1. 在 `showcase.registry.json` 中把目标条目标为 `tier: "T1"`、`status: "active"`：
+   - 填好 `preset` / `binding`（以及可选的 `artifactDir`、`screenshot`）→ 进入 **runnable**；
+   - 只填 `acceptanceTest` → 进入 **test-only**。
+2. 运行 `python scripts/build-acceptance-index.py` 重新生成 `acceptance.index.json` 并一并提交。
+3. CI（`.github/workflows/ci-acceptance.yml`）会先跑 `build-acceptance-index.py --check`，
+   索引与注册表漂移即失败，因此两者始终同步。
+
+## 本地运行
+
+```bash
+# 生成 / 更新索引
+python scripts/build-acceptance-index.py
+
+# 校验索引与注册表同步（CI 同款检查）
+python scripts/build-acceptance-index.py --check
+
+# 实跑某条 runnable 验收（以 camera_acceptance 为例）
+scripts/run-mod-launcher.cmd cli launch camera_acceptance --adapter raylib --record artifacts/acceptance/launcher-camera-acceptance-raylib
+
+# 跑某条 test-only 验收（以 fog_of_war 为例）
+dotnet test src/Tests/GasTests/GasTests.csproj -c Debug --filter FullyQualifiedName~FogOfWarShowcaseAcceptanceTests -v minimal
+```
+
+## CI 流水线（ci-acceptance）
+
+`.github/workflows/ci-acceptance.yml`，windows-latest，触发方式：
+
+- **schedule**：每天 UTC 17:23（`23 17 * * *`，非整点非半点）；
+- **workflow_dispatch**：手动触发；
+- **push 到 main** 且路径命中 `scripts/acceptance/**`、`scripts/build-acceptance-index.py`
+  或 `showcase.registry.json`。
+
+步骤：checkout → 安装 .NET 8 + 9 SDK（globaljson pin 9.0.100）→ `--check` 校验索引 →
+编译 `GasTests` / `PresentationTests` / `UiShowcaseTests` → 逐条实跑 runnable 验收
+（单条 600s 超时，失败/超时不阻断后续条目）→ 上传 `artifacts/acceptance/` 产物 →
+输出 job summary（成功/失败条目表）→ Gate 步骤统一判定（任一失败则工作流失败）。

--- a/scripts/acceptance/acceptance.index.json
+++ b/scripts/acceptance/acceptance.index.json
@@ -1,0 +1,200 @@
+{
+  "schemaVersion": 1,
+  "source": "showcase.registry.json",
+  "selection": {
+    "tier": "T1",
+    "status": "active"
+  },
+  "counts": {
+    "runnable": 23,
+    "testOnly": 0,
+    "total": 23
+  },
+  "runnable": [
+    {
+      "id": "animation_acceptance",
+      "preset": "animation_acceptance_raylib",
+      "binding": "animation_acceptance",
+      "testFilter": "AnimationAcceptancePrototypeTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "blacksmith_test",
+      "preset": "blacksmith_test_raylib",
+      "binding": "blacksmith_test",
+      "testFilter": "BlacksmithPerformerUatTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "camera_acceptance",
+      "preset": "camera_acceptance_raylib",
+      "binding": "camera_acceptance",
+      "testFilter": "CameraAcceptanceModTests",
+      "artifactDir": "artifacts/acceptance/launcher-camera-acceptance-raylib",
+      "hasScreenshotEvidence": true
+    },
+    {
+      "id": "camera_acceptance_hotpath_entry",
+      "preset": "camera_acceptance_hotpath_raylib",
+      "binding": "camera_acceptance_hotpath",
+      "testFilter": "CameraAcceptanceModTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "capability_standard_mass_navigation_large_world_10k",
+      "preset": "capability_standard_mass_navigation_large_world_10k_raylib",
+      "binding": "capability_standard_mass_navigation_large_world_10k",
+      "testFilter": "CapabilityStandardMassNavigationLargeWorld10kProductionPathTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "capability_standard_participant_views",
+      "preset": "capability_standard_participant_views_raylib",
+      "binding": "capability_standard_participant_views",
+      "testFilter": "ParticipantViewKnowledgeShowcaseAcceptanceTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "capability_standard_physics2d",
+      "preset": "capability_standard_physics2d_raylib",
+      "binding": "capability_standard_physics2d",
+      "testFilter": "CapabilityStandardPhysics2DAcceptanceTests",
+      "artifactDir": "artifacts/showcases/capability-standard-physics2d",
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "capability_standard_physics2d_showcase",
+      "preset": "capability_standard_physics2d_showcase_raylib",
+      "binding": "capability_standard_physics2d_showcase",
+      "testFilter": "CapabilityStandardPhysics2DShowcaseAcceptanceTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "capability_standard_physics2d_stress",
+      "preset": "capability_standard_physics2d_stress_raylib",
+      "binding": "capability_standard_physics2d_stress",
+      "testFilter": "CapabilityStandardPhysics2DStressShowcaseAcceptanceTests",
+      "artifactDir": "artifacts/showcases/capability-standard-physics2d-stress",
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "capability_standard_time_flow_showcase",
+      "preset": "capability_standard_time_flow_showcase_raylib",
+      "binding": "capability_standard_time_flow_showcase",
+      "testFilter": "CapabilityStandardTimeFlowShowcaseAcceptanceTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "capability_standard_virtual_camera_showcase",
+      "preset": "capability_standard_virtual_camera_showcase_raylib",
+      "binding": "capability_standard_virtual_camera_showcase",
+      "testFilter": "CapabilityStandardVirtualCameraShowcaseAcceptanceTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "control_plane_projection",
+      "preset": "control_plane_projection_raylib",
+      "binding": "control_plane_projection_showcase",
+      "testFilter": "ControlPlaneProjectionShowcaseAcceptanceTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "entity_command_panel",
+      "preset": "entity_command_panel_raylib",
+      "binding": "entity_command_panel_showcase",
+      "testFilter": "EntityCommandPanelShowcaseAcceptanceTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "fog_of_war",
+      "preset": "fog_of_war_raylib",
+      "binding": "fog_of_war",
+      "testFilter": "FogOfWarShowcaseAcceptanceTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "fog_vision_decay",
+      "preset": "fog_vision_decay_raylib",
+      "binding": "fog_vision_decay",
+      "testFilter": "FogVisionDecayShowcaseAcceptanceTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "forge_socket",
+      "preset": "forge_socket_raylib",
+      "binding": "forge_socket",
+      "testFilter": "ItemSystemShowcasePlayableAcceptanceTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "interaction",
+      "preset": "interaction_raylib",
+      "binding": "interaction_showcase",
+      "testFilter": "InteractionShowcasePlayableAcceptanceTests",
+      "artifactDir": "artifacts/acceptance/interaction-showcase",
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "item_loadout",
+      "preset": "item_loadout_raylib",
+      "binding": "item_loadout",
+      "testFilter": "ItemSystemShowcasePlayableAcceptanceTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "item_system",
+      "preset": "item_system_raylib",
+      "binding": "item_system",
+      "testFilter": "ItemSystemShowcasePlayableAcceptanceTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "progression_scope",
+      "preset": "progression_scope_raylib",
+      "binding": "progression_scope",
+      "testFilter": "ProgressionScopeShowcaseAcceptanceTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "raid_loop",
+      "preset": "raid_loop_raylib",
+      "binding": "raid_loop",
+      "testFilter": "ItemSystemShowcasePlayableAcceptanceTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "superweapon_context",
+      "preset": "superweapon_context_raylib",
+      "binding": "superweapon_context_showcase",
+      "testFilter": "SuperweaponContextShowcaseAcceptanceTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    },
+    {
+      "id": "weapon_bench",
+      "preset": "weapon_bench_raylib",
+      "binding": "weapon_bench",
+      "testFilter": "ItemSystemShowcasePlayableAcceptanceTests",
+      "artifactDir": null,
+      "hasScreenshotEvidence": false
+    }
+  ],
+  "testOnly": []
+}

--- a/scripts/build-acceptance-index.py
+++ b/scripts/build-acceptance-index.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""从 showcase.registry.json 生成验收套件索引 scripts/acceptance/acceptance.index.json。
+
+筛选规则：tier == "T1" 且 status == "active" 的条目，分两级：
+- runnable : preset 非空，可通过 run-mod-launcher.cmd cli launch <binding> --adapter raylib --record <dir> 实跑；
+- test-only: preset 为空但有 acceptanceTest，仅通过 dotnet test 过滤器覆盖。
+
+用法：
+    python scripts/build-acceptance-index.py          # 生成/更新 acceptance.index.json
+    python scripts/build-acceptance-index.py --check  # CI 校验：index 与 registry 漂移即退出 1
+
+仅使用 Python 标准库。
+"""
+
+import argparse
+import difflib
+import json
+import sys
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REGISTRY_PATH = REPO_ROOT / "showcase.registry.json"
+INDEX_PATH = REPO_ROOT / "scripts" / "acceptance" / "acceptance.index.json"
+
+
+def load_registry(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def build_index(registry: dict) -> tuple:
+    """返回 (index, skipped_ids)。skipped 为 T1 active 但既无 preset 也无 acceptanceTest 的条目。"""
+    runnable = []
+    test_only = []
+    skipped = []
+
+    for entry in registry.get("showcases", []):
+        if entry.get("tier") != "T1" or entry.get("status") != "active":
+            continue
+
+        preset = entry.get("preset") or None
+        acceptance_test = entry.get("acceptanceTest") or None
+        item = {
+            "id": entry["id"],
+            "preset": preset,
+            "binding": entry.get("binding") or None,
+            "testFilter": acceptance_test,
+            "artifactDir": entry.get("artifactDir") or None,
+            "hasScreenshotEvidence": bool(entry.get("screenshot")),
+        }
+
+        if preset:
+            runnable.append(item)
+        elif acceptance_test:
+            test_only.append(item)
+        else:
+            skipped.append(entry["id"])
+
+    runnable.sort(key=lambda x: x["id"])
+    test_only.sort(key=lambda x: x["id"])
+
+    index = {
+        "schemaVersion": SCHEMA_VERSION,
+        "source": "showcase.registry.json",
+        "selection": {"tier": "T1", "status": "active"},
+        "counts": {
+            "runnable": len(runnable),
+            "testOnly": len(test_only),
+            "total": len(runnable) + len(test_only),
+        },
+        "runnable": runnable,
+        "testOnly": test_only,
+    }
+    return index, skipped
+
+
+def render(index: dict) -> str:
+    return json.dumps(index, ensure_ascii=False, indent=2) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="生成/校验验收套件索引 acceptance.index.json")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="校验模式：不写入文件，index 与 registry 漂移时退出 1",
+    )
+    args = parser.parse_args()
+
+    if not REGISTRY_PATH.is_file():
+        print(f"[ERROR] 注册表不存在: {REGISTRY_PATH}", file=sys.stderr)
+        return 2
+
+    registry = load_registry(REGISTRY_PATH)
+    index, skipped = build_index(registry)
+    rendered = render(index)
+
+    if skipped:
+        print(
+            "[WARN] 以下 T1 active 条目既无 preset 也无 acceptanceTest，未纳入索引: "
+            + ", ".join(skipped),
+            file=sys.stderr,
+        )
+
+    if args.check:
+        if not INDEX_PATH.is_file():
+            print(f"[FAIL] 索引文件不存在: {INDEX_PATH}，请运行 scripts/build-acceptance-index.py 生成", file=sys.stderr)
+            return 1
+        current = INDEX_PATH.read_text(encoding="utf-8")
+        if current == rendered:
+            print(
+                f"[OK] acceptance.index.json 与 showcase.registry.json 同步 "
+                f"(runnable={index['counts']['runnable']}, test-only={index['counts']['testOnly']})"
+            )
+            return 0
+        print("[FAIL] acceptance.index.json 与 showcase.registry.json 漂移，请重新运行 scripts/build-acceptance-index.py", file=sys.stderr)
+        diff = difflib.unified_diff(
+            current.splitlines(),
+            rendered.splitlines(),
+            fromfile="acceptance.index.json (当前)",
+            tofile="acceptance.index.json (期望)",
+            lineterm="",
+        )
+        for i, line in enumerate(diff):
+            if i >= 80:
+                print("... (diff 截断)", file=sys.stderr)
+                break
+            print(line, file=sys.stderr)
+        return 1
+
+    INDEX_PATH.parent.mkdir(parents=True, exist_ok=True)
+    INDEX_PATH.write_text(rendered, encoding="utf-8")
+    print(
+        f"[OK] 已生成 {INDEX_PATH.relative_to(REPO_ROOT)} "
+        f"(runnable={index['counts']['runnable']}, test-only={index['counts']['testOnly']}, total={index['counts']['total']})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run-entity-command-panel-showcase.ps1
+++ b/scripts/run-entity-command-panel-showcase.ps1
@@ -3,6 +3,13 @@ param(
     [switch]$NoBuild
 )
 
+# 推荐使用新增 preset（canonical 入口，经 launcher 统一解析 binding/构建依赖）：
+#   scripts/run-mod-launcher.cmd cli launch --preset entity_command_panel_raylib
+#   等价 selector 形式（见 gitbook/reference/cli-runbook.md）：
+#   scripts/run-mod-launcher.cmd cli launch 'preset:entity_command_panel_raylib'
+# 本脚本为历史遗留的手动路径：绕过 launcher 直接逐个 dotnet build 4 个 mod 并启动
+# Raylib 宿主，仅用于需要精细控制构建顺序/参数的场景；常规验收请走上面的 preset。
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
@@ -63,3 +70,10 @@ try {
 finally {
     Pop-Location
 }
+
+# 等价 canonical 命令（launcher preset 入口）：
+#   scripts/run-mod-launcher.cmd cli launch --preset entity_command_panel_raylib
+#   等价 selector 形式（见 gitbook/reference/cli-runbook.md）：
+#   scripts/run-mod-launcher.cmd cli launch 'preset:entity_command_panel_raylib'
+# preset 定义见 launcher.presets.json（selectors: $entity_command_panel_showcase），
+# binding 定义见 launcher.config.json（entity_command_panel_showcase）。

--- a/scripts/validate-docs.ps1
+++ b/scripts/validate-docs.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding()]
+﻿[CmdletBinding()]
 param(
     [string[]]$Paths = @()
 )
@@ -63,6 +63,37 @@ function Resolve-RepoTarget {
     }
 
     return [System.IO.Path]::GetFullPath((Join-Path (Split-Path -Parent $SourceFile) $normalizedTarget))
+}
+
+# 稀疏检出容错：Test-Path 失败时回退 git 树查询（blobless/sparse 克隆中
+# 未物料化的路径在文件系统不存在，但可能真实存在于 HEAD 树中）。
+function Test-RepoPath {
+    param(
+        [string]$RepoRoot,
+        [string]$ResolvedPath
+    )
+
+    if (Test-Path $ResolvedPath) {
+        return $true
+    }
+
+    $fullRoot = [System.IO.Path]::GetFullPath($RepoRoot)
+    $fullPath = [System.IO.Path]::GetFullPath($ResolvedPath)
+    if (-not $fullPath.StartsWith($fullRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $false
+    }
+
+    $relative = $fullPath.Substring($fullRoot.Length).TrimStart('\', '/').Replace('\', '/')
+    if ([string]::IsNullOrWhiteSpace($relative)) {
+        return $false
+    }
+
+    try {
+        $output = & git -C $fullRoot ls-tree HEAD -- $relative 2>$null
+        return (-not [string]::IsNullOrWhiteSpace(($output | Out-String)))
+    } catch {
+        return $false
+    }
 }
 
 function Get-MarkdownLinks {
@@ -245,7 +276,7 @@ foreach ($file in $filesToValidate) {
             continue
         }
 
-        if (-not (Test-Path $resolved)) {
+        if (-not (Test-RepoPath -RepoRoot $repoRoot -ResolvedPath $resolved)) {
             Add-Finding -Collection $findings -Rule 'missing-link-target' -Source $relativeSource -Detail "markdown link target not found: '$target'"
         }
     }
@@ -271,7 +302,7 @@ foreach ($file in $filesToValidate) {
             $normalizedToken = $Matches[1]
         }
 
-        if (-not (Test-Path $resolved)) {
+        if (-not (Test-RepoPath -RepoRoot $repoRoot -ResolvedPath $resolved)) {
             if ([string]::IsNullOrWhiteSpace([System.IO.Path]::GetExtension($normalizedToken))) {
                 continue
             }

--- a/showcase.registry.json
+++ b/showcase.registry.json
@@ -20,14 +20,15 @@
         "animation",
         "skinned"
       ],
-      "binding": null,
-      "preset": null,
+      "binding": "animation_acceptance",
+      "preset": "animation_acceptance_raylib",
       "docsPath": null,
       "readmePath": null,
       "acceptanceTest": "AnimationAcceptancePrototypeTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "blacksmith_test",
@@ -41,14 +42,15 @@
         "performer",
         "uat"
       ],
-      "binding": null,
-      "preset": null,
+      "binding": "blacksmith_test",
+      "preset": "blacksmith_test_raylib",
       "docsPath": "gitbook/architecture/performer-raylib-uat.md",
       "readmePath": null,
       "acceptanceTest": "BlacksmithPerformerUatTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "camera_acceptance",
@@ -90,7 +92,8 @@
       "acceptanceTest": "CameraAcceptanceModTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "capability_standard_mass_navigation_large_world_10k",
@@ -112,7 +115,8 @@
       "acceptanceTest": "CapabilityStandardMassNavigationLargeWorld10kProductionPathTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "capability_standard_participant_views",
@@ -133,7 +137,8 @@
       "acceptanceTest": "ParticipantViewKnowledgeShowcaseAcceptanceTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "capability_standard_physics2d",
@@ -153,7 +158,8 @@
       "acceptanceTest": "CapabilityStandardPhysics2DAcceptanceTests",
       "artifactDir": "artifacts/showcases/capability-standard-physics2d",
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "capability_standard_physics2d_showcase",
@@ -174,7 +180,8 @@
       "acceptanceTest": "CapabilityStandardPhysics2DShowcaseAcceptanceTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "capability_standard_physics2d_stress",
@@ -195,7 +202,8 @@
       "acceptanceTest": "CapabilityStandardPhysics2DStressShowcaseAcceptanceTests",
       "artifactDir": "artifacts/showcases/capability-standard-physics2d-stress",
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "capability_standard_time_flow_showcase",
@@ -215,7 +223,8 @@
       "acceptanceTest": "CapabilityStandardTimeFlowShowcaseAcceptanceTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "capability_standard_virtual_camera_showcase",
@@ -229,14 +238,15 @@
         "camera",
         "virtual-camera"
       ],
-      "binding": null,
-      "preset": null,
+      "binding": "capability_standard_virtual_camera_showcase",
+      "preset": "capability_standard_virtual_camera_showcase_raylib",
       "docsPath": "gitbook/architecture/capability-standard-showcases.md",
       "readmePath": null,
       "acceptanceTest": "CapabilityStandardVirtualCameraShowcaseAcceptanceTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "control_plane_projection",
@@ -252,13 +262,14 @@
         "dataplane"
       ],
       "binding": "control_plane_projection_showcase",
-      "preset": null,
+      "preset": "control_plane_projection_raylib",
       "docsPath": null,
       "readmePath": "mods/showcases/control_plane_projection/ControlPlaneProjectionShowcaseMod/README.md",
       "acceptanceTest": "ControlPlaneProjectionShowcaseAcceptanceTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "entity_command_panel",
@@ -273,13 +284,14 @@
         "command"
       ],
       "binding": "entity_command_panel_showcase",
-      "preset": null,
+      "preset": "entity_command_panel_raylib",
       "docsPath": null,
       "readmePath": null,
       "acceptanceTest": "EntityCommandPanelShowcaseAcceptanceTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "fog_of_war",
@@ -293,14 +305,15 @@
         "fog-of-war",
         "vision"
       ],
-      "binding": null,
-      "preset": null,
+      "binding": "fog_of_war",
+      "preset": "fog_of_war_raylib",
       "docsPath": null,
       "readmePath": null,
       "acceptanceTest": "FogOfWarShowcaseAcceptanceTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "fog_vision_decay",
@@ -314,14 +327,15 @@
         "fog-of-war",
         "vision"
       ],
-      "binding": null,
-      "preset": null,
+      "binding": "fog_vision_decay",
+      "preset": "fog_vision_decay_raylib",
       "docsPath": null,
       "readmePath": null,
       "acceptanceTest": "FogVisionDecayShowcaseAcceptanceTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "forge_socket",
@@ -335,14 +349,15 @@
         "item",
         "forge"
       ],
-      "binding": null,
-      "preset": null,
+      "binding": "forge_socket",
+      "preset": "forge_socket_raylib",
       "docsPath": null,
       "readmePath": null,
       "acceptanceTest": "ItemSystemShowcasePlayableAcceptanceTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "interaction",
@@ -357,13 +372,14 @@
         "input"
       ],
       "binding": "interaction_showcase",
-      "preset": null,
+      "preset": "interaction_raylib",
       "docsPath": null,
       "readmePath": null,
       "acceptanceTest": "InteractionShowcasePlayableAcceptanceTests",
       "artifactDir": "artifacts/acceptance/interaction-showcase",
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "item_loadout",
@@ -376,14 +392,15 @@
       "tags": [
         "item"
       ],
-      "binding": null,
-      "preset": null,
+      "binding": "item_loadout",
+      "preset": "item_loadout_raylib",
       "docsPath": null,
       "readmePath": null,
       "acceptanceTest": "ItemSystemShowcasePlayableAcceptanceTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "item_system",
@@ -397,14 +414,15 @@
         "item",
         "inventory"
       ],
-      "binding": null,
-      "preset": null,
+      "binding": "item_system",
+      "preset": "item_system_raylib",
       "docsPath": null,
       "readmePath": null,
       "acceptanceTest": "ItemSystemShowcasePlayableAcceptanceTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "progression_scope",
@@ -424,7 +442,8 @@
       "acceptanceTest": "ProgressionScopeShowcaseAcceptanceTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "raid_loop",
@@ -438,14 +457,15 @@
         "item",
         "raid"
       ],
-      "binding": null,
-      "preset": null,
+      "binding": "raid_loop",
+      "preset": "raid_loop_raylib",
       "docsPath": null,
       "readmePath": null,
       "acceptanceTest": "ItemSystemShowcasePlayableAcceptanceTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "superweapon_context",
@@ -460,13 +480,14 @@
         "targeting"
       ],
       "binding": "superweapon_context_showcase",
-      "preset": null,
+      "preset": "superweapon_context_raylib",
       "docsPath": null,
       "readmePath": null,
       "acceptanceTest": "SuperweaponContextShowcaseAcceptanceTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "weapon_bench",
@@ -479,14 +500,15 @@
       "tags": [
         "item"
       ],
-      "binding": null,
-      "preset": null,
+      "binding": "weapon_bench",
+      "preset": "weapon_bench_raylib",
       "docsPath": null,
       "readmePath": null,
       "acceptanceTest": "ItemSystemShowcasePlayableAcceptanceTests",
       "artifactDir": null,
       "screenshot": null,
-      "status": "active"
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
     },
     {
       "id": "arpg_demo",


### PR DESCRIPTION
## 总览
承接 PR #691，把治理 backlog 中可闭环的项全部清零。

## 改动（10 文件，+1025/-50）
- **注册表完备化**：launcher.config.json +10 bindings（item_system 家族×5、fog×2、animation/blacksmith fixtures、virtual_camera_showcase）；launcher.presets.json +14 raylib presets；registry 同步——**binding/preset 类警告清零**（40 bindings / 40 presets 三方一致）；22 个缺截图 T1 条目加 notes 标注（待 CI 产物补录）
- **验收 CI 化**：`build-acceptance-index.py` 从注册表 T1 自动生成 acceptance.index.json（**23 条全部 runnable**），`--check` 防漂移；`ci-acceptance.yml` 每夜 17:23 UTC + 手动触发：编译测试项目 → 逐条 `--record` 实跑 → upload-artifact → job summary 门禁；`scripts/acceptance/README.md` 套件指南
- **文档校验容错**：`validate-docs.ps1` 新增 Test-RepoPath（Test-Path 失败回退 git ls-tree）——经核实原 108 条'基线告警'全部是本地稀疏检出的环境误报（84/84 token 在 HEAD 树中存在，CI 全量检出下本为绿色），修复后**本地校验 exit 0**
- **文档补全**：cli-runbook.md 新增「产物录制与验收联动」章节（--record 六件套、无头截图环境变量、LUDOTS_ACCEPTANCE_REQUIRE_RAYLIB_EVIDENCE 断言联动）；entity-command-panel 脚本补 canonical preset 注释

## 验证
- validate-registry：0 错误 / 22 警告（全部 screenshot 待补，已标注）
- build-acceptance-index --check：同步通过（23 runnable）
- validate-docs.ps1：本地 exit 0
- build-site.py：0 告警，134 条目注入画廊

## 合并后
- ci-acceptance 每夜自动跑验收并上传证据产物，22 条 screenshot notes 将随产物补录逐步清零（已建 issue 跟踪）