### PR TITLE
Productize Raylib VFX render path

### DIFF
--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -33,6 +33,7 @@
   - [空间尺度与分辨率 SSOT](architecture/spatial-scale-and-resolution-ssot.md)
   - [Core Field2D](architecture/core-field2d.md)
   - [Global Field Rendering](architecture/global-field-rendering.md)
+  - [Raylib Render Productization](architecture/raylib-render-productization.md)
   - [MassNavigation 数值域与确定性边界](architecture/mass-navigation-numeric-domain.md)
   - [Prefab Grounding 与 Visual Height](architecture/prefab-grounding-and-visual-height.md)
   - [Structure Collision Surfaces](architecture/structure-collision-surfaces.md)

--- a/gitbook/architecture/README.md
+++ b/gitbook/architecture/README.md
@@ -26,6 +26,7 @@
 - [Core Minimap Authoring](core-minimap-authoring.md)
 - [Core Field2D](core-field2d.md)
 - [Global Field Rendering](global-field-rendering.md)
+- [Raylib Render Productization](raylib-render-productization.md)
 - [Map-Owned Participant Contract](map-owned-participant-contract.md)
 - [Transport Network SSOT](transport-network-ssot.md)
 - [Placement Validation SSOT](placement-validation-ssot.md)

--- a/gitbook/architecture/raylib-render-productization.md
+++ b/gitbook/architecture/raylib-render-productization.md
@@ -1,0 +1,53 @@
+# Raylib Render Productization
+
+本页记录 Raylib 客户端产品化的第一条正式口径：Raylib host 负责窗口、输入、生命周期和诊断；画面组织由 renderer 模块接管；VFX 必须从 Presentation 资产数据进入渲染，不允许在 adapter 里临时硬编码效果。
+
+## 渲染入口
+
+`RaylibHostLoop` 只负责驱动每帧。具体画面顺序由 `RaylibFrameRenderer` 统一组织：
+
+1. 清屏与 3D 相机状态
+2. 地形、全局场、benchmark 场景
+3. primitive / prefab / performer 输出
+4. 地面提示、道路样条、debug draw
+5. browser layer 与 UI composite
+
+这个顺序是 Raylib 后续接入 PBR、后处理、阴影、粒子和平台资源缓存的正式入口。新增 pass 应该进入 frame renderer，而不是回到 host loop 里继续堆条件分支。
+
+## VFX 资产
+
+VFX effect 是 Presentation 资产，不是 Raylib 私有配置。当前 SSOT 是 `MeshAssetRegistry`：
+
+- `prefabs.json` 的 VFX part 使用 `effectAssetId` 引用资产 key；
+- `instanced_batches.json` 的 effect 操作也使用同一类资产 key；
+- 被引用的 effect asset 必须在 `mesh_assets.json` 中声明 `vfx.emitter`；
+- 裸数字、未知 key、缺少 emitter 数据都会直接报错。
+
+最小示例：
+
+```json
+{
+  "id": "effect.camera.projection_cue",
+  "type": "Primitive",
+  "primitiveKind": "Sphere",
+  "vfx": {
+    "emitter": {
+      "shape": "PrimitiveSphere",
+      "particleCount": 24,
+      "ringSegments": 20,
+      "radiusScale": 1.15,
+      "coreRadiusScale": 0.28,
+      "particleRadiusScale": 0.085,
+      "lifetimeSeconds": 0.75,
+      "pulseSpeedRadPerSecond": 5.2,
+      "orbitSpeedRadPerSecond": 1.7
+    }
+  }
+}
+```
+
+Raylib 只消费 finalization 后的 VFX leaf 与 effect asset 数据，生成本帧 emitter plan 并绘制。它不拥有 effect key 解析，不创建平行 registry，也不替 prefab 或 performer 决定语义。
+
+## 演进方向
+
+下一阶段如果要做接近 Quarks 的粒子框架，应继续扩展这份 Presentation-owned effect asset contract，例如多 emitter、curve、burst、shape module、material binding 和 GPU buffer plan。Raylib adapter 只增加执行能力；Core 仍然负责配置合同、校验和平台无关的 runtime leaf。

--- a/mods/fixtures/camera/CameraAcceptanceMod/assets/Presentation/mesh_assets.json
+++ b/mods/fixtures/camera/CameraAcceptanceMod/assets/Presentation/mesh_assets.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "effect.camera.projection_cue",
+    "type": "Primitive",
+    "primitiveKind": "Sphere",
+    "vfx": {
+      "emitter": {
+        "shape": "PrimitiveSphere",
+        "particleCount": 24,
+        "ringSegments": 20,
+        "radiusScale": 1.15,
+        "coreRadiusScale": 0.28,
+        "particleRadiusScale": 0.085,
+        "lifetimeSeconds": 0.75,
+        "pulseSpeedRadPerSecond": 5.2,
+        "orbitSpeedRadPerSecond": 1.7
+      }
+    }
+  }
+]

--- a/mods/fixtures/camera/CameraAcceptanceMod/assets/Presentation/prefabs.json
+++ b/mods/fixtures/camera/CameraAcceptanceMod/assets/Presentation/prefabs.json
@@ -22,7 +22,7 @@
       },
       {
         "kind": "Vfx",
-        "effectAssetId": 201,
+        "effectAssetId": "effect.camera.projection_cue",
         "localPosition": [0, 0.18, 0],
         "localScale": [0.5, 0.5, 0.5],
         "colorTint": [0.35, 0.95, 1, 0.85],

--- a/mods/showcases/capability_standard/CapabilityStandardStaticPerformer30kMod/assets/Presentation/host_assets.json
+++ b/mods/showcases/capability_standard/CapabilityStandardStaticPerformer30kMod/assets/Presentation/host_assets.json
@@ -52,14 +52,5 @@
     "sourceUris": [
       "CapabilityStandardStaticPerformer30kMod:assets/Models/Knight.glb"
     ]
-  },
-  {
-    "id": "capability_static_performer.smoke.billboard.raylib",
-    "assetKind": "Mesh",
-    "assetId": "capability_static_performer.smoke.billboard",
-    "backendId": "raylib",
-    "sourceUris": [
-      "CapabilityStandardStaticPerformer30kMod:assets/Textures/smoke_puff.png"
-    ]
   }
 ]

--- a/mods/showcases/capability_standard/CapabilityStandardStaticPerformer30kMod/assets/Presentation/mesh_assets.json
+++ b/mods/showcases/capability_standard/CapabilityStandardStaticPerformer30kMod/assets/Presentation/mesh_assets.json
@@ -25,7 +25,21 @@
   },
   {
     "id": "capability_static_performer.smoke.billboard",
-    "type": "Billboard"
+    "type": "Primitive",
+    "primitiveKind": "Sphere",
+    "vfx": {
+      "emitter": {
+        "shape": "PrimitiveSphere",
+        "particleCount": 32,
+        "ringSegments": 24,
+        "radiusScale": 1.4,
+        "coreRadiusScale": 0.22,
+        "particleRadiusScale": 0.075,
+        "lifetimeSeconds": 1.2,
+        "pulseSpeedRadPerSecond": 2.6,
+        "orbitSpeedRadPerSecond": 0.65
+      }
+    }
   },
   {
     "id": "capability_static_performer.worker.patrol",

--- a/mods/showcases/performer_blacksmith/PerformerBlacksmithShowcaseMod/assets/Presentation/host_assets.json
+++ b/mods/showcases/performer_blacksmith/PerformerBlacksmithShowcaseMod/assets/Presentation/host_assets.json
@@ -52,14 +52,5 @@
     "sourceUris": [
       "PerformerBlacksmithShowcaseMod:assets/Models/Knight.glb"
     ]
-  },
-  {
-    "id": "blacksmith.smoke.billboard.raylib",
-    "assetKind": "Mesh",
-    "assetId": "blacksmith.smoke.billboard",
-    "backendId": "raylib",
-    "sourceUris": [
-      "PerformerBlacksmithShowcaseMod:assets/Textures/smoke_puff.png"
-    ]
   }
 ]

--- a/mods/showcases/performer_blacksmith/PerformerBlacksmithShowcaseMod/assets/Presentation/mesh_assets.json
+++ b/mods/showcases/performer_blacksmith/PerformerBlacksmithShowcaseMod/assets/Presentation/mesh_assets.json
@@ -25,7 +25,21 @@
   },
   {
     "id": "blacksmith.smoke.billboard",
-    "type": "Billboard"
+    "type": "Primitive",
+    "primitiveKind": "Sphere",
+    "vfx": {
+      "emitter": {
+        "shape": "PrimitiveSphere",
+        "particleCount": 32,
+        "ringSegments": 24,
+        "radiusScale": 1.4,
+        "coreRadiusScale": 0.22,
+        "particleRadiusScale": 0.075,
+        "lifetimeSeconds": 1.2,
+        "pulseSpeedRadPerSecond": 2.6,
+        "orbitSpeedRadPerSecond": 0.65
+      }
+    }
   },
   {
     "id": "blacksmith.worker.patrol",

--- a/src/Adapters/Raylib/Ludots.Adapter.Raylib/RaylibHostLoop.cs
+++ b/src/Adapters/Raylib/Ludots.Adapter.Raylib/RaylibHostLoop.cs
@@ -163,6 +163,10 @@ namespace Ludots.Adapter.Raylib
             int targetFps = config.TargetFps == 0 ? 0 : (config.TargetFps < 0 ? 60 : config.TargetFps);
             bool windowOpened = false;
             bool windowResizable = config.WindowResizable || config.WindowStartMaximized;
+            string? diagnosticPath = Environment.GetEnvironmentVariable("LUDOTS_RAYLIB_DIAGNOSTIC_PATH");
+            AppendRaylibDiagnostic(
+                diagnosticPath,
+                $"launch-stage run-enter map={config.StartupMapId} size={screenWidth}x{screenHeight} targetFps={targetFps}");
 
             var terrainRenderer = new RaylibTerrainRenderer
             {
@@ -183,6 +187,7 @@ namespace Ludots.Adapter.Raylib
 
             try
             {
+                AppendRaylibDiagnostic(diagnosticPath, "launch-stage before-init-window");
                 if (windowResizable)
                 {
                     Rl.SetConfigFlags(FlagWindowResizable);
@@ -190,6 +195,7 @@ namespace Ludots.Adapter.Raylib
 
                 Rl.InitWindow(screenWidth, screenHeight, title);
                 windowOpened = true;
+                AppendRaylibDiagnostic(diagnosticPath, "launch-stage after-init-window");
                 if (config.WindowStartMaximized)
                 {
                     Rl.MaximizeWindow();
@@ -274,6 +280,7 @@ namespace Ludots.Adapter.Raylib
                 }
 
                 ValidateRequiredContextBeforeLoop(engine);
+                AppendRaylibDiagnostic(diagnosticPath, "launch-stage after-required-context");
 
                 var debugDrawRenderer = new RaylibDebugDrawRenderer { PlaneY = 0.35f };
                 GlobalFieldVisualBuffer? globalFieldVisualBuffer = engine.GetService(CoreServiceKeys.GlobalFieldVisualBuffer);
@@ -291,18 +298,36 @@ namespace Ludots.Adapter.Raylib
                     benchmarkRenderer = new RaylibBenchmarkRenderService(primitiveRenderer, benchmarkMeshes, benchmarkHud, benchmarkOverlay);
                     engine.SetService(RaylibBenchmarkRendererKey, (IRaylibBenchmarkRenderer)benchmarkRenderer);
                 }
+                var frameRenderer = new RaylibFrameRenderer(
+                    engine,
+                    uiRoot,
+                    skiaRenderer,
+                    overlayCompositor,
+                    browserLayerRenderer,
+                    terrainRenderer,
+                    visualHeightmapRenderer,
+                    fieldRenderPerformer,
+                    primitiveRenderer,
+                    debugDrawRenderer,
+                    benchmarkRenderer,
+                    globalFieldVisualBuffer,
+                    screenOverlayBuffer,
+                    presentationTiming);
 
+                AppendRaylibDiagnostic(diagnosticPath, "launch-stage before-engine-start");
                 engine.Start();
+                AppendRaylibDiagnostic(diagnosticPath, "launch-stage after-engine-start");
                 if (string.IsNullOrWhiteSpace(config.StartupMapId))
                 {
                     throw new InvalidOperationException("Invalid launcher bootstrap: 'StartupMapId' cannot be empty.");
                 }
+                AppendRaylibDiagnostic(diagnosticPath, $"launch-stage before-load-map map={config.StartupMapId}");
                 engine.LoadStartupMap();
+                AppendRaylibDiagnostic(diagnosticPath, "launch-stage after-load-map");
 
                 int lastW = screenWidth;
                 int lastH = screenHeight;
                 string? screenshotPath = Environment.GetEnvironmentVariable("LUDOTS_TAKE_SCREENSHOT_PATH");
-                string? diagnosticPath = Environment.GetEnvironmentVariable("LUDOTS_RAYLIB_DIAGNOSTIC_PATH");
                 string? screenshotTargetPath = string.IsNullOrWhiteSpace(screenshotPath)
                     ? null
                     : Path.GetFullPath(screenshotPath);
@@ -338,6 +363,9 @@ namespace Ludots.Adapter.Raylib
                 float autoOrbitDegPerSecond = float.TryParse(Environment.GetEnvironmentVariable("LUDOTS_RAYLIB_AUTO_ORBIT_DEG_PER_SEC"), out float parsedAutoOrbitDegPerSecond)
                     ? parsedAutoOrbitDegPerSecond
                     : 0f;
+                AppendRaylibDiagnostic(
+                    diagnosticPath,
+                    $"launch-stage before-frame-loop autoExitFrame={autoExitFrame} screenshotPending={screenshotPending} autoOrbit={autoOrbitDegPerSecond}");
                 SyntheticUiPlayback syntheticUiPlayback = ReadSyntheticUiPlayback();
                 int frameIndex = 0;
                 Stopwatch runtimeStopwatch = Stopwatch.StartNew();
@@ -458,188 +486,29 @@ namespace Ludots.Adapter.Raylib
                         }
                         presentationTiming?.ObserveHostPostTick(ElapsedMs(postTickStart));
 
-                        long beginDrawingStart = Stopwatch.GetTimestamp();
-                        Rl.BeginDrawing();
-                        presentationTiming?.ObserveBeginDrawing(ElapsedMs(beginDrawingStart));
-                        Restore3DDepthState();
-                        Rl.ClearBackground(activeMapRequestsDeepBackground
-                            ? new Raylib_cs.Color(6, 10, 16, 255)
-                            : new Raylib_cs.Color(0, 0, 0, 255));
-
                         var activeCamera = cameraAdapter.Camera;
                         CameraRenderState3D activeCameraState = cameraPresenter.SmoothedRenderState;
-                        long mode3DStart = Stopwatch.GetTimestamp();
-                        Restore3DDepthState();
-                        BeginCoreMode3D(activeCamera, in activeCameraState);
-                        Restore3DDepthState();
-
-                        if (drawDebugDraw &&
-                            !(drawVisualHeightmap && hasVisualHeightmap) &&
-                            !hostDebugGuidesSuppressed)
-                        {
-                            DrawInfiniteGrid(activeCamera.target, 300, 1.0f, 10);
-
-                            var target = activeCamera.target;
-                            Rl.DrawLine3D(target, target + new Vector3(2.0f, 0, 0), Color.RED);
-                            Rl.DrawLine3D(target, target + new Vector3(0, 0, 2.0f), Color.BLUE);
-                            Rl.DrawLine3D(target, target + new Vector3(0, 2.0f, 0), Color.GREEN);
-                        }
-
-                        if (drawVisualHeightmap &&
-                            engine.TryGetService(CoreServiceKeys.VisualHeightmap, out IVisualHeightmap? visualHeightmapForTerrain) &&
-                            visualHeightmapForTerrain is IVisualHeightmapRenderSource visualTerrainSource)
-                        {
-                            long terrainStart = Stopwatch.GetTimestamp();
-                            visualHeightmapRenderer.Render(visualTerrainSource, activeCamera);
-                            presentationTiming?.ObserveTerrain(
-                                ElapsedMs(terrainStart),
-                                visualHeightmapRenderer.ChunkBuildMsLastFrame,
-                                visualHeightmapRenderer.DrawnChunkCountLastFrame,
-                                visualHeightmapRenderer.BuiltChunkCountLastFrame);
-                        }
-                        else if (drawTerrain)
-                        {
-                            long terrainStart = Stopwatch.GetTimestamp();
-                            terrainRenderer.Render(engine.VertexMap, activeCamera);
-                            presentationTiming?.ObserveTerrain(
-                                ElapsedMs(terrainStart),
-                                terrainRenderer.ChunkBuildMsLastFrame,
-                                terrainRenderer.DrawnChunkCountLastFrame,
-                                terrainRenderer.BuiltChunkCountLastFrame);
-                        }
-                        else
-                        {
-                            presentationTiming?.ObserveTerrain(0d, 0d, 0, 0);
-                        }
-
-                        if (drawFieldOverlays && globalFieldVisualBuffer != null)
-                        {
-                            long fieldRenderStart = Stopwatch.GetTimestamp();
-                            fieldRenderPerformer.Draw(globalFieldVisualBuffer);
-                            presentationTiming?.ObserveGlobalFieldRender(
-                                ElapsedMs(fieldRenderStart),
-                                fieldRenderPerformer.LastFieldTextureCount,
-                                fieldRenderPerformer.LastDirtyUploadCount,
-                                fieldRenderPerformer.LastDirtyUploadArea,
-                                fieldRenderPerformer.LastDrawCount);
-                        }
-                        else
-                        {
-                            presentationTiming?.ObserveGlobalFieldRender(0d, 0, 0, 0, 0);
-                        }
-
-                        bool benchmarkDrew = false;
-                        if (benchmarkRenderer != null)
-                        {
-                            benchmarkDrew = benchmarkRenderer.Draw(activeCamera);
-                        }
-
-                        if (!benchmarkDrew &&
-                            drawPrimitives &&
-                            engine.TryGetService(CoreServiceKeys.PresentationPrimitiveDrawBuffer, out PrimitiveDrawBuffer draw) &&
-                            engine.TryGetService(CoreServiceKeys.PresentationMeshAssetRegistry, out MeshAssetRegistry meshes))
-                        {
-                            if (!_emptyBufferWarned && draw.GetSpan().Length == 0)
-                            {
-                                System.Diagnostics.Debug.WriteLine("[RaylibHostLoop] PrimitiveDrawBuffer is empty on first render frame; no Marker3D performers emitting?");
-                                _emptyBufferWarned = true;
-                            }
-                            long primitiveStart = Stopwatch.GetTimestamp();
-                            PrimitiveDrawBuffer? snapshot = engine.GetService(CoreServiceKeys.PresentationVisualSnapshotBuffer);
-                            SkinnedVisualBatchBuffer? skinnedBatch = engine.GetService(CoreServiceKeys.PresentationSkinnedVisualBatchBuffer);
-                            engine.TryGetService(CoreServiceKeys.VisualHeightmap, out IVisualHeightmap? visualHeightmap);
-                            primitiveRenderer.Draw(draw, activeCamera, snapshot, skinnedBatch, meshes, renderDebug.AcceptanceScaleMultiplier, visualHeightmap);
-                            presentationTiming?.ObservePrimitiveRender(
-                                ElapsedMs(primitiveStart),
-                                primitiveRenderer.LastInstancedInstances,
-                                primitiveRenderer.LastInstancedBatches,
-                                primitiveRenderer.LastInstancedMatrixBuildMs,
-                                primitiveRenderer.LastInstancedMeshDrawMs,
-                                primitiveRenderer.LastInstancedMatrixCacheHits,
-                                primitiveRenderer.LastInstancedMatrixCacheMisses,
-                                primitiveRenderer.LastPersistentSyncMs,
-                                primitiveRenderer.LastPersistentBucketDrawMs,
-                                primitiveRenderer.LastImmediateDrawMs,
-                                primitiveRenderer.LastImmediateSkippedCount,
-                                skinnedBatch?.Count ?? 0,
-                                primitiveRenderer.LastGpuSkinnedInstances,
-                                primitiveRenderer.LastGpuSkinnedBatches,
-                                primitiveRenderer.LastGpuSkinnedMatrixBuildMs,
-                                primitiveRenderer.LastGpuSkinnedMeshDrawMs);
-                        }
-                        else
-                        {
-                            presentationTiming?.ObservePrimitiveRender(0d, 0, 0);
-                        }
-
-                        // Draw ground overlays (range circles, cones, etc.)
-                        if (!cleanPerformanceMode &&
-                            engine.TryGetService(CoreServiceKeys.GroundOverlayBuffer, out GroundOverlayBuffer overlays) &&
-                            overlays.Count > 0)
-                        {
-                            long groundOverlayStart = Stopwatch.GetTimestamp();
-                            DrawGroundOverlays(overlays);
-                            presentationTiming?.ObserveGroundOverlayRender(ElapsedMs(groundOverlayStart), overlays.Count);
-                        }
-                        else
-                        {
-                            presentationTiming?.ObserveGroundOverlayRender(0d, 0);
-                        }
-
-                        if (!cleanPerformanceMode &&
-                            engine.GlobalContext.TryGetValue(CoreServiceKeys.RoadSplineBuffer.Name, out var splineObj) &&
-                            splineObj is RoadSplineBuffer roadSplines && roadSplines.Count > 0)
-                        {
-                            long roadSplineStart = Stopwatch.GetTimestamp();
-                            DrawRoadSplines(roadSplines);
-                            presentationTiming?.ObserveRoadSplineRender(ElapsedMs(roadSplineStart), roadSplines.Count);
-                        }
-                        else
-                        {
-                            presentationTiming?.ObserveRoadSplineRender(0d, 0);
-                        }
-
-                        if (drawDebugDraw &&
-                            engine.TryGetService(CoreServiceKeys.DebugDrawCommandBuffer, out DebugDrawCommandBuffer dd))
-                        {
-                            long debugDrawStart = Stopwatch.GetTimestamp();
-                            debugDrawRenderer.Draw(dd);
-                            presentationTiming?.ObserveDebugDrawRender(
-                                ElapsedMs(debugDrawStart),
-                                dd.Lines.Count + dd.Circles.Count + dd.Boxes.Count);
-                        }
-                        else
-                        {
-                            presentationTiming?.ObserveDebugDrawRender(0d, 0);
-                        }
-
-                        EndCoreMode3D();
-                        presentationTiming?.ObserveMode3D(ElapsedMs(mode3DStart));
-
-                        if (drawSkiaUi)
-                        {
-                            browserLayerRenderer.Render(uiRoot.Scene, lastW, lastH);
-                        }
-
-                        long overlayStart = Stopwatch.GetTimestamp();
-                        OverlayCompositeResult overlayResult = overlayCompositor.Render(
+                        RaylibRenderFrameResult frameRenderResult = frameRenderer.RenderFrame(new RaylibRenderFrame(
+                            activeCamera,
+                            activeCameraState,
+                            renderDebug,
                             overlayScene,
-                            uiRoot,
-                            skiaRenderer,
+                            lastW,
+                            lastH,
+                            runtimeStopwatch.Elapsed.TotalSeconds,
+                            activeMapRequestsDeepBackground,
+                            hostDebugGuidesSuppressed,
+                            drawTerrain,
+                            drawVisualHeightmap,
+                            hasVisualHeightmap,
+                            drawPrimitives,
+                            drawDebugDraw,
+                            drawFieldOverlays,
                             drawSkiaUi,
-                            hostDiagnosticUiSuppressed);
-                        presentationTiming?.ObserveUiRender(overlayResult.UiRenderMs);
-                        presentationTiming?.ObserveUiUpload(overlayResult.UploadMs);
-                        presentationTiming?.ObserveCompositeSkip(!overlayResult.RefreshComposite);
-                        screenOverlayBuffer?.Clear();
-                        presentationTiming?.ObserveScreenOverlayDraw(
-                            ElapsedMs(overlayStart),
-                            overlayResult.PaintMs,
-                            overlayResult.CompositeMs,
-                            overlayResult.UploadMs,
-                            overlayResult.FinalDrawMs,
-                            overlayCompositor.OverlayRenderer.RebuiltLaneCountLastFrame,
-                            overlayCompositor.OverlayRenderer.CachedTextLayoutCount);
+                            cleanPerformanceMode,
+                            hostDiagnosticUiSuppressed,
+                            _emptyBufferWarned));
+                        _emptyBufferWarned = frameRenderResult.EmptyBufferWarned;
                         if (timingLogIntervalFrames > 0 && frameIndex % timingLogIntervalFrames == 0)
                         {
                             SkiaOverlayRenderer overlaySkiaRenderer = overlayCompositor.OverlayRenderer;
@@ -747,58 +616,6 @@ namespace Ludots.Adapter.Raylib
                 visualHeightmapRenderer.Dispose();
                 engine.Dispose();
             }
-        }
-
-        private static unsafe void BeginCoreMode3D(in Camera3D camera, in CameraRenderState3D cameraState)
-        {
-            Rl.rlDrawRenderBatchActive();
-            Rl.rlMatrixMode((int)RlMatrixMode.RL_PROJECTION);
-            Rl.rlPushMatrix();
-            Rl.rlLoadIdentity();
-
-            CameraClipPlanes clipPlanes = CameraViewportUtil.ResolveClipPlanes(in cameraState);
-            float aspect = MathF.Max(0.001f, Rl.GetScreenWidth() / (float)Math.Max(1, Rl.GetScreenHeight()));
-            if (camera.projection == CameraProjection.CAMERA_ORTHOGRAPHIC)
-            {
-                double top = camera.fovy / 2.0;
-                double right = top * aspect;
-                Rl.rlOrtho(-right, right, -top, top, clipPlanes.NearMeters, clipPlanes.FarMeters);
-            }
-            else
-            {
-                double top = clipPlanes.NearMeters * Math.Tan(WorldPlane2D.DegToRadValue(camera.fovy) * 0.5);
-                double right = top * aspect;
-                Rl.rlFrustum(-right, right, -top, top, clipPlanes.NearMeters, clipPlanes.FarMeters);
-            }
-
-            Rl.rlMatrixMode((int)RlMatrixMode.RL_MODELVIEW);
-            Rl.rlLoadIdentity();
-            Matrix4x4 view = Matrix4x4.CreateLookAt(camera.position, camera.target, camera.up);
-            RaylibMatrix raylibView = RaylibMatrix.FromSystemNumerics(in view);
-            MultMatrix(in raylibView);
-            Rl.rlEnableDepthTest();
-        }
-
-        private static unsafe void MultMatrix(in RaylibMatrix matrix)
-        {
-            float* values = stackalloc float[16]
-            {
-                matrix.m0, matrix.m1, matrix.m2, matrix.m3,
-                matrix.m4, matrix.m5, matrix.m6, matrix.m7,
-                matrix.m8, matrix.m9, matrix.m10, matrix.m11,
-                matrix.m12, matrix.m13, matrix.m14, matrix.m15
-            };
-            Rl.rlMultMatrixf(values);
-        }
-
-        private static void EndCoreMode3D()
-        {
-            Rl.rlDrawRenderBatchActive();
-            Rl.rlMatrixMode((int)RlMatrixMode.RL_PROJECTION);
-            Rl.rlPopMatrix();
-            Rl.rlMatrixMode((int)RlMatrixMode.RL_MODELVIEW);
-            Rl.rlLoadIdentity();
-            Rl.rlDisableDepthTest();
         }
 
         private static void AppendRaylibDiagnostic(string? diagnosticPath, string message)
@@ -1091,13 +908,6 @@ namespace Ludots.Adapter.Raylib
                 '|' => PackDiagnosticGlyph(0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100),
                 _ => PackDiagnosticGlyph(0b11111, 0b10001, 0b00001, 0b00110, 0b00100, 0b00000, 0b00100),
             };
-        }
-
-        private static void Restore3DDepthState()
-        {
-            Rl.rlEnableDepthTest();
-            Rl.rlEnableDepthMask();
-            Rl.rlEnableBackfaceCulling();
         }
 
         private static string BuildTimingDiagnostic(
@@ -1733,346 +1543,5 @@ namespace Ludots.Adapter.Raylib
         {
             return (Stopwatch.GetTimestamp() - startTicks) * 1000.0 / Stopwatch.Frequency;
         }
-
-        private static void DrawInfiniteGrid(Vector3 anchor, int halfCount, float spacing, int majorEvery)
-        {
-            float y = -0.05f;
-            float extent = halfCount * spacing;
-
-            float minX = anchor.X - extent;
-            float minZ = anchor.Z - extent;
-
-            float startX = MathF.Floor(minX / spacing) * spacing;
-            float startZ = MathF.Floor(minZ / spacing) * spacing;
-
-            float endX = startX + 2f * extent;
-            float endZ = startZ + 2f * extent;
-
-            var minor = new Color(80, 80, 80, 255);
-            var major = new Color(130, 130, 130, 255);
-
-            int lineCount = halfCount * 2;
-            for (int i = 0; i <= lineCount; i++)
-            {
-                float x = startX + i * spacing;
-                float z = startZ + i * spacing;
-
-                int xi = (int)MathF.Round(x / spacing);
-                int zi = (int)MathF.Round(z / spacing);
-
-                var xCol = majorEvery > 0 && (xi % majorEvery) == 0 ? major : minor;
-                var zCol = majorEvery > 0 && (zi % majorEvery) == 0 ? major : minor;
-
-                Rl.DrawLine3D(new Vector3(x, y, startZ), new Vector3(x, y, endZ), xCol);
-                Rl.DrawLine3D(new Vector3(startX, y, z), new Vector3(endX, y, z), zCol);
-            }
-        }
-
-        private static void DrawGroundOverlays(GroundOverlayBuffer overlays)
-        {
-            var span = overlays.GetSpan();
-            for (int i = 0; i < span.Length; i++)
-            {
-                ref readonly var item = ref span[i];
-                switch (item.Shape)
-                {
-                    case GroundOverlayShape.Circle:
-                        DrawGroundCircle(in item);
-                        break;
-                    case GroundOverlayShape.Cone:
-                        DrawGroundCone(in item);
-                        break;
-                    case GroundOverlayShape.Ring:
-                        DrawGroundRing(in item);
-                        break;
-                    case GroundOverlayShape.Line:
-                        DrawGroundLine(in item);
-                        break;
-                }
-            }
-        }
-
-        private static void DrawRoadSplines(RoadSplineBuffer splines)
-        {
-            ReadOnlySpan<float> p0x = splines.P0X;
-            ReadOnlySpan<float> p0y = splines.P0Y;
-            ReadOnlySpan<float> p0z = splines.P0Z;
-            ReadOnlySpan<float> p1x = splines.P1X;
-            ReadOnlySpan<float> p1y = splines.P1Y;
-            ReadOnlySpan<float> p1z = splines.P1Z;
-            ReadOnlySpan<float> p2x = splines.P2X;
-            ReadOnlySpan<float> p2y = splines.P2Y;
-            ReadOnlySpan<float> p2z = splines.P2Z;
-            ReadOnlySpan<float> p3x = splines.P3X;
-            ReadOnlySpan<float> p3y = splines.P3Y;
-            ReadOnlySpan<float> p3z = splines.P3Z;
-            ReadOnlySpan<float> width = splines.Width;
-            ReadOnlySpan<float> borderWidth = splines.BorderWidth;
-            ReadOnlySpan<float> fillR = splines.FillR;
-            ReadOnlySpan<float> fillG = splines.FillG;
-            ReadOnlySpan<float> fillB = splines.FillB;
-            ReadOnlySpan<float> fillA = splines.FillA;
-            ReadOnlySpan<float> borderR = splines.BorderR;
-            ReadOnlySpan<float> borderG = splines.BorderG;
-            ReadOnlySpan<float> borderB = splines.BorderB;
-            ReadOnlySpan<float> borderA = splines.BorderA;
-
-            for (int i = 0; i < splines.Count; i++)
-            {
-                Vector3 p0 = new(p0x[i], p0y[i], p0z[i]);
-                Vector3 p1 = new(p1x[i], p1y[i], p1z[i]);
-                Vector3 p2 = new(p2x[i], p2y[i], p2z[i]);
-                Vector3 p3 = new(p3x[i], p3y[i], p3z[i]);
-                float drawWidth = MathF.Max(0.02f, width[i]);
-                float drawBorder = MathF.Max(0.01f, borderWidth[i]);
-                var fill = ToRaylibColor(new Vector4(fillR[i], fillG[i], fillB[i], fillA[i]));
-                var border = ToRaylibColor(new Vector4(borderR[i], borderG[i], borderB[i], borderA[i]));
-                DrawRoadSplineRibbon(p0, p1, p2, p3, drawWidth, fill, border, drawBorder);
-            }
-        }
-
-        private static void DrawRoadSplineRibbon(
-            in Vector3 p0,
-            in Vector3 p1,
-            in Vector3 p2,
-            in Vector3 p3,
-            float width,
-            Color fill,
-            Color border,
-            float borderWidth)
-        {
-            const int samples = 20;
-            Span<Vector3> points = stackalloc Vector3[samples + 1];
-            for (int i = 0; i <= samples; i++)
-            {
-                float t = i / (float)samples;
-                points[i] = EvaluateCubicBezier(p0, p1, p2, p3, t);
-            }
-
-            if (fill.a > 0)
-            {
-                int lanes = Math.Max(1, (int)MathF.Ceiling(width / 0.08f));
-                for (int lane = 0; lane < lanes; lane++)
-                {
-                    float alpha = lanes == 1 ? 0f : lane / (float)(lanes - 1);
-                    float offset = (alpha - 0.5f) * width;
-                    DrawOffsetPolyline(points, offset, fill);
-                }
-            }
-
-            if (border.a > 0)
-            {
-                float edgeOffset = (width * 0.5f) + borderWidth;
-                DrawOffsetPolyline(points, edgeOffset, border);
-                DrawOffsetPolyline(points, -edgeOffset, border);
-            }
-        }
-
-        private static void DrawOffsetPolyline(ReadOnlySpan<Vector3> points, float offset, Color color)
-        {
-            if (points.Length < 2)
-            {
-                return;
-            }
-
-            Vector3 previous = OffsetPoint(points, 0, offset);
-            for (int i = 1; i < points.Length; i++)
-            {
-                Vector3 current = OffsetPoint(points, i, offset);
-                Rl.DrawLine3D(previous, current, color);
-                previous = current;
-            }
-        }
-
-        private static Vector3 OffsetPoint(ReadOnlySpan<Vector3> points, int index, float offset)
-        {
-            Vector3 current = points[index];
-            Vector3 forward = index == points.Length - 1
-                ? current - points[index - 1]
-                : points[index + 1] - current;
-            Vector2 lateral = new(-forward.Z, forward.X);
-            float length = lateral.Length();
-            if (length <= 0.0001f)
-            {
-                return current;
-            }
-
-            lateral /= length;
-            return new Vector3(current.X + lateral.X * offset, current.Y, current.Z + lateral.Y * offset);
-        }
-
-        private static Vector3 EvaluateCubicBezier(in Vector3 p0, in Vector3 p1, in Vector3 p2, in Vector3 p3, float t)
-        {
-            float oneMinusT = 1f - t;
-            float a = oneMinusT * oneMinusT * oneMinusT;
-            float b = 3f * oneMinusT * oneMinusT * t;
-            float c = 3f * oneMinusT * t * t;
-            float d = t * t * t;
-            return (p0 * a) + (p1 * b) + (p2 * c) + (p3 * d);
-        }
-
-        private static void DrawGroundCircle(in GroundOverlayItem item)
-        {
-            const int segments = 48;
-            float step = MathF.PI * 2f / segments;
-            var center = item.Center;
-
-            // Draw fill as multiple concentric rings (approximation since Raylib has no DrawTriangle3D)
-            if (item.FillColor.W > 0.01f)
-            {
-                var fillColor = ToRaylibColor(item.FillColor);
-                const int fillRings = 4;
-                for (int r = 1; r <= fillRings; r++)
-                {
-                    float radius = item.Radius * r / fillRings;
-                    for (int s = 0; s < segments; s++)
-                    {
-                        float a0 = s * step;
-                        float a1 = (s + 1) * step;
-                        var p0 = new Vector3(center.X + MathF.Cos(a0) * radius, center.Y, center.Z + MathF.Sin(a0) * radius);
-                        var p1 = new Vector3(center.X + MathF.Cos(a1) * radius, center.Y, center.Z + MathF.Sin(a1) * radius);
-                        Rl.DrawLine3D(p0, p1, fillColor);
-                    }
-                }
-            }
-
-            // Draw border as line loop (outermost ring, thicker appearance via slight offset)
-            if (item.BorderColor.W > 0.01f && item.BorderWidth > 0f)
-            {
-                var border = ToRaylibColor(item.BorderColor);
-                for (int s = 0; s < segments; s++)
-                {
-                    float a0 = s * step;
-                    float a1 = (s + 1) * step;
-                    var p0 = new Vector3(center.X + MathF.Cos(a0) * item.Radius, center.Y, center.Z + MathF.Sin(a0) * item.Radius);
-                    var p1 = new Vector3(center.X + MathF.Cos(a1) * item.Radius, center.Y, center.Z + MathF.Sin(a1) * item.Radius);
-                    Rl.DrawLine3D(p0, p1, border);
-                }
-            }
-        }
-
-        private static void DrawGroundRing(in GroundOverlayItem item)
-        {
-            const int segments = 48;
-            float innerRadius = Math.Clamp(item.InnerRadius, 0f, item.Radius);
-            float outerRadius = MathF.Max(item.Radius, innerRadius);
-            var center = item.Center;
-
-            if (item.FillColor.W > 0.01f && outerRadius > innerRadius)
-            {
-                var fillColor = ToRaylibColor(item.FillColor);
-                const int bands = 6;
-                for (int band = 0; band < bands; band++)
-                {
-                    float radius = innerRadius + (outerRadius - innerRadius) * (band + 0.5f) / bands;
-                    DrawGroundArcLoop(center, radius, 0f, MathF.PI * 2f, segments, fillColor);
-                }
-            }
-
-            if (item.BorderColor.W > 0.01f && item.BorderWidth > 0f)
-            {
-                var border = ToRaylibColor(item.BorderColor);
-                DrawGroundArcLoop(center, outerRadius, 0f, MathF.PI * 2f, segments, border);
-                if (innerRadius > 0.001f)
-                {
-                    DrawGroundArcLoop(center, innerRadius, 0f, MathF.PI * 2f, segments, border);
-                }
-            }
-        }
-
-        private static void DrawGroundCone(in GroundOverlayItem item)
-        {
-            const int segments = 24;
-            float radius = MathF.Max(item.Radius, 0f);
-            float start = item.Rotation - item.Angle;
-            float end = item.Rotation + item.Angle;
-            var center = item.Center;
-
-            if (radius <= 0f)
-            {
-                return;
-            }
-
-            if (item.FillColor.W > 0.01f)
-            {
-                var fillColor = ToRaylibColor(item.FillColor);
-                const int bands = 6;
-                for (int band = 1; band <= bands; band++)
-                {
-                    float ringRadius = radius * band / bands;
-                    DrawGroundArcLoop(center, ringRadius, start, end, segments, fillColor);
-                }
-            }
-
-            if (item.BorderColor.W > 0.01f && item.BorderWidth > 0f)
-            {
-                var border = ToRaylibColor(item.BorderColor);
-                DrawGroundArcLoop(center, radius, start, end, segments, border);
-                var left = new Vector3(center.X + MathF.Cos(start) * radius, center.Y, center.Z + MathF.Sin(start) * radius);
-                var right = new Vector3(center.X + MathF.Cos(end) * radius, center.Y, center.Z + MathF.Sin(end) * radius);
-                Rl.DrawLine3D(center, left, border);
-                Rl.DrawLine3D(center, right, border);
-            }
-        }
-
-        private static void DrawGroundLine(in GroundOverlayItem item)
-        {
-            float length = item.Length > 0f ? item.Length : item.Radius;
-            if (length <= 0f)
-            {
-                return;
-            }
-
-            float dx = MathF.Cos(item.Rotation) * length;
-            float dz = MathF.Sin(item.Rotation) * length;
-            var a = item.Center;
-            var b = new Vector3(a.X + dx, a.Y, a.Z + dz);
-            float halfWidth = MathF.Max(0f, item.Width) * 0.5f;
-            var normal = new Vector3(-MathF.Sin(item.Rotation), 0f, MathF.Cos(item.Rotation));
-
-            if (item.FillColor.W > 0.01f)
-            {
-                var fill = ToRaylibColor(item.FillColor);
-                int stripes = halfWidth > 0.001f ? Math.Clamp((int)MathF.Ceiling(halfWidth / 0.12f), 1, 8) : 1;
-                for (int stripe = -stripes; stripe <= stripes; stripe++)
-                {
-                    float offset = stripes == 0 ? 0f : halfWidth * stripe / Math.Max(stripes, 1);
-                    var delta = normal * offset;
-                    Rl.DrawLine3D(a + delta, b + delta, fill);
-                }
-            }
-
-            if (item.BorderColor.W > 0.01f)
-            {
-                var border = ToRaylibColor(item.BorderColor);
-                Rl.DrawLine3D(a, b, border);
-                if (halfWidth > 0.001f)
-                {
-                    var delta = normal * halfWidth;
-                    Rl.DrawLine3D(a + delta, b + delta, border);
-                    Rl.DrawLine3D(a - delta, b - delta, border);
-                }
-            }
-        }
-
-        private static void DrawGroundArcLoop(Vector3 center, float radius, float startAngle, float endAngle, int segments, Color color)
-        {
-            if (segments <= 0 || radius <= 0f)
-            {
-                return;
-            }
-
-            float step = (endAngle - startAngle) / segments;
-            for (int s = 0; s < segments; s++)
-            {
-                float a0 = startAngle + s * step;
-                float a1 = startAngle + (s + 1) * step;
-                var p0 = new Vector3(center.X + MathF.Cos(a0) * radius, center.Y, center.Z + MathF.Sin(a0) * radius);
-                var p1 = new Vector3(center.X + MathF.Cos(a1) * radius, center.Y, center.Z + MathF.Sin(a1) * radius);
-                Rl.DrawLine3D(p0, p1, color);
-            }
-        }
-
-        private static Color ToRaylibColor(Vector4 c) => RaylibColorUtil.ToRaylibColor(in c);
     }
 }

--- a/src/Adapters/Raylib/Ludots.Adapter.Raylib/Rendering/RaylibFrameRenderer.cs
+++ b/src/Adapters/Raylib/Ludots.Adapter.Raylib/Rendering/RaylibFrameRenderer.cs
@@ -1,0 +1,522 @@
+using System;
+using System.Diagnostics;
+using System.Numerics;
+using Ludots.Adapter.Raylib.Services;
+using Ludots.Client.Raylib.Rendering;
+using Ludots.Core.Diagnostics;
+using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.Camera;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Presentation.Assets;
+using Ludots.Core.Presentation.Camera;
+using Ludots.Core.Presentation.DebugDraw;
+using Ludots.Core.Presentation.Hud;
+using Ludots.Core.Presentation.Rendering;
+using Ludots.Core.Presentation.Terrain;
+using Ludots.Core.Scripting;
+using Ludots.UI;
+using Ludots.UI.Skia;
+using Raylib_cs;
+using Rl = Raylib_cs.Raylib;
+
+namespace Ludots.Adapter.Raylib
+{
+    internal enum RaylibFramePass
+    {
+        Clear,
+        BeginWorld3D,
+        DebugGuides,
+        Terrain,
+        GlobalField,
+        BenchmarkScene,
+        PrimitiveVisuals,
+        GroundOverlay,
+        RoadSpline,
+        DebugDraw,
+        EndWorld3D,
+        BrowserLayer,
+        OverlayComposite,
+    }
+
+    internal readonly record struct RaylibFramePassPlanInput(
+        bool DrawDebugGuides,
+        bool DrawTerrain,
+        bool DrawVisualHeightmap,
+        bool HasGlobalFieldBuffer,
+        bool DrawFieldOverlays,
+        bool HasBenchmarkRenderer,
+        bool DrawPrimitives,
+        bool HasGroundOverlays,
+        bool HasRoadSplines,
+        bool DrawDebugDraw,
+        bool DrawSkiaUi);
+
+    internal readonly record struct RaylibRenderFrame(
+        Camera3D ActiveCamera,
+        CameraRenderState3D ActiveCameraState,
+        RenderDebugState RenderDebug,
+        PresentationOverlayScene? OverlayScene,
+        int Width,
+        int Height,
+        double TimeSeconds,
+        bool ActiveMapRequestsDeepBackground,
+        bool HostDebugGuidesSuppressed,
+        bool DrawTerrain,
+        bool DrawVisualHeightmap,
+        bool HasVisualHeightmap,
+        bool DrawPrimitives,
+        bool DrawDebugDraw,
+        bool DrawFieldOverlays,
+        bool DrawSkiaUi,
+        bool CleanPerformanceMode,
+        bool HostDiagnosticUiSuppressed,
+        bool EmptyBufferWarned);
+
+    internal readonly record struct RaylibRenderFrameResult(bool EmptyBufferWarned);
+
+    internal sealed class RaylibFrameRenderer
+    {
+        private readonly GameEngine _engine;
+        private readonly UIRoot _uiRoot;
+        private readonly SkiaUiRenderer _skiaRenderer;
+        private readonly RaylibOverlayCompositor _overlayCompositor;
+        private readonly RaylibBrowserLayerRenderer _browserLayerRenderer;
+        private readonly RaylibTerrainRenderer _terrainRenderer;
+        private readonly RaylibVisualHeightmapRenderer _visualHeightmapRenderer;
+        private readonly RaylibFieldRenderPerformer _fieldRenderPerformer;
+        private readonly RaylibPrimitiveRenderer _primitiveRenderer;
+        private readonly RaylibDebugDrawRenderer _debugDrawRenderer;
+        private readonly RaylibBenchmarkRenderService? _benchmarkRenderer;
+        private readonly GlobalFieldVisualBuffer? _globalFieldVisualBuffer;
+        private readonly ScreenOverlayBuffer? _screenOverlayBuffer;
+        private readonly PresentationTimingDiagnostics? _presentationTiming;
+
+        public RaylibFrameRenderer(
+            GameEngine engine,
+            UIRoot uiRoot,
+            SkiaUiRenderer skiaRenderer,
+            RaylibOverlayCompositor overlayCompositor,
+            RaylibBrowserLayerRenderer browserLayerRenderer,
+            RaylibTerrainRenderer terrainRenderer,
+            RaylibVisualHeightmapRenderer visualHeightmapRenderer,
+            RaylibFieldRenderPerformer fieldRenderPerformer,
+            RaylibPrimitiveRenderer primitiveRenderer,
+            RaylibDebugDrawRenderer debugDrawRenderer,
+            RaylibBenchmarkRenderService? benchmarkRenderer,
+            GlobalFieldVisualBuffer? globalFieldVisualBuffer,
+            ScreenOverlayBuffer? screenOverlayBuffer,
+            PresentationTimingDiagnostics? presentationTiming)
+        {
+            _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+            _uiRoot = uiRoot ?? throw new ArgumentNullException(nameof(uiRoot));
+            _skiaRenderer = skiaRenderer ?? throw new ArgumentNullException(nameof(skiaRenderer));
+            _overlayCompositor = overlayCompositor ?? throw new ArgumentNullException(nameof(overlayCompositor));
+            _browserLayerRenderer = browserLayerRenderer ?? throw new ArgumentNullException(nameof(browserLayerRenderer));
+            _terrainRenderer = terrainRenderer ?? throw new ArgumentNullException(nameof(terrainRenderer));
+            _visualHeightmapRenderer = visualHeightmapRenderer ?? throw new ArgumentNullException(nameof(visualHeightmapRenderer));
+            _fieldRenderPerformer = fieldRenderPerformer ?? throw new ArgumentNullException(nameof(fieldRenderPerformer));
+            _primitiveRenderer = primitiveRenderer ?? throw new ArgumentNullException(nameof(primitiveRenderer));
+            _debugDrawRenderer = debugDrawRenderer ?? throw new ArgumentNullException(nameof(debugDrawRenderer));
+            _benchmarkRenderer = benchmarkRenderer;
+            _globalFieldVisualBuffer = globalFieldVisualBuffer;
+            _screenOverlayBuffer = screenOverlayBuffer;
+            _presentationTiming = presentationTiming;
+        }
+
+        public RaylibRenderFrameResult RenderFrame(in RaylibRenderFrame frame)
+        {
+            bool emptyBufferWarned = frame.EmptyBufferWarned;
+            long beginDrawingStart = Stopwatch.GetTimestamp();
+            Rl.BeginDrawing();
+            _presentationTiming?.ObserveBeginDrawing(ElapsedMs(beginDrawingStart));
+            Restore3DDepthState();
+            Rl.ClearBackground(frame.ActiveMapRequestsDeepBackground
+                ? new Color(6, 10, 16, 255)
+                : new Color(0, 0, 0, 255));
+
+            long mode3DStart = Stopwatch.GetTimestamp();
+            Restore3DDepthState();
+            CameraRenderState3D activeCameraState = frame.ActiveCameraState;
+            BeginCoreMode3D(frame.ActiveCamera, in activeCameraState);
+            Restore3DDepthState();
+
+            DrawDebugGuides(in frame);
+            DrawTerrain(in frame);
+            DrawGlobalFields(in frame);
+            bool benchmarkDrew = DrawBenchmarkScene(frame.ActiveCamera);
+            emptyBufferWarned = DrawPrimitiveVisuals(in frame, benchmarkDrew, emptyBufferWarned);
+            DrawGroundOverlays(frame.CleanPerformanceMode);
+            DrawRoadSplines(frame.CleanPerformanceMode);
+            DrawDebugCommands(in frame);
+
+            EndCoreMode3D();
+            _presentationTiming?.ObserveMode3D(ElapsedMs(mode3DStart));
+
+            DrawUiLayers(in frame);
+            return new RaylibRenderFrameResult(emptyBufferWarned);
+        }
+
+        public static int BuildPassPlan(in RaylibFramePassPlanInput input, Span<RaylibFramePass> output)
+        {
+            int count = 0;
+            Add(output, ref count, RaylibFramePass.Clear);
+            Add(output, ref count, RaylibFramePass.BeginWorld3D);
+            if (input.DrawDebugGuides)
+            {
+                Add(output, ref count, RaylibFramePass.DebugGuides);
+            }
+
+            if (input.DrawTerrain || input.DrawVisualHeightmap)
+            {
+                Add(output, ref count, RaylibFramePass.Terrain);
+            }
+
+            if (input.DrawFieldOverlays && input.HasGlobalFieldBuffer)
+            {
+                Add(output, ref count, RaylibFramePass.GlobalField);
+            }
+
+            if (input.HasBenchmarkRenderer)
+            {
+                Add(output, ref count, RaylibFramePass.BenchmarkScene);
+            }
+
+            if (input.DrawPrimitives)
+            {
+                Add(output, ref count, RaylibFramePass.PrimitiveVisuals);
+            }
+
+            if (input.HasGroundOverlays)
+            {
+                Add(output, ref count, RaylibFramePass.GroundOverlay);
+            }
+
+            if (input.HasRoadSplines)
+            {
+                Add(output, ref count, RaylibFramePass.RoadSpline);
+            }
+
+            if (input.DrawDebugDraw)
+            {
+                Add(output, ref count, RaylibFramePass.DebugDraw);
+            }
+
+            Add(output, ref count, RaylibFramePass.EndWorld3D);
+            if (input.DrawSkiaUi)
+            {
+                Add(output, ref count, RaylibFramePass.BrowserLayer);
+            }
+
+            Add(output, ref count, RaylibFramePass.OverlayComposite);
+            return count;
+        }
+
+        private static void Add(Span<RaylibFramePass> output, ref int count, RaylibFramePass pass)
+        {
+            if (count >= output.Length)
+            {
+                throw new InvalidOperationException(
+                    $"Raylib frame pass output capacity {output.Length} is too small.");
+            }
+
+            output[count++] = pass;
+        }
+
+        private void DrawDebugGuides(in RaylibRenderFrame frame)
+        {
+            if (!frame.DrawDebugDraw ||
+                (frame.DrawVisualHeightmap && frame.HasVisualHeightmap) ||
+                frame.HostDebugGuidesSuppressed)
+            {
+                return;
+            }
+
+            DrawInfiniteGrid(frame.ActiveCamera.target, 300, 1.0f, 10);
+
+            Vector3 target = frame.ActiveCamera.target;
+            Rl.DrawLine3D(target, target + new Vector3(2.0f, 0, 0), Color.RED);
+            Rl.DrawLine3D(target, target + new Vector3(0, 0, 2.0f), Color.BLUE);
+            Rl.DrawLine3D(target, target + new Vector3(0, 2.0f, 0), Color.GREEN);
+        }
+
+        private void DrawTerrain(in RaylibRenderFrame frame)
+        {
+            if (frame.DrawVisualHeightmap &&
+                _engine.TryGetService(CoreServiceKeys.VisualHeightmap, out IVisualHeightmap? visualHeightmapForTerrain) &&
+                visualHeightmapForTerrain is IVisualHeightmapRenderSource visualTerrainSource)
+            {
+                long terrainStart = Stopwatch.GetTimestamp();
+                _visualHeightmapRenderer.Render(visualTerrainSource, frame.ActiveCamera);
+                _presentationTiming?.ObserveTerrain(
+                    ElapsedMs(terrainStart),
+                    _visualHeightmapRenderer.ChunkBuildMsLastFrame,
+                    _visualHeightmapRenderer.DrawnChunkCountLastFrame,
+                    _visualHeightmapRenderer.BuiltChunkCountLastFrame);
+                return;
+            }
+
+            if (frame.DrawTerrain)
+            {
+                long terrainStart = Stopwatch.GetTimestamp();
+                _terrainRenderer.Render(_engine.VertexMap, frame.ActiveCamera);
+                _presentationTiming?.ObserveTerrain(
+                    ElapsedMs(terrainStart),
+                    _terrainRenderer.ChunkBuildMsLastFrame,
+                    _terrainRenderer.DrawnChunkCountLastFrame,
+                    _terrainRenderer.BuiltChunkCountLastFrame);
+                return;
+            }
+
+            _presentationTiming?.ObserveTerrain(0d, 0d, 0, 0);
+        }
+
+        private void DrawGlobalFields(in RaylibRenderFrame frame)
+        {
+            if (frame.DrawFieldOverlays && _globalFieldVisualBuffer != null)
+            {
+                long fieldRenderStart = Stopwatch.GetTimestamp();
+                _fieldRenderPerformer.Draw(_globalFieldVisualBuffer);
+                _presentationTiming?.ObserveGlobalFieldRender(
+                    ElapsedMs(fieldRenderStart),
+                    _fieldRenderPerformer.LastFieldTextureCount,
+                    _fieldRenderPerformer.LastDirtyUploadCount,
+                    _fieldRenderPerformer.LastDirtyUploadArea,
+                    _fieldRenderPerformer.LastDrawCount);
+                return;
+            }
+
+            _presentationTiming?.ObserveGlobalFieldRender(0d, 0, 0, 0, 0);
+        }
+
+        private bool DrawBenchmarkScene(in Camera3D activeCamera)
+        {
+            return _benchmarkRenderer != null && _benchmarkRenderer.Draw(activeCamera);
+        }
+
+        private bool DrawPrimitiveVisuals(
+            in RaylibRenderFrame frame,
+            bool benchmarkDrew,
+            bool emptyBufferWarned)
+        {
+            if (!benchmarkDrew &&
+                frame.DrawPrimitives &&
+                _engine.TryGetService(CoreServiceKeys.PresentationPrimitiveDrawBuffer, out PrimitiveDrawBuffer draw) &&
+                _engine.TryGetService(CoreServiceKeys.PresentationMeshAssetRegistry, out MeshAssetRegistry meshes))
+            {
+                if (!emptyBufferWarned && draw.GetSpan().Length == 0)
+                {
+                    Debug.WriteLine("[RaylibHostLoop] PrimitiveDrawBuffer is empty on first render frame; no Marker3D performers emitting?");
+                    emptyBufferWarned = true;
+                }
+
+                long primitiveStart = Stopwatch.GetTimestamp();
+                PrimitiveDrawBuffer? snapshot = _engine.GetService(CoreServiceKeys.PresentationVisualSnapshotBuffer);
+                SkinnedVisualBatchBuffer? skinnedBatch = _engine.GetService(CoreServiceKeys.PresentationSkinnedVisualBatchBuffer);
+                _engine.TryGetService(CoreServiceKeys.VisualHeightmap, out IVisualHeightmap? visualHeightmap);
+                _primitiveRenderer.Draw(
+                    draw,
+                    frame.ActiveCamera,
+                    snapshot,
+                    skinnedBatch,
+                    meshes,
+                    frame.RenderDebug.AcceptanceScaleMultiplier,
+                    visualHeightmap,
+                    frame.TimeSeconds);
+                _presentationTiming?.ObservePrimitiveRender(
+                    ElapsedMs(primitiveStart),
+                    _primitiveRenderer.LastInstancedInstances,
+                    _primitiveRenderer.LastInstancedBatches,
+                    _primitiveRenderer.LastInstancedMatrixBuildMs,
+                    _primitiveRenderer.LastInstancedMeshDrawMs,
+                    _primitiveRenderer.LastInstancedMatrixCacheHits,
+                    _primitiveRenderer.LastInstancedMatrixCacheMisses,
+                    _primitiveRenderer.LastPersistentSyncMs,
+                    _primitiveRenderer.LastPersistentBucketDrawMs,
+                    _primitiveRenderer.LastImmediateDrawMs,
+                    _primitiveRenderer.LastImmediateSkippedCount,
+                    skinnedBatch?.Count ?? 0,
+                    _primitiveRenderer.LastGpuSkinnedInstances,
+                    _primitiveRenderer.LastGpuSkinnedBatches,
+                    _primitiveRenderer.LastGpuSkinnedMatrixBuildMs,
+                    _primitiveRenderer.LastGpuSkinnedMeshDrawMs);
+                return emptyBufferWarned;
+            }
+
+            _presentationTiming?.ObservePrimitiveRender(0d, 0, 0);
+            return emptyBufferWarned;
+        }
+
+        private void DrawGroundOverlays(bool cleanPerformanceMode)
+        {
+            if (!cleanPerformanceMode &&
+                _engine.TryGetService(CoreServiceKeys.GroundOverlayBuffer, out GroundOverlayBuffer overlays) &&
+                overlays.Count > 0)
+            {
+                long groundOverlayStart = Stopwatch.GetTimestamp();
+                RaylibWorldOverlayRenderer.DrawGroundOverlays(overlays);
+                _presentationTiming?.ObserveGroundOverlayRender(ElapsedMs(groundOverlayStart), overlays.Count);
+                return;
+            }
+
+            _presentationTiming?.ObserveGroundOverlayRender(0d, 0);
+        }
+
+        private void DrawRoadSplines(bool cleanPerformanceMode)
+        {
+            if (!cleanPerformanceMode &&
+                _engine.GlobalContext.TryGetValue(CoreServiceKeys.RoadSplineBuffer.Name, out object? splineObj) &&
+                splineObj is RoadSplineBuffer roadSplines &&
+                roadSplines.Count > 0)
+            {
+                long roadSplineStart = Stopwatch.GetTimestamp();
+                RaylibWorldOverlayRenderer.DrawRoadSplines(roadSplines);
+                _presentationTiming?.ObserveRoadSplineRender(ElapsedMs(roadSplineStart), roadSplines.Count);
+                return;
+            }
+
+            _presentationTiming?.ObserveRoadSplineRender(0d, 0);
+        }
+
+        private void DrawDebugCommands(in RaylibRenderFrame frame)
+        {
+            if (frame.DrawDebugDraw &&
+                _engine.TryGetService(CoreServiceKeys.DebugDrawCommandBuffer, out DebugDrawCommandBuffer dd))
+            {
+                long debugDrawStart = Stopwatch.GetTimestamp();
+                _debugDrawRenderer.Draw(dd);
+                _presentationTiming?.ObserveDebugDrawRender(
+                    ElapsedMs(debugDrawStart),
+                    dd.Lines.Count + dd.Circles.Count + dd.Boxes.Count);
+                return;
+            }
+
+            _presentationTiming?.ObserveDebugDrawRender(0d, 0);
+        }
+
+        private void DrawUiLayers(in RaylibRenderFrame frame)
+        {
+            if (frame.DrawSkiaUi)
+            {
+                _browserLayerRenderer.Render(_uiRoot.Scene, frame.Width, frame.Height);
+            }
+
+            long overlayStart = Stopwatch.GetTimestamp();
+            OverlayCompositeResult overlayResult = _overlayCompositor.Render(
+                frame.OverlayScene,
+                _uiRoot,
+                _skiaRenderer,
+                frame.DrawSkiaUi,
+                frame.HostDiagnosticUiSuppressed);
+            _presentationTiming?.ObserveUiRender(overlayResult.UiRenderMs);
+            _presentationTiming?.ObserveUiUpload(overlayResult.UploadMs);
+            _presentationTiming?.ObserveCompositeSkip(!overlayResult.RefreshComposite);
+            _screenOverlayBuffer?.Clear();
+            _presentationTiming?.ObserveScreenOverlayDraw(
+                ElapsedMs(overlayStart),
+                overlayResult.PaintMs,
+                overlayResult.CompositeMs,
+                overlayResult.UploadMs,
+                overlayResult.FinalDrawMs,
+                _overlayCompositor.OverlayRenderer.RebuiltLaneCountLastFrame,
+                _overlayCompositor.OverlayRenderer.CachedTextLayoutCount);
+        }
+
+        internal static void Restore3DDepthState()
+        {
+            Rl.rlEnableDepthTest();
+            Rl.rlEnableDepthMask();
+            Rl.rlEnableBackfaceCulling();
+        }
+
+        internal static unsafe void BeginCoreMode3D(in Camera3D camera, in CameraRenderState3D cameraState)
+        {
+            Rl.rlDrawRenderBatchActive();
+            Rl.rlMatrixMode((int)RlMatrixMode.RL_PROJECTION);
+            Rl.rlPushMatrix();
+            Rl.rlLoadIdentity();
+
+            CameraClipPlanes clipPlanes = CameraViewportUtil.ResolveClipPlanes(in cameraState);
+            float aspect = MathF.Max(0.001f, Rl.GetScreenWidth() / (float)Math.Max(1, Rl.GetScreenHeight()));
+            if (camera.projection == CameraProjection.CAMERA_ORTHOGRAPHIC)
+            {
+                double top = camera.fovy / 2.0;
+                double right = top * aspect;
+                Rl.rlOrtho(-right, right, -top, top, clipPlanes.NearMeters, clipPlanes.FarMeters);
+            }
+            else
+            {
+                double top = clipPlanes.NearMeters * Math.Tan(WorldPlane2D.DegToRadValue(camera.fovy) * 0.5);
+                double right = top * aspect;
+                Rl.rlFrustum(-right, right, -top, top, clipPlanes.NearMeters, clipPlanes.FarMeters);
+            }
+
+            Rl.rlMatrixMode((int)RlMatrixMode.RL_MODELVIEW);
+            Rl.rlLoadIdentity();
+            Matrix4x4 view = Matrix4x4.CreateLookAt(camera.position, camera.target, camera.up);
+            RaylibMatrix raylibView = RaylibMatrix.FromSystemNumerics(in view);
+            MultMatrix(in raylibView);
+            Rl.rlEnableDepthTest();
+        }
+
+        internal static void EndCoreMode3D()
+        {
+            Rl.rlDrawRenderBatchActive();
+            Rl.rlMatrixMode((int)RlMatrixMode.RL_PROJECTION);
+            Rl.rlPopMatrix();
+            Rl.rlMatrixMode((int)RlMatrixMode.RL_MODELVIEW);
+            Rl.rlLoadIdentity();
+            Rl.rlDisableDepthTest();
+        }
+
+        private static unsafe void MultMatrix(in RaylibMatrix matrix)
+        {
+            float* values = stackalloc float[16]
+            {
+                matrix.m0, matrix.m1, matrix.m2, matrix.m3,
+                matrix.m4, matrix.m5, matrix.m6, matrix.m7,
+                matrix.m8, matrix.m9, matrix.m10, matrix.m11,
+                matrix.m12, matrix.m13, matrix.m14, matrix.m15
+            };
+            Rl.rlMultMatrixf(values);
+        }
+
+        private static void DrawInfiniteGrid(Vector3 anchor, int halfCount, float spacing, int majorEvery)
+        {
+            float y = -0.05f;
+            float extent = halfCount * spacing;
+
+            float minX = anchor.X - extent;
+            float minZ = anchor.Z - extent;
+
+            float startX = MathF.Floor(minX / spacing) * spacing;
+            float startZ = MathF.Floor(minZ / spacing) * spacing;
+
+            float endX = startX + 2f * extent;
+            float endZ = startZ + 2f * extent;
+
+            var minor = new Color(80, 80, 80, 255);
+            var major = new Color(130, 130, 130, 255);
+
+            int lineCount = halfCount * 2;
+            for (int i = 0; i <= lineCount; i++)
+            {
+                float x = startX + i * spacing;
+                float z = startZ + i * spacing;
+
+                int xi = (int)MathF.Round(x / spacing);
+                int zi = (int)MathF.Round(z / spacing);
+
+                Color xCol = majorEvery > 0 && (xi % majorEvery) == 0 ? major : minor;
+                Color zCol = majorEvery > 0 && (zi % majorEvery) == 0 ? major : minor;
+
+                Rl.DrawLine3D(new Vector3(x, y, startZ), new Vector3(x, y, endZ), xCol);
+                Rl.DrawLine3D(new Vector3(startX, y, z), new Vector3(endX, y, z), zCol);
+            }
+        }
+
+        private static double ElapsedMs(long startTicks)
+        {
+            return (Stopwatch.GetTimestamp() - startTicks) * 1000.0 / Stopwatch.Frequency;
+        }
+    }
+}

--- a/src/Adapters/Raylib/Ludots.Adapter.Raylib/Rendering/RaylibWorldOverlayRenderer.cs
+++ b/src/Adapters/Raylib/Ludots.Adapter.Raylib/Rendering/RaylibWorldOverlayRenderer.cs
@@ -1,0 +1,327 @@
+using System;
+using System.Numerics;
+using Ludots.Client.Raylib.Rendering;
+using Ludots.Core.Presentation.Rendering;
+using Raylib_cs;
+using Rl = Raylib_cs.Raylib;
+
+namespace Ludots.Adapter.Raylib
+{
+    internal static class RaylibWorldOverlayRenderer
+    {
+        public static void DrawGroundOverlays(GroundOverlayBuffer overlays)
+        {
+            if (overlays == null)
+            {
+                throw new ArgumentNullException(nameof(overlays));
+            }
+
+            ReadOnlySpan<GroundOverlayItem> span = overlays.GetSpan();
+            for (int i = 0; i < span.Length; i++)
+            {
+                ref readonly GroundOverlayItem item = ref span[i];
+                switch (item.Shape)
+                {
+                    case GroundOverlayShape.Circle:
+                        DrawGroundCircle(in item);
+                        break;
+                    case GroundOverlayShape.Cone:
+                        DrawGroundCone(in item);
+                        break;
+                    case GroundOverlayShape.Ring:
+                        DrawGroundRing(in item);
+                        break;
+                    case GroundOverlayShape.Line:
+                        DrawGroundLine(in item);
+                        break;
+                }
+            }
+        }
+
+        public static void DrawRoadSplines(RoadSplineBuffer splines)
+        {
+            if (splines == null)
+            {
+                throw new ArgumentNullException(nameof(splines));
+            }
+
+            ReadOnlySpan<float> p0x = splines.P0X;
+            ReadOnlySpan<float> p0y = splines.P0Y;
+            ReadOnlySpan<float> p0z = splines.P0Z;
+            ReadOnlySpan<float> p1x = splines.P1X;
+            ReadOnlySpan<float> p1y = splines.P1Y;
+            ReadOnlySpan<float> p1z = splines.P1Z;
+            ReadOnlySpan<float> p2x = splines.P2X;
+            ReadOnlySpan<float> p2y = splines.P2Y;
+            ReadOnlySpan<float> p2z = splines.P2Z;
+            ReadOnlySpan<float> p3x = splines.P3X;
+            ReadOnlySpan<float> p3y = splines.P3Y;
+            ReadOnlySpan<float> p3z = splines.P3Z;
+            ReadOnlySpan<float> width = splines.Width;
+            ReadOnlySpan<float> borderWidth = splines.BorderWidth;
+            ReadOnlySpan<float> fillR = splines.FillR;
+            ReadOnlySpan<float> fillG = splines.FillG;
+            ReadOnlySpan<float> fillB = splines.FillB;
+            ReadOnlySpan<float> fillA = splines.FillA;
+            ReadOnlySpan<float> borderR = splines.BorderR;
+            ReadOnlySpan<float> borderG = splines.BorderG;
+            ReadOnlySpan<float> borderB = splines.BorderB;
+            ReadOnlySpan<float> borderA = splines.BorderA;
+
+            for (int i = 0; i < splines.Count; i++)
+            {
+                Vector3 p0 = new(p0x[i], p0y[i], p0z[i]);
+                Vector3 p1 = new(p1x[i], p1y[i], p1z[i]);
+                Vector3 p2 = new(p2x[i], p2y[i], p2z[i]);
+                Vector3 p3 = new(p3x[i], p3y[i], p3z[i]);
+                float drawWidth = MathF.Max(0.02f, width[i]);
+                float drawBorder = MathF.Max(0.01f, borderWidth[i]);
+                Color fill = ToRaylibColor(new Vector4(fillR[i], fillG[i], fillB[i], fillA[i]));
+                Color border = ToRaylibColor(new Vector4(borderR[i], borderG[i], borderB[i], borderA[i]));
+                DrawRoadSplineRibbon(p0, p1, p2, p3, drawWidth, fill, border, drawBorder);
+            }
+        }
+
+        private static void DrawRoadSplineRibbon(
+            in Vector3 p0,
+            in Vector3 p1,
+            in Vector3 p2,
+            in Vector3 p3,
+            float width,
+            Color fill,
+            Color border,
+            float borderWidth)
+        {
+            const int samples = 20;
+            Span<Vector3> points = stackalloc Vector3[samples + 1];
+            for (int i = 0; i <= samples; i++)
+            {
+                float t = i / (float)samples;
+                points[i] = EvaluateCubicBezier(p0, p1, p2, p3, t);
+            }
+
+            if (fill.a > 0)
+            {
+                int lanes = Math.Max(1, (int)MathF.Ceiling(width / 0.08f));
+                for (int lane = 0; lane < lanes; lane++)
+                {
+                    float alpha = lanes == 1 ? 0f : lane / (float)(lanes - 1);
+                    float offset = (alpha - 0.5f) * width;
+                    DrawOffsetPolyline(points, offset, fill);
+                }
+            }
+
+            if (border.a > 0)
+            {
+                float edgeOffset = (width * 0.5f) + borderWidth;
+                DrawOffsetPolyline(points, edgeOffset, border);
+                DrawOffsetPolyline(points, -edgeOffset, border);
+            }
+        }
+
+        private static void DrawOffsetPolyline(ReadOnlySpan<Vector3> points, float offset, Color color)
+        {
+            if (points.Length < 2)
+            {
+                return;
+            }
+
+            Vector3 previous = OffsetPoint(points, 0, offset);
+            for (int i = 1; i < points.Length; i++)
+            {
+                Vector3 current = OffsetPoint(points, i, offset);
+                Rl.DrawLine3D(previous, current, color);
+                previous = current;
+            }
+        }
+
+        private static Vector3 OffsetPoint(ReadOnlySpan<Vector3> points, int index, float offset)
+        {
+            Vector3 current = points[index];
+            Vector3 forward = index == points.Length - 1
+                ? current - points[index - 1]
+                : points[index + 1] - current;
+            Vector2 lateral = new(-forward.Z, forward.X);
+            float length = lateral.Length();
+            if (length <= 0.0001f)
+            {
+                return current;
+            }
+
+            lateral /= length;
+            return new Vector3(current.X + lateral.X * offset, current.Y, current.Z + lateral.Y * offset);
+        }
+
+        private static Vector3 EvaluateCubicBezier(in Vector3 p0, in Vector3 p1, in Vector3 p2, in Vector3 p3, float t)
+        {
+            float oneMinusT = 1f - t;
+            float a = oneMinusT * oneMinusT * oneMinusT;
+            float b = 3f * oneMinusT * oneMinusT * t;
+            float c = 3f * oneMinusT * t * t;
+            float d = t * t * t;
+            return (p0 * a) + (p1 * b) + (p2 * c) + (p3 * d);
+        }
+
+        private static void DrawGroundCircle(in GroundOverlayItem item)
+        {
+            const int segments = 48;
+            float step = MathF.PI * 2f / segments;
+            Vector3 center = item.Center;
+
+            if (item.FillColor.W > 0.01f)
+            {
+                Color fillColor = ToRaylibColor(item.FillColor);
+                const int fillRings = 4;
+                for (int r = 1; r <= fillRings; r++)
+                {
+                    float radius = item.Radius * r / fillRings;
+                    for (int s = 0; s < segments; s++)
+                    {
+                        float a0 = s * step;
+                        float a1 = (s + 1) * step;
+                        Vector3 p0 = new(center.X + MathF.Cos(a0) * radius, center.Y, center.Z + MathF.Sin(a0) * radius);
+                        Vector3 p1 = new(center.X + MathF.Cos(a1) * radius, center.Y, center.Z + MathF.Sin(a1) * radius);
+                        Rl.DrawLine3D(p0, p1, fillColor);
+                    }
+                }
+            }
+
+            if (item.BorderColor.W > 0.01f && item.BorderWidth > 0f)
+            {
+                Color border = ToRaylibColor(item.BorderColor);
+                for (int s = 0; s < segments; s++)
+                {
+                    float a0 = s * step;
+                    float a1 = (s + 1) * step;
+                    Vector3 p0 = new(center.X + MathF.Cos(a0) * item.Radius, center.Y, center.Z + MathF.Sin(a0) * item.Radius);
+                    Vector3 p1 = new(center.X + MathF.Cos(a1) * item.Radius, center.Y, center.Z + MathF.Sin(a1) * item.Radius);
+                    Rl.DrawLine3D(p0, p1, border);
+                }
+            }
+        }
+
+        private static void DrawGroundRing(in GroundOverlayItem item)
+        {
+            const int segments = 48;
+            float innerRadius = Math.Clamp(item.InnerRadius, 0f, item.Radius);
+            float outerRadius = MathF.Max(item.Radius, innerRadius);
+            Vector3 center = item.Center;
+
+            if (item.FillColor.W > 0.01f && outerRadius > innerRadius)
+            {
+                Color fillColor = ToRaylibColor(item.FillColor);
+                const int bands = 6;
+                for (int band = 0; band < bands; band++)
+                {
+                    float radius = innerRadius + (outerRadius - innerRadius) * (band + 0.5f) / bands;
+                    DrawGroundArcLoop(center, radius, 0f, MathF.PI * 2f, segments, fillColor);
+                }
+            }
+
+            if (item.BorderColor.W > 0.01f && item.BorderWidth > 0f)
+            {
+                Color border = ToRaylibColor(item.BorderColor);
+                DrawGroundArcLoop(center, outerRadius, 0f, MathF.PI * 2f, segments, border);
+                if (innerRadius > 0.001f)
+                {
+                    DrawGroundArcLoop(center, innerRadius, 0f, MathF.PI * 2f, segments, border);
+                }
+            }
+        }
+
+        private static void DrawGroundCone(in GroundOverlayItem item)
+        {
+            const int segments = 24;
+            float radius = MathF.Max(item.Radius, 0f);
+            float start = item.Rotation - item.Angle;
+            float end = item.Rotation + item.Angle;
+            Vector3 center = item.Center;
+
+            if (radius <= 0f)
+            {
+                return;
+            }
+
+            if (item.FillColor.W > 0.01f)
+            {
+                Color fillColor = ToRaylibColor(item.FillColor);
+                const int bands = 6;
+                for (int band = 1; band <= bands; band++)
+                {
+                    float ringRadius = radius * band / bands;
+                    DrawGroundArcLoop(center, ringRadius, start, end, segments, fillColor);
+                }
+            }
+
+            if (item.BorderColor.W > 0.01f && item.BorderWidth > 0f)
+            {
+                Color border = ToRaylibColor(item.BorderColor);
+                DrawGroundArcLoop(center, radius, start, end, segments, border);
+                Vector3 left = new(center.X + MathF.Cos(start) * radius, center.Y, center.Z + MathF.Sin(start) * radius);
+                Vector3 right = new(center.X + MathF.Cos(end) * radius, center.Y, center.Z + MathF.Sin(end) * radius);
+                Rl.DrawLine3D(center, left, border);
+                Rl.DrawLine3D(center, right, border);
+            }
+        }
+
+        private static void DrawGroundLine(in GroundOverlayItem item)
+        {
+            float length = item.Length > 0f ? item.Length : item.Radius;
+            if (length <= 0f)
+            {
+                return;
+            }
+
+            float dx = MathF.Cos(item.Rotation) * length;
+            float dz = MathF.Sin(item.Rotation) * length;
+            Vector3 a = item.Center;
+            Vector3 b = new(a.X + dx, a.Y, a.Z + dz);
+            float halfWidth = MathF.Max(0f, item.Width) * 0.5f;
+            Vector3 normal = new(-MathF.Sin(item.Rotation), 0f, MathF.Cos(item.Rotation));
+
+            if (item.FillColor.W > 0.01f)
+            {
+                Color fill = ToRaylibColor(item.FillColor);
+                int stripes = halfWidth > 0.001f ? Math.Clamp((int)MathF.Ceiling(halfWidth / 0.12f), 1, 8) : 1;
+                for (int stripe = -stripes; stripe <= stripes; stripe++)
+                {
+                    float offset = stripes == 0 ? 0f : halfWidth * stripe / Math.Max(stripes, 1);
+                    Vector3 delta = normal * offset;
+                    Rl.DrawLine3D(a + delta, b + delta, fill);
+                }
+            }
+
+            if (item.BorderColor.W > 0.01f)
+            {
+                Color border = ToRaylibColor(item.BorderColor);
+                Rl.DrawLine3D(a, b, border);
+                if (halfWidth > 0.001f)
+                {
+                    Vector3 delta = normal * halfWidth;
+                    Rl.DrawLine3D(a + delta, b + delta, border);
+                    Rl.DrawLine3D(a - delta, b - delta, border);
+                }
+            }
+        }
+
+        private static void DrawGroundArcLoop(Vector3 center, float radius, float startAngle, float endAngle, int segments, Color color)
+        {
+            if (segments <= 0 || radius <= 0f)
+            {
+                return;
+            }
+
+            float step = (endAngle - startAngle) / segments;
+            for (int s = 0; s < segments; s++)
+            {
+                float a0 = startAngle + s * step;
+                float a1 = startAngle + (s + 1) * step;
+                Vector3 p0 = new(center.X + MathF.Cos(a0) * radius, center.Y, center.Z + MathF.Sin(a0) * radius);
+                Vector3 p1 = new(center.X + MathF.Cos(a1) * radius, center.Y, center.Z + MathF.Sin(a1) * radius);
+                Rl.DrawLine3D(p0, p1, color);
+            }
+        }
+
+        private static Color ToRaylibColor(in Vector4 c) => RaylibColorUtil.ToRaylibColor(in c);
+    }
+}

--- a/src/Client/Ludots.Client.Raylib/Properties/AssemblyInfo.cs
+++ b/src/Client/Ludots.Client.Raylib/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Ludots.Adapter.Raylib.Tests")]

--- a/src/Client/Ludots.Client.Raylib/Rendering/RaylibPrimitiveRenderer.cs
+++ b/src/Client/Ludots.Client.Raylib/Rendering/RaylibPrimitiveRenderer.cs
@@ -48,6 +48,7 @@ namespace Ludots.Client.Raylib.Rendering
         private readonly Dictionary<GpuSkinnedInstanceBatchKey, GpuSkinnedInstanceBatch> _gpuSkinnedInstanceBatches = new();
         private readonly List<GpuSkinnedInstanceBatch> _activeGpuSkinnedInstanceBatches = new(64);
         private readonly RaylibIsmRenderBridge _ismBridge = new RaylibIsmRenderBridge();
+        private readonly RaylibVfxRenderer _vfxRenderer = new();
 
         private readonly Dictionary<int, CachedModel> _modelCache = new Dictionary<int, CachedModel>();
         private readonly Dictionary<int, CachedProceduralMesh> _proceduralMeshCache = new Dictionary<int, CachedProceduralMesh>();
@@ -100,14 +101,14 @@ namespace Ludots.Client.Raylib.Rendering
             _maxModelInstancesPerDraw = ResolveMaxModelInstancesPerDraw();
         }
 
-        public void Draw(PrimitiveDrawBuffer draw, Camera3D camera, MeshAssetRegistry meshes, float scaleMul = 1f, IVisualHeightmap? visualHeightmap = null)
+        public void Draw(PrimitiveDrawBuffer draw, Camera3D camera, MeshAssetRegistry meshes, float scaleMul = 1f, IVisualHeightmap? visualHeightmap = null, double timeSeconds = 0d)
         {
-            Draw(draw, camera, snapshot: null, skinnedBatch: null, meshes, scaleMul, visualHeightmap);
+            Draw(draw, camera, snapshot: null, skinnedBatch: null, meshes, scaleMul, visualHeightmap, timeSeconds);
         }
 
-        public void Draw(PrimitiveDrawBuffer draw, Camera3D camera, PrimitiveDrawBuffer? snapshot, MeshAssetRegistry meshes, float scaleMul = 1f, IVisualHeightmap? visualHeightmap = null)
+        public void Draw(PrimitiveDrawBuffer draw, Camera3D camera, PrimitiveDrawBuffer? snapshot, MeshAssetRegistry meshes, float scaleMul = 1f, IVisualHeightmap? visualHeightmap = null, double timeSeconds = 0d)
         {
-            Draw(draw, camera, snapshot, skinnedBatch: null, meshes, scaleMul, visualHeightmap);
+            Draw(draw, camera, snapshot, skinnedBatch: null, meshes, scaleMul, visualHeightmap, timeSeconds);
         }
 
         public void Draw(
@@ -117,7 +118,8 @@ namespace Ludots.Client.Raylib.Rendering
             SkinnedVisualBatchBuffer? skinnedBatch,
             MeshAssetRegistry meshes,
             float scaleMul = 1f,
-            IVisualHeightmap? visualHeightmap = null)
+            IVisualHeightmap? visualHeightmap = null,
+            double timeSeconds = 0d)
         {
             if (draw == null) throw new ArgumentNullException(nameof(draw));
             if (meshes == null) throw new ArgumentNullException(nameof(meshes));
@@ -144,47 +146,55 @@ namespace Ludots.Client.Raylib.Rendering
             LastVfxVisualCount = 0;
             LastSurfaceVisualCount = 0;
             var finalizationContext = new PrefabFinalizationContext(visualHeightmap);
+            _vfxRenderer.BeginFrame();
 
-            var span = draw.GetSpan();
-            bool usePersistentStaticLanes = snapshot != null;
-            if (usePersistentStaticLanes)
+            try
             {
-                _ismBridge.SyncPersistentLanes(snapshot);
-                LastPersistentSyncMs = _ismBridge.LastPersistentSyncMs;
-                LastPersistentCreates = _ismBridge.Planner.LastCreateCount;
-                LastPersistentUpdates = _ismBridge.Planner.LastUpdateCount;
-                LastPersistentRemoves = _ismBridge.Planner.LastRemoveCount;
-                long bucketStart = Stopwatch.GetTimestamp();
-                DrawPersistentStaticLanes(camera, meshes, scaleMul, in finalizationContext);
-                LastPersistentBucketDrawMs = (Stopwatch.GetTimestamp() - bucketStart) * 1000d / Stopwatch.Frequency;
-                if (skinnedBatch != null)
+                var span = draw.GetSpan();
+                bool usePersistentStaticLanes = snapshot != null;
+                if (usePersistentStaticLanes)
                 {
-                    DrawSkinnedBatch(skinnedBatch, camera, meshes, scaleMul, in finalizationContext);
+                    _ismBridge.SyncPersistentLanes(snapshot);
+                    LastPersistentSyncMs = _ismBridge.LastPersistentSyncMs;
+                    LastPersistentCreates = _ismBridge.Planner.LastCreateCount;
+                    LastPersistentUpdates = _ismBridge.Planner.LastUpdateCount;
+                    LastPersistentRemoves = _ismBridge.Planner.LastRemoveCount;
+                    long bucketStart = Stopwatch.GetTimestamp();
+                    DrawPersistentStaticLanes(camera, meshes, scaleMul, timeSeconds, in finalizationContext);
+                    LastPersistentBucketDrawMs = (Stopwatch.GetTimestamp() - bucketStart) * 1000d / Stopwatch.Frequency;
+                    if (skinnedBatch != null)
+                    {
+                        DrawSkinnedBatch(skinnedBatch, camera, meshes, scaleMul, timeSeconds, in finalizationContext);
+                    }
+
+                    long dynamicLaneStart = Stopwatch.GetTimestamp();
+                    DrawSnapshotDynamicLanes(span, camera, meshes, scaleMul, skinnedBatchActive: skinnedBatch != null, timeSeconds, in finalizationContext);
+                    LastImmediateDrawMs = (Stopwatch.GetTimestamp() - dynamicLaneStart) * 1000d / Stopwatch.Frequency;
+
+                    return;
                 }
 
-                long dynamicLaneStart = Stopwatch.GetTimestamp();
-                DrawSnapshotDynamicLanes(span, camera, meshes, scaleMul, skinnedBatchActive: skinnedBatch != null, in finalizationContext);
-                LastImmediateDrawMs = (Stopwatch.GetTimestamp() - dynamicLaneStart) * 1000d / Stopwatch.Frequency;
+                if (_mode == RaylibPrimitiveRenderMode.Instanced)
+                {
+                    DrawHybridInstanced(span, camera, meshes, scaleMul, timeSeconds, in finalizationContext);
+                    return;
+                }
 
-                return;
+                long immediateDrawStart = Stopwatch.GetTimestamp();
+                DrawImmediateWithDescriptors(span, camera, meshes, scaleMul, persistentStaticLanesActive: false, skinnedBatchActive: false, timeSeconds, in finalizationContext);
+                LastImmediateDrawMs = (Stopwatch.GetTimestamp() - immediateDrawStart) * 1000d / Stopwatch.Frequency;
             }
-
-            if (_mode == RaylibPrimitiveRenderMode.Instanced)
+            finally
             {
-                DrawHybridInstanced(span, camera, meshes, scaleMul, in finalizationContext);
-                return;
+                _vfxRenderer.EndFrame();
             }
-
-            long immediateDrawStart = Stopwatch.GetTimestamp();
-            DrawImmediateWithDescriptors(span, camera, meshes, scaleMul, persistentStaticLanesActive: false, skinnedBatchActive: false, in finalizationContext);
-            LastImmediateDrawMs = (Stopwatch.GetTimestamp() - immediateDrawStart) * 1000d / Stopwatch.Frequency;
         }
 
-        private void DrawPersistentStaticLanes(Camera3D camera, MeshAssetRegistry meshes, float scaleMul, in PrefabFinalizationContext finalizationContext)
+        private void DrawPersistentStaticLanes(Camera3D camera, MeshAssetRegistry meshes, float scaleMul, double timeSeconds, in PrefabFinalizationContext finalizationContext)
         {
             foreach (RaylibIsmRenderBridge.Bucket bucket in _ismBridge.ActiveBuckets)
             {
-                DrawInstancedBucket(bucket, meshes, scaleMul);
+                DrawInstancedBucket(bucket, meshes, scaleMul, timeSeconds);
             }
         }
 
@@ -195,6 +205,7 @@ namespace Ludots.Client.Raylib.Rendering
             float scaleMul,
             bool persistentStaticLanesActive,
             bool skinnedBatchActive,
+            double timeSeconds,
             in PrefabFinalizationContext finalizationContext)
         {
             for (int i = 0; i < span.Length; i++)
@@ -223,13 +234,7 @@ namespace Ludots.Client.Raylib.Rendering
                     continue;
                 }
 
-                DrawAssetRecursive(
-                    item.MeshAssetId, item.Position,
-                    item.Rotation,
-                    item.Scale * scaleMul, item.Color,
-                    camera,
-                    meshes,
-                    in finalizationContext);
+                DrawPrimitiveItem(in item, camera, meshes, scaleMul, timeSeconds, in finalizationContext);
             }
         }
 
@@ -239,6 +244,7 @@ namespace Ludots.Client.Raylib.Rendering
             MeshAssetRegistry meshes,
             float scaleMul,
             bool skinnedBatchActive,
+            double timeSeconds,
             in PrefabFinalizationContext finalizationContext)
         {
             EnsureInitialized();
@@ -269,15 +275,7 @@ namespace Ludots.Client.Raylib.Rendering
                     continue;
                 }
 
-                SubmitAssetRecursive(
-                    item.MeshAssetId,
-                    item.Position,
-                    item.Rotation,
-                    item.Scale * scaleMul,
-                    item.Color,
-                    camera,
-                    meshes,
-                    in finalizationContext);
+                SubmitPrimitiveItem(in item, camera, meshes, scaleMul, timeSeconds, in finalizationContext);
             }
 
             FlushInstancedBatches();
@@ -295,7 +293,7 @@ namespace Ludots.Client.Raylib.Rendering
             return _ismBridge.ActiveBindings.ContainsKey(item.StableId);
         }
 
-        private void DrawHybridInstanced(ReadOnlySpan<PrimitiveDrawItem> span, Camera3D camera, MeshAssetRegistry meshes, float scaleMul, in PrefabFinalizationContext finalizationContext)
+        private void DrawHybridInstanced(ReadOnlySpan<PrimitiveDrawItem> span, Camera3D camera, MeshAssetRegistry meshes, float scaleMul, double timeSeconds, in PrefabFinalizationContext finalizationContext)
         {
             EnsureInitialized();
 
@@ -312,27 +310,71 @@ namespace Ludots.Client.Raylib.Rendering
                     continue;
                 }
 
-                SubmitAssetRecursive(
-                    item.MeshAssetId,
-                    item.Position,
-                    item.Rotation,
-                    item.Scale * scaleMul,
-                    item.Color,
-                    camera,
-                    meshes,
-                    in finalizationContext);
+                SubmitPrimitiveItem(in item, camera, meshes, scaleMul, timeSeconds, in finalizationContext);
             }
 
             FlushInstancedBatches();
         }
 
-        private void SubmitAssetRecursive(int meshAssetId, Vector3 position, Quaternion rotation, Vector3 scale, Vector4 color, Camera3D camera, MeshAssetRegistry meshes, in PrefabFinalizationContext finalizationContext)
+        private void SubmitPrimitiveItem(
+            in PrimitiveDrawItem item,
+            Camera3D camera,
+            MeshAssetRegistry meshes,
+            float scaleMul,
+            double timeSeconds,
+            in PrefabFinalizationContext finalizationContext)
+        {
+            if (TrySubmitDirectVfx(in item, camera, meshes, scaleMul, timeSeconds))
+            {
+                return;
+            }
+
+            SubmitAssetRecursive(
+                item.MeshAssetId,
+                item.Position,
+                item.Rotation,
+                item.Scale * scaleMul,
+                item.Color,
+                camera,
+                meshes,
+                item.StableId,
+                timeSeconds,
+                in finalizationContext);
+        }
+
+        private void DrawPrimitiveItem(
+            in PrimitiveDrawItem item,
+            Camera3D camera,
+            MeshAssetRegistry meshes,
+            float scaleMul,
+            double timeSeconds,
+            in PrefabFinalizationContext finalizationContext)
+        {
+            if (TryDrawDirectVfx(in item, camera, meshes, scaleMul, timeSeconds))
+            {
+                return;
+            }
+
+            DrawAssetRecursive(
+                item.MeshAssetId,
+                item.Position,
+                item.Rotation,
+                item.Scale * scaleMul,
+                item.Color,
+                camera,
+                meshes,
+                item.StableId,
+                timeSeconds,
+                in finalizationContext);
+        }
+
+        private void SubmitAssetRecursive(int meshAssetId, Vector3 position, Quaternion rotation, Vector3 scale, Vector4 color, Camera3D camera, MeshAssetRegistry meshes, int stableId, double timeSeconds, in PrefabFinalizationContext finalizationContext)
         {
             _prefabVisuals.Clear();
             PrefabFinalizationPipeline.FinalizeVisuals(
                 meshes,
                 meshAssetId,
-                stableId: 0,
+                stableId,
                 position,
                 rotation,
                 scale,
@@ -342,7 +384,7 @@ namespace Ludots.Client.Raylib.Rendering
 
             foreach (ref readonly var visual in _prefabVisuals.GetSpan())
             {
-                SubmitFinalizedVisual(in visual, camera);
+                SubmitFinalizedVisual(in visual, camera, meshes, timeSeconds);
             }
         }
 
@@ -351,7 +393,73 @@ namespace Ludots.Client.Raylib.Rendering
             return item.AssetKind == AssetKind.Surface || item.RenderPath.IsSurfaceLane();
         }
 
-        private void SubmitFinalizedVisual(in PrefabFinalizedVisual visual, Camera3D camera)
+        private bool TrySubmitDirectVfx(
+            in PrimitiveDrawItem item,
+            Camera3D camera,
+            MeshAssetRegistry meshes,
+            float scaleMul,
+            double timeSeconds)
+        {
+            if (!TryBuildDirectVfxVisual(in item, scaleMul, out PrefabFinalizedVisual visual))
+            {
+                return false;
+            }
+
+            SubmitFinalizedVisual(in visual, camera, meshes, timeSeconds);
+            return true;
+        }
+
+        private bool TryDrawDirectVfx(
+            in PrimitiveDrawItem item,
+            Camera3D camera,
+            MeshAssetRegistry meshes,
+            float scaleMul,
+            double timeSeconds)
+        {
+            if (!TryBuildDirectVfxVisual(in item, scaleMul, out PrefabFinalizedVisual visual))
+            {
+                return false;
+            }
+
+            DrawFinalizedVisual(in visual, camera, meshes, timeSeconds);
+            return true;
+        }
+
+        internal static bool TryBuildDirectVfxVisual(
+            in PrimitiveDrawItem item,
+            float scaleMul,
+            out PrefabFinalizedVisual visual)
+        {
+            if (item.AssetKind != AssetKind.VFX)
+            {
+                visual = default;
+                return false;
+            }
+
+            if (item.MeshAssetId <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"VFX primitive stableId={item.StableId} requires a positive effect meshAssetId.");
+            }
+
+            if (item.StableId <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"VFX primitive effectAssetId={item.MeshAssetId} requires a positive stableId.");
+            }
+
+            visual = PrefabFinalizedVisual.Vfx(
+                item.StableId,
+                item.Position,
+                item.Rotation,
+                item.Scale * scaleMul,
+                item.Color,
+                item.MeshAssetId,
+                PrefabVfxSpawnMode.Loop);
+            return true;
+        }
+
+        private void SubmitFinalizedVisual(in PrefabFinalizedVisual visual, Camera3D camera, MeshAssetRegistry meshes, double timeSeconds)
         {
             TrackVisualKind(visual.Kind);
 
@@ -367,7 +475,7 @@ namespace Ludots.Client.Raylib.Rendering
                     DrawDecalVisual(in visual);
                     break;
                 case PrefabVisualPartKind.Vfx:
-                    DrawVfxVisual(in visual);
+                    DrawVfxVisual(in visual, meshes, timeSeconds);
                     break;
                 case PrefabVisualPartKind.Surface:
                     DrawSurfaceVisual(in visual, camera);
@@ -431,7 +539,7 @@ namespace Ludots.Client.Raylib.Rendering
             }
         }
 
-        private void DrawSkinnedBatch(SkinnedVisualBatchBuffer skinnedBatch, Camera3D camera, MeshAssetRegistry meshes, float scaleMul, in PrefabFinalizationContext finalizationContext)
+        private void DrawSkinnedBatch(SkinnedVisualBatchBuffer skinnedBatch, Camera3D camera, MeshAssetRegistry meshes, float scaleMul, double timeSeconds, in PrefabFinalizationContext finalizationContext)
         {
             var span = skinnedBatch.GetSpan();
             PrepareGpuSkinnedInstanceBatches();
@@ -461,6 +569,8 @@ namespace Ludots.Client.Raylib.Rendering
                     item.Color,
                     camera,
                     meshes,
+                    item.StableId,
+                    timeSeconds,
                     in finalizationContext);
             }
 
@@ -599,13 +709,13 @@ namespace Ludots.Client.Raylib.Rendering
             };
         }
 
-        private void DrawAssetRecursive(int meshAssetId, Vector3 position, Quaternion rotation, Vector3 scale, Vector4 color, Camera3D camera, MeshAssetRegistry meshes, in PrefabFinalizationContext finalizationContext)
+        private void DrawAssetRecursive(int meshAssetId, Vector3 position, Quaternion rotation, Vector3 scale, Vector4 color, Camera3D camera, MeshAssetRegistry meshes, int stableId, double timeSeconds, in PrefabFinalizationContext finalizationContext)
         {
             _prefabVisuals.Clear();
             PrefabFinalizationPipeline.FinalizeVisuals(
                 meshes,
                 meshAssetId,
-                stableId: 0,
+                stableId,
                 position,
                 rotation,
                 scale,
@@ -615,11 +725,11 @@ namespace Ludots.Client.Raylib.Rendering
 
             foreach (ref readonly var visual in _prefabVisuals.GetSpan())
             {
-                DrawFinalizedVisual(in visual, camera);
+                DrawFinalizedVisual(in visual, camera, meshes, timeSeconds);
             }
         }
 
-        private void DrawFinalizedVisual(in PrefabFinalizedVisual visual, Camera3D camera)
+        private void DrawFinalizedVisual(in PrefabFinalizedVisual visual, Camera3D camera, MeshAssetRegistry meshes, double timeSeconds)
         {
             TrackVisualKind(visual.Kind);
 
@@ -635,7 +745,7 @@ namespace Ludots.Client.Raylib.Rendering
                     DrawDecalVisual(in visual);
                     break;
                 case PrefabVisualPartKind.Vfx:
-                    DrawVfxVisual(in visual);
+                    DrawVfxVisual(in visual, meshes, timeSeconds);
                     break;
                 case PrefabVisualPartKind.Surface:
                     DrawSurfaceVisual(in visual, camera);
@@ -752,27 +862,9 @@ namespace Ludots.Client.Raylib.Rendering
             Rl.DrawLine3D(center, markerTop, edge);
         }
 
-        private void DrawVfxVisual(in PrefabFinalizedVisual visual)
+        private void DrawVfxVisual(in PrefabFinalizedVisual visual, MeshAssetRegistry meshes, double timeSeconds)
         {
-            Quaternion rotation = WorldPlane2D.NormalizeOrIdentity(visual.Rotation);
-            float baseExtent = MathF.Max(0.12f, MathF.Max(MathF.Abs(visual.Scale.X), MathF.Max(MathF.Abs(visual.Scale.Y), MathF.Abs(visual.Scale.Z))) * 0.45f);
-            float radius = visual.VfxSpawnMode == PrefabVfxSpawnMode.Loop
-                ? baseExtent * 1.15f
-                : baseExtent * 0.9f;
-            Vector4 pulseColor = BlendSemanticColor(visual.Color, visual.EffectAssetId, 0.6f);
-            Vector4 shellColor = LerpColor(pulseColor, new Vector4(1f, 1f, 1f, pulseColor.W), 0.35f);
-
-            DrawPrototypeSphere(visual.Position, radius * 0.28f, pulseColor);
-            DrawRotatedRing(visual.Position, rotation, radius, 12, MultiplyColor(shellColor, 1f, 1f, 1f, 0.72f));
-            DrawRotatedRing(visual.Position, rotation * Quaternion.CreateFromAxisAngle(Vector3.UnitX, MathF.PI * 0.5f), radius * 0.82f, 10, MultiplyColor(shellColor, 0.92f, 1f, 1.1f, 0.64f));
-
-            Vector3 right = Vector3.Normalize(Vector3.Transform(Vector3.UnitX, rotation));
-            Vector3 up = Vector3.Normalize(Vector3.Transform(Vector3.UnitY, rotation));
-            Vector3 forward = Vector3.Normalize(Vector3.Transform(-Vector3.UnitZ, rotation));
-            Color beamColor = ToRaylibColor(MultiplyColor(pulseColor, 1.1f, 1.08f, 1.18f, 0.88f));
-            Rl.DrawLine3D(visual.Position - (right * radius), visual.Position + (right * radius), beamColor);
-            Rl.DrawLine3D(visual.Position - (up * radius * 0.8f), visual.Position + (up * radius * 0.8f), beamColor);
-            Rl.DrawLine3D(visual.Position - (forward * radius * 0.9f), visual.Position + (forward * radius * 0.9f), beamColor);
+            _vfxRenderer.Draw(in visual, meshes, timeSeconds);
         }
 
         private void DrawSurfaceVisual(in PrefabFinalizedVisual visual, Camera3D camera)
@@ -1664,6 +1756,12 @@ namespace Ludots.Client.Raylib.Rendering
             for (int i = 0; i < span.Length; i++)
             {
                 ref readonly var item = ref span[i];
+                if (item.AssetKind == AssetKind.VFX)
+                {
+                    throw new InvalidOperationException(
+                        $"{nameof(DrawInstanced)} cannot draw VFX primitives because it has no frame time. Use {nameof(Draw)} with timeSeconds.");
+                }
+
                 if (!meshes.TryGetPrimitiveKind(item.MeshAssetId, out var kind)) continue;
 
                 SubmitPrimitive(kind, item.Position, item.Rotation, item.Scale, item.Color);
@@ -1686,7 +1784,7 @@ namespace Ludots.Client.Raylib.Rendering
             LastInstancedMatrixCacheMisses = 0;
         }
 
-        public void DrawInstancedBucket(RaylibIsmRenderBridge.Bucket bucket, MeshAssetRegistry meshes, float scaleMul = 1f)
+        public void DrawInstancedBucket(RaylibIsmRenderBridge.Bucket bucket, MeshAssetRegistry meshes, float scaleMul = 1f, double timeSeconds = 0d)
         {
             if (bucket == null) throw new ArgumentNullException(nameof(bucket));
             if (meshes == null) throw new ArgumentNullException(nameof(meshes));
@@ -1707,6 +1805,11 @@ namespace Ludots.Client.Raylib.Rendering
             for (int i = 0; i < items.Count; i++)
             {
                 PrimitiveDrawItem item = items[i];
+                if (TryDrawDirectVfx(in item, default, meshes, scaleMul, timeSeconds))
+                {
+                    continue;
+                }
+
                 if (!meshes.TryGetDescriptor(item.MeshAssetId, out MeshAssetDescriptor descriptor))
                 {
                     continue;
@@ -1728,6 +1831,8 @@ namespace Ludots.Client.Raylib.Rendering
                             item.Color,
                             default,
                             meshes,
+                            item.StableId,
+                            timeSeconds,
                             new PrefabFinalizationContext(null));
                         break;
                 }
@@ -1738,6 +1843,14 @@ namespace Ludots.Client.Raylib.Rendering
 
         private bool TryDrawModelInstancedBucket(RaylibIsmRenderBridge.Bucket bucket, List<PrimitiveDrawItem> items, MeshAssetRegistry meshes, float scaleMul)
         {
+            for (int i = 0; i < items.Count; i++)
+            {
+                if (items[i].AssetKind != AssetKind.Mesh)
+                {
+                    return false;
+                }
+            }
+
             PrimitiveDrawItem first = items[0];
             if (!meshes.TryGetDescriptor(first.MeshAssetId, out MeshAssetDescriptor descriptor) ||
                 descriptor.Type != MeshAssetType.Model)

--- a/src/Client/Ludots.Client.Raylib/Rendering/RaylibVfxRenderer.cs
+++ b/src/Client/Ludots.Client.Raylib/Rendering/RaylibVfxRenderer.cs
@@ -1,0 +1,350 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Presentation.Assets;
+using Raylib_cs;
+using Rl = Raylib_cs.Raylib;
+
+namespace Ludots.Client.Raylib.Rendering
+{
+    public readonly record struct RaylibVfxEmitterPlan(
+        int StableId,
+        int EffectAssetId,
+        VfxEmitterShape Shape,
+        PrefabVfxSpawnMode SpawnMode,
+        Vector3 Position,
+        Quaternion Rotation,
+        float AgeSeconds,
+        float Life01,
+        float ShellRadius,
+        float CoreRadius,
+        float ParticleRadius,
+        int ParticleCount,
+        int RingSegments,
+        float OrbitPhase,
+        Vector4 CoreColor,
+        Vector4 ShellColor,
+        Vector4 ParticleColor);
+
+    internal readonly record struct RaylibVfxEffectKey(int StableId, int EffectAssetId);
+
+    public sealed class RaylibVfxRenderer
+    {
+        private readonly Dictionary<RaylibVfxEffectKey, double> _effectStartSeconds = new();
+        private readonly HashSet<RaylibVfxEffectKey> _activeKeys = new();
+        private readonly List<RaylibVfxEffectKey> _inactiveKeys = new();
+
+        public void BeginFrame()
+        {
+            _activeKeys.Clear();
+        }
+
+        public void Draw(in PrefabFinalizedVisual visual, MeshAssetRegistry effectAssets, double timeSeconds)
+        {
+            if (effectAssets == null)
+            {
+                throw new ArgumentNullException(nameof(effectAssets));
+            }
+
+            if (visual.Kind != PrefabVisualPartKind.Vfx)
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(RaylibVfxRenderer)} can only draw finalized VFX visuals, but received '{visual.Kind}'.");
+            }
+
+            if (visual.StableId <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"VFX visual effectAssetId={visual.EffectAssetId} requires a positive stableId for renderer lifetime tracking.");
+            }
+
+            if (!effectAssets.TryGetDescriptor(visual.EffectAssetId, out MeshAssetDescriptor descriptor))
+            {
+                throw new InvalidOperationException(
+                    $"VFX visual stableId={visual.StableId} references unknown effect asset id {visual.EffectAssetId}.");
+            }
+
+            RaylibVfxEffectKey key = ComposeEffectKey(visual.StableId, visual.EffectAssetId);
+            _activeKeys.Add(key);
+            if (!_effectStartSeconds.TryGetValue(key, out double startSeconds))
+            {
+                startSeconds = timeSeconds;
+                _effectStartSeconds.Add(key, startSeconds);
+            }
+
+            double ageSeconds = Math.Max(0d, timeSeconds - startSeconds);
+            RaylibVfxEmitterPlan plan = BuildEmitterPlan(in visual, in descriptor, ageSeconds);
+            if (plan.CoreColor.W <= 0.001f &&
+                plan.ShellColor.W <= 0.001f &&
+                plan.ParticleColor.W <= 0.001f)
+            {
+                return;
+            }
+
+            Draw(in plan);
+        }
+
+        public void EndFrame()
+        {
+            if (_effectStartSeconds.Count == _activeKeys.Count)
+            {
+                return;
+            }
+
+            _inactiveKeys.Clear();
+            foreach (RaylibVfxEffectKey key in _effectStartSeconds.Keys)
+            {
+                if (!_activeKeys.Contains(key))
+                {
+                    _inactiveKeys.Add(key);
+                }
+            }
+
+            for (int i = 0; i < _inactiveKeys.Count; i++)
+            {
+                _effectStartSeconds.Remove(_inactiveKeys[i]);
+            }
+        }
+
+        public static RaylibVfxEmitterPlan BuildEmitterPlan(
+            in PrefabFinalizedVisual visual,
+            in MeshAssetDescriptor effectDescriptor,
+            double ageSeconds)
+        {
+            if (visual.Kind != PrefabVisualPartKind.Vfx)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot build a VFX emitter plan for finalized visual kind '{visual.Kind}'.");
+            }
+
+            if (visual.StableId <= 0)
+            {
+                throw new InvalidOperationException("VFX emitter plans require a positive stableId.");
+            }
+
+            if (visual.EffectAssetId <= 0)
+            {
+                throw new InvalidOperationException("VFX emitter plans require a positive effectAssetId.");
+            }
+
+            if (!effectDescriptor.VfxEffectData.IsValid)
+            {
+                throw new InvalidOperationException(
+                    $"VFX effect asset id {effectDescriptor.Id} must declare vfx emitter data.");
+            }
+
+            VfxEmitterDescriptor emitter = effectDescriptor.VfxEffectData.Emitter;
+            float age = Math.Max(0f, (float)ageSeconds);
+            float maxScale = MathF.Max(
+                MathF.Abs(visual.Scale.X),
+                MathF.Max(MathF.Abs(visual.Scale.Y), MathF.Abs(visual.Scale.Z)));
+            float baseExtent = MathF.Max(0.12f, maxScale * 0.45f);
+            float life01 = visual.VfxSpawnMode == PrefabVfxSpawnMode.Once
+                ? Math.Clamp(age / emitter.LifetimeSeconds, 0f, 1f)
+                : 0f;
+            float pulse01 = visual.VfxSpawnMode == PrefabVfxSpawnMode.Loop
+                ? (MathF.Sin(age * emitter.PulseSpeedRadPerSecond) * 0.5f) + 0.5f
+                : 1f - life01;
+            float alphaMultiplier = visual.VfxSpawnMode == PrefabVfxSpawnMode.Once
+                ? 1f - life01
+                : 0.72f + (pulse01 * 0.28f);
+
+            Vector4 core = BlendSemanticColor(visual.Color, visual.EffectAssetId, 0.6f);
+            Vector4 shell = LerpColor(core, new Vector4(1f, 1f, 1f, core.W), 0.35f);
+            Vector4 particle = LerpColor(core, shell, 0.5f);
+            core.W *= alphaMultiplier;
+            shell.W *= alphaMultiplier * 0.72f;
+            particle.W *= alphaMultiplier * 0.9f;
+
+            float burstScale = visual.VfxSpawnMode == PrefabVfxSpawnMode.Once
+                ? 0.85f + (life01 * 0.45f)
+                : 0.92f + (pulse01 * 0.12f);
+            float shellRadius = baseExtent * emitter.RadiusScale * burstScale;
+
+            return new RaylibVfxEmitterPlan(
+                visual.StableId,
+                visual.EffectAssetId,
+                emitter.Shape,
+                visual.VfxSpawnMode,
+                visual.Position,
+                WorldPlane2D.NormalizeOrIdentity(visual.Rotation),
+                age,
+                life01,
+                shellRadius,
+                MathF.Max(0.025f, shellRadius * emitter.CoreRadiusScale),
+                MathF.Max(0.012f, shellRadius * emitter.ParticleRadiusScale),
+                emitter.ParticleCount,
+                emitter.RingSegments,
+                age * emitter.OrbitSpeedRadPerSecond,
+                ClampColor(core),
+                ClampColor(shell),
+                ClampColor(particle));
+        }
+
+        private static void Draw(in RaylibVfxEmitterPlan plan)
+        {
+            DrawCore(in plan);
+            DrawRotatedRing(plan.Position, plan.Rotation, plan.ShellRadius, plan.RingSegments, plan.ShellColor);
+            DrawRotatedRing(
+                plan.Position,
+                plan.Rotation * Quaternion.CreateFromAxisAngle(Vector3.UnitX, MathF.PI * 0.5f),
+                plan.ShellRadius * 0.82f,
+                Math.Max(3, plan.RingSegments - 4),
+                MultiplyColor(plan.ShellColor, 0.92f, 1f, 1.1f, 0.8f));
+
+            Vector3 right = Vector3.Normalize(Vector3.Transform(Vector3.UnitX, plan.Rotation));
+            Vector3 up = Vector3.Normalize(Vector3.Transform(Vector3.UnitY, plan.Rotation));
+            Vector3 forward = Vector3.Normalize(Vector3.Transform(-Vector3.UnitZ, plan.Rotation));
+            Color beamColor = ToRaylibColor(MultiplyColor(plan.CoreColor, 1.1f, 1.08f, 1.18f, 0.82f));
+            Rl.DrawLine3D(plan.Position - (right * plan.ShellRadius), plan.Position + (right * plan.ShellRadius), beamColor);
+            Rl.DrawLine3D(plan.Position - (up * plan.ShellRadius * 0.8f), plan.Position + (up * plan.ShellRadius * 0.8f), beamColor);
+            Rl.DrawLine3D(plan.Position - (forward * plan.ShellRadius * 0.9f), plan.Position + (forward * plan.ShellRadius * 0.9f), beamColor);
+
+            DrawParticles(in plan);
+        }
+
+        private static void DrawCore(in RaylibVfxEmitterPlan plan)
+        {
+            Color color = ToRaylibColor(plan.CoreColor);
+            switch (plan.Shape)
+            {
+                case VfxEmitterShape.BillboardSprite:
+                    throw new InvalidOperationException(
+                        "Raylib VFX emitter shape 'BillboardSprite' requires a billboard texture renderer. Author PrimitiveSphere or PrimitiveCube until that renderer exists.");
+                case VfxEmitterShape.PrimitiveSphere:
+                    Rl.DrawSphere(plan.Position, plan.CoreRadius, color);
+                    break;
+                case VfxEmitterShape.PrimitiveCube:
+                    Vector3 size = new(plan.CoreRadius * 1.6f, plan.CoreRadius * 1.6f, plan.CoreRadius * 1.6f);
+                    Rl.DrawCube(plan.Position, size.X, size.Y, size.Z, color);
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Raylib VFX emitter shape '{plan.Shape}' is not supported.");
+            }
+        }
+
+        private static void DrawParticles(in RaylibVfxEmitterPlan plan)
+        {
+            const float goldenAngle = 2.3999631f;
+            for (int i = 0; i < plan.ParticleCount; i++)
+            {
+                float lane = i / (float)Math.Max(1, plan.ParticleCount - 1);
+                float angle = (i * goldenAngle) + plan.OrbitPhase;
+                float radius = plan.ShellRadius * (0.55f + (0.32f * MathF.Sin(plan.OrbitPhase * 0.7f + i)));
+                float y = plan.ShellRadius * (lane - 0.5f) * 0.9f;
+                Vector3 local = new(MathF.Cos(angle) * radius, y, MathF.Sin(angle) * radius);
+                Vector3 particlePosition = TransformLocal(plan.Position, plan.Rotation, local);
+                Vector4 color = MultiplyColor(
+                    plan.ParticleColor,
+                    1f,
+                    1f,
+                    1f,
+                    0.55f + (0.45f * MathF.Sin(plan.OrbitPhase + i)));
+                if (plan.Shape == VfxEmitterShape.PrimitiveCube)
+                {
+                    Vector3 size = new(plan.ParticleRadius * 1.55f, plan.ParticleRadius * 1.55f, plan.ParticleRadius * 1.55f);
+                    Rl.DrawCube(particlePosition, size.X, size.Y, size.Z, ToRaylibColor(color));
+                }
+                else
+                {
+                    Rl.DrawSphere(particlePosition, plan.ParticleRadius, ToRaylibColor(color));
+                }
+            }
+        }
+
+        internal static RaylibVfxEffectKey ComposeEffectKey(int stableId, int effectAssetId)
+        {
+            return new RaylibVfxEffectKey(stableId, effectAssetId);
+        }
+
+        private static void DrawRotatedRing(Vector3 center, Quaternion rotation, float radius, int segments, Vector4 color)
+        {
+            if (segments < 3 || radius <= 0f)
+            {
+                return;
+            }
+
+            Quaternion normalized = WorldPlane2D.NormalizeOrIdentity(rotation);
+            Color ringColor = ToRaylibColor(color);
+            float step = MathF.Tau / segments;
+            Vector3 previous = TransformLocal(center, normalized, new Vector3(radius, 0f, 0f));
+            for (int index = 1; index <= segments; index++)
+            {
+                float angle = index * step;
+                Vector3 current = TransformLocal(
+                    center,
+                    normalized,
+                    new Vector3(MathF.Cos(angle) * radius, 0f, MathF.Sin(angle) * radius));
+                Rl.DrawLine3D(previous, current, ringColor);
+                previous = current;
+            }
+        }
+
+        private static Vector3 TransformLocal(Vector3 origin, Quaternion rotation, Vector3 local)
+        {
+            return origin + Vector3.Transform(local, WorldPlane2D.NormalizeOrIdentity(rotation));
+        }
+
+        private static Vector4 BlendSemanticColor(Vector4 baseColor, int semanticId, float semanticWeight)
+        {
+            Vector4 semanticColor = ResolveSemanticColor(semanticId, baseColor.W);
+            Vector4 tinted = LerpColor(baseColor, semanticColor, semanticWeight);
+            tinted.W = Math.Max(baseColor.W, semanticColor.W * 0.8f);
+            return tinted;
+        }
+
+        private static Vector4 ResolveSemanticColor(int semanticId, float alpha)
+        {
+            uint seed = semanticId == 0 ? 0x9E3779B9u : Hash((uint)semanticId);
+            float r = 0.28f + (((seed >> 0) & 0xFF) / 255f) * 0.62f;
+            float g = 0.28f + (((seed >> 8) & 0xFF) / 255f) * 0.62f;
+            float b = 0.28f + (((seed >> 16) & 0xFF) / 255f) * 0.62f;
+            return new Vector4(r, g, b, Math.Clamp(alpha, 0.35f, 1f));
+        }
+
+        private static uint Hash(uint value)
+        {
+            value ^= value >> 16;
+            value *= 0x7FEB352Du;
+            value ^= value >> 15;
+            value *= 0x846CA68Bu;
+            value ^= value >> 16;
+            return value;
+        }
+
+        private static Vector4 MultiplyColor(Vector4 color, float r, float g, float b, float a)
+        {
+            return new Vector4(
+                Math.Clamp(color.X * r, 0f, 1f),
+                Math.Clamp(color.Y * g, 0f, 1f),
+                Math.Clamp(color.Z * b, 0f, 1f),
+                Math.Clamp(color.W * a, 0f, 1f));
+        }
+
+        private static Vector4 LerpColor(Vector4 from, Vector4 to, float t)
+        {
+            t = Math.Clamp(t, 0f, 1f);
+            return new Vector4(
+                from.X + (to.X - from.X) * t,
+                from.Y + (to.Y - from.Y) * t,
+                from.Z + (to.Z - from.Z) * t,
+                from.W + (to.W - from.W) * t);
+        }
+
+        private static Vector4 ClampColor(Vector4 color)
+        {
+            return new Vector4(
+                Math.Clamp(color.X, 0f, 1f),
+                Math.Clamp(color.Y, 0f, 1f),
+                Math.Clamp(color.Z, 0f, 1f),
+                Math.Clamp(color.W, 0f, 1f));
+        }
+
+        private static Color ToRaylibColor(in Vector4 color)
+        {
+            return RaylibColorUtil.ToRaylibColor(in color);
+        }
+    }
+}

--- a/src/Core/Engine/GameEngine.cs
+++ b/src/Core/Engine/GameEngine.cs
@@ -1204,7 +1204,7 @@ namespace Ludots.Core.Engine
                     AssetKind.Mesh => meshAssets.GetId(key),
                     AssetKind.SkinnedMesh => meshAssets.GetId(key),
                     AssetKind.Decal => meshAssets.GetId(key),
-                    AssetKind.VFX => meshAssets.GetId(key),
+                    AssetKind.VFX => ResolveVfxEffectAssetId(key),
                     AssetKind.Spline => meshAssets.GetId(key),
                     AssetKind.Surface => meshAssets.GetId(key),
                     AssetKind.Sound => meshAssets.GetId(key),
@@ -1214,6 +1214,25 @@ namespace Ludots.Core.Engine
                 },
                 instancedBatchAssets.GetId,
                 entityCollectionKeyRegistry.Register).Load(ConfigCatalog, ConfigConflictReport);
+
+            int ResolveVfxEffectAssetId(string key)
+            {
+                int assetId = meshAssets.GetId(key);
+                if (assetId <= 0)
+                {
+                    return 0;
+                }
+
+                if (!meshAssets.TryGetDescriptor(assetId, out MeshAssetDescriptor descriptor) ||
+                    !descriptor.VfxEffectData.IsValid)
+                {
+                    throw new InvalidOperationException(
+                        $"Performer behavior VFX asset '{key}' must declare vfx emitter data.");
+                }
+
+                return assetId;
+            }
+
             performerDefinitions.RebuildCompiledViews();
             MapLoader.SetPresentationRuntime(
                 presentationStableIds,

--- a/src/Core/Presentation/Assets/MeshAssetDescriptor.cs
+++ b/src/Core/Presentation/Assets/MeshAssetDescriptor.cs
@@ -8,6 +8,7 @@ namespace Ludots.Core.Presentation.Assets
         public string[] SourceUris;
         public PrefabPart[] PrefabParts;
         public ProceduralMeshAssetData ProceduralMeshData;
+        public VfxEffectAssetData VfxEffectData;
 
         public static MeshAssetDescriptor Primitive(int id, PrimitiveMeshKind kind)
         {

--- a/src/Core/Presentation/Assets/VfxEffectAssetData.cs
+++ b/src/Core/Presentation/Assets/VfxEffectAssetData.cs
@@ -1,0 +1,121 @@
+using System;
+
+namespace Ludots.Core.Presentation.Assets
+{
+    public enum VfxEmitterShape : byte
+    {
+        None = 0,
+        BillboardSprite = 1,
+        PrimitiveCube = 2,
+        PrimitiveSphere = 3,
+    }
+
+    public readonly struct VfxEmitterDescriptor
+    {
+        public VfxEmitterDescriptor(
+            VfxEmitterShape shape,
+            int particleCount,
+            int ringSegments,
+            float radiusScale,
+            float coreRadiusScale,
+            float particleRadiusScale,
+            float lifetimeSeconds,
+            float pulseSpeedRadPerSecond,
+            float orbitSpeedRadPerSecond)
+        {
+            if (shape == VfxEmitterShape.None)
+            {
+                throw new ArgumentOutOfRangeException(nameof(shape));
+            }
+
+            if (particleCount <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(particleCount));
+            }
+
+            if (ringSegments < 3)
+            {
+                throw new ArgumentOutOfRangeException(nameof(ringSegments));
+            }
+
+            ValidatePositive(radiusScale, nameof(radiusScale));
+            ValidatePositive(coreRadiusScale, nameof(coreRadiusScale));
+            ValidatePositive(particleRadiusScale, nameof(particleRadiusScale));
+            ValidatePositive(lifetimeSeconds, nameof(lifetimeSeconds));
+            ValidateNonNegative(pulseSpeedRadPerSecond, nameof(pulseSpeedRadPerSecond));
+            ValidateNonNegative(orbitSpeedRadPerSecond, nameof(orbitSpeedRadPerSecond));
+
+            Shape = shape;
+            ParticleCount = particleCount;
+            RingSegments = ringSegments;
+            RadiusScale = radiusScale;
+            CoreRadiusScale = coreRadiusScale;
+            ParticleRadiusScale = particleRadiusScale;
+            LifetimeSeconds = lifetimeSeconds;
+            PulseSpeedRadPerSecond = pulseSpeedRadPerSecond;
+            OrbitSpeedRadPerSecond = orbitSpeedRadPerSecond;
+        }
+
+        public VfxEmitterShape Shape { get; }
+
+        public int ParticleCount { get; }
+
+        public int RingSegments { get; }
+
+        public float RadiusScale { get; }
+
+        public float CoreRadiusScale { get; }
+
+        public float ParticleRadiusScale { get; }
+
+        public float LifetimeSeconds { get; }
+
+        public float PulseSpeedRadPerSecond { get; }
+
+        public float OrbitSpeedRadPerSecond { get; }
+
+        public bool IsValid =>
+            Shape != VfxEmitterShape.None &&
+            ParticleCount > 0 &&
+            RingSegments >= 3 &&
+            RadiusScale > 0f &&
+            CoreRadiusScale > 0f &&
+            ParticleRadiusScale > 0f &&
+            LifetimeSeconds > 0f &&
+            PulseSpeedRadPerSecond >= 0f &&
+            OrbitSpeedRadPerSecond >= 0f;
+
+        private static void ValidatePositive(float value, string name)
+        {
+            if (!float.IsFinite(value) || value <= 0f)
+            {
+                throw new ArgumentOutOfRangeException(name);
+            }
+        }
+
+        private static void ValidateNonNegative(float value, string name)
+        {
+            if (!float.IsFinite(value) || value < 0f)
+            {
+                throw new ArgumentOutOfRangeException(name);
+            }
+        }
+    }
+
+    public readonly struct VfxEffectAssetData
+    {
+        public VfxEffectAssetData(in VfxEmitterDescriptor emitter)
+        {
+            if (!emitter.IsValid)
+            {
+                throw new ArgumentException("VFX effect assets require a valid emitter descriptor.", nameof(emitter));
+            }
+
+            Emitter = emitter;
+        }
+
+        public VfxEmitterDescriptor Emitter { get; }
+
+        public bool IsValid => Emitter.IsValid;
+    }
+}

--- a/src/Core/Presentation/Config/InstancedBatchAssetConfigLoader.cs
+++ b/src/Core/Presentation/Config/InstancedBatchAssetConfigLoader.cs
@@ -598,10 +598,16 @@ namespace Ludots.Core.Presentation.Config
                 node,
                 $"Instanced batch '{batchKey}' behavior '{behaviorKey}' target.effectAssetId");
             int effectAssetId = _meshes.GetId(effectKey);
-            if (effectAssetId <= 0 || !_meshes.TryGetDescriptor(effectAssetId, out _))
+            if (effectAssetId <= 0 || !_meshes.TryGetDescriptor(effectAssetId, out MeshAssetDescriptor descriptor))
             {
                 throw new InvalidOperationException(
                     $"Instanced batch '{batchKey}' behavior '{behaviorKey}' references unknown effect asset '{effectKey}'.");
+            }
+
+            if (!descriptor.VfxEffectData.IsValid)
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' behavior '{behaviorKey}' references effect asset '{effectKey}' without vfx emitter data.");
             }
 
             return effectAssetId;

--- a/src/Core/Presentation/Config/MeshAssetConfigLoader.cs
+++ b/src/Core/Presentation/Config/MeshAssetConfigLoader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Numerics;
 using System.Text.Json.Nodes;
 using Ludots.Core.Config;
@@ -103,23 +104,30 @@ namespace Ludots.Core.Presentation.Config
 
         private MeshAssetDescriptor ParseDescriptor(JsonNode node, string key)
         {
-            string typeStr = node["type"]?.GetValue<string>();
-            if (!Enum.TryParse<MeshAssetType>(typeStr, ignoreCase: false, out var type))
+            MeshAssetType type = ReadRequiredEnum<MeshAssetType>(
+                node["type"],
+                $"Presentation/mesh_assets.json asset '{key}' type");
+            if (type == MeshAssetType.None)
             {
-                throw new InvalidOperationException($"Presentation/mesh_assets.json asset '{key}' has invalid or missing type '{typeStr}'.");
+                throw new InvalidOperationException($"Presentation/mesh_assets.json asset '{key}' type must not be None.");
             }
 
             switch (type)
             {
                 case MeshAssetType.Primitive:
                 {
-                    string kindStr = node["primitiveKind"]?.GetValue<string>();
-                    if (!Enum.TryParse<PrimitiveMeshKind>(kindStr, ignoreCase: false, out var kind))
+                    PrimitiveMeshKind kind = ReadRequiredEnum<PrimitiveMeshKind>(
+                        node["primitiveKind"],
+                        $"Presentation/mesh_assets.json primitive asset '{key}' primitiveKind");
+                    if (kind == PrimitiveMeshKind.None)
                     {
-                        throw new InvalidOperationException($"Presentation/mesh_assets.json primitive asset '{key}' has invalid or missing primitiveKind '{kindStr}'.");
+                        throw new InvalidOperationException(
+                            $"Presentation/mesh_assets.json primitive asset '{key}' primitiveKind must not be None.");
                     }
 
-                    return MeshAssetDescriptor.Primitive(0, kind);
+                    var descriptor = MeshAssetDescriptor.Primitive(0, kind);
+                    descriptor.VfxEffectData = ParseVfxEffectData(node["vfx"], key);
+                    return descriptor;
                 }
                 case MeshAssetType.Model:
                 case MeshAssetType.Billboard:
@@ -130,14 +138,18 @@ namespace Ludots.Core.Presentation.Config
                             $"Presentation/mesh_assets.json asset '{key}' declares sourceUris. Platform paths belong in Presentation/host_assets.json.");
                     }
 
-                    return type == MeshAssetType.Billboard
+                    var descriptor = type == MeshAssetType.Billboard
                         ? MeshAssetDescriptor.Billboard(0, Array.Empty<string>())
                         : MeshAssetDescriptor.Model(0, Array.Empty<string>());
+                    descriptor.VfxEffectData = ParseVfxEffectData(node["vfx"], key);
+                    return descriptor;
                 }
                 case MeshAssetType.Prefab:
                 {
                     var parts = ParseParts(node["parts"]);
-                    return MeshAssetDescriptor.Prefab(0, parts);
+                    var descriptor = MeshAssetDescriptor.Prefab(0, parts);
+                    descriptor.VfxEffectData = ParseVfxEffectData(node["vfx"], key);
+                    return descriptor;
                 }
                 default:
                     throw new InvalidOperationException($"Presentation/mesh_assets.json asset '{key}' uses unsupported mesh asset type '{type}'.");
@@ -159,10 +171,9 @@ namespace Ludots.Core.Presentation.Config
                     throw new InvalidOperationException($"Prefab part at index {j} must declare an explicit kind.");
                 }
 
-                if (!Enum.TryParse(kindText, ignoreCase: false, out PrefabVisualPartKind kind))
-                {
-                    throw new InvalidOperationException($"Prefab part has invalid kind '{kindText}'.");
-                }
+                PrefabVisualPartKind kind = ParseRequiredEnumText<PrefabVisualPartKind>(
+                    kindText,
+                    $"Prefab part at index {j} kind");
 
                 string meshRef = p?["meshAssetId"]?.GetValue<string>();
                 int meshId = 0;
@@ -175,7 +186,7 @@ namespace Ludots.Core.Presentation.Config
                         p?["materialId"]?.GetValue<int>() ?? 0,
                         ParseVector2WithDefault(p?["size"], Vector2.One)),
                     PrefabVisualPartKind.Vfx => PrefabPart.Vfx(
-                        p?["effectAssetId"]?.GetValue<int>() ?? 0,
+                        ResolveEffectAssetId(p?["effectAssetId"], $"Prefab part at index {j}"),
                         ParseSpawnMode(p?["spawnMode"]?.GetValue<string>())),
                     PrefabVisualPartKind.Surface => PrefabPart.Surface(
                         meshId,
@@ -191,7 +202,6 @@ namespace Ludots.Core.Presentation.Config
                 part.ColorTint = ParseVector4WithDefault(p?["colorTint"], Vector4.One);
                 part.Grounding = ParseGrounding(p?["grounding"]);
                 part.MaterialId = p?["materialId"]?.GetValue<int>() ?? part.MaterialId;
-                part.EffectAssetId = p?["effectAssetId"]?.GetValue<int>() ?? part.EffectAssetId;
                 part.Size = ParseVector2WithDefault(p?["size"], part.Size == Vector2.Zero ? Vector2.One : part.Size);
                 part.Tiling = ParseVector2WithDefault(p?["tiling"], part.Tiling == Vector2.Zero ? Vector2.One : part.Tiling);
                 part.AlignToSurface = p?["alignToSurface"]?.GetValue<bool>() ?? part.AlignToSurface;
@@ -202,17 +212,89 @@ namespace Ludots.Core.Presentation.Config
             return parts;
         }
 
+        private int ResolveEffectAssetId(JsonNode? node, string partLabel)
+        {
+            string effectKey = ReadRequiredString(node, $"{partLabel} effectAssetId");
+            int effectAssetId = _meshRegistry.GetId(effectKey);
+            if (effectAssetId <= 0 || !_meshRegistry.TryGetDescriptor(effectAssetId, out MeshAssetDescriptor descriptor))
+            {
+                throw new InvalidOperationException(
+                    $"{partLabel} references unknown VFX effect asset '{effectKey}'.");
+            }
+
+            if (!descriptor.VfxEffectData.IsValid)
+            {
+                throw new InvalidOperationException(
+                    $"{partLabel} references VFX effect asset '{effectKey}' without vfx emitter data.");
+            }
+
+            return effectAssetId;
+        }
+
+        private static VfxEffectAssetData ParseVfxEffectData(JsonNode? node, string key)
+        {
+            if (node == null)
+            {
+                return default;
+            }
+
+            if (node is not JsonObject obj)
+            {
+                throw new InvalidOperationException(
+                    $"Presentation/mesh_assets.json asset '{key}' vfx must be an object.");
+            }
+
+            ValidateObjectFields(
+                obj,
+                $"Presentation/mesh_assets.json asset '{key}' vfx",
+                "emitter");
+
+            if (obj["emitter"] is not JsonObject emitter)
+            {
+                throw new InvalidOperationException(
+                    $"Presentation/mesh_assets.json asset '{key}' vfx.emitter must be an object.");
+            }
+
+            ValidateObjectFields(
+                emitter,
+                $"Presentation/mesh_assets.json asset '{key}' vfx.emitter",
+                "shape",
+                "particleCount",
+                "ringSegments",
+                "radiusScale",
+                "coreRadiusScale",
+                "particleRadiusScale",
+                "lifetimeSeconds",
+                "pulseSpeedRadPerSecond",
+                "orbitSpeedRadPerSecond");
+
+            string shapeLabel = $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.shape";
+            VfxEmitterShape shape = ReadRequiredEnum<VfxEmitterShape>(emitter["shape"], shapeLabel);
+            if (shape == VfxEmitterShape.None)
+            {
+                throw new InvalidOperationException($"{shapeLabel} must not be None.");
+            }
+
+            return new VfxEffectAssetData(new VfxEmitterDescriptor(
+                shape,
+                ReadRequiredPositiveInt(emitter["particleCount"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.particleCount"),
+                ReadRequiredMinInt(emitter["ringSegments"], 3, $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.ringSegments"),
+                ReadRequiredPositiveFloat(emitter["radiusScale"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.radiusScale"),
+                ReadRequiredPositiveFloat(emitter["coreRadiusScale"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.coreRadiusScale"),
+                ReadRequiredPositiveFloat(emitter["particleRadiusScale"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.particleRadiusScale"),
+                ReadRequiredPositiveFloat(emitter["lifetimeSeconds"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.lifetimeSeconds"),
+                ReadRequiredNonNegativeFloat(emitter["pulseSpeedRadPerSecond"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.pulseSpeedRadPerSecond"),
+                ReadRequiredNonNegativeFloat(emitter["orbitSpeedRadPerSecond"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.orbitSpeedRadPerSecond")));
+        }
+
         private static PrefabVfxSpawnMode ParseSpawnMode(string? spawnModeText)
         {
             string resolved = string.IsNullOrWhiteSpace(spawnModeText)
                 ? nameof(PrefabVfxSpawnMode.Once)
                 : spawnModeText;
-            if (!Enum.TryParse(resolved, ignoreCase: false, out PrefabVfxSpawnMode spawnMode))
-            {
-                throw new InvalidOperationException($"Prefab part VFX spawnMode has invalid value '{resolved}'.");
-            }
-
-            return spawnMode;
+            return ParseRequiredEnumText<PrefabVfxSpawnMode>(
+                resolved,
+                "Prefab part VFX spawnMode");
         }
 
         private static PrefabPartGrounding ParseGrounding(JsonNode node)
@@ -228,10 +310,9 @@ namespace Ludots.Core.Presentation.Config
             }
 
             string modeText = obj["mode"]?.GetValue<string>() ?? nameof(PrefabPartGroundingMode.None);
-            if (!Enum.TryParse(modeText, ignoreCase: false, out PrefabPartGroundingMode mode))
-            {
-                throw new InvalidOperationException($"Prefab part grounding has invalid mode '{modeText}'.");
-            }
+            PrefabPartGroundingMode mode = ParseRequiredEnumText<PrefabPartGroundingMode>(
+                modeText,
+                "Prefab part grounding mode");
 
             int layerIndex = obj["layerIndex"]?.GetValue<int>() ?? 0;
             if (layerIndex < 0)
@@ -244,6 +325,122 @@ namespace Ludots.Core.Presentation.Config
                 obj["verticalOffsetMeters"]?.GetValue<float>() ?? 0f,
                 obj["alignToGroundNormal"]?.GetValue<bool>() ?? false,
                 layerIndex);
+        }
+
+        private static string ReadRequiredString(JsonNode? node, string label)
+        {
+            if (node is not JsonValue valueNode || !valueNode.TryGetValue(out string? value))
+            {
+                throw new InvalidOperationException($"{label} must be a non-empty asset key.");
+            }
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new InvalidOperationException($"{label} must be a non-empty asset key.");
+            }
+
+            if (!string.Equals(value, value.Trim(), StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"{label} must not include leading or trailing whitespace.");
+            }
+
+            return value;
+        }
+
+        private static T ReadRequiredEnum<T>(JsonNode? node, string label)
+            where T : struct, Enum
+        {
+            string value = ReadRequiredString(node, label);
+            return ParseRequiredEnumText<T>(value, label);
+        }
+
+        private static T ParseRequiredEnumText<T>(string value, string label)
+            where T : struct, Enum
+        {
+            if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+            {
+                throw new InvalidOperationException($"{label} has invalid value '{value}'. Use the enum name, not a numeric string.");
+            }
+
+            if (!Enum.TryParse(value, ignoreCase: false, out T parsed) ||
+                !Enum.IsDefined(typeof(T), parsed))
+            {
+                throw new InvalidOperationException($"{label} has invalid value '{value}'.");
+            }
+
+            return parsed;
+        }
+
+        private static int ReadRequiredPositiveInt(JsonNode? node, string label)
+        {
+            return ReadRequiredMinInt(node, 1, label);
+        }
+
+        private static int ReadRequiredMinInt(JsonNode? node, int min, string label)
+        {
+            if (node is not JsonValue valueNode || !valueNode.TryGetValue(out int value))
+            {
+                throw new InvalidOperationException($"{label} must be an integer greater than or equal to {min}.");
+            }
+
+            if (value < min)
+            {
+                throw new InvalidOperationException($"{label} must be greater than or equal to {min}.");
+            }
+
+            return value;
+        }
+
+        private static float ReadRequiredPositiveFloat(JsonNode? node, string label)
+        {
+            if (node is not JsonValue valueNode || !valueNode.TryGetValue(out float value))
+            {
+                throw new InvalidOperationException($"{label} must be a finite number greater than 0.");
+            }
+
+            if (!float.IsFinite(value) || value <= 0f)
+            {
+                throw new InvalidOperationException($"{label} must be a finite number greater than 0.");
+            }
+
+            return value;
+        }
+
+        private static float ReadRequiredNonNegativeFloat(JsonNode? node, string label)
+        {
+            if (node is not JsonValue valueNode || !valueNode.TryGetValue(out float value))
+            {
+                throw new InvalidOperationException($"{label} must be a finite number greater than or equal to 0.");
+            }
+
+            if (!float.IsFinite(value) || value < 0f)
+            {
+                throw new InvalidOperationException($"{label} must be a finite number greater than or equal to 0.");
+            }
+
+            return value;
+        }
+
+        private static void ValidateObjectFields(JsonObject obj, string context, params string[] allowedFields)
+        {
+            foreach (var property in obj)
+            {
+                bool allowed = false;
+                for (int i = 0; i < allowedFields.Length; i++)
+                {
+                    if (string.Equals(property.Key, allowedFields[i], StringComparison.Ordinal))
+                    {
+                        allowed = true;
+                        break;
+                    }
+                }
+
+                if (!allowed)
+                {
+                    throw new InvalidOperationException(
+                        $"{context} uses unsupported field '{property.Key}'.");
+                }
+            }
         }
 
         private static Vector3 ParseVector3(JsonNode node)

--- a/src/Libraries/Arch/src/Arch/Core/Events/World.Events.cs
+++ b/src/Libraries/Arch/src/Arch/Core/Events/World.Events.cs
@@ -55,7 +55,11 @@ public partial class World
     /// <param name="handler">The delegate to call.</param>
     public void SubscribeEntityDestroyed(EntityDestroyedHandler handler)
     {
-        ArgumentNullException.ThrowIfNull(handler);
+        if (handler == null)
+        {
+            throw new ArgumentNullException(nameof(handler));
+        }
+
         lock (_entityDestroyedHandlersWriteLock)
         {
             EntityDestroyedHandler[] current = Volatile.Read(ref _entityDestroyedHandlers);

--- a/src/Tests/ArchitectureTests/PresentationBehaviorAndPrefabConfigContractTests.cs
+++ b/src/Tests/ArchitectureTests/PresentationBehaviorAndPrefabConfigContractTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using Ludots.Core.Config;
 using Ludots.Core.Engine;
 using Ludots.Core.EntityCollections;
@@ -55,6 +56,240 @@ namespace Ludots.Tests.Architecture
             var ex = Assert.Throws<InvalidOperationException>(() =>
                 new MeshAssetConfigLoader(pipeline, meshes, prefabs).Load(catalog));
             Assert.That(ex!.Message, Does.Contain("must declare an explicit kind"));
+        }
+
+        [Test]
+        public void MeshAssetConfigLoader_PrefabVfxEffectAssetId_ResolvesMeshAssetKey()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "Ludots_PresentationVfxConfigContracts", Guid.NewGuid().ToString("N"));
+            string core = Path.Combine(root, "Core");
+            Directory.CreateDirectory(Path.Combine(core, "Configs", "Presentation"));
+            WriteCatalog(core, "Presentation/mesh_assets.json", "ArrayById", "id", "Presentation/prefabs.json", "ArrayById", "id");
+            File.WriteAllText(Path.Combine(core, "Configs", "Presentation", "mesh_assets.json"), """
+[
+  { "id": "cube", "type": "Primitive", "primitiveKind": "Cube" },
+  {
+    "id": "effect.spark",
+    "type": "Primitive",
+    "primitiveKind": "Sphere",
+    "vfx": {
+      "emitter": {
+        "shape": "PrimitiveSphere",
+        "particleCount": 24,
+        "ringSegments": 20,
+        "radiusScale": 1.15,
+        "coreRadiusScale": 0.28,
+        "particleRadiusScale": 0.085,
+        "lifetimeSeconds": 0.75,
+        "pulseSpeedRadPerSecond": 5.2,
+        "orbitSpeedRadPerSecond": 1.7
+      }
+    }
+  }
+]
+""");
+            File.WriteAllText(Path.Combine(core, "Configs", "Presentation", "prefabs.json"), """
+[
+  {
+    "id": "prefab.vfx",
+    "parts": [
+      {
+        "kind": "Vfx",
+        "effectAssetId": "effect.spark",
+        "spawnMode": "Loop"
+      }
+    ]
+  }
+]
+""");
+
+            var vfs = new VirtualFileSystem();
+            vfs.Mount("Core", core);
+            var pipeline = new ConfigPipeline(vfs, modLoader: null!);
+            var catalog = ConfigCatalogLoader.Load(pipeline);
+            var meshes = new MeshAssetRegistry();
+            var prefabs = new PrefabRegistry();
+
+            new MeshAssetConfigLoader(pipeline, meshes, prefabs).Load(catalog);
+
+            int prefabMeshId = meshes.GetId("prefab.vfx");
+            Assert.That(meshes.TryGetDescriptor(prefabMeshId, out MeshAssetDescriptor descriptor), Is.True);
+            Assert.That(descriptor.PrefabParts[0].EffectAssetId, Is.EqualTo(meshes.GetId("effect.spark")));
+            Assert.That(descriptor.PrefabParts[0].VfxSpawnMode, Is.EqualTo(PrefabVfxSpawnMode.Loop));
+        }
+
+        [Test]
+        public void MeshAssetConfigLoader_PrefabVfxEffectAssetId_RejectsRawNumber()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "Ludots_PresentationVfxConfigContracts", Guid.NewGuid().ToString("N"));
+            string core = Path.Combine(root, "Core");
+            Directory.CreateDirectory(Path.Combine(core, "Configs", "Presentation"));
+            WriteCatalog(core, "Presentation/mesh_assets.json", "ArrayById", "id", "Presentation/prefabs.json", "ArrayById", "id");
+            File.WriteAllText(Path.Combine(core, "Configs", "Presentation", "mesh_assets.json"), """
+[
+  { "id": "cube", "type": "Primitive", "primitiveKind": "Cube" }
+]
+""");
+            File.WriteAllText(Path.Combine(core, "Configs", "Presentation", "prefabs.json"), """
+[
+  {
+    "id": "prefab.bad.vfx",
+    "parts": [
+      {
+        "kind": "Vfx",
+        "effectAssetId": 201
+      }
+    ]
+  }
+]
+""");
+
+            var vfs = new VirtualFileSystem();
+            vfs.Mount("Core", core);
+            var pipeline = new ConfigPipeline(vfs, modLoader: null!);
+            var catalog = ConfigCatalogLoader.Load(pipeline);
+            var meshes = new MeshAssetRegistry();
+            var prefabs = new PrefabRegistry();
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                new MeshAssetConfigLoader(pipeline, meshes, prefabs).Load(catalog));
+            Assert.That(ex!.Message, Does.Contain("effectAssetId must be a non-empty asset key"));
+        }
+
+        [Test]
+        public void MeshAssetConfigLoader_PrefabVfxEffectAssetId_RejectsAssetWithoutVfxEmitterData()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "Ludots_PresentationVfxConfigContracts", Guid.NewGuid().ToString("N"));
+            string core = Path.Combine(root, "Core");
+            Directory.CreateDirectory(Path.Combine(core, "Configs", "Presentation"));
+            WriteCatalog(core, "Presentation/mesh_assets.json", "ArrayById", "id", "Presentation/prefabs.json", "ArrayById", "id");
+            File.WriteAllText(Path.Combine(core, "Configs", "Presentation", "mesh_assets.json"), """
+[
+  { "id": "effect.spark", "type": "Billboard" }
+]
+""");
+            File.WriteAllText(Path.Combine(core, "Configs", "Presentation", "prefabs.json"), """
+[
+  {
+    "id": "prefab.bad.vfx",
+    "parts": [
+      {
+        "kind": "Vfx",
+        "effectAssetId": "effect.spark"
+      }
+    ]
+  }
+]
+""");
+
+            var vfs = new VirtualFileSystem();
+            vfs.Mount("Core", core);
+            var pipeline = new ConfigPipeline(vfs, modLoader: null!);
+            var catalog = ConfigCatalogLoader.Load(pipeline);
+            var meshes = new MeshAssetRegistry();
+            var prefabs = new PrefabRegistry();
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                new MeshAssetConfigLoader(pipeline, meshes, prefabs).Load(catalog));
+            Assert.That(ex!.Message, Does.Contain("without vfx emitter data"));
+        }
+
+        [Test]
+        public void MeshAssetConfigLoader_VfxEmitterShape_RejectsNumericString()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "Ludots_PresentationVfxConfigContracts", Guid.NewGuid().ToString("N"));
+            string core = Path.Combine(root, "Core");
+            Directory.CreateDirectory(Path.Combine(core, "Configs", "Presentation"));
+            WriteCatalog(core, "Presentation/mesh_assets.json", "ArrayById", "id");
+            File.WriteAllText(Path.Combine(core, "Configs", "Presentation", "mesh_assets.json"), """
+[
+  {
+    "id": "effect.spark",
+    "type": "Billboard",
+    "vfx": {
+      "emitter": {
+        "shape": "99",
+        "particleCount": 24,
+        "ringSegments": 20,
+        "radiusScale": 1.15,
+        "coreRadiusScale": 0.28,
+        "particleRadiusScale": 0.085,
+        "lifetimeSeconds": 0.75,
+        "pulseSpeedRadPerSecond": 5.2,
+        "orbitSpeedRadPerSecond": 1.7
+      }
+    }
+  }
+]
+""");
+
+            var vfs = new VirtualFileSystem();
+            vfs.Mount("Core", core);
+            var pipeline = new ConfigPipeline(vfs, modLoader: null!);
+            var catalog = ConfigCatalogLoader.Load(pipeline);
+            var meshes = new MeshAssetRegistry();
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                new MeshAssetConfigLoader(pipeline, meshes).Load(catalog));
+            Assert.That(ex!.Message, Does.Contain("vfx.emitter.shape"));
+            Assert.That(ex.Message, Does.Contain("not a numeric string"));
+        }
+
+        [Test]
+        public void MeshAssetConfigLoader_PrefabVfxSpawnMode_RejectsNumericString()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "Ludots_PresentationVfxConfigContracts", Guid.NewGuid().ToString("N"));
+            string core = Path.Combine(root, "Core");
+            Directory.CreateDirectory(Path.Combine(core, "Configs", "Presentation"));
+            WriteCatalog(core, "Presentation/mesh_assets.json", "ArrayById", "id", "Presentation/prefabs.json", "ArrayById", "id");
+            File.WriteAllText(Path.Combine(core, "Configs", "Presentation", "mesh_assets.json"), """
+[
+  {
+    "id": "effect.spark",
+    "type": "Primitive",
+    "primitiveKind": "Sphere",
+    "vfx": {
+      "emitter": {
+        "shape": "PrimitiveSphere",
+        "particleCount": 24,
+        "ringSegments": 20,
+        "radiusScale": 1.15,
+        "coreRadiusScale": 0.28,
+        "particleRadiusScale": 0.085,
+        "lifetimeSeconds": 0.75,
+        "pulseSpeedRadPerSecond": 5.2,
+        "orbitSpeedRadPerSecond": 1.7
+      }
+    }
+  }
+]
+""");
+            File.WriteAllText(Path.Combine(core, "Configs", "Presentation", "prefabs.json"), """
+[
+  {
+    "id": "prefab.bad.spawn",
+    "parts": [
+      {
+        "kind": "Vfx",
+        "effectAssetId": "effect.spark",
+        "spawnMode": "99"
+      }
+    ]
+  }
+]
+""");
+
+            var vfs = new VirtualFileSystem();
+            vfs.Mount("Core", core);
+            var pipeline = new ConfigPipeline(vfs, modLoader: null!);
+            var catalog = ConfigCatalogLoader.Load(pipeline);
+            var meshes = new MeshAssetRegistry();
+            var prefabs = new PrefabRegistry();
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                new MeshAssetConfigLoader(pipeline, meshes, prefabs).Load(catalog));
+            Assert.That(ex!.Message, Does.Contain("VFX spawnMode"));
+            Assert.That(ex.Message, Does.Contain("not a numeric string"));
         }
 
         [Test]
@@ -113,6 +348,33 @@ namespace Ludots.Tests.Architecture
 
             Assert.That(engine.GetService(CoreServiceKeys.PresentationBehaviorRegistry), Is.Not.Null);
             Assert.That(engine.GetService(CoreServiceKeys.PresentationBehaviorResolver), Is.Not.Null);
+        }
+
+        [Test]
+        public void BlacksmithSmokeShowcases_AuthorVfxEmitterWithoutRaylibHostTexture()
+        {
+            string repoRoot = FindRepoRoot();
+
+            AssertSmokeAssetIsPrimitiveVfx(
+                repoRoot,
+                Path.Combine(
+                    "mods",
+                    "showcases",
+                    "performer_blacksmith",
+                    "PerformerBlacksmithShowcaseMod",
+                    "assets",
+                    "Presentation"),
+                "blacksmith.smoke.billboard");
+            AssertSmokeAssetIsPrimitiveVfx(
+                repoRoot,
+                Path.Combine(
+                    "mods",
+                    "showcases",
+                    "capability_standard",
+                    "CapabilityStandardStaticPerformer30kMod",
+                    "assets",
+                    "Presentation"),
+                "capability_static_performer.smoke.billboard");
         }
 
         [Test]
@@ -1217,11 +1479,15 @@ namespace Ludots.Tests.Architecture
                 color: System.Numerics.Vector4.One,
                 output);
 
-            PrefabVisualPartKind[] kinds = output.GetSpan().ToArray().Select(static visual => visual.Kind).ToArray();
+            PrefabFinalizedVisual[] visuals = output.GetSpan().ToArray();
+            PrefabVisualPartKind[] kinds = visuals.Select(static visual => visual.Kind).ToArray();
             Assert.That(kinds, Does.Contain(PrefabVisualPartKind.Mesh));
             Assert.That(kinds, Does.Contain(PrefabVisualPartKind.Decal));
             Assert.That(kinds, Does.Contain(PrefabVisualPartKind.Vfx));
             Assert.That(kinds, Does.Contain(PrefabVisualPartKind.Surface));
+            Assert.That(
+                visuals.Single(static visual => visual.Kind == PrefabVisualPartKind.Vfx).EffectAssetId,
+                Is.EqualTo(meshes.GetId("effect.camera.projection_cue")));
         }
 
         private static string FindRepoRoot()
@@ -1239,6 +1505,51 @@ namespace Ludots.Tests.Architecture
             }
 
             throw new DirectoryNotFoundException("Could not locate repo root containing src/Core/Ludots.Core.csproj");
+        }
+
+        private static void AssertSmokeAssetIsPrimitiveVfx(
+            string repoRoot,
+            string presentationRelativeDirectory,
+            string smokeAssetId)
+        {
+            string presentationDirectory = Path.Combine(repoRoot, presentationRelativeDirectory);
+            JsonObject meshAsset = RequireJsonObjectById(
+                Path.Combine(presentationDirectory, "mesh_assets.json"),
+                smokeAssetId);
+
+            Assert.That(meshAsset["type"]?.GetValue<string>(), Is.EqualTo("Primitive"));
+            Assert.That(meshAsset["primitiveKind"]?.GetValue<string>(), Is.EqualTo("Sphere"));
+            Assert.That(meshAsset["vfx"]?["emitter"]?["shape"]?.GetValue<string>(), Is.EqualTo("PrimitiveSphere"));
+            Assert.That(meshAsset["vfx"]?["emitter"]?["particleCount"]?.GetValue<int>(), Is.GreaterThan(0));
+
+            JsonArray hostAssets = ReadJsonArray(Path.Combine(presentationDirectory, "host_assets.json"));
+            foreach (JsonNode? node in hostAssets)
+            {
+                Assert.That(
+                    node?["assetId"]?.GetValue<string>(),
+                    Is.Not.EqualTo(smokeAssetId),
+                    "Raylib host texture registration must not target authored Primitive VFX smoke.");
+            }
+        }
+
+        private static JsonObject RequireJsonObjectById(string path, string id)
+        {
+            foreach (JsonNode? node in ReadJsonArray(path))
+            {
+                if (node is JsonObject candidate &&
+                    string.Equals(candidate["id"]?.GetValue<string>(), id, StringComparison.Ordinal))
+                {
+                    return candidate;
+                }
+            }
+
+            throw new InvalidOperationException($"Config object '{id}' was not found in '{path}'.");
+        }
+
+        private static JsonArray ReadJsonArray(string path)
+        {
+            return JsonNode.Parse(File.ReadAllText(path))?.AsArray()
+                ?? throw new InvalidOperationException($"Config file '{path}' must contain a JSON array.");
         }
 
         private static void WriteCatalog(string coreRoot, params string[] triples)

--- a/src/Tests/PresentationTests/Performer/BlacksmithPerformerUatTests.cs
+++ b/src/Tests/PresentationTests/Performer/BlacksmithPerformerUatTests.cs
@@ -140,6 +140,7 @@ namespace Ludots.Tests.Presentation
                 "src",
                 "Tests",
                 "PresentationTests",
+                "Performer",
                 "BlacksmithPerformerUatTests.cs");
 
             string source = File.ReadAllText(sourcePath);
@@ -584,12 +585,31 @@ namespace Ludots.Tests.Presentation
                 {
                     return kind switch
                     {
-                        AssetKind.Mesh or AssetKind.SkinnedMesh or AssetKind.VFX => meshAssets.GetId(key),
+                        AssetKind.Mesh or AssetKind.SkinnedMesh => meshAssets.GetId(key),
+                        AssetKind.VFX => ResolveVfxFixtureAssetId(key),
                         AssetKind.Spline when string.Equals(key, PatrolSplineAssetKey, StringComparison.Ordinal) => PatrolSplineAssetId,
                         AssetKind.Sound when string.Equals(key, HammerSoundAssetKey, StringComparison.Ordinal) => HammerSoundAssetId,
                         _ => throw new InvalidOperationException(
                             $"Blacksmith performer UAT has no fixture asset registered for {kind} '{key}'."),
                     };
+                }
+
+                int ResolveVfxFixtureAssetId(string key)
+                {
+                    int assetId = meshAssets.GetId(key);
+                    if (assetId <= 0)
+                    {
+                        return 0;
+                    }
+
+                    if (!meshAssets.TryGetDescriptor(assetId, out MeshAssetDescriptor descriptor) ||
+                        !descriptor.VfxEffectData.IsValid)
+                    {
+                        throw new InvalidOperationException(
+                            $"Blacksmith performer UAT VFX fixture asset '{key}' must declare vfx emitter data.");
+                    }
+
+                    return assetId;
                 }
 
                 int ResolveUnsupportedEffectTemplateId(string key)
@@ -612,7 +632,7 @@ namespace Ludots.Tests.Presentation
                 RegisterPrimitiveMesh(meshAssets, WorkshopDamagedAssetKey);
                 RegisterPrimitiveMesh(meshAssets, WorkshopRuinedAssetKey);
                 RegisterPrimitiveMesh(meshAssets, FurnaceAssetKey);
-                RegisterPrimitiveMesh(meshAssets, SmokeAssetKey);
+                RegisterVfxEffect(meshAssets, SmokeAssetKey);
                 RegisterPrimitiveMesh(meshAssets, WorkerAssetKey);
                 materialAssets.Register(
                     BrickNorthMaterialKey,
@@ -629,6 +649,22 @@ namespace Ludots.Tests.Presentation
             private static void RegisterPrimitiveMesh(MeshAssetRegistry meshAssets, string key)
             {
                 MeshAssetDescriptor descriptor = MeshAssetDescriptor.Primitive(0, PrimitiveMeshKind.Cube);
+                meshAssets.Register(key, in descriptor);
+            }
+
+            private static void RegisterVfxEffect(MeshAssetRegistry meshAssets, string key)
+            {
+                MeshAssetDescriptor descriptor = MeshAssetDescriptor.Primitive(0, PrimitiveMeshKind.Sphere);
+                descriptor.VfxEffectData = new VfxEffectAssetData(new VfxEmitterDescriptor(
+                    VfxEmitterShape.PrimitiveSphere,
+                    particleCount: 24,
+                    ringSegments: 20,
+                    radiusScale: 1.15f,
+                    coreRadiusScale: 0.28f,
+                    particleRadiusScale: 0.085f,
+                    lifetimeSeconds: 0.75f,
+                    pulseSpeedRadPerSecond: 5.2f,
+                    orbitSpeedRadPerSecond: 1.7f));
                 meshAssets.Register(key, in descriptor);
             }
 

--- a/src/Tests/PresentationTests/Performer/PerformerBlacksmithShowcaseRuntimeTests.cs
+++ b/src/Tests/PresentationTests/Performer/PerformerBlacksmithShowcaseRuntimeTests.cs
@@ -85,6 +85,27 @@ namespace Ludots.Tests.Presentation
             return count;
         }
 
+        private static int CountVisiblePrimitivesByMeshAndKind(
+            Ludots.Core.Engine.GameEngine engine,
+            int meshAssetId,
+            AssetKind assetKind)
+        {
+            var primitives = engine.GetService(CoreServiceKeys.PresentationPrimitiveDrawBuffer)
+                ?? throw new InvalidOperationException("PrimitiveDrawBuffer missing.");
+            int count = 0;
+            foreach (ref readonly PrimitiveDrawItem item in primitives.GetSpan())
+            {
+                if (item.Visibility == VisualVisibility.Visible &&
+                    item.MeshAssetId == meshAssetId &&
+                    item.AssetKind == assetKind)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
         private static int CountVisibleSkinnedByMesh(Ludots.Core.Engine.GameEngine engine, int meshAssetId)
         {
             var skinned = engine.GetService(CoreServiceKeys.PresentationSkinnedVisualBatchBuffer)
@@ -245,6 +266,10 @@ namespace Ludots.Tests.Presentation
 
             int smokeMeshId = ResolveMeshAssetId(engine, "blacksmith.smoke.billboard");
             int workerMeshId = ResolveMeshAssetId(engine, "blacksmith.worker.knight");
+            var meshes = engine.GetService(CoreServiceKeys.PresentationMeshAssetRegistry)
+                ?? throw new InvalidOperationException("MeshAssetRegistry missing.");
+            Assert.That(meshes.TryGetDescriptor(smokeMeshId, out MeshAssetDescriptor smokeDescriptor), Is.True);
+            Assert.That(smokeDescriptor.VfxEffectData.IsValid, Is.True, "Blacksmith smoke must be an authored VFX effect asset, not a plain billboard fallback.");
             int smokeDefId = ResolvePerformerDefId(engine, PerformerBlacksmithShowcaseIds.SmokeDefinitionId);
             int workerDefId = ResolvePerformerDefId(engine, PerformerBlacksmithShowcaseIds.WorkerDefinitionId);
             var sounds = engine.GetService(CoreServiceKeys.SoundRequestBuffer)
@@ -265,6 +290,7 @@ namespace Ludots.Tests.Presentation
             PerformerBlacksmithShowcaseTestHarness.Tick(engine, 8);
 
             Assert.That(CountVisiblePrimitivesByMesh(engine, smokeMeshId), Is.GreaterThanOrEqualTo(1), "Smoke should become visible when working.");
+            Assert.That(CountVisiblePrimitivesByMeshAndKind(engine, smokeMeshId, AssetKind.VFX), Is.GreaterThanOrEqualTo(1), "Smoke should enter the VFX renderer path.");
             Assert.That(CountVisibleSkinnedByMesh(engine, workerMeshId), Is.GreaterThanOrEqualTo(1), "Worker should become visible when working.");
             Assert.That(sounds.Count, Is.GreaterThanOrEqualTo(1), "Worker sound loop should emit when working.");
             Assert.That((engine.World.Get<PerformerState>(smokeEntity).BehaviorActiveMask & (1u << 0)) != 0u, Is.True, "Smoke asset binding slot should be active.");

--- a/src/Tests/PresentationTests/Rendering/InstancedBatchContractTests.cs
+++ b/src/Tests/PresentationTests/Rendering/InstancedBatchContractTests.cs
@@ -1415,7 +1415,7 @@ namespace Ludots.Tests.Presentation
             registry = new InstancedBatchAssetRegistry();
 
             meshes.Register("mesh.unit", MeshAssetDescriptor.Model(0));
-            meshes.Register("effect.batch.spark", MeshAssetDescriptor.Billboard(0));
+            meshes.Register("effect.batch.spark", CreateEffectDescriptor());
 
             materials.Register("material.unit", MaterialAssetDomain.Surface, Array.Empty<string>(), MaterialAssetFlags.None);
             return new InstancedBatchAssetConfigLoader(
@@ -1433,6 +1433,22 @@ namespace Ludots.Tests.Presentation
             return eventKind == PresentationEventKind.EffectApplied
                 ? EffectTemplateIdRegistry.GetId(key)
                 : AbilityIdRegistry.GetId(key);
+        }
+
+        private static MeshAssetDescriptor CreateEffectDescriptor()
+        {
+            MeshAssetDescriptor descriptor = MeshAssetDescriptor.Primitive(0, PrimitiveMeshKind.Sphere);
+            descriptor.VfxEffectData = new VfxEffectAssetData(new VfxEmitterDescriptor(
+                VfxEmitterShape.PrimitiveSphere,
+                particleCount: 24,
+                ringSegments: 20,
+                radiusScale: 1.15f,
+                coreRadiusScale: 0.28f,
+                particleRadiusScale: 0.085f,
+                lifetimeSeconds: 0.75f,
+                pulseSpeedRadPerSecond: 5.2f,
+                orbitSpeedRadPerSecond: 1.7f));
+            return descriptor;
         }
 
         private static int ResolvePresentationEventKey(PresentationEventKind eventKind, string key)

--- a/src/Tests/RaylibAdapterTests/RaylibFrameRendererTests.cs
+++ b/src/Tests/RaylibAdapterTests/RaylibFrameRendererTests.cs
@@ -1,0 +1,104 @@
+using Ludots.Adapter.Raylib;
+using NUnit.Framework;
+
+namespace Ludots.Tests.RaylibAdapter;
+
+[TestFixture]
+public sealed class RaylibFrameRendererTests
+{
+    [Test]
+    public void BuildPassPlan_KeepsWorldPassesBeforeUiComposite()
+    {
+        Span<RaylibFramePass> passes = stackalloc RaylibFramePass[16];
+        int count = RaylibFrameRenderer.BuildPassPlan(
+            new RaylibFramePassPlanInput(
+                DrawDebugGuides: true,
+                DrawTerrain: true,
+                DrawVisualHeightmap: false,
+                HasGlobalFieldBuffer: true,
+                DrawFieldOverlays: true,
+                HasBenchmarkRenderer: true,
+                DrawPrimitives: true,
+                HasGroundOverlays: true,
+                HasRoadSplines: true,
+                DrawDebugDraw: true,
+                DrawSkiaUi: true),
+            passes);
+
+        Assert.That(passes[..count].ToArray(), Is.EqualTo(new[]
+        {
+            RaylibFramePass.Clear,
+            RaylibFramePass.BeginWorld3D,
+            RaylibFramePass.DebugGuides,
+            RaylibFramePass.Terrain,
+            RaylibFramePass.GlobalField,
+            RaylibFramePass.BenchmarkScene,
+            RaylibFramePass.PrimitiveVisuals,
+            RaylibFramePass.GroundOverlay,
+            RaylibFramePass.RoadSpline,
+            RaylibFramePass.DebugDraw,
+            RaylibFramePass.EndWorld3D,
+            RaylibFramePass.BrowserLayer,
+            RaylibFramePass.OverlayComposite,
+        }));
+    }
+
+    [Test]
+    public void BuildPassPlan_CanSuppressOptionalPassesWithoutMovingOverlay()
+    {
+        Span<RaylibFramePass> passes = stackalloc RaylibFramePass[16];
+        int count = RaylibFrameRenderer.BuildPassPlan(
+            new RaylibFramePassPlanInput(
+                DrawDebugGuides: false,
+                DrawTerrain: false,
+                DrawVisualHeightmap: false,
+                HasGlobalFieldBuffer: false,
+                DrawFieldOverlays: true,
+                HasBenchmarkRenderer: false,
+                DrawPrimitives: false,
+                HasGroundOverlays: false,
+                HasRoadSplines: false,
+                DrawDebugDraw: false,
+                DrawSkiaUi: false),
+            passes);
+
+        Assert.That(passes[..count].ToArray(), Is.EqualTo(new[]
+        {
+            RaylibFramePass.Clear,
+            RaylibFramePass.BeginWorld3D,
+            RaylibFramePass.EndWorld3D,
+            RaylibFramePass.OverlayComposite,
+        }));
+    }
+
+    [Test]
+    public void BuildPassPlan_FailsFastWhenOutputSpanIsTooSmall()
+    {
+        Span<RaylibFramePass> passes = stackalloc RaylibFramePass[1];
+
+        InvalidOperationException? error = null;
+        try
+        {
+            RaylibFrameRenderer.BuildPassPlan(
+                new RaylibFramePassPlanInput(
+                    DrawDebugGuides: true,
+                    DrawTerrain: true,
+                    DrawVisualHeightmap: true,
+                    HasGlobalFieldBuffer: true,
+                    DrawFieldOverlays: true,
+                    HasBenchmarkRenderer: true,
+                    DrawPrimitives: true,
+                    HasGroundOverlays: true,
+                    HasRoadSplines: true,
+                    DrawDebugDraw: true,
+                    DrawSkiaUi: true),
+                passes);
+        }
+        catch (InvalidOperationException ex)
+        {
+            error = ex;
+        }
+
+        Assert.That(error, Is.Not.Null);
+    }
+}

--- a/src/Tests/RaylibAdapterTests/RaylibVfxRendererTests.cs
+++ b/src/Tests/RaylibAdapterTests/RaylibVfxRendererTests.cs
@@ -1,0 +1,173 @@
+using System.Numerics;
+using Ludots.Client.Raylib.Rendering;
+using Ludots.Core.Presentation.Assets;
+using Ludots.Core.Presentation.Components;
+using Ludots.Core.Presentation.Performers;
+using Ludots.Core.Presentation.Rendering;
+using NUnit.Framework;
+
+namespace Ludots.Tests.RaylibAdapter;
+
+[TestFixture]
+public sealed class RaylibVfxRendererTests
+{
+    [Test]
+    public void TryBuildDirectVfxVisual_PerformerVfxPrimitive_BuildsLoopEffectVisual()
+    {
+        var primitive = new PrimitiveDrawItem
+        {
+            MeshAssetId = 42,
+            Position = new Vector3(1f, 2f, 3f),
+            Rotation = Quaternion.Identity,
+            Scale = new Vector3(2f, 3f, 4f),
+            Color = new Vector4(0.3f, 0.4f, 0.5f, 0.6f),
+            StableId = 99,
+            RenderPath = VisualRenderPath.StaticMesh,
+            AssetKind = AssetKind.VFX,
+            Mobility = VisualMobility.Movable,
+            Visibility = VisualVisibility.Visible,
+        };
+
+        bool handled = RaylibPrimitiveRenderer.TryBuildDirectVfxVisual(
+            in primitive,
+            scaleMul: 0.5f,
+            out PrefabFinalizedVisual visual);
+
+        Assert.That(handled, Is.True);
+        Assert.That(visual.Kind, Is.EqualTo(PrefabVisualPartKind.Vfx));
+        Assert.That(visual.StableId, Is.EqualTo(99));
+        Assert.That(visual.EffectAssetId, Is.EqualTo(42));
+        Assert.That(visual.VfxSpawnMode, Is.EqualTo(PrefabVfxSpawnMode.Loop));
+        Assert.That(visual.Scale, Is.EqualTo(new Vector3(1f, 1.5f, 2f)));
+    }
+
+    [Test]
+    public void ComposeEffectKey_UsesFullStableAndEffectIdentity()
+    {
+        RaylibVfxEffectKey first = RaylibVfxRenderer.ComposeEffectKey(17, 42);
+        RaylibVfxEffectKey same = RaylibVfxRenderer.ComposeEffectKey(17, 42);
+        RaylibVfxEffectKey differentEffect = RaylibVfxRenderer.ComposeEffectKey(17, 43);
+
+        Assert.That(first, Is.EqualTo(same));
+        Assert.That(first, Is.Not.EqualTo(differentEffect));
+    }
+
+    [Test]
+    public void BuildEmitterPlan_PrimitiveSphereLoop_ProducesAnimatedParticlePlan()
+    {
+        PrefabFinalizedVisual visual = PrefabFinalizedVisual.Vfx(
+            stableId: 17,
+            position: new Vector3(1f, 2f, 3f),
+            rotation: Quaternion.Identity,
+            scale: new Vector3(2f, 1f, 1f),
+            color: new Vector4(0.35f, 0.95f, 1f, 0.85f),
+            effectAssetId: 42,
+            spawnMode: PrefabVfxSpawnMode.Loop);
+        MeshAssetDescriptor descriptor = CreateSphereEffectDescriptor(42);
+
+        RaylibVfxEmitterPlan plan = RaylibVfxRenderer.BuildEmitterPlan(
+            in visual,
+            in descriptor,
+            ageSeconds: 1.25d);
+
+        Assert.That(plan.Shape, Is.EqualTo(VfxEmitterShape.PrimitiveSphere));
+        Assert.That(plan.SpawnMode, Is.EqualTo(PrefabVfxSpawnMode.Loop));
+        Assert.That(plan.ParticleCount, Is.EqualTo(24));
+        Assert.That(plan.RingSegments, Is.EqualTo(20));
+        Assert.That(plan.ShellRadius, Is.GreaterThan(0f));
+        Assert.That(plan.OrbitPhase, Is.GreaterThan(0f));
+        Assert.That(plan.CoreColor.W, Is.GreaterThan(0f));
+        Assert.That(plan.Life01, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void BuildEmitterPlan_Once_FadesOutByLifetime()
+    {
+        PrefabFinalizedVisual visual = PrefabFinalizedVisual.Vfx(
+            stableId: 23,
+            position: Vector3.Zero,
+            rotation: Quaternion.Identity,
+            scale: Vector3.One,
+            color: Vector4.One,
+            effectAssetId: 77,
+            spawnMode: PrefabVfxSpawnMode.Once);
+        MeshAssetDescriptor descriptor = CreateSphereEffectDescriptor(77);
+
+        RaylibVfxEmitterPlan plan = RaylibVfxRenderer.BuildEmitterPlan(
+            in visual,
+            in descriptor,
+            ageSeconds: 1.0d);
+
+        Assert.That(plan.Life01, Is.EqualTo(1f));
+        Assert.That(plan.CoreColor.W, Is.EqualTo(0f));
+        Assert.That(plan.ShellColor.W, Is.EqualTo(0f));
+        Assert.That(plan.ParticleColor.W, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void BuildEmitterPlan_RejectsEffectAssetWithoutEmitterData()
+    {
+        PrefabFinalizedVisual visual = PrefabFinalizedVisual.Vfx(
+            stableId: 31,
+            position: Vector3.Zero,
+            rotation: Quaternion.Identity,
+            scale: Vector3.One,
+            color: Vector4.One,
+            effectAssetId: 88,
+            spawnMode: PrefabVfxSpawnMode.Loop);
+        MeshAssetDescriptor descriptor = MeshAssetDescriptor.Billboard(88);
+
+        Assert.That(
+            () => RaylibVfxRenderer.BuildEmitterPlan(in visual, in descriptor, ageSeconds: 0d),
+            Throws.InvalidOperationException.With.Message.Contains("must declare vfx emitter data"));
+    }
+
+    [Test]
+    public void BuildEmitterPlan_PrimitiveCube_UsesAuthoredShapeAndParticleBudget()
+    {
+        PrefabFinalizedVisual visual = PrefabFinalizedVisual.Vfx(
+            stableId: 41,
+            position: Vector3.Zero,
+            rotation: Quaternion.Identity,
+            scale: Vector3.One,
+            color: Vector4.One,
+            effectAssetId: 91,
+            spawnMode: PrefabVfxSpawnMode.Loop);
+        MeshAssetDescriptor descriptor = MeshAssetDescriptor.Primitive(91, PrimitiveMeshKind.Cube);
+        descriptor.VfxEffectData = new VfxEffectAssetData(new VfxEmitterDescriptor(
+            VfxEmitterShape.PrimitiveCube,
+            particleCount: 9,
+            ringSegments: 11,
+            radiusScale: 0.8f,
+            coreRadiusScale: 0.2f,
+            particleRadiusScale: 0.06f,
+            lifetimeSeconds: 0.5f,
+            pulseSpeedRadPerSecond: 3.2f,
+            orbitSpeedRadPerSecond: 1.1f));
+
+        RaylibVfxEmitterPlan plan = RaylibVfxRenderer.BuildEmitterPlan(
+            in visual,
+            in descriptor,
+            ageSeconds: 0.2d);
+
+        Assert.That(plan.Shape, Is.EqualTo(VfxEmitterShape.PrimitiveCube));
+        Assert.That(plan.ParticleCount, Is.EqualTo(9));
+        Assert.That(plan.RingSegments, Is.EqualTo(11));
+    }
+
+    private static MeshAssetDescriptor CreateSphereEffectDescriptor(int id)
+    {
+        MeshAssetDescriptor descriptor = MeshAssetDescriptor.Primitive(id, PrimitiveMeshKind.Sphere);
+        descriptor.VfxEffectData = new VfxEffectAssetData(new VfxEmitterDescriptor(
+            VfxEmitterShape.PrimitiveSphere,
+            particleCount: 24,
+            ringSegments: 20,
+            radiusScale: 1.15f,
+            coreRadiusScale: 0.28f,
+            particleRadiusScale: 0.085f,
+            lifetimeSeconds: 0.75f,
+            pulseSpeedRadPerSecond: 5.2f,
+            orbitSpeedRadPerSecond: 1.7f));
+        return descriptor;
+    }
+}


### PR DESCRIPTION
﻿## Summary
- productize Raylib VFX rendering from performer `AssetKind.VFX` into the formal Raylib VFX renderer path
- replace Blacksmith and capability-standard smoke from legacy billboard host texture wiring with authored Primitive VFX emitter data
- split Raylib frame/world overlay rendering out of the host loop and add diagnostic launch stages for Raylib startup evidence
- tighten presentation asset config parsing so invalid numeric enum strings and VFX assets without emitter data fail early

## Validation
- `dotnet test src\Tests\ArchitectureTests\ArchitectureTests.csproj --filter "FullyQualifiedName~PresentationBehaviorAndPrefabConfigContractTests" -v:minimal`
- `dotnet test src\Tests\PresentationTests\PresentationTests.csproj --filter "FullyQualifiedName~BlacksmithPerformerUatTests|FullyQualifiedName~PerformerBlacksmithShowcaseRuntimeTests|FullyQualifiedName~PerformerBlacksmithShowcaseProductionPathTests|FullyQualifiedName~InstancedBatchContractTests" -v:minimal`
- `dotnet test src\Tests\RaylibAdapterTests\RaylibAdapterTests.csproj --filter "FullyQualifiedName~RaylibVfxRendererTests|FullyQualifiedName~RaylibFrameRendererTests" -v:minimal`
- `dotnet test src\Tests\ThreeCTests\ThreeCTests.csproj --filter "FullyQualifiedName~CameraAcceptanceModTests" -v:minimal`
- `dotnet build src\Adapters\Raylib\Ludots.Adapter.Raylib\Ludots.Adapter.Raylib.csproj -v:minimal /clp:ErrorsOnly`
- `git diff --check`

## Runtime Checks
- `performer_blacksmith_showcase_raylib`: real Raylib launch to auto-exit frame 120, stderr empty
- `capability_standard_static_performer_30k_raylib`: real Raylib launch to auto-exit frame 60, stderr empty

## Notes
- This establishes a formal Raylib VFX path and data contract; it is not yet a Quarks-class GPU particle framework.
- Decal direct Performer to typed Raylib decal rendering remains a separate productization slice.
