### PR TITLE
docs(portal): 修正双发布表述与注册计数

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -254,10 +254,10 @@
       <div class="card stat-card">
         <div class="value">70</div>
         <div class="label">篇正式文档</div>
-        <div class="note">gitbook/ 写作源 · GitBook 与门户双发布</div>
+        <div class="note">gitbook/ 写作源 · 本门户为唯一对外发布面</div>
       </div>
       <div class="card stat-card">
-        <div class="value">82</div>
+        <div class="value">134</div>
         <div class="label">个注册 Showcase</div>
         <div class="note">showcase.registry.json · T1–T4 分层治理</div>
       </div>


### PR DESCRIPTION
首页 stat 卡：「GitBook 与门户双发布」→「本门户为唯一对外发布面」（对齐去 GitBook 双轨决策）；注册 Showcase 计数 82 → 134（与 showcase.registry.json 实际条目一致）。