### PR TITLE
feat(raylib): productize terrain environment rendering

### DIFF
--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -33,6 +33,7 @@
   - [空间尺度与分辨率 SSOT](architecture/spatial-scale-and-resolution-ssot.md)
   - [Core Field2D](architecture/core-field2d.md)
   - [Global Field Rendering](architecture/global-field-rendering.md)
+  - [Raylib Render Productization](architecture/raylib-render-productization.md)
   - [MassNavigation 数值域与确定性边界](architecture/mass-navigation-numeric-domain.md)
   - [Prefab Grounding 与 Visual Height](architecture/prefab-grounding-and-visual-height.md)
   - [Structure Collision Surfaces](architecture/structure-collision-surfaces.md)

--- a/gitbook/architecture/README.md
+++ b/gitbook/architecture/README.md
@@ -26,6 +26,7 @@
 - [Core Minimap Authoring](core-minimap-authoring.md)
 - [Core Field2D](core-field2d.md)
 - [Global Field Rendering](global-field-rendering.md)
+- [Raylib Render Productization](raylib-render-productization.md)
 - [Map-Owned Participant Contract](map-owned-participant-contract.md)
 - [Transport Network SSOT](transport-network-ssot.md)
 - [Placement Validation SSOT](placement-validation-ssot.md)

--- a/gitbook/architecture/raylib-render-productization.md
+++ b/gitbook/architecture/raylib-render-productization.md
@@ -1,0 +1,53 @@
+# Raylib Render Productization
+
+本页记录 Raylib 客户端产品化的第一条正式口径：Raylib host 负责窗口、输入、生命周期和诊断；画面组织由 renderer 模块接管；VFX 必须从 Presentation 资产数据进入渲染，不允许在 adapter 里临时硬编码效果。
+
+## 渲染入口
+
+`RaylibHostLoop` 只负责驱动每帧。具体画面顺序由 `RaylibFrameRenderer` 统一组织：
+
+1. 清屏与 3D 相机状态
+2. 地形、全局场、benchmark 场景
+3. primitive / prefab / performer 输出
+4. 地面提示、道路样条、debug draw
+5. browser layer 与 UI composite
+
+这个顺序是 Raylib 后续接入 PBR、后处理、阴影、粒子和平台资源缓存的正式入口。新增 pass 应该进入 frame renderer，而不是回到 host loop 里继续堆条件分支。
+
+## VFX 资产
+
+VFX effect 是 Presentation 资产，不是 Raylib 私有配置。当前 SSOT 是 `MeshAssetRegistry`：
+
+- `prefabs.json` 的 VFX part 使用 `effectAssetId` 引用资产 key；
+- `instanced_batches.json` 的 effect 操作也使用同一类资产 key；
+- 被引用的 effect asset 必须在 `mesh_assets.json` 中声明 `vfx.emitter`；
+- 裸数字、未知 key、缺少 emitter 数据都会直接报错。
+
+最小示例：
+
+```json
+{
+  "id": "effect.camera.projection_cue",
+  "type": "Primitive",
+  "primitiveKind": "Sphere",
+  "vfx": {
+    "emitter": {
+      "shape": "PrimitiveSphere",
+      "particleCount": 24,
+      "ringSegments": 20,
+      "radiusScale": 1.15,
+      "coreRadiusScale": 0.28,
+      "particleRadiusScale": 0.085,
+      "lifetimeSeconds": 0.75,
+      "pulseSpeedRadPerSecond": 5.2,
+      "orbitSpeedRadPerSecond": 1.7
+    }
+  }
+}
+```
+
+Raylib 只消费 finalization 后的 VFX leaf 与 effect asset 数据，生成本帧 emitter plan 并绘制。它不拥有 effect key 解析，不创建平行 registry，也不替 prefab 或 performer 决定语义。
+
+## 演进方向
+
+下一阶段如果要做接近 Quarks 的粒子框架，应继续扩展这份 Presentation-owned effect asset contract，例如多 emitter、curve、burst、shape module、material binding 和 GPU buffer plan。Raylib adapter 只增加执行能力；Core 仍然负责配置合同、校验和平台无关的 runtime leaf。

--- a/mods/fixtures/blacksmith/BlacksmithTestMod/assets/Presentation/material_assets.json
+++ b/mods/fixtures/blacksmith/BlacksmithTestMod/assets/Presentation/material_assets.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "blacksmith.fixture.brick.north",
+    "domain": "Surface"
+  },
+  {
+    "id": "blacksmith.fixture.brick.south",
+    "domain": "Surface"
+  }
+]

--- a/mods/fixtures/blacksmith/BlacksmithTestMod/assets/Presentation/mesh_assets.json
+++ b/mods/fixtures/blacksmith/BlacksmithTestMod/assets/Presentation/mesh_assets.json
@@ -1,0 +1,61 @@
+[
+  {
+    "id": "blacksmith.fixture.workshop.intact",
+    "type": "Primitive",
+    "primitiveKind": "Cube"
+  },
+  {
+    "id": "blacksmith.fixture.workshop.damaged",
+    "type": "Primitive",
+    "primitiveKind": "Cube"
+  },
+  {
+    "id": "blacksmith.fixture.workshop.ruined",
+    "type": "Primitive",
+    "primitiveKind": "Cube"
+  },
+  {
+    "id": "blacksmith.fixture.furnace",
+    "type": "Primitive",
+    "primitiveKind": "Cube"
+  },
+  {
+    "id": "blacksmith.fixture.smoke",
+    "type": "Primitive",
+    "primitiveKind": "Sphere",
+    "vfx": {
+      "emitter": {
+        "shape": "PrimitiveSphere",
+        "particleCount": 24,
+        "ringSegments": 20,
+        "radiusScale": 1.15,
+        "coreRadiusScale": 0.28,
+        "particleRadiusScale": 0.085,
+        "lifetimeSeconds": 0.75,
+        "pulseSpeedRadPerSecond": 5.2,
+        "orbitSpeedRadPerSecond": 1.7,
+        "shellRingCount": 2,
+        "beamCount": 0
+      },
+      "spawnMode": "Loop",
+      "coreColor": [0.42, 0.43, 0.39, 0.48],
+      "shellColor": [0.72, 0.72, 0.67, 0.32],
+      "particleColor": [0.86, 0.83, 0.74, 0.42]
+    }
+  },
+  {
+    "id": "blacksmith.fixture.worker",
+    "type": "Primitive",
+    "primitiveKind": "Sphere"
+  },
+  {
+    "id": "blacksmith.fixture.anvil_hammering",
+    "type": "Primitive",
+    "primitiveKind": "Cube"
+  },
+  {
+    "id": "blacksmith.fixture.patrol",
+    "type": "Primitive",
+    "primitiveKind": "Cube"
+  }
+]

--- a/mods/fixtures/camera/CameraAcceptanceMod/assets/Presentation/mesh_assets.json
+++ b/mods/fixtures/camera/CameraAcceptanceMod/assets/Presentation/mesh_assets.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "effect.camera.projection_cue",
+    "type": "Primitive",
+    "primitiveKind": "Sphere",
+    "vfx": {
+      "emitter": {
+        "shape": "PrimitiveSphere",
+        "particleCount": 24,
+        "ringSegments": 20,
+        "radiusScale": 1.15,
+        "coreRadiusScale": 0.28,
+        "particleRadiusScale": 0.085,
+        "lifetimeSeconds": 0.75,
+        "pulseSpeedRadPerSecond": 5.2,
+        "orbitSpeedRadPerSecond": 1.7
+      }
+    }
+  }
+]

--- a/mods/fixtures/camera/CameraAcceptanceMod/assets/Presentation/mesh_assets.json
+++ b/mods/fixtures/camera/CameraAcceptanceMod/assets/Presentation/mesh_assets.json
@@ -13,8 +13,14 @@
         "particleRadiusScale": 0.085,
         "lifetimeSeconds": 0.75,
         "pulseSpeedRadPerSecond": 5.2,
-        "orbitSpeedRadPerSecond": 1.7
-      }
+        "orbitSpeedRadPerSecond": 1.7,
+        "shellRingCount": 2,
+        "beamCount": 3
+      },
+      "spawnMode": "Loop",
+      "coreColor": [0.20, 0.85, 1.00, 0.88],
+      "shellColor": [0.55, 0.95, 1.00, 0.62],
+      "particleColor": [1.00, 0.92, 0.32, 0.86]
     }
   }
 ]

--- a/mods/fixtures/camera/CameraAcceptanceMod/assets/Presentation/prefabs.json
+++ b/mods/fixtures/camera/CameraAcceptanceMod/assets/Presentation/prefabs.json
@@ -22,7 +22,7 @@
       },
       {
         "kind": "Vfx",
-        "effectAssetId": 201,
+        "effectAssetId": "effect.camera.projection_cue",
         "localPosition": [0, 0.18, 0],
         "localScale": [0.5, 0.5, 0.5],
         "colorTint": [0.35, 0.95, 1, 0.85],

--- a/mods/showcases/capability_standard/CapabilityStandardStaticPerformer30kMod/Runtime/CapabilityStandardStaticPerformer30kRuntime.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardStaticPerformer30kMod/Runtime/CapabilityStandardStaticPerformer30kRuntime.cs
@@ -71,6 +71,7 @@ namespace CapabilityStandardStaticPerformer30kMod.Runtime
         private const string MinimapMarkerScatterSeedMetadataKey = "minimapMarkerScatterSeed";
         private const string ForcePanelEnvKey = "LUDOTS_CAPABILITY_STANDARD_STATIC_PERFORMER_30K_FORCE_PANEL";
         private const string ForceBenchmarkUiEnvKey = "LUDOTS_CAPABILITY_STANDARD_STATIC_PERFORMER_30K_FORCE_BENCHMARK_UI";
+        private const string AutoWorkingEnvKey = "LUDOTS_CAPABILITY_STANDARD_STATIC_PERFORMER_30K_AUTO_WORKING";
         private const float PanelRefreshIntervalSeconds = 0.25f;
         private const float LargeCrowdPanelRefreshIntervalSeconds = 1.5f;
 
@@ -97,6 +98,7 @@ namespace CapabilityStandardStaticPerformer30kMod.Runtime
         private bool _autoMeshBenchmarkApplied;
         private bool _autoDynamicWorkerBenchmarkApplied;
         private bool _autoMinimapMarkerShowcaseApplied;
+        private bool _autoWorkingApplied;
         private float _panelRefreshCooldown;
         private bool _panelDirty = true;
         private CapabilityStandardStaticPerformer30kPanelState _cachedPanelState = CapabilityStandardStaticPerformer30kPanelState.Empty;
@@ -160,6 +162,7 @@ namespace CapabilityStandardStaticPerformer30kMod.Runtime
             _autoDynamicWorkerBenchmarkApplied = IsDynamicWorkerBenchmarkMode(engine) && CountDynamicWorkerEntities(engine) > 0;
             _autoMinimapMarkerShowcaseApplied = IsMinimapMarkerShowcaseMode(engine) && CountMinimapMarkerBallEntities(engine) > 0;
             TryApplyStartupBenchmarkLayout(engine);
+            TryApplyAutoWorkingState(engine);
             MarkPanelDirty();
             return Task.CompletedTask;
         }
@@ -178,6 +181,7 @@ namespace CapabilityStandardStaticPerformer30kMod.Runtime
             _autoMeshBenchmarkApplied = false;
             _autoDynamicWorkerBenchmarkApplied = false;
             _autoMinimapMarkerShowcaseApplied = false;
+            _autoWorkingApplied = false;
             _panelDirty = true;
             _panelRefreshCooldown = 0f;
             _cachedPanelState = CapabilityStandardStaticPerformer30kPanelState.Empty;
@@ -196,6 +200,7 @@ namespace CapabilityStandardStaticPerformer30kMod.Runtime
             if (IsInteractiveMode(engine))
             {
                 RefreshRootEntity(engine);
+                TryApplyAutoWorkingState(engine);
             }
 
             _panelRefreshCooldown = MathF.Max(0f, _panelRefreshCooldown - (1f / 60f));
@@ -216,7 +221,34 @@ namespace CapabilityStandardStaticPerformer30kMod.Runtime
                 return;
             }
 
-            _isWorking = !_isWorking;
+            SetWorkingState(engine, !_isWorking, $"Working => {(!_isWorking ? "ON" : "OFF")}");
+        }
+
+        private void TryApplyAutoWorkingState(GameEngine engine)
+        {
+            if (_autoWorkingApplied || !ReadStrictBoolEnv(AutoWorkingEnvKey))
+            {
+                return;
+            }
+
+            if (_destroyed || _buildingEntity == Entity.Null || !engine.World.IsAlive(_buildingEntity))
+            {
+                return;
+            }
+
+            SetWorkingState(engine, enabled: true, "Auto working => ON");
+            _autoWorkingApplied = true;
+        }
+
+        private void SetWorkingState(GameEngine engine, bool enabled, string flashLabel)
+        {
+            if (_isWorking == enabled)
+            {
+                _autoWorkingApplied = _autoWorkingApplied || enabled;
+                return;
+            }
+
+            _isWorking = enabled;
             EnsureGameplayTagState(engine, _buildingEntity);
             TagOps tagOps = engine.GetService(CoreServiceKeys.TagOps)
                 ?? throw new InvalidOperationException("TagOps service missing.");
@@ -229,7 +261,7 @@ namespace CapabilityStandardStaticPerformer30kMod.Runtime
                 tagOps.RemoveTag(engine.World, _buildingEntity, _workingTagId);
             }
 
-            Flash($"Working => {(_isWorking ? "ON" : "OFF")}");
+            Flash(flashLabel);
         }
 
         internal void ToggleDayNight()
@@ -1551,6 +1583,7 @@ namespace CapabilityStandardStaticPerformer30kMod.Runtime
             _autoMeshBenchmarkApplied = false;
             _autoDynamicWorkerBenchmarkApplied = false;
             _autoMinimapMarkerShowcaseApplied = false;
+            _autoWorkingApplied = false;
             MarkPanelDirty();
         }
 

--- a/mods/showcases/capability_standard/CapabilityStandardStaticPerformer30kMod/assets/Presentation/host_assets.json
+++ b/mods/showcases/capability_standard/CapabilityStandardStaticPerformer30kMod/assets/Presentation/host_assets.json
@@ -52,14 +52,5 @@
     "sourceUris": [
       "CapabilityStandardStaticPerformer30kMod:assets/Models/Knight.glb"
     ]
-  },
-  {
-    "id": "capability_static_performer.smoke.billboard.raylib",
-    "assetKind": "Mesh",
-    "assetId": "capability_static_performer.smoke.billboard",
-    "backendId": "raylib",
-    "sourceUris": [
-      "CapabilityStandardStaticPerformer30kMod:assets/Textures/smoke_puff.png"
-    ]
   }
 ]

--- a/mods/showcases/capability_standard/CapabilityStandardStaticPerformer30kMod/assets/Presentation/mesh_assets.json
+++ b/mods/showcases/capability_standard/CapabilityStandardStaticPerformer30kMod/assets/Presentation/mesh_assets.json
@@ -25,7 +25,21 @@
   },
   {
     "id": "capability_static_performer.smoke.billboard",
-    "type": "Billboard"
+    "type": "Primitive",
+    "primitiveKind": "Sphere",
+    "vfx": {
+      "emitter": {
+        "shape": "PrimitiveSphere",
+        "particleCount": 32,
+        "ringSegments": 24,
+        "radiusScale": 1.4,
+        "coreRadiusScale": 0.22,
+        "particleRadiusScale": 0.075,
+        "lifetimeSeconds": 1.2,
+        "pulseSpeedRadPerSecond": 2.6,
+        "orbitSpeedRadPerSecond": 0.65
+      }
+    }
   },
   {
     "id": "capability_static_performer.worker.patrol",

--- a/mods/showcases/capability_standard/CapabilityStandardStaticPerformer30kMod/assets/Presentation/mesh_assets.json
+++ b/mods/showcases/capability_standard/CapabilityStandardStaticPerformer30kMod/assets/Presentation/mesh_assets.json
@@ -37,8 +37,14 @@
         "particleRadiusScale": 0.075,
         "lifetimeSeconds": 1.2,
         "pulseSpeedRadPerSecond": 2.6,
-        "orbitSpeedRadPerSecond": 0.65
-      }
+        "orbitSpeedRadPerSecond": 0.65,
+        "shellRingCount": 2,
+        "beamCount": 0
+      },
+      "spawnMode": "Loop",
+      "coreColor": [0.42, 0.43, 0.39, 0.48],
+      "shellColor": [0.72, 0.72, 0.67, 0.32],
+      "particleColor": [0.86, 0.83, 0.74, 0.42]
     }
   },
   {

--- a/mods/showcases/performer_blacksmith/PerformerBlacksmithShowcaseMod/Runtime/PerformerBlacksmithShowcaseRuntime.cs
+++ b/mods/showcases/performer_blacksmith/PerformerBlacksmithShowcaseMod/Runtime/PerformerBlacksmithShowcaseRuntime.cs
@@ -75,6 +75,7 @@ namespace PerformerBlacksmithShowcaseMod.Runtime
         private const string MinimapMarkerScatterSeedMetadataKey = "minimapMarkerScatterSeed";
         private const string ForcePanelEnvKey = "LUDOTS_BLACKSMITH_FORCE_PANEL";
         private const string ForceBenchmarkUiEnvKey = "LUDOTS_BLACKSMITH_FORCE_BENCHMARK_UI";
+        private const string AutoWorkingEnvKey = "LUDOTS_BLACKSMITH_AUTO_WORKING";
         private const float PanelRefreshIntervalSeconds = 0.25f;
         private const float LargeCrowdPanelRefreshIntervalSeconds = 1.5f;
 
@@ -106,6 +107,7 @@ namespace PerformerBlacksmithShowcaseMod.Runtime
         private bool _autoMeshBenchmarkApplied;
         private bool _autoDynamicWorkerBenchmarkApplied;
         private bool _autoMinimapMarkerShowcaseApplied;
+        private bool _autoWorkingApplied;
         private float _panelRefreshCooldown;
         private bool _panelDirty = true;
         private PerformerBlacksmithShowcasePanelState _cachedPanelState = PerformerBlacksmithShowcasePanelState.Empty;
@@ -169,6 +171,7 @@ namespace PerformerBlacksmithShowcaseMod.Runtime
             _autoDynamicWorkerBenchmarkApplied = IsDynamicWorkerBenchmarkMode(engine) && CountDynamicWorkerEntities(engine) > 0;
             _autoMinimapMarkerShowcaseApplied = IsMinimapMarkerShowcaseMode(engine) && CountMinimapMarkerBallEntities(engine) > 0;
             TryApplyStartupBenchmarkLayout(engine);
+            TryApplyAutoWorkingState(engine);
             EnsureShowcaseKnowledgeProjection(engine);
             MarkPanelDirty();
             return Task.CompletedTask;
@@ -189,6 +192,7 @@ namespace PerformerBlacksmithShowcaseMod.Runtime
             _autoMeshBenchmarkApplied = false;
             _autoDynamicWorkerBenchmarkApplied = false;
             _autoMinimapMarkerShowcaseApplied = false;
+            _autoWorkingApplied = false;
             _panelDirty = true;
             _panelRefreshCooldown = 0f;
             _cachedPanelState = PerformerBlacksmithShowcasePanelState.Empty;
@@ -207,6 +211,7 @@ namespace PerformerBlacksmithShowcaseMod.Runtime
             if (IsInteractiveMode(engine))
             {
                 RefreshRootEntity(engine);
+                TryApplyAutoWorkingState(engine);
             }
 
             _panelRefreshCooldown = MathF.Max(0f, _panelRefreshCooldown - (1f / 60f));
@@ -238,7 +243,34 @@ namespace PerformerBlacksmithShowcaseMod.Runtime
                 return;
             }
 
-            _isWorking = !_isWorking;
+            SetWorkingState(engine, !_isWorking, $"Working => {(!_isWorking ? "ON" : "OFF")}");
+        }
+
+        private void TryApplyAutoWorkingState(GameEngine engine)
+        {
+            if (_autoWorkingApplied || !ReadStrictBoolEnv(AutoWorkingEnvKey))
+            {
+                return;
+            }
+
+            if (_destroyed || _buildingEntity == Entity.Null || !engine.World.IsAlive(_buildingEntity))
+            {
+                return;
+            }
+
+            SetWorkingState(engine, enabled: true, "Auto working => ON");
+            _autoWorkingApplied = true;
+        }
+
+        private void SetWorkingState(GameEngine engine, bool enabled, string flashLabel)
+        {
+            if (_isWorking == enabled)
+            {
+                _autoWorkingApplied = _autoWorkingApplied || enabled;
+                return;
+            }
+
+            _isWorking = enabled;
             EnsureGameplayTagState(engine, _buildingEntity);
             TagOps tagOps = engine.GetService(CoreServiceKeys.TagOps)
                 ?? throw new InvalidOperationException("TagOps service missing.");
@@ -251,7 +283,7 @@ namespace PerformerBlacksmithShowcaseMod.Runtime
                 tagOps.RemoveTag(engine.World, _buildingEntity, _workingTagId);
             }
 
-            Flash($"Working => {(_isWorking ? "ON" : "OFF")}");
+            Flash(flashLabel);
         }
 
         internal void ToggleDayNight()
@@ -1748,6 +1780,7 @@ namespace PerformerBlacksmithShowcaseMod.Runtime
             _autoMeshBenchmarkApplied = false;
             _autoDynamicWorkerBenchmarkApplied = false;
             _autoMinimapMarkerShowcaseApplied = false;
+            _autoWorkingApplied = false;
             MarkPanelDirty();
         }
 

--- a/mods/showcases/performer_blacksmith/PerformerBlacksmithShowcaseMod/assets/Maps/performer_blacksmith_minimap_marker_large_world_showcase.json
+++ b/mods/showcases/performer_blacksmith/PerformerBlacksmithShowcaseMod/assets/Maps/performer_blacksmith_minimap_marker_large_world_showcase.json
@@ -1,6 +1,15 @@
 {
   "Id": "performer_blacksmith_minimap_marker_large_world_showcase",
   "VisualHeightmapAsset": "assets/terrain/performer_blacksmith_minimap_marker_large_world_relief.vhtm",
+  "VisualHeightmap": {
+    "Asset": "assets/terrain/performer_blacksmith_minimap_marker_large_world_relief.vhtm",
+    "RenderProfile": {
+      "WaterEnabled": true,
+      "SeaLevelCm": 0,
+      "DisplayHeightScale": 1.25,
+      "ColorContrast": 1.35
+    }
+  },
   "Tags": ["showcase", "performer", "minimap", "large-world"],
   "Metadata": {
     "performerBlacksmith": {

--- a/mods/showcases/performer_blacksmith/PerformerBlacksmithShowcaseMod/assets/Presentation/host_assets.json
+++ b/mods/showcases/performer_blacksmith/PerformerBlacksmithShowcaseMod/assets/Presentation/host_assets.json
@@ -52,14 +52,5 @@
     "sourceUris": [
       "PerformerBlacksmithShowcaseMod:assets/Models/Knight.glb"
     ]
-  },
-  {
-    "id": "blacksmith.smoke.billboard.raylib",
-    "assetKind": "Mesh",
-    "assetId": "blacksmith.smoke.billboard",
-    "backendId": "raylib",
-    "sourceUris": [
-      "PerformerBlacksmithShowcaseMod:assets/Textures/smoke_puff.png"
-    ]
   }
 ]

--- a/mods/showcases/performer_blacksmith/PerformerBlacksmithShowcaseMod/assets/Presentation/mesh_assets.json
+++ b/mods/showcases/performer_blacksmith/PerformerBlacksmithShowcaseMod/assets/Presentation/mesh_assets.json
@@ -25,7 +25,21 @@
   },
   {
     "id": "blacksmith.smoke.billboard",
-    "type": "Billboard"
+    "type": "Primitive",
+    "primitiveKind": "Sphere",
+    "vfx": {
+      "emitter": {
+        "shape": "PrimitiveSphere",
+        "particleCount": 32,
+        "ringSegments": 24,
+        "radiusScale": 1.4,
+        "coreRadiusScale": 0.22,
+        "particleRadiusScale": 0.075,
+        "lifetimeSeconds": 1.2,
+        "pulseSpeedRadPerSecond": 2.6,
+        "orbitSpeedRadPerSecond": 0.65
+      }
+    }
   },
   {
     "id": "blacksmith.worker.patrol",

--- a/mods/showcases/performer_blacksmith/PerformerBlacksmithShowcaseMod/assets/Presentation/mesh_assets.json
+++ b/mods/showcases/performer_blacksmith/PerformerBlacksmithShowcaseMod/assets/Presentation/mesh_assets.json
@@ -37,8 +37,14 @@
         "particleRadiusScale": 0.075,
         "lifetimeSeconds": 1.2,
         "pulseSpeedRadPerSecond": 2.6,
-        "orbitSpeedRadPerSecond": 0.65
-      }
+        "orbitSpeedRadPerSecond": 0.65,
+        "shellRingCount": 2,
+        "beamCount": 0
+      },
+      "spawnMode": "Loop",
+      "coreColor": [0.42, 0.43, 0.39, 0.48],
+      "shellColor": [0.72, 0.72, 0.67, 0.32],
+      "particleColor": [0.86, 0.83, 0.74, 0.42]
     }
   },
   {

--- a/mods/showcases/visual_terrain_editor/VisualTerrainEditorMod/Runtime/VisualTerrainEditorDocument.cs
+++ b/mods/showcases/visual_terrain_editor/VisualTerrainEditorMod/Runtime/VisualTerrainEditorDocument.cs
@@ -570,6 +570,8 @@ internal sealed class VisualTerrainEditorDocument : IDisposable
         float meshStepX = 1f / (_asset.RenderColumnsPerChunk - 1);
         float meshStepY = 1f / (_asset.RenderRowsPerChunk - 1);
         WorldAabbCm chunkBounds = GetChunkBounds(state.ChunkX, state.ChunkY);
+        float chunkCenterXMeters = ((chunkBounds.Left + chunkBounds.Right) * 0.5f) * 0.01f;
+        float chunkCenterZMeters = ((chunkBounds.Top + chunkBounds.Bottom) * 0.5f) * 0.01f;
         int renderColumns = _asset.RenderColumnsPerChunk;
         int renderRows = _asset.RenderRowsPerChunk;
         int vertexCount = renderColumns * renderRows;
@@ -581,7 +583,7 @@ internal sealed class VisualTerrainEditorDocument : IDisposable
             for (int x = 0; x < renderColumns; x++)
             {
                 float u = x * meshStepX;
-                RenderVertexData vertex = BuildRenderVertex(chunkBounds, u, v);
+                RenderVertexData vertex = BuildRenderVertex(chunkBounds, chunkCenterXMeters, chunkCenterZMeters, u, v);
                 WriteProceduralVertex(state.ProceduralMesh, (y * renderColumns) + x, in vertex, u, v);
             }
         });
@@ -611,9 +613,9 @@ internal sealed class VisualTerrainEditorDocument : IDisposable
             new[] { new ProceduralSubmeshDescriptor(0, indexCount, state.MaterialAssetId) },
             new ProceduralMeshBounds(
                 new Vector3(
-                    ((chunkBounds.Left + chunkBounds.Right) * 0.5f) * 0.01f,
+                    0f,
                     ((state.MinHeightCm + state.MaxHeightCm) * 0.5f) * 0.01f,
-                    ((chunkBounds.Top + chunkBounds.Bottom) * 0.5f) * 0.01f),
+                    0f),
                 new Vector3(
                     chunkBounds.Width * 0.005f,
                     MathF.Max(0.5f, (state.MaxHeightCm - state.MinHeightCm) * 0.005f),
@@ -627,7 +629,12 @@ internal sealed class VisualTerrainEditorDocument : IDisposable
         return normal.Y < 0f ? -normal : normal;
     }
 
-    private RenderVertexData BuildRenderVertex(WorldAabbCm chunkBounds, float localU, float localV)
+    private RenderVertexData BuildRenderVertex(
+        WorldAabbCm chunkBounds,
+        float chunkCenterXMeters,
+        float chunkCenterZMeters,
+        float localU,
+        float localV)
     {
         float worldXMeters = Lerp(chunkBounds.Left, chunkBounds.Right, localU) * 0.01f;
         float worldZMeters = Lerp(chunkBounds.Top, chunkBounds.Bottom, localV) * 0.01f;
@@ -649,9 +656,9 @@ internal sealed class VisualTerrainEditorDocument : IDisposable
         }
 
         Vector3 position = new(
-            worldXMeters,
+            worldXMeters - chunkCenterXMeters,
             HeightToMeters(height, _asset.DefaultHeight01),
-            worldZMeters);
+            worldZMeters - chunkCenterZMeters);
         Vector3 color = ViewMode switch
         {
             TerrainViewMode.Base => ShadeSurface(baseHeight, normal, ridge, 0f),
@@ -1058,11 +1065,7 @@ internal sealed class VisualTerrainEditorDocument : IDisposable
         proceduralMesh.Normals[floatOffset + 2] = vertex.Normal.Z;
 
         int tangentOffset = vertexIndex * 4;
-        Vector3 tangent = Vector3.Normalize(Vector3.Cross(Vector3.UnitY, vertex.Normal));
-        if (tangent.LengthSquared() <= 1e-6f)
-        {
-            tangent = Vector3.UnitX;
-        }
+        Vector3 tangent = ComputeRenderTangent(vertex.Normal);
 
         proceduralMesh.Tangents[tangentOffset + 0] = tangent.X;
         proceduralMesh.Tangents[tangentOffset + 1] = tangent.Y;
@@ -1083,6 +1086,36 @@ internal sealed class VisualTerrainEditorDocument : IDisposable
     private static float HeightToMeters(float height, float defaultHeight01)
     {
         return (height - defaultHeight01) * HeightAmplitudeCm * 0.01f;
+    }
+
+    private static Vector3 ComputeRenderTangent(Vector3 normal)
+    {
+        if (!IsFiniteNonZero(normal))
+        {
+            throw new InvalidOperationException("Visual terrain editor render vertex requires a finite non-zero normal.");
+        }
+
+        Vector3 unitNormal = Vector3.Normalize(normal);
+        Vector3 tangent = Vector3.Cross(Vector3.UnitY, unitNormal);
+        if (!IsFiniteNonZero(tangent))
+        {
+            tangent = Vector3.Cross(Vector3.UnitZ, unitNormal);
+        }
+
+        if (!IsFiniteNonZero(tangent))
+        {
+            throw new InvalidOperationException("Visual terrain editor render vertex could not derive a finite non-zero tangent.");
+        }
+
+        return Vector3.Normalize(tangent);
+    }
+
+    private static bool IsFiniteNonZero(Vector3 value)
+    {
+        return float.IsFinite(value.X) &&
+            float.IsFinite(value.Y) &&
+            float.IsFinite(value.Z) &&
+            value.LengthSquared() > 1e-10f;
     }
 
     private int WorldToChunkX(int worldXCm)

--- a/src/Adapters/Raylib/Ludots.Adapter.Raylib/RaylibHostLoop.cs
+++ b/src/Adapters/Raylib/Ludots.Adapter.Raylib/RaylibHostLoop.cs
@@ -44,6 +44,7 @@ namespace Ludots.Adapter.Raylib
     internal static class RaylibHostLoop
     {
         private const uint FlagWindowResizable = 4;
+        private const string RequireVfxVisualsEnvKey = "LUDOTS_RAYLIB_REQUIRE_VFX_VISUALS";
         private static readonly ServiceKey<IRaylibBenchmarkRenderer> RaylibBenchmarkRendererKey = new("Platform.RaylibBenchmarkRenderer");
         private static bool _uiPointerCaptured;
         private static PointerButton? _uiCapturedPointerButton;
@@ -168,21 +169,19 @@ namespace Ludots.Adapter.Raylib
                 diagnosticPath,
                 $"launch-stage run-enter map={config.StartupMapId} size={screenWidth}x{screenHeight} targetFps={targetFps}");
 
+            RaylibRenderEnvironmentConfig renderEnvironmentConfig = RaylibRenderEnvironmentConfig.CreateDefault();
+            var environmentRenderer = new RaylibRenderEnvironmentRenderer(renderEnvironmentConfig);
             var terrainRenderer = new RaylibTerrainRenderer
             {
+                EnvironmentConfig = renderEnvironmentConfig,
                 HeightScale = 2.0f,
                 VisibleRadius = 900f,
-                SimplifiedCliffRadius = 350f,
-                LightPosition = new Vector3(50f, 200f, 100f),
-                Ambient = 0.8f,
-                LightIntensity = 1.0f
+                SimplifiedCliffRadius = 350f
             };
             var visualHeightmapRenderer = new RaylibVisualHeightmapRenderer
             {
-                VisibleRadiusCm = 140_000f,
-                LightPosition = new Vector3(50f, 200f, 100f),
-                Ambient = 0.45f,
-                LightIntensity = 0.55f
+                EnvironmentConfig = renderEnvironmentConfig,
+                VisibleRadiusCm = 140_000f
             };
 
             try
@@ -304,6 +303,7 @@ namespace Ludots.Adapter.Raylib
                     skiaRenderer,
                     overlayCompositor,
                     browserLayerRenderer,
+                    environmentRenderer,
                     terrainRenderer,
                     visualHeightmapRenderer,
                     fieldRenderPerformer,
@@ -577,6 +577,7 @@ namespace Ludots.Adapter.Raylib
                                 File.Copy(screenshotWorkingFilePath, fullScreenshotPath, overwrite: true);
                                 File.Delete(screenshotWorkingFilePath);
                             }
+                            ValidateRuntimeScreenshotEvidence(fullScreenshotPath, lastW, lastH);
                             presentationTiming?.ObserveScreenshot(ElapsedMs(screenshotStart));
 
                             if (screenshotSequenceEnabled)
@@ -599,21 +600,30 @@ namespace Ludots.Adapter.Raylib
                         {
                             AppendRaylibDiagnostic(diagnosticPath, $"auto-exit frame={frameIndex}");
                             AppendRaylibDiagnostic(diagnosticPath, BuildTimingDiagnostic(engine, presentationTiming, overlayScene));
+                            AppendRaylibDiagnostic(diagnosticPath, primitiveRenderer.BuildVisualKindDiagnosticSummary());
+                            if (ReadEnvBoolOrDefault(RequireVfxVisualsEnvKey, defaultValue: false) &&
+                                primitiveRenderer.TotalDrawnVfxEffectCount <= 0)
+                            {
+                                throw new InvalidOperationException(
+                                    $"Raylib smoke required VFX visuals via {RequireVfxVisualsEnvKey}, but no VFX effect was drawn before auto-exit frame {frameIndex}.");
+                            }
+
                             break;
                         }
                     }
                     catch (Exception ex)
                     {
                         Log.Error(in LogChannels.Engine, $"Unhandled exception in game loop: {ex}");
-                        break;
+                        throw;
                     }
                 }
             }
             finally
             {
-                if (windowOpened) Rl.CloseWindow();
+                environmentRenderer.Dispose();
                 terrainRenderer.Dispose();
                 visualHeightmapRenderer.Dispose();
+                if (windowOpened) Rl.CloseWindow();
                 engine.Dispose();
             }
         }
@@ -633,6 +643,94 @@ namespace Ludots.Adapter.Raylib
             }
 
             File.AppendAllText(fullPath, $"[{DateTime.UtcNow:O}] {message}{Environment.NewLine}");
+        }
+
+        internal static void ValidateRuntimeScreenshotEvidence(string screenshotPath, int expectedWidth, int expectedHeight)
+        {
+            if (string.IsNullOrWhiteSpace(screenshotPath))
+            {
+                throw new ArgumentException("Raylib screenshot evidence path cannot be null or whitespace.", nameof(screenshotPath));
+            }
+
+            if (expectedWidth <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(expectedWidth));
+            }
+
+            if (expectedHeight <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(expectedHeight));
+            }
+
+            string fullPath = Path.GetFullPath(screenshotPath);
+            if (!File.Exists(fullPath))
+            {
+                throw new InvalidOperationException($"Raylib screenshot evidence was not written: {fullPath}");
+            }
+
+            var fileInfo = new FileInfo(fullPath);
+            if (fileInfo.Length < 24)
+            {
+                throw new InvalidOperationException($"Raylib screenshot evidence is too small to be a valid PNG: {fullPath} length={fileInfo.Length}.");
+            }
+
+            if (!string.Equals(Path.GetExtension(fullPath), ".png", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException($"Raylib screenshot evidence must be a PNG so dimensions can be verified: {fullPath}");
+            }
+
+            using var bitmap = SKBitmap.Decode(fullPath);
+            if (bitmap == null)
+            {
+                throw new InvalidOperationException($"Raylib screenshot evidence is not a decodable PNG image: {fullPath}");
+            }
+
+            int actualWidth = bitmap.Width;
+            int actualHeight = bitmap.Height;
+            if (actualWidth != expectedWidth || actualHeight != expectedHeight)
+            {
+                throw new InvalidOperationException(
+                    $"Raylib screenshot evidence dimensions mismatch: {fullPath} actual={actualWidth}x{actualHeight} expected={expectedWidth}x{expectedHeight}.");
+            }
+
+            if (IsVisuallyFlat(bitmap))
+            {
+                throw new InvalidOperationException($"Raylib screenshot evidence is visually flat and cannot prove a rendered scene: {fullPath}");
+            }
+        }
+
+        private static bool IsVisuallyFlat(SKBitmap bitmap)
+        {
+            int width = bitmap.Width;
+            int height = bitmap.Height;
+            if (width <= 0 || height <= 0)
+            {
+                return true;
+            }
+
+            SKColor first = bitmap.GetPixel(0, 0);
+            int stepX = Math.Max(1, width / 16);
+            int stepY = Math.Max(1, height / 16);
+            for (int y = 0; y < height; y += stepY)
+            {
+                for (int x = 0; x < width; x += stepX)
+                {
+                    if (ColorDistance(bitmap.GetPixel(x, y), first) > 6)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return ColorDistance(bitmap.GetPixel(width - 1, height - 1), first) <= 6;
+        }
+
+        private static int ColorDistance(SKColor a, SKColor b)
+        {
+            return Math.Abs(a.Red - b.Red) +
+                Math.Abs(a.Green - b.Green) +
+                Math.Abs(a.Blue - b.Blue) +
+                Math.Abs(a.Alpha - b.Alpha);
         }
 
         private static bool IsCleanPerformanceScene(IBenchmarkSceneController? benchmarkController)

--- a/src/Adapters/Raylib/Ludots.Adapter.Raylib/RaylibHostLoop.cs
+++ b/src/Adapters/Raylib/Ludots.Adapter.Raylib/RaylibHostLoop.cs
@@ -163,6 +163,10 @@ namespace Ludots.Adapter.Raylib
             int targetFps = config.TargetFps == 0 ? 0 : (config.TargetFps < 0 ? 60 : config.TargetFps);
             bool windowOpened = false;
             bool windowResizable = config.WindowResizable || config.WindowStartMaximized;
+            string? diagnosticPath = Environment.GetEnvironmentVariable("LUDOTS_RAYLIB_DIAGNOSTIC_PATH");
+            AppendRaylibDiagnostic(
+                diagnosticPath,
+                $"launch-stage run-enter map={config.StartupMapId} size={screenWidth}x{screenHeight} targetFps={targetFps}");
 
             var terrainRenderer = new RaylibTerrainRenderer
             {
@@ -183,6 +187,7 @@ namespace Ludots.Adapter.Raylib
 
             try
             {
+                AppendRaylibDiagnostic(diagnosticPath, "launch-stage before-init-window");
                 if (windowResizable)
                 {
                     Rl.SetConfigFlags(FlagWindowResizable);
@@ -190,6 +195,7 @@ namespace Ludots.Adapter.Raylib
 
                 Rl.InitWindow(screenWidth, screenHeight, title);
                 windowOpened = true;
+                AppendRaylibDiagnostic(diagnosticPath, "launch-stage after-init-window");
                 if (config.WindowStartMaximized)
                 {
                     Rl.MaximizeWindow();
@@ -274,6 +280,7 @@ namespace Ludots.Adapter.Raylib
                 }
 
                 ValidateRequiredContextBeforeLoop(engine);
+                AppendRaylibDiagnostic(diagnosticPath, "launch-stage after-required-context");
 
                 var debugDrawRenderer = new RaylibDebugDrawRenderer { PlaneY = 0.35f };
                 GlobalFieldVisualBuffer? globalFieldVisualBuffer = engine.GetService(CoreServiceKeys.GlobalFieldVisualBuffer);
@@ -291,18 +298,36 @@ namespace Ludots.Adapter.Raylib
                     benchmarkRenderer = new RaylibBenchmarkRenderService(primitiveRenderer, benchmarkMeshes, benchmarkHud, benchmarkOverlay);
                     engine.SetService(RaylibBenchmarkRendererKey, (IRaylibBenchmarkRenderer)benchmarkRenderer);
                 }
+                var frameRenderer = new RaylibFrameRenderer(
+                    engine,
+                    uiRoot,
+                    skiaRenderer,
+                    overlayCompositor,
+                    browserLayerRenderer,
+                    terrainRenderer,
+                    visualHeightmapRenderer,
+                    fieldRenderPerformer,
+                    primitiveRenderer,
+                    debugDrawRenderer,
+                    benchmarkRenderer,
+                    globalFieldVisualBuffer,
+                    screenOverlayBuffer,
+                    presentationTiming);
 
+                AppendRaylibDiagnostic(diagnosticPath, "launch-stage before-engine-start");
                 engine.Start();
+                AppendRaylibDiagnostic(diagnosticPath, "launch-stage after-engine-start");
                 if (string.IsNullOrWhiteSpace(config.StartupMapId))
                 {
                     throw new InvalidOperationException("Invalid launcher bootstrap: 'StartupMapId' cannot be empty.");
                 }
+                AppendRaylibDiagnostic(diagnosticPath, $"launch-stage before-load-map map={config.StartupMapId}");
                 engine.LoadStartupMap();
+                AppendRaylibDiagnostic(diagnosticPath, "launch-stage after-load-map");
 
                 int lastW = screenWidth;
                 int lastH = screenHeight;
                 string? screenshotPath = Environment.GetEnvironmentVariable("LUDOTS_TAKE_SCREENSHOT_PATH");
-                string? diagnosticPath = Environment.GetEnvironmentVariable("LUDOTS_RAYLIB_DIAGNOSTIC_PATH");
                 string? screenshotTargetPath = string.IsNullOrWhiteSpace(screenshotPath)
                     ? null
                     : Path.GetFullPath(screenshotPath);
@@ -338,6 +363,9 @@ namespace Ludots.Adapter.Raylib
                 float autoOrbitDegPerSecond = float.TryParse(Environment.GetEnvironmentVariable("LUDOTS_RAYLIB_AUTO_ORBIT_DEG_PER_SEC"), out float parsedAutoOrbitDegPerSecond)
                     ? parsedAutoOrbitDegPerSecond
                     : 0f;
+                AppendRaylibDiagnostic(
+                    diagnosticPath,
+                    $"launch-stage before-frame-loop autoExitFrame={autoExitFrame} screenshotPending={screenshotPending} autoOrbit={autoOrbitDegPerSecond}");
                 SyntheticUiPlayback syntheticUiPlayback = ReadSyntheticUiPlayback();
                 int frameIndex = 0;
                 Stopwatch runtimeStopwatch = Stopwatch.StartNew();
@@ -458,188 +486,29 @@ namespace Ludots.Adapter.Raylib
                         }
                         presentationTiming?.ObserveHostPostTick(ElapsedMs(postTickStart));
 
-                        long beginDrawingStart = Stopwatch.GetTimestamp();
-                        Rl.BeginDrawing();
-                        presentationTiming?.ObserveBeginDrawing(ElapsedMs(beginDrawingStart));
-                        Restore3DDepthState();
-                        Rl.ClearBackground(activeMapRequestsDeepBackground
-                            ? new Raylib_cs.Color(6, 10, 16, 255)
-                            : new Raylib_cs.Color(0, 0, 0, 255));
-
                         var activeCamera = cameraAdapter.Camera;
                         CameraRenderState3D activeCameraState = cameraPresenter.SmoothedRenderState;
-                        long mode3DStart = Stopwatch.GetTimestamp();
-                        Restore3DDepthState();
-                        BeginCoreMode3D(activeCamera, in activeCameraState);
-                        Restore3DDepthState();
-
-                        if (drawDebugDraw &&
-                            !(drawVisualHeightmap && hasVisualHeightmap) &&
-                            !hostDebugGuidesSuppressed)
-                        {
-                            DrawInfiniteGrid(activeCamera.target, 300, 1.0f, 10);
-
-                            var target = activeCamera.target;
-                            Rl.DrawLine3D(target, target + new Vector3(2.0f, 0, 0), Color.RED);
-                            Rl.DrawLine3D(target, target + new Vector3(0, 0, 2.0f), Color.BLUE);
-                            Rl.DrawLine3D(target, target + new Vector3(0, 2.0f, 0), Color.GREEN);
-                        }
-
-                        if (drawVisualHeightmap &&
-                            engine.TryGetService(CoreServiceKeys.VisualHeightmap, out IVisualHeightmap? visualHeightmapForTerrain) &&
-                            visualHeightmapForTerrain is IVisualHeightmapRenderSource visualTerrainSource)
-                        {
-                            long terrainStart = Stopwatch.GetTimestamp();
-                            visualHeightmapRenderer.Render(visualTerrainSource, activeCamera);
-                            presentationTiming?.ObserveTerrain(
-                                ElapsedMs(terrainStart),
-                                visualHeightmapRenderer.ChunkBuildMsLastFrame,
-                                visualHeightmapRenderer.DrawnChunkCountLastFrame,
-                                visualHeightmapRenderer.BuiltChunkCountLastFrame);
-                        }
-                        else if (drawTerrain)
-                        {
-                            long terrainStart = Stopwatch.GetTimestamp();
-                            terrainRenderer.Render(engine.VertexMap, activeCamera);
-                            presentationTiming?.ObserveTerrain(
-                                ElapsedMs(terrainStart),
-                                terrainRenderer.ChunkBuildMsLastFrame,
-                                terrainRenderer.DrawnChunkCountLastFrame,
-                                terrainRenderer.BuiltChunkCountLastFrame);
-                        }
-                        else
-                        {
-                            presentationTiming?.ObserveTerrain(0d, 0d, 0, 0);
-                        }
-
-                        if (drawFieldOverlays && globalFieldVisualBuffer != null)
-                        {
-                            long fieldRenderStart = Stopwatch.GetTimestamp();
-                            fieldRenderPerformer.Draw(globalFieldVisualBuffer);
-                            presentationTiming?.ObserveGlobalFieldRender(
-                                ElapsedMs(fieldRenderStart),
-                                fieldRenderPerformer.LastFieldTextureCount,
-                                fieldRenderPerformer.LastDirtyUploadCount,
-                                fieldRenderPerformer.LastDirtyUploadArea,
-                                fieldRenderPerformer.LastDrawCount);
-                        }
-                        else
-                        {
-                            presentationTiming?.ObserveGlobalFieldRender(0d, 0, 0, 0, 0);
-                        }
-
-                        bool benchmarkDrew = false;
-                        if (benchmarkRenderer != null)
-                        {
-                            benchmarkDrew = benchmarkRenderer.Draw(activeCamera);
-                        }
-
-                        if (!benchmarkDrew &&
-                            drawPrimitives &&
-                            engine.TryGetService(CoreServiceKeys.PresentationPrimitiveDrawBuffer, out PrimitiveDrawBuffer draw) &&
-                            engine.TryGetService(CoreServiceKeys.PresentationMeshAssetRegistry, out MeshAssetRegistry meshes))
-                        {
-                            if (!_emptyBufferWarned && draw.GetSpan().Length == 0)
-                            {
-                                System.Diagnostics.Debug.WriteLine("[RaylibHostLoop] PrimitiveDrawBuffer is empty on first render frame; no Marker3D performers emitting?");
-                                _emptyBufferWarned = true;
-                            }
-                            long primitiveStart = Stopwatch.GetTimestamp();
-                            PrimitiveDrawBuffer? snapshot = engine.GetService(CoreServiceKeys.PresentationVisualSnapshotBuffer);
-                            SkinnedVisualBatchBuffer? skinnedBatch = engine.GetService(CoreServiceKeys.PresentationSkinnedVisualBatchBuffer);
-                            engine.TryGetService(CoreServiceKeys.VisualHeightmap, out IVisualHeightmap? visualHeightmap);
-                            primitiveRenderer.Draw(draw, activeCamera, snapshot, skinnedBatch, meshes, renderDebug.AcceptanceScaleMultiplier, visualHeightmap);
-                            presentationTiming?.ObservePrimitiveRender(
-                                ElapsedMs(primitiveStart),
-                                primitiveRenderer.LastInstancedInstances,
-                                primitiveRenderer.LastInstancedBatches,
-                                primitiveRenderer.LastInstancedMatrixBuildMs,
-                                primitiveRenderer.LastInstancedMeshDrawMs,
-                                primitiveRenderer.LastInstancedMatrixCacheHits,
-                                primitiveRenderer.LastInstancedMatrixCacheMisses,
-                                primitiveRenderer.LastPersistentSyncMs,
-                                primitiveRenderer.LastPersistentBucketDrawMs,
-                                primitiveRenderer.LastImmediateDrawMs,
-                                primitiveRenderer.LastImmediateSkippedCount,
-                                skinnedBatch?.Count ?? 0,
-                                primitiveRenderer.LastGpuSkinnedInstances,
-                                primitiveRenderer.LastGpuSkinnedBatches,
-                                primitiveRenderer.LastGpuSkinnedMatrixBuildMs,
-                                primitiveRenderer.LastGpuSkinnedMeshDrawMs);
-                        }
-                        else
-                        {
-                            presentationTiming?.ObservePrimitiveRender(0d, 0, 0);
-                        }
-
-                        // Draw ground overlays (range circles, cones, etc.)
-                        if (!cleanPerformanceMode &&
-                            engine.TryGetService(CoreServiceKeys.GroundOverlayBuffer, out GroundOverlayBuffer overlays) &&
-                            overlays.Count > 0)
-                        {
-                            long groundOverlayStart = Stopwatch.GetTimestamp();
-                            DrawGroundOverlays(overlays);
-                            presentationTiming?.ObserveGroundOverlayRender(ElapsedMs(groundOverlayStart), overlays.Count);
-                        }
-                        else
-                        {
-                            presentationTiming?.ObserveGroundOverlayRender(0d, 0);
-                        }
-
-                        if (!cleanPerformanceMode &&
-                            engine.GlobalContext.TryGetValue(CoreServiceKeys.RoadSplineBuffer.Name, out var splineObj) &&
-                            splineObj is RoadSplineBuffer roadSplines && roadSplines.Count > 0)
-                        {
-                            long roadSplineStart = Stopwatch.GetTimestamp();
-                            DrawRoadSplines(roadSplines);
-                            presentationTiming?.ObserveRoadSplineRender(ElapsedMs(roadSplineStart), roadSplines.Count);
-                        }
-                        else
-                        {
-                            presentationTiming?.ObserveRoadSplineRender(0d, 0);
-                        }
-
-                        if (drawDebugDraw &&
-                            engine.TryGetService(CoreServiceKeys.DebugDrawCommandBuffer, out DebugDrawCommandBuffer dd))
-                        {
-                            long debugDrawStart = Stopwatch.GetTimestamp();
-                            debugDrawRenderer.Draw(dd);
-                            presentationTiming?.ObserveDebugDrawRender(
-                                ElapsedMs(debugDrawStart),
-                                dd.Lines.Count + dd.Circles.Count + dd.Boxes.Count);
-                        }
-                        else
-                        {
-                            presentationTiming?.ObserveDebugDrawRender(0d, 0);
-                        }
-
-                        EndCoreMode3D();
-                        presentationTiming?.ObserveMode3D(ElapsedMs(mode3DStart));
-
-                        if (drawSkiaUi)
-                        {
-                            browserLayerRenderer.Render(uiRoot.Scene, lastW, lastH);
-                        }
-
-                        long overlayStart = Stopwatch.GetTimestamp();
-                        OverlayCompositeResult overlayResult = overlayCompositor.Render(
+                        RaylibRenderFrameResult frameRenderResult = frameRenderer.RenderFrame(new RaylibRenderFrame(
+                            activeCamera,
+                            activeCameraState,
+                            renderDebug,
                             overlayScene,
-                            uiRoot,
-                            skiaRenderer,
+                            lastW,
+                            lastH,
+                            runtimeStopwatch.Elapsed.TotalSeconds,
+                            activeMapRequestsDeepBackground,
+                            hostDebugGuidesSuppressed,
+                            drawTerrain,
+                            drawVisualHeightmap,
+                            hasVisualHeightmap,
+                            drawPrimitives,
+                            drawDebugDraw,
+                            drawFieldOverlays,
                             drawSkiaUi,
-                            hostDiagnosticUiSuppressed);
-                        presentationTiming?.ObserveUiRender(overlayResult.UiRenderMs);
-                        presentationTiming?.ObserveUiUpload(overlayResult.UploadMs);
-                        presentationTiming?.ObserveCompositeSkip(!overlayResult.RefreshComposite);
-                        screenOverlayBuffer?.Clear();
-                        presentationTiming?.ObserveScreenOverlayDraw(
-                            ElapsedMs(overlayStart),
-                            overlayResult.PaintMs,
-                            overlayResult.CompositeMs,
-                            overlayResult.UploadMs,
-                            overlayResult.FinalDrawMs,
-                            overlayCompositor.OverlayRenderer.RebuiltLaneCountLastFrame,
-                            overlayCompositor.OverlayRenderer.CachedTextLayoutCount);
+                            cleanPerformanceMode,
+                            hostDiagnosticUiSuppressed,
+                            _emptyBufferWarned));
+                        _emptyBufferWarned = frameRenderResult.EmptyBufferWarned;
                         if (timingLogIntervalFrames > 0 && frameIndex % timingLogIntervalFrames == 0)
                         {
                             SkiaOverlayRenderer overlaySkiaRenderer = overlayCompositor.OverlayRenderer;
@@ -747,58 +616,6 @@ namespace Ludots.Adapter.Raylib
                 visualHeightmapRenderer.Dispose();
                 engine.Dispose();
             }
-        }
-
-        private static unsafe void BeginCoreMode3D(in Camera3D camera, in CameraRenderState3D cameraState)
-        {
-            Rl.rlDrawRenderBatchActive();
-            Rl.rlMatrixMode((int)RlMatrixMode.RL_PROJECTION);
-            Rl.rlPushMatrix();
-            Rl.rlLoadIdentity();
-
-            CameraClipPlanes clipPlanes = CameraViewportUtil.ResolveClipPlanes(in cameraState);
-            float aspect = MathF.Max(0.001f, Rl.GetScreenWidth() / (float)Math.Max(1, Rl.GetScreenHeight()));
-            if (camera.projection == CameraProjection.CAMERA_ORTHOGRAPHIC)
-            {
-                double top = camera.fovy / 2.0;
-                double right = top * aspect;
-                Rl.rlOrtho(-right, right, -top, top, clipPlanes.NearMeters, clipPlanes.FarMeters);
-            }
-            else
-            {
-                double top = clipPlanes.NearMeters * Math.Tan(WorldPlane2D.DegToRadValue(camera.fovy) * 0.5);
-                double right = top * aspect;
-                Rl.rlFrustum(-right, right, -top, top, clipPlanes.NearMeters, clipPlanes.FarMeters);
-            }
-
-            Rl.rlMatrixMode((int)RlMatrixMode.RL_MODELVIEW);
-            Rl.rlLoadIdentity();
-            Matrix4x4 view = Matrix4x4.CreateLookAt(camera.position, camera.target, camera.up);
-            RaylibMatrix raylibView = RaylibMatrix.FromSystemNumerics(in view);
-            MultMatrix(in raylibView);
-            Rl.rlEnableDepthTest();
-        }
-
-        private static unsafe void MultMatrix(in RaylibMatrix matrix)
-        {
-            float* values = stackalloc float[16]
-            {
-                matrix.m0, matrix.m1, matrix.m2, matrix.m3,
-                matrix.m4, matrix.m5, matrix.m6, matrix.m7,
-                matrix.m8, matrix.m9, matrix.m10, matrix.m11,
-                matrix.m12, matrix.m13, matrix.m14, matrix.m15
-            };
-            Rl.rlMultMatrixf(values);
-        }
-
-        private static void EndCoreMode3D()
-        {
-            Rl.rlDrawRenderBatchActive();
-            Rl.rlMatrixMode((int)RlMatrixMode.RL_PROJECTION);
-            Rl.rlPopMatrix();
-            Rl.rlMatrixMode((int)RlMatrixMode.RL_MODELVIEW);
-            Rl.rlLoadIdentity();
-            Rl.rlDisableDepthTest();
         }
 
         private static void AppendRaylibDiagnostic(string? diagnosticPath, string message)
@@ -1091,13 +908,6 @@ namespace Ludots.Adapter.Raylib
                 '|' => PackDiagnosticGlyph(0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100, 0b00100),
                 _ => PackDiagnosticGlyph(0b11111, 0b10001, 0b00001, 0b00110, 0b00100, 0b00000, 0b00100),
             };
-        }
-
-        private static void Restore3DDepthState()
-        {
-            Rl.rlEnableDepthTest();
-            Rl.rlEnableDepthMask();
-            Rl.rlEnableBackfaceCulling();
         }
 
         private static string BuildTimingDiagnostic(
@@ -1733,346 +1543,5 @@ namespace Ludots.Adapter.Raylib
         {
             return (Stopwatch.GetTimestamp() - startTicks) * 1000.0 / Stopwatch.Frequency;
         }
-
-        private static void DrawInfiniteGrid(Vector3 anchor, int halfCount, float spacing, int majorEvery)
-        {
-            float y = -0.05f;
-            float extent = halfCount * spacing;
-
-            float minX = anchor.X - extent;
-            float minZ = anchor.Z - extent;
-
-            float startX = MathF.Floor(minX / spacing) * spacing;
-            float startZ = MathF.Floor(minZ / spacing) * spacing;
-
-            float endX = startX + 2f * extent;
-            float endZ = startZ + 2f * extent;
-
-            var minor = new Color(80, 80, 80, 255);
-            var major = new Color(130, 130, 130, 255);
-
-            int lineCount = halfCount * 2;
-            for (int i = 0; i <= lineCount; i++)
-            {
-                float x = startX + i * spacing;
-                float z = startZ + i * spacing;
-
-                int xi = (int)MathF.Round(x / spacing);
-                int zi = (int)MathF.Round(z / spacing);
-
-                var xCol = majorEvery > 0 && (xi % majorEvery) == 0 ? major : minor;
-                var zCol = majorEvery > 0 && (zi % majorEvery) == 0 ? major : minor;
-
-                Rl.DrawLine3D(new Vector3(x, y, startZ), new Vector3(x, y, endZ), xCol);
-                Rl.DrawLine3D(new Vector3(startX, y, z), new Vector3(endX, y, z), zCol);
-            }
-        }
-
-        private static void DrawGroundOverlays(GroundOverlayBuffer overlays)
-        {
-            var span = overlays.GetSpan();
-            for (int i = 0; i < span.Length; i++)
-            {
-                ref readonly var item = ref span[i];
-                switch (item.Shape)
-                {
-                    case GroundOverlayShape.Circle:
-                        DrawGroundCircle(in item);
-                        break;
-                    case GroundOverlayShape.Cone:
-                        DrawGroundCone(in item);
-                        break;
-                    case GroundOverlayShape.Ring:
-                        DrawGroundRing(in item);
-                        break;
-                    case GroundOverlayShape.Line:
-                        DrawGroundLine(in item);
-                        break;
-                }
-            }
-        }
-
-        private static void DrawRoadSplines(RoadSplineBuffer splines)
-        {
-            ReadOnlySpan<float> p0x = splines.P0X;
-            ReadOnlySpan<float> p0y = splines.P0Y;
-            ReadOnlySpan<float> p0z = splines.P0Z;
-            ReadOnlySpan<float> p1x = splines.P1X;
-            ReadOnlySpan<float> p1y = splines.P1Y;
-            ReadOnlySpan<float> p1z = splines.P1Z;
-            ReadOnlySpan<float> p2x = splines.P2X;
-            ReadOnlySpan<float> p2y = splines.P2Y;
-            ReadOnlySpan<float> p2z = splines.P2Z;
-            ReadOnlySpan<float> p3x = splines.P3X;
-            ReadOnlySpan<float> p3y = splines.P3Y;
-            ReadOnlySpan<float> p3z = splines.P3Z;
-            ReadOnlySpan<float> width = splines.Width;
-            ReadOnlySpan<float> borderWidth = splines.BorderWidth;
-            ReadOnlySpan<float> fillR = splines.FillR;
-            ReadOnlySpan<float> fillG = splines.FillG;
-            ReadOnlySpan<float> fillB = splines.FillB;
-            ReadOnlySpan<float> fillA = splines.FillA;
-            ReadOnlySpan<float> borderR = splines.BorderR;
-            ReadOnlySpan<float> borderG = splines.BorderG;
-            ReadOnlySpan<float> borderB = splines.BorderB;
-            ReadOnlySpan<float> borderA = splines.BorderA;
-
-            for (int i = 0; i < splines.Count; i++)
-            {
-                Vector3 p0 = new(p0x[i], p0y[i], p0z[i]);
-                Vector3 p1 = new(p1x[i], p1y[i], p1z[i]);
-                Vector3 p2 = new(p2x[i], p2y[i], p2z[i]);
-                Vector3 p3 = new(p3x[i], p3y[i], p3z[i]);
-                float drawWidth = MathF.Max(0.02f, width[i]);
-                float drawBorder = MathF.Max(0.01f, borderWidth[i]);
-                var fill = ToRaylibColor(new Vector4(fillR[i], fillG[i], fillB[i], fillA[i]));
-                var border = ToRaylibColor(new Vector4(borderR[i], borderG[i], borderB[i], borderA[i]));
-                DrawRoadSplineRibbon(p0, p1, p2, p3, drawWidth, fill, border, drawBorder);
-            }
-        }
-
-        private static void DrawRoadSplineRibbon(
-            in Vector3 p0,
-            in Vector3 p1,
-            in Vector3 p2,
-            in Vector3 p3,
-            float width,
-            Color fill,
-            Color border,
-            float borderWidth)
-        {
-            const int samples = 20;
-            Span<Vector3> points = stackalloc Vector3[samples + 1];
-            for (int i = 0; i <= samples; i++)
-            {
-                float t = i / (float)samples;
-                points[i] = EvaluateCubicBezier(p0, p1, p2, p3, t);
-            }
-
-            if (fill.a > 0)
-            {
-                int lanes = Math.Max(1, (int)MathF.Ceiling(width / 0.08f));
-                for (int lane = 0; lane < lanes; lane++)
-                {
-                    float alpha = lanes == 1 ? 0f : lane / (float)(lanes - 1);
-                    float offset = (alpha - 0.5f) * width;
-                    DrawOffsetPolyline(points, offset, fill);
-                }
-            }
-
-            if (border.a > 0)
-            {
-                float edgeOffset = (width * 0.5f) + borderWidth;
-                DrawOffsetPolyline(points, edgeOffset, border);
-                DrawOffsetPolyline(points, -edgeOffset, border);
-            }
-        }
-
-        private static void DrawOffsetPolyline(ReadOnlySpan<Vector3> points, float offset, Color color)
-        {
-            if (points.Length < 2)
-            {
-                return;
-            }
-
-            Vector3 previous = OffsetPoint(points, 0, offset);
-            for (int i = 1; i < points.Length; i++)
-            {
-                Vector3 current = OffsetPoint(points, i, offset);
-                Rl.DrawLine3D(previous, current, color);
-                previous = current;
-            }
-        }
-
-        private static Vector3 OffsetPoint(ReadOnlySpan<Vector3> points, int index, float offset)
-        {
-            Vector3 current = points[index];
-            Vector3 forward = index == points.Length - 1
-                ? current - points[index - 1]
-                : points[index + 1] - current;
-            Vector2 lateral = new(-forward.Z, forward.X);
-            float length = lateral.Length();
-            if (length <= 0.0001f)
-            {
-                return current;
-            }
-
-            lateral /= length;
-            return new Vector3(current.X + lateral.X * offset, current.Y, current.Z + lateral.Y * offset);
-        }
-
-        private static Vector3 EvaluateCubicBezier(in Vector3 p0, in Vector3 p1, in Vector3 p2, in Vector3 p3, float t)
-        {
-            float oneMinusT = 1f - t;
-            float a = oneMinusT * oneMinusT * oneMinusT;
-            float b = 3f * oneMinusT * oneMinusT * t;
-            float c = 3f * oneMinusT * t * t;
-            float d = t * t * t;
-            return (p0 * a) + (p1 * b) + (p2 * c) + (p3 * d);
-        }
-
-        private static void DrawGroundCircle(in GroundOverlayItem item)
-        {
-            const int segments = 48;
-            float step = MathF.PI * 2f / segments;
-            var center = item.Center;
-
-            // Draw fill as multiple concentric rings (approximation since Raylib has no DrawTriangle3D)
-            if (item.FillColor.W > 0.01f)
-            {
-                var fillColor = ToRaylibColor(item.FillColor);
-                const int fillRings = 4;
-                for (int r = 1; r <= fillRings; r++)
-                {
-                    float radius = item.Radius * r / fillRings;
-                    for (int s = 0; s < segments; s++)
-                    {
-                        float a0 = s * step;
-                        float a1 = (s + 1) * step;
-                        var p0 = new Vector3(center.X + MathF.Cos(a0) * radius, center.Y, center.Z + MathF.Sin(a0) * radius);
-                        var p1 = new Vector3(center.X + MathF.Cos(a1) * radius, center.Y, center.Z + MathF.Sin(a1) * radius);
-                        Rl.DrawLine3D(p0, p1, fillColor);
-                    }
-                }
-            }
-
-            // Draw border as line loop (outermost ring, thicker appearance via slight offset)
-            if (item.BorderColor.W > 0.01f && item.BorderWidth > 0f)
-            {
-                var border = ToRaylibColor(item.BorderColor);
-                for (int s = 0; s < segments; s++)
-                {
-                    float a0 = s * step;
-                    float a1 = (s + 1) * step;
-                    var p0 = new Vector3(center.X + MathF.Cos(a0) * item.Radius, center.Y, center.Z + MathF.Sin(a0) * item.Radius);
-                    var p1 = new Vector3(center.X + MathF.Cos(a1) * item.Radius, center.Y, center.Z + MathF.Sin(a1) * item.Radius);
-                    Rl.DrawLine3D(p0, p1, border);
-                }
-            }
-        }
-
-        private static void DrawGroundRing(in GroundOverlayItem item)
-        {
-            const int segments = 48;
-            float innerRadius = Math.Clamp(item.InnerRadius, 0f, item.Radius);
-            float outerRadius = MathF.Max(item.Radius, innerRadius);
-            var center = item.Center;
-
-            if (item.FillColor.W > 0.01f && outerRadius > innerRadius)
-            {
-                var fillColor = ToRaylibColor(item.FillColor);
-                const int bands = 6;
-                for (int band = 0; band < bands; band++)
-                {
-                    float radius = innerRadius + (outerRadius - innerRadius) * (band + 0.5f) / bands;
-                    DrawGroundArcLoop(center, radius, 0f, MathF.PI * 2f, segments, fillColor);
-                }
-            }
-
-            if (item.BorderColor.W > 0.01f && item.BorderWidth > 0f)
-            {
-                var border = ToRaylibColor(item.BorderColor);
-                DrawGroundArcLoop(center, outerRadius, 0f, MathF.PI * 2f, segments, border);
-                if (innerRadius > 0.001f)
-                {
-                    DrawGroundArcLoop(center, innerRadius, 0f, MathF.PI * 2f, segments, border);
-                }
-            }
-        }
-
-        private static void DrawGroundCone(in GroundOverlayItem item)
-        {
-            const int segments = 24;
-            float radius = MathF.Max(item.Radius, 0f);
-            float start = item.Rotation - item.Angle;
-            float end = item.Rotation + item.Angle;
-            var center = item.Center;
-
-            if (radius <= 0f)
-            {
-                return;
-            }
-
-            if (item.FillColor.W > 0.01f)
-            {
-                var fillColor = ToRaylibColor(item.FillColor);
-                const int bands = 6;
-                for (int band = 1; band <= bands; band++)
-                {
-                    float ringRadius = radius * band / bands;
-                    DrawGroundArcLoop(center, ringRadius, start, end, segments, fillColor);
-                }
-            }
-
-            if (item.BorderColor.W > 0.01f && item.BorderWidth > 0f)
-            {
-                var border = ToRaylibColor(item.BorderColor);
-                DrawGroundArcLoop(center, radius, start, end, segments, border);
-                var left = new Vector3(center.X + MathF.Cos(start) * radius, center.Y, center.Z + MathF.Sin(start) * radius);
-                var right = new Vector3(center.X + MathF.Cos(end) * radius, center.Y, center.Z + MathF.Sin(end) * radius);
-                Rl.DrawLine3D(center, left, border);
-                Rl.DrawLine3D(center, right, border);
-            }
-        }
-
-        private static void DrawGroundLine(in GroundOverlayItem item)
-        {
-            float length = item.Length > 0f ? item.Length : item.Radius;
-            if (length <= 0f)
-            {
-                return;
-            }
-
-            float dx = MathF.Cos(item.Rotation) * length;
-            float dz = MathF.Sin(item.Rotation) * length;
-            var a = item.Center;
-            var b = new Vector3(a.X + dx, a.Y, a.Z + dz);
-            float halfWidth = MathF.Max(0f, item.Width) * 0.5f;
-            var normal = new Vector3(-MathF.Sin(item.Rotation), 0f, MathF.Cos(item.Rotation));
-
-            if (item.FillColor.W > 0.01f)
-            {
-                var fill = ToRaylibColor(item.FillColor);
-                int stripes = halfWidth > 0.001f ? Math.Clamp((int)MathF.Ceiling(halfWidth / 0.12f), 1, 8) : 1;
-                for (int stripe = -stripes; stripe <= stripes; stripe++)
-                {
-                    float offset = stripes == 0 ? 0f : halfWidth * stripe / Math.Max(stripes, 1);
-                    var delta = normal * offset;
-                    Rl.DrawLine3D(a + delta, b + delta, fill);
-                }
-            }
-
-            if (item.BorderColor.W > 0.01f)
-            {
-                var border = ToRaylibColor(item.BorderColor);
-                Rl.DrawLine3D(a, b, border);
-                if (halfWidth > 0.001f)
-                {
-                    var delta = normal * halfWidth;
-                    Rl.DrawLine3D(a + delta, b + delta, border);
-                    Rl.DrawLine3D(a - delta, b - delta, border);
-                }
-            }
-        }
-
-        private static void DrawGroundArcLoop(Vector3 center, float radius, float startAngle, float endAngle, int segments, Color color)
-        {
-            if (segments <= 0 || radius <= 0f)
-            {
-                return;
-            }
-
-            float step = (endAngle - startAngle) / segments;
-            for (int s = 0; s < segments; s++)
-            {
-                float a0 = startAngle + s * step;
-                float a1 = startAngle + (s + 1) * step;
-                var p0 = new Vector3(center.X + MathF.Cos(a0) * radius, center.Y, center.Z + MathF.Sin(a0) * radius);
-                var p1 = new Vector3(center.X + MathF.Cos(a1) * radius, center.Y, center.Z + MathF.Sin(a1) * radius);
-                Rl.DrawLine3D(p0, p1, color);
-            }
-        }
-
-        private static Color ToRaylibColor(Vector4 c) => RaylibColorUtil.ToRaylibColor(in c);
     }
 }

--- a/src/Adapters/Raylib/Ludots.Adapter.Raylib/Rendering/RaylibFrameRenderer.cs
+++ b/src/Adapters/Raylib/Ludots.Adapter.Raylib/Rendering/RaylibFrameRenderer.cs
@@ -1,0 +1,522 @@
+using System;
+using System.Diagnostics;
+using System.Numerics;
+using Ludots.Adapter.Raylib.Services;
+using Ludots.Client.Raylib.Rendering;
+using Ludots.Core.Diagnostics;
+using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.Camera;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Presentation.Assets;
+using Ludots.Core.Presentation.Camera;
+using Ludots.Core.Presentation.DebugDraw;
+using Ludots.Core.Presentation.Hud;
+using Ludots.Core.Presentation.Rendering;
+using Ludots.Core.Presentation.Terrain;
+using Ludots.Core.Scripting;
+using Ludots.UI;
+using Ludots.UI.Skia;
+using Raylib_cs;
+using Rl = Raylib_cs.Raylib;
+
+namespace Ludots.Adapter.Raylib
+{
+    internal enum RaylibFramePass
+    {
+        Clear,
+        BeginWorld3D,
+        DebugGuides,
+        Terrain,
+        GlobalField,
+        BenchmarkScene,
+        PrimitiveVisuals,
+        GroundOverlay,
+        RoadSpline,
+        DebugDraw,
+        EndWorld3D,
+        BrowserLayer,
+        OverlayComposite,
+    }
+
+    internal readonly record struct RaylibFramePassPlanInput(
+        bool DrawDebugGuides,
+        bool DrawTerrain,
+        bool DrawVisualHeightmap,
+        bool HasGlobalFieldBuffer,
+        bool DrawFieldOverlays,
+        bool HasBenchmarkRenderer,
+        bool DrawPrimitives,
+        bool HasGroundOverlays,
+        bool HasRoadSplines,
+        bool DrawDebugDraw,
+        bool DrawSkiaUi);
+
+    internal readonly record struct RaylibRenderFrame(
+        Camera3D ActiveCamera,
+        CameraRenderState3D ActiveCameraState,
+        RenderDebugState RenderDebug,
+        PresentationOverlayScene? OverlayScene,
+        int Width,
+        int Height,
+        double TimeSeconds,
+        bool ActiveMapRequestsDeepBackground,
+        bool HostDebugGuidesSuppressed,
+        bool DrawTerrain,
+        bool DrawVisualHeightmap,
+        bool HasVisualHeightmap,
+        bool DrawPrimitives,
+        bool DrawDebugDraw,
+        bool DrawFieldOverlays,
+        bool DrawSkiaUi,
+        bool CleanPerformanceMode,
+        bool HostDiagnosticUiSuppressed,
+        bool EmptyBufferWarned);
+
+    internal readonly record struct RaylibRenderFrameResult(bool EmptyBufferWarned);
+
+    internal sealed class RaylibFrameRenderer
+    {
+        private readonly GameEngine _engine;
+        private readonly UIRoot _uiRoot;
+        private readonly SkiaUiRenderer _skiaRenderer;
+        private readonly RaylibOverlayCompositor _overlayCompositor;
+        private readonly RaylibBrowserLayerRenderer _browserLayerRenderer;
+        private readonly RaylibTerrainRenderer _terrainRenderer;
+        private readonly RaylibVisualHeightmapRenderer _visualHeightmapRenderer;
+        private readonly RaylibFieldRenderPerformer _fieldRenderPerformer;
+        private readonly RaylibPrimitiveRenderer _primitiveRenderer;
+        private readonly RaylibDebugDrawRenderer _debugDrawRenderer;
+        private readonly RaylibBenchmarkRenderService? _benchmarkRenderer;
+        private readonly GlobalFieldVisualBuffer? _globalFieldVisualBuffer;
+        private readonly ScreenOverlayBuffer? _screenOverlayBuffer;
+        private readonly PresentationTimingDiagnostics? _presentationTiming;
+
+        public RaylibFrameRenderer(
+            GameEngine engine,
+            UIRoot uiRoot,
+            SkiaUiRenderer skiaRenderer,
+            RaylibOverlayCompositor overlayCompositor,
+            RaylibBrowserLayerRenderer browserLayerRenderer,
+            RaylibTerrainRenderer terrainRenderer,
+            RaylibVisualHeightmapRenderer visualHeightmapRenderer,
+            RaylibFieldRenderPerformer fieldRenderPerformer,
+            RaylibPrimitiveRenderer primitiveRenderer,
+            RaylibDebugDrawRenderer debugDrawRenderer,
+            RaylibBenchmarkRenderService? benchmarkRenderer,
+            GlobalFieldVisualBuffer? globalFieldVisualBuffer,
+            ScreenOverlayBuffer? screenOverlayBuffer,
+            PresentationTimingDiagnostics? presentationTiming)
+        {
+            _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+            _uiRoot = uiRoot ?? throw new ArgumentNullException(nameof(uiRoot));
+            _skiaRenderer = skiaRenderer ?? throw new ArgumentNullException(nameof(skiaRenderer));
+            _overlayCompositor = overlayCompositor ?? throw new ArgumentNullException(nameof(overlayCompositor));
+            _browserLayerRenderer = browserLayerRenderer ?? throw new ArgumentNullException(nameof(browserLayerRenderer));
+            _terrainRenderer = terrainRenderer ?? throw new ArgumentNullException(nameof(terrainRenderer));
+            _visualHeightmapRenderer = visualHeightmapRenderer ?? throw new ArgumentNullException(nameof(visualHeightmapRenderer));
+            _fieldRenderPerformer = fieldRenderPerformer ?? throw new ArgumentNullException(nameof(fieldRenderPerformer));
+            _primitiveRenderer = primitiveRenderer ?? throw new ArgumentNullException(nameof(primitiveRenderer));
+            _debugDrawRenderer = debugDrawRenderer ?? throw new ArgumentNullException(nameof(debugDrawRenderer));
+            _benchmarkRenderer = benchmarkRenderer;
+            _globalFieldVisualBuffer = globalFieldVisualBuffer;
+            _screenOverlayBuffer = screenOverlayBuffer;
+            _presentationTiming = presentationTiming;
+        }
+
+        public RaylibRenderFrameResult RenderFrame(in RaylibRenderFrame frame)
+        {
+            bool emptyBufferWarned = frame.EmptyBufferWarned;
+            long beginDrawingStart = Stopwatch.GetTimestamp();
+            Rl.BeginDrawing();
+            _presentationTiming?.ObserveBeginDrawing(ElapsedMs(beginDrawingStart));
+            Restore3DDepthState();
+            Rl.ClearBackground(frame.ActiveMapRequestsDeepBackground
+                ? new Color(6, 10, 16, 255)
+                : new Color(0, 0, 0, 255));
+
+            long mode3DStart = Stopwatch.GetTimestamp();
+            Restore3DDepthState();
+            CameraRenderState3D activeCameraState = frame.ActiveCameraState;
+            BeginCoreMode3D(frame.ActiveCamera, in activeCameraState);
+            Restore3DDepthState();
+
+            DrawDebugGuides(in frame);
+            DrawTerrain(in frame);
+            DrawGlobalFields(in frame);
+            bool benchmarkDrew = DrawBenchmarkScene(frame.ActiveCamera);
+            emptyBufferWarned = DrawPrimitiveVisuals(in frame, benchmarkDrew, emptyBufferWarned);
+            DrawGroundOverlays(frame.CleanPerformanceMode);
+            DrawRoadSplines(frame.CleanPerformanceMode);
+            DrawDebugCommands(in frame);
+
+            EndCoreMode3D();
+            _presentationTiming?.ObserveMode3D(ElapsedMs(mode3DStart));
+
+            DrawUiLayers(in frame);
+            return new RaylibRenderFrameResult(emptyBufferWarned);
+        }
+
+        public static int BuildPassPlan(in RaylibFramePassPlanInput input, Span<RaylibFramePass> output)
+        {
+            int count = 0;
+            Add(output, ref count, RaylibFramePass.Clear);
+            Add(output, ref count, RaylibFramePass.BeginWorld3D);
+            if (input.DrawDebugGuides)
+            {
+                Add(output, ref count, RaylibFramePass.DebugGuides);
+            }
+
+            if (input.DrawTerrain || input.DrawVisualHeightmap)
+            {
+                Add(output, ref count, RaylibFramePass.Terrain);
+            }
+
+            if (input.DrawFieldOverlays && input.HasGlobalFieldBuffer)
+            {
+                Add(output, ref count, RaylibFramePass.GlobalField);
+            }
+
+            if (input.HasBenchmarkRenderer)
+            {
+                Add(output, ref count, RaylibFramePass.BenchmarkScene);
+            }
+
+            if (input.DrawPrimitives)
+            {
+                Add(output, ref count, RaylibFramePass.PrimitiveVisuals);
+            }
+
+            if (input.HasGroundOverlays)
+            {
+                Add(output, ref count, RaylibFramePass.GroundOverlay);
+            }
+
+            if (input.HasRoadSplines)
+            {
+                Add(output, ref count, RaylibFramePass.RoadSpline);
+            }
+
+            if (input.DrawDebugDraw)
+            {
+                Add(output, ref count, RaylibFramePass.DebugDraw);
+            }
+
+            Add(output, ref count, RaylibFramePass.EndWorld3D);
+            if (input.DrawSkiaUi)
+            {
+                Add(output, ref count, RaylibFramePass.BrowserLayer);
+            }
+
+            Add(output, ref count, RaylibFramePass.OverlayComposite);
+            return count;
+        }
+
+        private static void Add(Span<RaylibFramePass> output, ref int count, RaylibFramePass pass)
+        {
+            if (count >= output.Length)
+            {
+                throw new InvalidOperationException(
+                    $"Raylib frame pass output capacity {output.Length} is too small.");
+            }
+
+            output[count++] = pass;
+        }
+
+        private void DrawDebugGuides(in RaylibRenderFrame frame)
+        {
+            if (!frame.DrawDebugDraw ||
+                (frame.DrawVisualHeightmap && frame.HasVisualHeightmap) ||
+                frame.HostDebugGuidesSuppressed)
+            {
+                return;
+            }
+
+            DrawInfiniteGrid(frame.ActiveCamera.target, 300, 1.0f, 10);
+
+            Vector3 target = frame.ActiveCamera.target;
+            Rl.DrawLine3D(target, target + new Vector3(2.0f, 0, 0), Color.RED);
+            Rl.DrawLine3D(target, target + new Vector3(0, 0, 2.0f), Color.BLUE);
+            Rl.DrawLine3D(target, target + new Vector3(0, 2.0f, 0), Color.GREEN);
+        }
+
+        private void DrawTerrain(in RaylibRenderFrame frame)
+        {
+            if (frame.DrawVisualHeightmap &&
+                _engine.TryGetService(CoreServiceKeys.VisualHeightmap, out IVisualHeightmap? visualHeightmapForTerrain) &&
+                visualHeightmapForTerrain is IVisualHeightmapRenderSource visualTerrainSource)
+            {
+                long terrainStart = Stopwatch.GetTimestamp();
+                _visualHeightmapRenderer.Render(visualTerrainSource, frame.ActiveCamera);
+                _presentationTiming?.ObserveTerrain(
+                    ElapsedMs(terrainStart),
+                    _visualHeightmapRenderer.ChunkBuildMsLastFrame,
+                    _visualHeightmapRenderer.DrawnChunkCountLastFrame,
+                    _visualHeightmapRenderer.BuiltChunkCountLastFrame);
+                return;
+            }
+
+            if (frame.DrawTerrain)
+            {
+                long terrainStart = Stopwatch.GetTimestamp();
+                _terrainRenderer.Render(_engine.VertexMap, frame.ActiveCamera);
+                _presentationTiming?.ObserveTerrain(
+                    ElapsedMs(terrainStart),
+                    _terrainRenderer.ChunkBuildMsLastFrame,
+                    _terrainRenderer.DrawnChunkCountLastFrame,
+                    _terrainRenderer.BuiltChunkCountLastFrame);
+                return;
+            }
+
+            _presentationTiming?.ObserveTerrain(0d, 0d, 0, 0);
+        }
+
+        private void DrawGlobalFields(in RaylibRenderFrame frame)
+        {
+            if (frame.DrawFieldOverlays && _globalFieldVisualBuffer != null)
+            {
+                long fieldRenderStart = Stopwatch.GetTimestamp();
+                _fieldRenderPerformer.Draw(_globalFieldVisualBuffer);
+                _presentationTiming?.ObserveGlobalFieldRender(
+                    ElapsedMs(fieldRenderStart),
+                    _fieldRenderPerformer.LastFieldTextureCount,
+                    _fieldRenderPerformer.LastDirtyUploadCount,
+                    _fieldRenderPerformer.LastDirtyUploadArea,
+                    _fieldRenderPerformer.LastDrawCount);
+                return;
+            }
+
+            _presentationTiming?.ObserveGlobalFieldRender(0d, 0, 0, 0, 0);
+        }
+
+        private bool DrawBenchmarkScene(in Camera3D activeCamera)
+        {
+            return _benchmarkRenderer != null && _benchmarkRenderer.Draw(activeCamera);
+        }
+
+        private bool DrawPrimitiveVisuals(
+            in RaylibRenderFrame frame,
+            bool benchmarkDrew,
+            bool emptyBufferWarned)
+        {
+            if (!benchmarkDrew &&
+                frame.DrawPrimitives &&
+                _engine.TryGetService(CoreServiceKeys.PresentationPrimitiveDrawBuffer, out PrimitiveDrawBuffer draw) &&
+                _engine.TryGetService(CoreServiceKeys.PresentationMeshAssetRegistry, out MeshAssetRegistry meshes))
+            {
+                if (!emptyBufferWarned && draw.GetSpan().Length == 0)
+                {
+                    Debug.WriteLine("[RaylibHostLoop] PrimitiveDrawBuffer is empty on first render frame; no Marker3D performers emitting?");
+                    emptyBufferWarned = true;
+                }
+
+                long primitiveStart = Stopwatch.GetTimestamp();
+                PrimitiveDrawBuffer? snapshot = _engine.GetService(CoreServiceKeys.PresentationVisualSnapshotBuffer);
+                SkinnedVisualBatchBuffer? skinnedBatch = _engine.GetService(CoreServiceKeys.PresentationSkinnedVisualBatchBuffer);
+                _engine.TryGetService(CoreServiceKeys.VisualHeightmap, out IVisualHeightmap? visualHeightmap);
+                _primitiveRenderer.Draw(
+                    draw,
+                    frame.ActiveCamera,
+                    snapshot,
+                    skinnedBatch,
+                    meshes,
+                    frame.RenderDebug.AcceptanceScaleMultiplier,
+                    visualHeightmap,
+                    frame.TimeSeconds);
+                _presentationTiming?.ObservePrimitiveRender(
+                    ElapsedMs(primitiveStart),
+                    _primitiveRenderer.LastInstancedInstances,
+                    _primitiveRenderer.LastInstancedBatches,
+                    _primitiveRenderer.LastInstancedMatrixBuildMs,
+                    _primitiveRenderer.LastInstancedMeshDrawMs,
+                    _primitiveRenderer.LastInstancedMatrixCacheHits,
+                    _primitiveRenderer.LastInstancedMatrixCacheMisses,
+                    _primitiveRenderer.LastPersistentSyncMs,
+                    _primitiveRenderer.LastPersistentBucketDrawMs,
+                    _primitiveRenderer.LastImmediateDrawMs,
+                    _primitiveRenderer.LastImmediateSkippedCount,
+                    skinnedBatch?.Count ?? 0,
+                    _primitiveRenderer.LastGpuSkinnedInstances,
+                    _primitiveRenderer.LastGpuSkinnedBatches,
+                    _primitiveRenderer.LastGpuSkinnedMatrixBuildMs,
+                    _primitiveRenderer.LastGpuSkinnedMeshDrawMs);
+                return emptyBufferWarned;
+            }
+
+            _presentationTiming?.ObservePrimitiveRender(0d, 0, 0);
+            return emptyBufferWarned;
+        }
+
+        private void DrawGroundOverlays(bool cleanPerformanceMode)
+        {
+            if (!cleanPerformanceMode &&
+                _engine.TryGetService(CoreServiceKeys.GroundOverlayBuffer, out GroundOverlayBuffer overlays) &&
+                overlays.Count > 0)
+            {
+                long groundOverlayStart = Stopwatch.GetTimestamp();
+                RaylibWorldOverlayRenderer.DrawGroundOverlays(overlays);
+                _presentationTiming?.ObserveGroundOverlayRender(ElapsedMs(groundOverlayStart), overlays.Count);
+                return;
+            }
+
+            _presentationTiming?.ObserveGroundOverlayRender(0d, 0);
+        }
+
+        private void DrawRoadSplines(bool cleanPerformanceMode)
+        {
+            if (!cleanPerformanceMode &&
+                _engine.GlobalContext.TryGetValue(CoreServiceKeys.RoadSplineBuffer.Name, out object? splineObj) &&
+                splineObj is RoadSplineBuffer roadSplines &&
+                roadSplines.Count > 0)
+            {
+                long roadSplineStart = Stopwatch.GetTimestamp();
+                RaylibWorldOverlayRenderer.DrawRoadSplines(roadSplines);
+                _presentationTiming?.ObserveRoadSplineRender(ElapsedMs(roadSplineStart), roadSplines.Count);
+                return;
+            }
+
+            _presentationTiming?.ObserveRoadSplineRender(0d, 0);
+        }
+
+        private void DrawDebugCommands(in RaylibRenderFrame frame)
+        {
+            if (frame.DrawDebugDraw &&
+                _engine.TryGetService(CoreServiceKeys.DebugDrawCommandBuffer, out DebugDrawCommandBuffer dd))
+            {
+                long debugDrawStart = Stopwatch.GetTimestamp();
+                _debugDrawRenderer.Draw(dd);
+                _presentationTiming?.ObserveDebugDrawRender(
+                    ElapsedMs(debugDrawStart),
+                    dd.Lines.Count + dd.Circles.Count + dd.Boxes.Count);
+                return;
+            }
+
+            _presentationTiming?.ObserveDebugDrawRender(0d, 0);
+        }
+
+        private void DrawUiLayers(in RaylibRenderFrame frame)
+        {
+            if (frame.DrawSkiaUi)
+            {
+                _browserLayerRenderer.Render(_uiRoot.Scene, frame.Width, frame.Height);
+            }
+
+            long overlayStart = Stopwatch.GetTimestamp();
+            OverlayCompositeResult overlayResult = _overlayCompositor.Render(
+                frame.OverlayScene,
+                _uiRoot,
+                _skiaRenderer,
+                frame.DrawSkiaUi,
+                frame.HostDiagnosticUiSuppressed);
+            _presentationTiming?.ObserveUiRender(overlayResult.UiRenderMs);
+            _presentationTiming?.ObserveUiUpload(overlayResult.UploadMs);
+            _presentationTiming?.ObserveCompositeSkip(!overlayResult.RefreshComposite);
+            _screenOverlayBuffer?.Clear();
+            _presentationTiming?.ObserveScreenOverlayDraw(
+                ElapsedMs(overlayStart),
+                overlayResult.PaintMs,
+                overlayResult.CompositeMs,
+                overlayResult.UploadMs,
+                overlayResult.FinalDrawMs,
+                _overlayCompositor.OverlayRenderer.RebuiltLaneCountLastFrame,
+                _overlayCompositor.OverlayRenderer.CachedTextLayoutCount);
+        }
+
+        internal static void Restore3DDepthState()
+        {
+            Rl.rlEnableDepthTest();
+            Rl.rlEnableDepthMask();
+            Rl.rlEnableBackfaceCulling();
+        }
+
+        internal static unsafe void BeginCoreMode3D(in Camera3D camera, in CameraRenderState3D cameraState)
+        {
+            Rl.rlDrawRenderBatchActive();
+            Rl.rlMatrixMode((int)RlMatrixMode.RL_PROJECTION);
+            Rl.rlPushMatrix();
+            Rl.rlLoadIdentity();
+
+            CameraClipPlanes clipPlanes = CameraViewportUtil.ResolveClipPlanes(in cameraState);
+            float aspect = MathF.Max(0.001f, Rl.GetScreenWidth() / (float)Math.Max(1, Rl.GetScreenHeight()));
+            if (camera.projection == CameraProjection.CAMERA_ORTHOGRAPHIC)
+            {
+                double top = camera.fovy / 2.0;
+                double right = top * aspect;
+                Rl.rlOrtho(-right, right, -top, top, clipPlanes.NearMeters, clipPlanes.FarMeters);
+            }
+            else
+            {
+                double top = clipPlanes.NearMeters * Math.Tan(WorldPlane2D.DegToRadValue(camera.fovy) * 0.5);
+                double right = top * aspect;
+                Rl.rlFrustum(-right, right, -top, top, clipPlanes.NearMeters, clipPlanes.FarMeters);
+            }
+
+            Rl.rlMatrixMode((int)RlMatrixMode.RL_MODELVIEW);
+            Rl.rlLoadIdentity();
+            Matrix4x4 view = Matrix4x4.CreateLookAt(camera.position, camera.target, camera.up);
+            RaylibMatrix raylibView = RaylibMatrix.FromSystemNumerics(in view);
+            MultMatrix(in raylibView);
+            Rl.rlEnableDepthTest();
+        }
+
+        internal static void EndCoreMode3D()
+        {
+            Rl.rlDrawRenderBatchActive();
+            Rl.rlMatrixMode((int)RlMatrixMode.RL_PROJECTION);
+            Rl.rlPopMatrix();
+            Rl.rlMatrixMode((int)RlMatrixMode.RL_MODELVIEW);
+            Rl.rlLoadIdentity();
+            Rl.rlDisableDepthTest();
+        }
+
+        private static unsafe void MultMatrix(in RaylibMatrix matrix)
+        {
+            float* values = stackalloc float[16]
+            {
+                matrix.m0, matrix.m1, matrix.m2, matrix.m3,
+                matrix.m4, matrix.m5, matrix.m6, matrix.m7,
+                matrix.m8, matrix.m9, matrix.m10, matrix.m11,
+                matrix.m12, matrix.m13, matrix.m14, matrix.m15
+            };
+            Rl.rlMultMatrixf(values);
+        }
+
+        private static void DrawInfiniteGrid(Vector3 anchor, int halfCount, float spacing, int majorEvery)
+        {
+            float y = -0.05f;
+            float extent = halfCount * spacing;
+
+            float minX = anchor.X - extent;
+            float minZ = anchor.Z - extent;
+
+            float startX = MathF.Floor(minX / spacing) * spacing;
+            float startZ = MathF.Floor(minZ / spacing) * spacing;
+
+            float endX = startX + 2f * extent;
+            float endZ = startZ + 2f * extent;
+
+            var minor = new Color(80, 80, 80, 255);
+            var major = new Color(130, 130, 130, 255);
+
+            int lineCount = halfCount * 2;
+            for (int i = 0; i <= lineCount; i++)
+            {
+                float x = startX + i * spacing;
+                float z = startZ + i * spacing;
+
+                int xi = (int)MathF.Round(x / spacing);
+                int zi = (int)MathF.Round(z / spacing);
+
+                Color xCol = majorEvery > 0 && (xi % majorEvery) == 0 ? major : minor;
+                Color zCol = majorEvery > 0 && (zi % majorEvery) == 0 ? major : minor;
+
+                Rl.DrawLine3D(new Vector3(x, y, startZ), new Vector3(x, y, endZ), xCol);
+                Rl.DrawLine3D(new Vector3(startX, y, z), new Vector3(endX, y, z), zCol);
+            }
+        }
+
+        private static double ElapsedMs(long startTicks)
+        {
+            return (Stopwatch.GetTimestamp() - startTicks) * 1000.0 / Stopwatch.Frequency;
+        }
+    }
+}

--- a/src/Adapters/Raylib/Ludots.Adapter.Raylib/Rendering/RaylibFrameRenderer.cs
+++ b/src/Adapters/Raylib/Ludots.Adapter.Raylib/Rendering/RaylibFrameRenderer.cs
@@ -24,7 +24,9 @@ namespace Ludots.Adapter.Raylib
     internal enum RaylibFramePass
     {
         Clear,
+        BeginWorldTexture,
         BeginWorld3D,
+        Skybox,
         DebugGuides,
         Terrain,
         GlobalField,
@@ -34,6 +36,7 @@ namespace Ludots.Adapter.Raylib
         RoadSpline,
         DebugDraw,
         EndWorld3D,
+        PostProcessComposite,
         BrowserLayer,
         OverlayComposite,
     }
@@ -49,7 +52,9 @@ namespace Ludots.Adapter.Raylib
         bool HasGroundOverlays,
         bool HasRoadSplines,
         bool DrawDebugDraw,
-        bool DrawSkiaUi);
+        bool DrawSkiaUi,
+        bool DrawEnvironment,
+        bool UsePostProcess);
 
     internal readonly record struct RaylibRenderFrame(
         Camera3D ActiveCamera,
@@ -81,6 +86,7 @@ namespace Ludots.Adapter.Raylib
         private readonly SkiaUiRenderer _skiaRenderer;
         private readonly RaylibOverlayCompositor _overlayCompositor;
         private readonly RaylibBrowserLayerRenderer _browserLayerRenderer;
+        private readonly RaylibRenderEnvironmentRenderer _environmentRenderer;
         private readonly RaylibTerrainRenderer _terrainRenderer;
         private readonly RaylibVisualHeightmapRenderer _visualHeightmapRenderer;
         private readonly RaylibFieldRenderPerformer _fieldRenderPerformer;
@@ -97,6 +103,7 @@ namespace Ludots.Adapter.Raylib
             SkiaUiRenderer skiaRenderer,
             RaylibOverlayCompositor overlayCompositor,
             RaylibBrowserLayerRenderer browserLayerRenderer,
+            RaylibRenderEnvironmentRenderer environmentRenderer,
             RaylibTerrainRenderer terrainRenderer,
             RaylibVisualHeightmapRenderer visualHeightmapRenderer,
             RaylibFieldRenderPerformer fieldRenderPerformer,
@@ -112,6 +119,7 @@ namespace Ludots.Adapter.Raylib
             _skiaRenderer = skiaRenderer ?? throw new ArgumentNullException(nameof(skiaRenderer));
             _overlayCompositor = overlayCompositor ?? throw new ArgumentNullException(nameof(overlayCompositor));
             _browserLayerRenderer = browserLayerRenderer ?? throw new ArgumentNullException(nameof(browserLayerRenderer));
+            _environmentRenderer = environmentRenderer ?? throw new ArgumentNullException(nameof(environmentRenderer));
             _terrainRenderer = terrainRenderer ?? throw new ArgumentNullException(nameof(terrainRenderer));
             _visualHeightmapRenderer = visualHeightmapRenderer ?? throw new ArgumentNullException(nameof(visualHeightmapRenderer));
             _fieldRenderPerformer = fieldRenderPerformer ?? throw new ArgumentNullException(nameof(fieldRenderPerformer));
@@ -126,41 +134,85 @@ namespace Ludots.Adapter.Raylib
         public RaylibRenderFrameResult RenderFrame(in RaylibRenderFrame frame)
         {
             bool emptyBufferWarned = frame.EmptyBufferWarned;
-            long beginDrawingStart = Stopwatch.GetTimestamp();
-            Rl.BeginDrawing();
-            _presentationTiming?.ObserveBeginDrawing(ElapsedMs(beginDrawingStart));
-            Restore3DDepthState();
-            Rl.ClearBackground(frame.ActiveMapRequestsDeepBackground
-                ? new Color(6, 10, 16, 255)
-                : new Color(0, 0, 0, 255));
+            bool drawingActive = false;
+            bool worldFrameActive = false;
+            bool mode3DActive = false;
+            bool frameCompleted = false;
 
-            long mode3DStart = Stopwatch.GetTimestamp();
-            Restore3DDepthState();
-            CameraRenderState3D activeCameraState = frame.ActiveCameraState;
-            BeginCoreMode3D(frame.ActiveCamera, in activeCameraState);
-            Restore3DDepthState();
+            try
+            {
+                long beginDrawingStart = Stopwatch.GetTimestamp();
+                Rl.BeginDrawing();
+                drawingActive = true;
+                _presentationTiming?.ObserveBeginDrawing(ElapsedMs(beginDrawingStart));
+                Restore3DDepthState();
+                worldFrameActive = true;
+                _environmentRenderer.BeginWorldFrame(frame.Width, frame.Height, frame.ActiveMapRequestsDeepBackground);
 
-            DrawDebugGuides(in frame);
-            DrawTerrain(in frame);
-            DrawGlobalFields(in frame);
-            bool benchmarkDrew = DrawBenchmarkScene(frame.ActiveCamera);
-            emptyBufferWarned = DrawPrimitiveVisuals(in frame, benchmarkDrew, emptyBufferWarned);
-            DrawGroundOverlays(frame.CleanPerformanceMode);
-            DrawRoadSplines(frame.CleanPerformanceMode);
-            DrawDebugCommands(in frame);
+                long mode3DStart = Stopwatch.GetTimestamp();
+                Restore3DDepthState();
+                CameraRenderState3D activeCameraState = frame.ActiveCameraState;
+                mode3DActive = true;
+                BeginCoreMode3D(frame.ActiveCamera, in activeCameraState);
+                Restore3DDepthState();
 
-            EndCoreMode3D();
-            _presentationTiming?.ObserveMode3D(ElapsedMs(mode3DStart));
+                _environmentRenderer.DrawSkybox(frame.ActiveCamera, frame.TimeSeconds);
+                DrawDebugGuides(in frame);
+                DrawTerrain(in frame);
+                DrawGlobalFields(in frame);
+                bool benchmarkDrew = DrawBenchmarkScene(frame.ActiveCamera);
+                emptyBufferWarned = DrawPrimitiveVisuals(in frame, benchmarkDrew, emptyBufferWarned);
+                DrawGroundOverlays(frame.CleanPerformanceMode);
+                DrawRoadSplines(frame.CleanPerformanceMode);
+                DrawDebugCommands(in frame);
 
-            DrawUiLayers(in frame);
-            return new RaylibRenderFrameResult(emptyBufferWarned);
+                EndCoreMode3D();
+                mode3DActive = false;
+                _presentationTiming?.ObserveMode3D(ElapsedMs(mode3DStart));
+                _environmentRenderer.EndWorldFrame(frame.TimeSeconds);
+                worldFrameActive = false;
+
+                DrawUiLayers(in frame);
+                frameCompleted = true;
+                return new RaylibRenderFrameResult(emptyBufferWarned);
+            }
+            finally
+            {
+                if (!frameCompleted)
+                {
+                    if (mode3DActive)
+                    {
+                        EndCoreMode3D();
+                    }
+
+                    if (worldFrameActive)
+                    {
+                        _environmentRenderer.AbortWorldFrame();
+                    }
+
+                    if (drawingActive)
+                    {
+                        Rl.EndDrawing();
+                    }
+                }
+            }
         }
 
         public static int BuildPassPlan(in RaylibFramePassPlanInput input, Span<RaylibFramePass> output)
         {
             int count = 0;
             Add(output, ref count, RaylibFramePass.Clear);
+            if (input.UsePostProcess)
+            {
+                Add(output, ref count, RaylibFramePass.BeginWorldTexture);
+            }
+
             Add(output, ref count, RaylibFramePass.BeginWorld3D);
+            if (input.DrawEnvironment)
+            {
+                Add(output, ref count, RaylibFramePass.Skybox);
+            }
+
             if (input.DrawDebugGuides)
             {
                 Add(output, ref count, RaylibFramePass.DebugGuides);
@@ -202,6 +254,11 @@ namespace Ludots.Adapter.Raylib
             }
 
             Add(output, ref count, RaylibFramePass.EndWorld3D);
+            if (input.UsePostProcess)
+            {
+                Add(output, ref count, RaylibFramePass.PostProcessComposite);
+            }
+
             if (input.DrawSkiaUi)
             {
                 Add(output, ref count, RaylibFramePass.BrowserLayer);
@@ -246,7 +303,7 @@ namespace Ludots.Adapter.Raylib
                 visualHeightmapForTerrain is IVisualHeightmapRenderSource visualTerrainSource)
             {
                 long terrainStart = Stopwatch.GetTimestamp();
-                _visualHeightmapRenderer.Render(visualTerrainSource, frame.ActiveCamera);
+                _visualHeightmapRenderer.Render(visualTerrainSource, frame.ActiveCamera, frame.TimeSeconds);
                 _presentationTiming?.ObserveTerrain(
                     ElapsedMs(terrainStart),
                     _visualHeightmapRenderer.ChunkBuildMsLastFrame,
@@ -258,7 +315,7 @@ namespace Ludots.Adapter.Raylib
             if (frame.DrawTerrain)
             {
                 long terrainStart = Stopwatch.GetTimestamp();
-                _terrainRenderer.Render(_engine.VertexMap, frame.ActiveCamera);
+                _terrainRenderer.Render(_engine.VertexMap, frame.ActiveCamera, frame.TimeSeconds);
                 _presentationTiming?.ObserveTerrain(
                     ElapsedMs(terrainStart),
                     _terrainRenderer.ChunkBuildMsLastFrame,

--- a/src/Adapters/Raylib/Ludots.Adapter.Raylib/Rendering/RaylibWorldOverlayRenderer.cs
+++ b/src/Adapters/Raylib/Ludots.Adapter.Raylib/Rendering/RaylibWorldOverlayRenderer.cs
@@ -1,0 +1,327 @@
+using System;
+using System.Numerics;
+using Ludots.Client.Raylib.Rendering;
+using Ludots.Core.Presentation.Rendering;
+using Raylib_cs;
+using Rl = Raylib_cs.Raylib;
+
+namespace Ludots.Adapter.Raylib
+{
+    internal static class RaylibWorldOverlayRenderer
+    {
+        public static void DrawGroundOverlays(GroundOverlayBuffer overlays)
+        {
+            if (overlays == null)
+            {
+                throw new ArgumentNullException(nameof(overlays));
+            }
+
+            ReadOnlySpan<GroundOverlayItem> span = overlays.GetSpan();
+            for (int i = 0; i < span.Length; i++)
+            {
+                ref readonly GroundOverlayItem item = ref span[i];
+                switch (item.Shape)
+                {
+                    case GroundOverlayShape.Circle:
+                        DrawGroundCircle(in item);
+                        break;
+                    case GroundOverlayShape.Cone:
+                        DrawGroundCone(in item);
+                        break;
+                    case GroundOverlayShape.Ring:
+                        DrawGroundRing(in item);
+                        break;
+                    case GroundOverlayShape.Line:
+                        DrawGroundLine(in item);
+                        break;
+                }
+            }
+        }
+
+        public static void DrawRoadSplines(RoadSplineBuffer splines)
+        {
+            if (splines == null)
+            {
+                throw new ArgumentNullException(nameof(splines));
+            }
+
+            ReadOnlySpan<float> p0x = splines.P0X;
+            ReadOnlySpan<float> p0y = splines.P0Y;
+            ReadOnlySpan<float> p0z = splines.P0Z;
+            ReadOnlySpan<float> p1x = splines.P1X;
+            ReadOnlySpan<float> p1y = splines.P1Y;
+            ReadOnlySpan<float> p1z = splines.P1Z;
+            ReadOnlySpan<float> p2x = splines.P2X;
+            ReadOnlySpan<float> p2y = splines.P2Y;
+            ReadOnlySpan<float> p2z = splines.P2Z;
+            ReadOnlySpan<float> p3x = splines.P3X;
+            ReadOnlySpan<float> p3y = splines.P3Y;
+            ReadOnlySpan<float> p3z = splines.P3Z;
+            ReadOnlySpan<float> width = splines.Width;
+            ReadOnlySpan<float> borderWidth = splines.BorderWidth;
+            ReadOnlySpan<float> fillR = splines.FillR;
+            ReadOnlySpan<float> fillG = splines.FillG;
+            ReadOnlySpan<float> fillB = splines.FillB;
+            ReadOnlySpan<float> fillA = splines.FillA;
+            ReadOnlySpan<float> borderR = splines.BorderR;
+            ReadOnlySpan<float> borderG = splines.BorderG;
+            ReadOnlySpan<float> borderB = splines.BorderB;
+            ReadOnlySpan<float> borderA = splines.BorderA;
+
+            for (int i = 0; i < splines.Count; i++)
+            {
+                Vector3 p0 = new(p0x[i], p0y[i], p0z[i]);
+                Vector3 p1 = new(p1x[i], p1y[i], p1z[i]);
+                Vector3 p2 = new(p2x[i], p2y[i], p2z[i]);
+                Vector3 p3 = new(p3x[i], p3y[i], p3z[i]);
+                float drawWidth = MathF.Max(0.02f, width[i]);
+                float drawBorder = MathF.Max(0.01f, borderWidth[i]);
+                Color fill = ToRaylibColor(new Vector4(fillR[i], fillG[i], fillB[i], fillA[i]));
+                Color border = ToRaylibColor(new Vector4(borderR[i], borderG[i], borderB[i], borderA[i]));
+                DrawRoadSplineRibbon(p0, p1, p2, p3, drawWidth, fill, border, drawBorder);
+            }
+        }
+
+        private static void DrawRoadSplineRibbon(
+            in Vector3 p0,
+            in Vector3 p1,
+            in Vector3 p2,
+            in Vector3 p3,
+            float width,
+            Color fill,
+            Color border,
+            float borderWidth)
+        {
+            const int samples = 20;
+            Span<Vector3> points = stackalloc Vector3[samples + 1];
+            for (int i = 0; i <= samples; i++)
+            {
+                float t = i / (float)samples;
+                points[i] = EvaluateCubicBezier(p0, p1, p2, p3, t);
+            }
+
+            if (fill.a > 0)
+            {
+                int lanes = Math.Max(1, (int)MathF.Ceiling(width / 0.08f));
+                for (int lane = 0; lane < lanes; lane++)
+                {
+                    float alpha = lanes == 1 ? 0f : lane / (float)(lanes - 1);
+                    float offset = (alpha - 0.5f) * width;
+                    DrawOffsetPolyline(points, offset, fill);
+                }
+            }
+
+            if (border.a > 0)
+            {
+                float edgeOffset = (width * 0.5f) + borderWidth;
+                DrawOffsetPolyline(points, edgeOffset, border);
+                DrawOffsetPolyline(points, -edgeOffset, border);
+            }
+        }
+
+        private static void DrawOffsetPolyline(ReadOnlySpan<Vector3> points, float offset, Color color)
+        {
+            if (points.Length < 2)
+            {
+                return;
+            }
+
+            Vector3 previous = OffsetPoint(points, 0, offset);
+            for (int i = 1; i < points.Length; i++)
+            {
+                Vector3 current = OffsetPoint(points, i, offset);
+                Rl.DrawLine3D(previous, current, color);
+                previous = current;
+            }
+        }
+
+        private static Vector3 OffsetPoint(ReadOnlySpan<Vector3> points, int index, float offset)
+        {
+            Vector3 current = points[index];
+            Vector3 forward = index == points.Length - 1
+                ? current - points[index - 1]
+                : points[index + 1] - current;
+            Vector2 lateral = new(-forward.Z, forward.X);
+            float length = lateral.Length();
+            if (length <= 0.0001f)
+            {
+                return current;
+            }
+
+            lateral /= length;
+            return new Vector3(current.X + lateral.X * offset, current.Y, current.Z + lateral.Y * offset);
+        }
+
+        private static Vector3 EvaluateCubicBezier(in Vector3 p0, in Vector3 p1, in Vector3 p2, in Vector3 p3, float t)
+        {
+            float oneMinusT = 1f - t;
+            float a = oneMinusT * oneMinusT * oneMinusT;
+            float b = 3f * oneMinusT * oneMinusT * t;
+            float c = 3f * oneMinusT * t * t;
+            float d = t * t * t;
+            return (p0 * a) + (p1 * b) + (p2 * c) + (p3 * d);
+        }
+
+        private static void DrawGroundCircle(in GroundOverlayItem item)
+        {
+            const int segments = 48;
+            float step = MathF.PI * 2f / segments;
+            Vector3 center = item.Center;
+
+            if (item.FillColor.W > 0.01f)
+            {
+                Color fillColor = ToRaylibColor(item.FillColor);
+                const int fillRings = 4;
+                for (int r = 1; r <= fillRings; r++)
+                {
+                    float radius = item.Radius * r / fillRings;
+                    for (int s = 0; s < segments; s++)
+                    {
+                        float a0 = s * step;
+                        float a1 = (s + 1) * step;
+                        Vector3 p0 = new(center.X + MathF.Cos(a0) * radius, center.Y, center.Z + MathF.Sin(a0) * radius);
+                        Vector3 p1 = new(center.X + MathF.Cos(a1) * radius, center.Y, center.Z + MathF.Sin(a1) * radius);
+                        Rl.DrawLine3D(p0, p1, fillColor);
+                    }
+                }
+            }
+
+            if (item.BorderColor.W > 0.01f && item.BorderWidth > 0f)
+            {
+                Color border = ToRaylibColor(item.BorderColor);
+                for (int s = 0; s < segments; s++)
+                {
+                    float a0 = s * step;
+                    float a1 = (s + 1) * step;
+                    Vector3 p0 = new(center.X + MathF.Cos(a0) * item.Radius, center.Y, center.Z + MathF.Sin(a0) * item.Radius);
+                    Vector3 p1 = new(center.X + MathF.Cos(a1) * item.Radius, center.Y, center.Z + MathF.Sin(a1) * item.Radius);
+                    Rl.DrawLine3D(p0, p1, border);
+                }
+            }
+        }
+
+        private static void DrawGroundRing(in GroundOverlayItem item)
+        {
+            const int segments = 48;
+            float innerRadius = Math.Clamp(item.InnerRadius, 0f, item.Radius);
+            float outerRadius = MathF.Max(item.Radius, innerRadius);
+            Vector3 center = item.Center;
+
+            if (item.FillColor.W > 0.01f && outerRadius > innerRadius)
+            {
+                Color fillColor = ToRaylibColor(item.FillColor);
+                const int bands = 6;
+                for (int band = 0; band < bands; band++)
+                {
+                    float radius = innerRadius + (outerRadius - innerRadius) * (band + 0.5f) / bands;
+                    DrawGroundArcLoop(center, radius, 0f, MathF.PI * 2f, segments, fillColor);
+                }
+            }
+
+            if (item.BorderColor.W > 0.01f && item.BorderWidth > 0f)
+            {
+                Color border = ToRaylibColor(item.BorderColor);
+                DrawGroundArcLoop(center, outerRadius, 0f, MathF.PI * 2f, segments, border);
+                if (innerRadius > 0.001f)
+                {
+                    DrawGroundArcLoop(center, innerRadius, 0f, MathF.PI * 2f, segments, border);
+                }
+            }
+        }
+
+        private static void DrawGroundCone(in GroundOverlayItem item)
+        {
+            const int segments = 24;
+            float radius = MathF.Max(item.Radius, 0f);
+            float start = item.Rotation - item.Angle;
+            float end = item.Rotation + item.Angle;
+            Vector3 center = item.Center;
+
+            if (radius <= 0f)
+            {
+                return;
+            }
+
+            if (item.FillColor.W > 0.01f)
+            {
+                Color fillColor = ToRaylibColor(item.FillColor);
+                const int bands = 6;
+                for (int band = 1; band <= bands; band++)
+                {
+                    float ringRadius = radius * band / bands;
+                    DrawGroundArcLoop(center, ringRadius, start, end, segments, fillColor);
+                }
+            }
+
+            if (item.BorderColor.W > 0.01f && item.BorderWidth > 0f)
+            {
+                Color border = ToRaylibColor(item.BorderColor);
+                DrawGroundArcLoop(center, radius, start, end, segments, border);
+                Vector3 left = new(center.X + MathF.Cos(start) * radius, center.Y, center.Z + MathF.Sin(start) * radius);
+                Vector3 right = new(center.X + MathF.Cos(end) * radius, center.Y, center.Z + MathF.Sin(end) * radius);
+                Rl.DrawLine3D(center, left, border);
+                Rl.DrawLine3D(center, right, border);
+            }
+        }
+
+        private static void DrawGroundLine(in GroundOverlayItem item)
+        {
+            float length = item.Length > 0f ? item.Length : item.Radius;
+            if (length <= 0f)
+            {
+                return;
+            }
+
+            float dx = MathF.Cos(item.Rotation) * length;
+            float dz = MathF.Sin(item.Rotation) * length;
+            Vector3 a = item.Center;
+            Vector3 b = new(a.X + dx, a.Y, a.Z + dz);
+            float halfWidth = MathF.Max(0f, item.Width) * 0.5f;
+            Vector3 normal = new(-MathF.Sin(item.Rotation), 0f, MathF.Cos(item.Rotation));
+
+            if (item.FillColor.W > 0.01f)
+            {
+                Color fill = ToRaylibColor(item.FillColor);
+                int stripes = halfWidth > 0.001f ? Math.Clamp((int)MathF.Ceiling(halfWidth / 0.12f), 1, 8) : 1;
+                for (int stripe = -stripes; stripe <= stripes; stripe++)
+                {
+                    float offset = stripes == 0 ? 0f : halfWidth * stripe / Math.Max(stripes, 1);
+                    Vector3 delta = normal * offset;
+                    Rl.DrawLine3D(a + delta, b + delta, fill);
+                }
+            }
+
+            if (item.BorderColor.W > 0.01f)
+            {
+                Color border = ToRaylibColor(item.BorderColor);
+                Rl.DrawLine3D(a, b, border);
+                if (halfWidth > 0.001f)
+                {
+                    Vector3 delta = normal * halfWidth;
+                    Rl.DrawLine3D(a + delta, b + delta, border);
+                    Rl.DrawLine3D(a - delta, b - delta, border);
+                }
+            }
+        }
+
+        private static void DrawGroundArcLoop(Vector3 center, float radius, float startAngle, float endAngle, int segments, Color color)
+        {
+            if (segments <= 0 || radius <= 0f)
+            {
+                return;
+            }
+
+            float step = (endAngle - startAngle) / segments;
+            for (int s = 0; s < segments; s++)
+            {
+                float a0 = startAngle + s * step;
+                float a1 = startAngle + (s + 1) * step;
+                Vector3 p0 = new(center.X + MathF.Cos(a0) * radius, center.Y, center.Z + MathF.Sin(a0) * radius);
+                Vector3 p1 = new(center.X + MathF.Cos(a1) * radius, center.Y, center.Z + MathF.Sin(a1) * radius);
+                Rl.DrawLine3D(p0, p1, color);
+            }
+        }
+
+        private static Color ToRaylibColor(in Vector4 c) => RaylibColorUtil.ToRaylibColor(in c);
+    }
+}

--- a/src/Apps/Raylib/Ludots.App.Raylib/Ludots.App.Raylib.csproj
+++ b/src/Apps/Raylib/Ludots.App.Raylib/Ludots.App.Raylib.csproj
@@ -53,6 +53,18 @@
       <Link>water.fs</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="..\..\..\Platforms\Desktop\skybox.vs">
+      <Link>skybox.vs</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\..\Platforms\Desktop\skybox.fs">
+      <Link>skybox.fs</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\..\Platforms\Desktop\postprocess.fs">
+      <Link>postprocess.fs</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="launcher.runtime.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -60,6 +72,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="launcher.visual-terrain-editor.runtime.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="raylib.launch.graph.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="launcher.mass-navigation.runtime.json">

--- a/src/Client/Ludots.Client.Raylib/Properties/AssemblyInfo.cs
+++ b/src/Client/Ludots.Client.Raylib/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Ludots.Adapter.Raylib.Tests")]

--- a/src/Client/Ludots.Client.Raylib/Rendering/RaylibPostProcessRenderer.cs
+++ b/src/Client/Ludots.Client.Raylib/Rendering/RaylibPostProcessRenderer.cs
@@ -1,0 +1,186 @@
+using System;
+using System.IO;
+using System.Numerics;
+using Raylib_cs;
+using Rl = Raylib_cs.Raylib;
+
+namespace Ludots.Client.Raylib.Rendering
+{
+    public sealed unsafe class RaylibPostProcessRenderer : IDisposable
+    {
+        private Shader _shader;
+        private RenderTexture2D _target;
+        private bool _shaderLoaded;
+        private bool _targetLoaded;
+        private bool _worldFrameActive;
+        private int _targetWidth;
+        private int _targetHeight;
+        private int _locResolution;
+        private int _locTime;
+        private int _locExposure;
+        private int _locContrast;
+        private int _locSaturation;
+        private int _locVignetteStrength;
+
+        public void BeginWorldFrame(int width, int height, Color clearColor, RaylibPostProcessConfig config)
+        {
+            config = config.Validate();
+            if (!config.Enabled)
+            {
+                Rl.ClearBackground(clearColor);
+                return;
+            }
+
+            EnsureRenderTarget(width, height);
+            EnsureShader();
+            if (_worldFrameActive)
+            {
+                throw new InvalidOperationException("Raylib post-process world frame is already active.");
+            }
+
+            Rl.BeginTextureMode(_target);
+            _worldFrameActive = true;
+            Rl.ClearBackground(clearColor);
+        }
+
+        public void EndWorldFrame(double timeSeconds, RaylibPostProcessConfig config)
+        {
+            config = config.Validate();
+            if (!config.Enabled)
+            {
+                return;
+            }
+
+            if (!_targetLoaded)
+            {
+                throw new InvalidOperationException("Raylib post-process render target was not initialized before EndWorldFrame.");
+            }
+
+            if (!_worldFrameActive)
+            {
+                throw new InvalidOperationException("Raylib post-process world frame was not active before EndWorldFrame.");
+            }
+
+            EnsureShader();
+            Rl.EndTextureMode();
+            _worldFrameActive = false;
+            UpdateUniforms(timeSeconds, config);
+
+            Rl.BeginShaderMode(_shader);
+            Rl.DrawTextureRec(_target.texture, BuildTextureSourceRectangle(_target.texture), Vector2.Zero, Color.WHITE);
+            Rl.EndShaderMode();
+        }
+
+        public void AbortWorldFrame()
+        {
+            if (!_worldFrameActive)
+            {
+                return;
+            }
+
+            Rl.EndTextureMode();
+            _worldFrameActive = false;
+        }
+
+        internal static Rectangle BuildTextureSourceRectangle(Texture2D texture)
+        {
+            return new Rectangle(0f, 0f, texture.width, -texture.height);
+        }
+
+        internal static bool NeedsRenderTargetResize(
+            bool loaded,
+            int currentWidth,
+            int currentHeight,
+            int requestedWidth,
+            int requestedHeight)
+        {
+            if (requestedWidth <= 0) throw new ArgumentOutOfRangeException(nameof(requestedWidth));
+            if (requestedHeight <= 0) throw new ArgumentOutOfRangeException(nameof(requestedHeight));
+            return !loaded || currentWidth != requestedWidth || currentHeight != requestedHeight;
+        }
+
+        private void EnsureRenderTarget(int width, int height)
+        {
+            if (!NeedsRenderTargetResize(_targetLoaded, _targetWidth, _targetHeight, width, height))
+            {
+                return;
+            }
+
+            if (_targetLoaded)
+            {
+                Rl.UnloadRenderTexture(_target);
+                _target = default;
+                _targetLoaded = false;
+            }
+
+            _target = Rl.LoadRenderTexture(width, height);
+            if (_target.id == 0 || _target.texture.id == 0)
+            {
+                throw new InvalidOperationException($"Raylib LoadRenderTexture returned an empty world target for {width}x{height}.");
+            }
+
+            Rl.SetTextureFilter(_target.texture, Rl.TextureFilter.TEXTURE_FILTER_BILINEAR);
+            _targetWidth = width;
+            _targetHeight = height;
+            _targetLoaded = true;
+        }
+
+        private void EnsureShader()
+        {
+            if (_shaderLoaded)
+            {
+                return;
+            }
+
+            string baseDir = AppContext.BaseDirectory;
+            _shader = Rl.LoadShader(null!, Path.Combine(baseDir, "postprocess.fs"));
+            if (_shader.id == 0)
+            {
+                throw new InvalidOperationException("Failed to load post-process shader (shader.id == 0).");
+            }
+
+            _locResolution = RaylibShaderBindingGuard.RequireUniform(_shader, "uResolution", "post-process");
+            _locTime = RaylibShaderBindingGuard.RequireUniform(_shader, "uTime", "post-process");
+            _locExposure = RaylibShaderBindingGuard.RequireUniform(_shader, "uExposure", "post-process");
+            _locContrast = RaylibShaderBindingGuard.RequireUniform(_shader, "uContrast", "post-process");
+            _locSaturation = RaylibShaderBindingGuard.RequireUniform(_shader, "uSaturation", "post-process");
+            _locVignetteStrength = RaylibShaderBindingGuard.RequireUniform(_shader, "uVignetteStrength", "post-process");
+            _shaderLoaded = true;
+        }
+
+        private void UpdateUniforms(double timeSeconds, RaylibPostProcessConfig config)
+        {
+            Vector2 resolution = new(_targetWidth, _targetHeight);
+            float time = (float)(timeSeconds % 100000.0);
+            float exposure = config.Exposure;
+            float contrast = config.Contrast;
+            float saturation = config.Saturation;
+            float vignetteStrength = config.VignetteStrength;
+
+            Rl.SetShaderValue(_shader, _locResolution, &resolution, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC2);
+            Rl.SetShaderValue(_shader, _locTime, &time, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_shader, _locExposure, &exposure, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_shader, _locContrast, &contrast, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_shader, _locSaturation, &saturation, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_shader, _locVignetteStrength, &vignetteStrength, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+        }
+
+        public void Dispose()
+        {
+            AbortWorldFrame();
+
+            if (_targetLoaded)
+            {
+                Rl.UnloadRenderTexture(_target);
+                _target = default;
+                _targetLoaded = false;
+            }
+
+            if (_shaderLoaded)
+            {
+                Rl.UnloadShader(_shader);
+                _shaderLoaded = false;
+            }
+        }
+    }
+}

--- a/src/Client/Ludots.Client.Raylib/Rendering/RaylibPrimitiveRenderer.cs
+++ b/src/Client/Ludots.Client.Raylib/Rendering/RaylibPrimitiveRenderer.cs
@@ -48,6 +48,7 @@ namespace Ludots.Client.Raylib.Rendering
         private readonly Dictionary<GpuSkinnedInstanceBatchKey, GpuSkinnedInstanceBatch> _gpuSkinnedInstanceBatches = new();
         private readonly List<GpuSkinnedInstanceBatch> _activeGpuSkinnedInstanceBatches = new(64);
         private readonly RaylibIsmRenderBridge _ismBridge = new RaylibIsmRenderBridge();
+        private readonly RaylibVfxRenderer _vfxRenderer = new();
 
         private readonly Dictionary<int, CachedModel> _modelCache = new Dictionary<int, CachedModel>();
         private readonly Dictionary<int, CachedProceduralMesh> _proceduralMeshCache = new Dictionary<int, CachedProceduralMesh>();
@@ -100,14 +101,14 @@ namespace Ludots.Client.Raylib.Rendering
             _maxModelInstancesPerDraw = ResolveMaxModelInstancesPerDraw();
         }
 
-        public void Draw(PrimitiveDrawBuffer draw, Camera3D camera, MeshAssetRegistry meshes, float scaleMul = 1f, IVisualHeightmap? visualHeightmap = null)
+        public void Draw(PrimitiveDrawBuffer draw, Camera3D camera, MeshAssetRegistry meshes, float scaleMul = 1f, IVisualHeightmap? visualHeightmap = null, double timeSeconds = 0d)
         {
-            Draw(draw, camera, snapshot: null, skinnedBatch: null, meshes, scaleMul, visualHeightmap);
+            Draw(draw, camera, snapshot: null, skinnedBatch: null, meshes, scaleMul, visualHeightmap, timeSeconds);
         }
 
-        public void Draw(PrimitiveDrawBuffer draw, Camera3D camera, PrimitiveDrawBuffer? snapshot, MeshAssetRegistry meshes, float scaleMul = 1f, IVisualHeightmap? visualHeightmap = null)
+        public void Draw(PrimitiveDrawBuffer draw, Camera3D camera, PrimitiveDrawBuffer? snapshot, MeshAssetRegistry meshes, float scaleMul = 1f, IVisualHeightmap? visualHeightmap = null, double timeSeconds = 0d)
         {
-            Draw(draw, camera, snapshot, skinnedBatch: null, meshes, scaleMul, visualHeightmap);
+            Draw(draw, camera, snapshot, skinnedBatch: null, meshes, scaleMul, visualHeightmap, timeSeconds);
         }
 
         public void Draw(
@@ -117,7 +118,8 @@ namespace Ludots.Client.Raylib.Rendering
             SkinnedVisualBatchBuffer? skinnedBatch,
             MeshAssetRegistry meshes,
             float scaleMul = 1f,
-            IVisualHeightmap? visualHeightmap = null)
+            IVisualHeightmap? visualHeightmap = null,
+            double timeSeconds = 0d)
         {
             if (draw == null) throw new ArgumentNullException(nameof(draw));
             if (meshes == null) throw new ArgumentNullException(nameof(meshes));
@@ -144,47 +146,55 @@ namespace Ludots.Client.Raylib.Rendering
             LastVfxVisualCount = 0;
             LastSurfaceVisualCount = 0;
             var finalizationContext = new PrefabFinalizationContext(visualHeightmap);
+            _vfxRenderer.BeginFrame();
 
-            var span = draw.GetSpan();
-            bool usePersistentStaticLanes = snapshot != null;
-            if (usePersistentStaticLanes)
+            try
             {
-                _ismBridge.SyncPersistentLanes(snapshot);
-                LastPersistentSyncMs = _ismBridge.LastPersistentSyncMs;
-                LastPersistentCreates = _ismBridge.Planner.LastCreateCount;
-                LastPersistentUpdates = _ismBridge.Planner.LastUpdateCount;
-                LastPersistentRemoves = _ismBridge.Planner.LastRemoveCount;
-                long bucketStart = Stopwatch.GetTimestamp();
-                DrawPersistentStaticLanes(camera, meshes, scaleMul, in finalizationContext);
-                LastPersistentBucketDrawMs = (Stopwatch.GetTimestamp() - bucketStart) * 1000d / Stopwatch.Frequency;
-                if (skinnedBatch != null)
+                var span = draw.GetSpan();
+                bool usePersistentStaticLanes = snapshot != null;
+                if (usePersistentStaticLanes)
                 {
-                    DrawSkinnedBatch(skinnedBatch, camera, meshes, scaleMul, in finalizationContext);
+                    _ismBridge.SyncPersistentLanes(snapshot);
+                    LastPersistentSyncMs = _ismBridge.LastPersistentSyncMs;
+                    LastPersistentCreates = _ismBridge.Planner.LastCreateCount;
+                    LastPersistentUpdates = _ismBridge.Planner.LastUpdateCount;
+                    LastPersistentRemoves = _ismBridge.Planner.LastRemoveCount;
+                    long bucketStart = Stopwatch.GetTimestamp();
+                    DrawPersistentStaticLanes(camera, meshes, scaleMul, timeSeconds, in finalizationContext);
+                    LastPersistentBucketDrawMs = (Stopwatch.GetTimestamp() - bucketStart) * 1000d / Stopwatch.Frequency;
+                    if (skinnedBatch != null)
+                    {
+                        DrawSkinnedBatch(skinnedBatch, camera, meshes, scaleMul, timeSeconds, in finalizationContext);
+                    }
+
+                    long dynamicLaneStart = Stopwatch.GetTimestamp();
+                    DrawSnapshotDynamicLanes(span, camera, meshes, scaleMul, skinnedBatchActive: skinnedBatch != null, timeSeconds, in finalizationContext);
+                    LastImmediateDrawMs = (Stopwatch.GetTimestamp() - dynamicLaneStart) * 1000d / Stopwatch.Frequency;
+
+                    return;
                 }
 
-                long dynamicLaneStart = Stopwatch.GetTimestamp();
-                DrawSnapshotDynamicLanes(span, camera, meshes, scaleMul, skinnedBatchActive: skinnedBatch != null, in finalizationContext);
-                LastImmediateDrawMs = (Stopwatch.GetTimestamp() - dynamicLaneStart) * 1000d / Stopwatch.Frequency;
+                if (_mode == RaylibPrimitiveRenderMode.Instanced)
+                {
+                    DrawHybridInstanced(span, camera, meshes, scaleMul, timeSeconds, in finalizationContext);
+                    return;
+                }
 
-                return;
+                long immediateDrawStart = Stopwatch.GetTimestamp();
+                DrawImmediateWithDescriptors(span, camera, meshes, scaleMul, persistentStaticLanesActive: false, skinnedBatchActive: false, timeSeconds, in finalizationContext);
+                LastImmediateDrawMs = (Stopwatch.GetTimestamp() - immediateDrawStart) * 1000d / Stopwatch.Frequency;
             }
-
-            if (_mode == RaylibPrimitiveRenderMode.Instanced)
+            finally
             {
-                DrawHybridInstanced(span, camera, meshes, scaleMul, in finalizationContext);
-                return;
+                _vfxRenderer.EndFrame();
             }
-
-            long immediateDrawStart = Stopwatch.GetTimestamp();
-            DrawImmediateWithDescriptors(span, camera, meshes, scaleMul, persistentStaticLanesActive: false, skinnedBatchActive: false, in finalizationContext);
-            LastImmediateDrawMs = (Stopwatch.GetTimestamp() - immediateDrawStart) * 1000d / Stopwatch.Frequency;
         }
 
-        private void DrawPersistentStaticLanes(Camera3D camera, MeshAssetRegistry meshes, float scaleMul, in PrefabFinalizationContext finalizationContext)
+        private void DrawPersistentStaticLanes(Camera3D camera, MeshAssetRegistry meshes, float scaleMul, double timeSeconds, in PrefabFinalizationContext finalizationContext)
         {
             foreach (RaylibIsmRenderBridge.Bucket bucket in _ismBridge.ActiveBuckets)
             {
-                DrawInstancedBucket(bucket, meshes, scaleMul);
+                DrawInstancedBucket(bucket, meshes, scaleMul, timeSeconds);
             }
         }
 
@@ -195,6 +205,7 @@ namespace Ludots.Client.Raylib.Rendering
             float scaleMul,
             bool persistentStaticLanesActive,
             bool skinnedBatchActive,
+            double timeSeconds,
             in PrefabFinalizationContext finalizationContext)
         {
             for (int i = 0; i < span.Length; i++)
@@ -223,13 +234,7 @@ namespace Ludots.Client.Raylib.Rendering
                     continue;
                 }
 
-                DrawAssetRecursive(
-                    item.MeshAssetId, item.Position,
-                    item.Rotation,
-                    item.Scale * scaleMul, item.Color,
-                    camera,
-                    meshes,
-                    in finalizationContext);
+                DrawPrimitiveItem(in item, camera, meshes, scaleMul, timeSeconds, in finalizationContext);
             }
         }
 
@@ -239,6 +244,7 @@ namespace Ludots.Client.Raylib.Rendering
             MeshAssetRegistry meshes,
             float scaleMul,
             bool skinnedBatchActive,
+            double timeSeconds,
             in PrefabFinalizationContext finalizationContext)
         {
             EnsureInitialized();
@@ -269,15 +275,7 @@ namespace Ludots.Client.Raylib.Rendering
                     continue;
                 }
 
-                SubmitAssetRecursive(
-                    item.MeshAssetId,
-                    item.Position,
-                    item.Rotation,
-                    item.Scale * scaleMul,
-                    item.Color,
-                    camera,
-                    meshes,
-                    in finalizationContext);
+                SubmitPrimitiveItem(in item, camera, meshes, scaleMul, timeSeconds, in finalizationContext);
             }
 
             FlushInstancedBatches();
@@ -295,7 +293,7 @@ namespace Ludots.Client.Raylib.Rendering
             return _ismBridge.ActiveBindings.ContainsKey(item.StableId);
         }
 
-        private void DrawHybridInstanced(ReadOnlySpan<PrimitiveDrawItem> span, Camera3D camera, MeshAssetRegistry meshes, float scaleMul, in PrefabFinalizationContext finalizationContext)
+        private void DrawHybridInstanced(ReadOnlySpan<PrimitiveDrawItem> span, Camera3D camera, MeshAssetRegistry meshes, float scaleMul, double timeSeconds, in PrefabFinalizationContext finalizationContext)
         {
             EnsureInitialized();
 
@@ -312,27 +310,71 @@ namespace Ludots.Client.Raylib.Rendering
                     continue;
                 }
 
-                SubmitAssetRecursive(
-                    item.MeshAssetId,
-                    item.Position,
-                    item.Rotation,
-                    item.Scale * scaleMul,
-                    item.Color,
-                    camera,
-                    meshes,
-                    in finalizationContext);
+                SubmitPrimitiveItem(in item, camera, meshes, scaleMul, timeSeconds, in finalizationContext);
             }
 
             FlushInstancedBatches();
         }
 
-        private void SubmitAssetRecursive(int meshAssetId, Vector3 position, Quaternion rotation, Vector3 scale, Vector4 color, Camera3D camera, MeshAssetRegistry meshes, in PrefabFinalizationContext finalizationContext)
+        private void SubmitPrimitiveItem(
+            in PrimitiveDrawItem item,
+            Camera3D camera,
+            MeshAssetRegistry meshes,
+            float scaleMul,
+            double timeSeconds,
+            in PrefabFinalizationContext finalizationContext)
+        {
+            if (TrySubmitDirectVfx(in item, camera, meshes, scaleMul, timeSeconds))
+            {
+                return;
+            }
+
+            SubmitAssetRecursive(
+                item.MeshAssetId,
+                item.Position,
+                item.Rotation,
+                item.Scale * scaleMul,
+                item.Color,
+                camera,
+                meshes,
+                item.StableId,
+                timeSeconds,
+                in finalizationContext);
+        }
+
+        private void DrawPrimitiveItem(
+            in PrimitiveDrawItem item,
+            Camera3D camera,
+            MeshAssetRegistry meshes,
+            float scaleMul,
+            double timeSeconds,
+            in PrefabFinalizationContext finalizationContext)
+        {
+            if (TryDrawDirectVfx(in item, camera, meshes, scaleMul, timeSeconds))
+            {
+                return;
+            }
+
+            DrawAssetRecursive(
+                item.MeshAssetId,
+                item.Position,
+                item.Rotation,
+                item.Scale * scaleMul,
+                item.Color,
+                camera,
+                meshes,
+                item.StableId,
+                timeSeconds,
+                in finalizationContext);
+        }
+
+        private void SubmitAssetRecursive(int meshAssetId, Vector3 position, Quaternion rotation, Vector3 scale, Vector4 color, Camera3D camera, MeshAssetRegistry meshes, int stableId, double timeSeconds, in PrefabFinalizationContext finalizationContext)
         {
             _prefabVisuals.Clear();
             PrefabFinalizationPipeline.FinalizeVisuals(
                 meshes,
                 meshAssetId,
-                stableId: 0,
+                stableId,
                 position,
                 rotation,
                 scale,
@@ -342,7 +384,7 @@ namespace Ludots.Client.Raylib.Rendering
 
             foreach (ref readonly var visual in _prefabVisuals.GetSpan())
             {
-                SubmitFinalizedVisual(in visual, camera);
+                SubmitFinalizedVisual(in visual, camera, meshes, timeSeconds);
             }
         }
 
@@ -351,7 +393,73 @@ namespace Ludots.Client.Raylib.Rendering
             return item.AssetKind == AssetKind.Surface || item.RenderPath.IsSurfaceLane();
         }
 
-        private void SubmitFinalizedVisual(in PrefabFinalizedVisual visual, Camera3D camera)
+        private bool TrySubmitDirectVfx(
+            in PrimitiveDrawItem item,
+            Camera3D camera,
+            MeshAssetRegistry meshes,
+            float scaleMul,
+            double timeSeconds)
+        {
+            if (!TryBuildDirectVfxVisual(in item, scaleMul, out PrefabFinalizedVisual visual))
+            {
+                return false;
+            }
+
+            SubmitFinalizedVisual(in visual, camera, meshes, timeSeconds);
+            return true;
+        }
+
+        private bool TryDrawDirectVfx(
+            in PrimitiveDrawItem item,
+            Camera3D camera,
+            MeshAssetRegistry meshes,
+            float scaleMul,
+            double timeSeconds)
+        {
+            if (!TryBuildDirectVfxVisual(in item, scaleMul, out PrefabFinalizedVisual visual))
+            {
+                return false;
+            }
+
+            DrawFinalizedVisual(in visual, camera, meshes, timeSeconds);
+            return true;
+        }
+
+        internal static bool TryBuildDirectVfxVisual(
+            in PrimitiveDrawItem item,
+            float scaleMul,
+            out PrefabFinalizedVisual visual)
+        {
+            if (item.AssetKind != AssetKind.VFX)
+            {
+                visual = default;
+                return false;
+            }
+
+            if (item.MeshAssetId <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"VFX primitive stableId={item.StableId} requires a positive effect meshAssetId.");
+            }
+
+            if (item.StableId <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"VFX primitive effectAssetId={item.MeshAssetId} requires a positive stableId.");
+            }
+
+            visual = PrefabFinalizedVisual.Vfx(
+                item.StableId,
+                item.Position,
+                item.Rotation,
+                item.Scale * scaleMul,
+                item.Color,
+                item.MeshAssetId,
+                PrefabVfxSpawnMode.Loop);
+            return true;
+        }
+
+        private void SubmitFinalizedVisual(in PrefabFinalizedVisual visual, Camera3D camera, MeshAssetRegistry meshes, double timeSeconds)
         {
             TrackVisualKind(visual.Kind);
 
@@ -367,7 +475,7 @@ namespace Ludots.Client.Raylib.Rendering
                     DrawDecalVisual(in visual);
                     break;
                 case PrefabVisualPartKind.Vfx:
-                    DrawVfxVisual(in visual);
+                    DrawVfxVisual(in visual, meshes, timeSeconds);
                     break;
                 case PrefabVisualPartKind.Surface:
                     DrawSurfaceVisual(in visual, camera);
@@ -431,7 +539,7 @@ namespace Ludots.Client.Raylib.Rendering
             }
         }
 
-        private void DrawSkinnedBatch(SkinnedVisualBatchBuffer skinnedBatch, Camera3D camera, MeshAssetRegistry meshes, float scaleMul, in PrefabFinalizationContext finalizationContext)
+        private void DrawSkinnedBatch(SkinnedVisualBatchBuffer skinnedBatch, Camera3D camera, MeshAssetRegistry meshes, float scaleMul, double timeSeconds, in PrefabFinalizationContext finalizationContext)
         {
             var span = skinnedBatch.GetSpan();
             PrepareGpuSkinnedInstanceBatches();
@@ -461,6 +569,8 @@ namespace Ludots.Client.Raylib.Rendering
                     item.Color,
                     camera,
                     meshes,
+                    item.StableId,
+                    timeSeconds,
                     in finalizationContext);
             }
 
@@ -599,13 +709,13 @@ namespace Ludots.Client.Raylib.Rendering
             };
         }
 
-        private void DrawAssetRecursive(int meshAssetId, Vector3 position, Quaternion rotation, Vector3 scale, Vector4 color, Camera3D camera, MeshAssetRegistry meshes, in PrefabFinalizationContext finalizationContext)
+        private void DrawAssetRecursive(int meshAssetId, Vector3 position, Quaternion rotation, Vector3 scale, Vector4 color, Camera3D camera, MeshAssetRegistry meshes, int stableId, double timeSeconds, in PrefabFinalizationContext finalizationContext)
         {
             _prefabVisuals.Clear();
             PrefabFinalizationPipeline.FinalizeVisuals(
                 meshes,
                 meshAssetId,
-                stableId: 0,
+                stableId,
                 position,
                 rotation,
                 scale,
@@ -615,11 +725,11 @@ namespace Ludots.Client.Raylib.Rendering
 
             foreach (ref readonly var visual in _prefabVisuals.GetSpan())
             {
-                DrawFinalizedVisual(in visual, camera);
+                DrawFinalizedVisual(in visual, camera, meshes, timeSeconds);
             }
         }
 
-        private void DrawFinalizedVisual(in PrefabFinalizedVisual visual, Camera3D camera)
+        private void DrawFinalizedVisual(in PrefabFinalizedVisual visual, Camera3D camera, MeshAssetRegistry meshes, double timeSeconds)
         {
             TrackVisualKind(visual.Kind);
 
@@ -635,7 +745,7 @@ namespace Ludots.Client.Raylib.Rendering
                     DrawDecalVisual(in visual);
                     break;
                 case PrefabVisualPartKind.Vfx:
-                    DrawVfxVisual(in visual);
+                    DrawVfxVisual(in visual, meshes, timeSeconds);
                     break;
                 case PrefabVisualPartKind.Surface:
                     DrawSurfaceVisual(in visual, camera);
@@ -752,27 +862,9 @@ namespace Ludots.Client.Raylib.Rendering
             Rl.DrawLine3D(center, markerTop, edge);
         }
 
-        private void DrawVfxVisual(in PrefabFinalizedVisual visual)
+        private void DrawVfxVisual(in PrefabFinalizedVisual visual, MeshAssetRegistry meshes, double timeSeconds)
         {
-            Quaternion rotation = WorldPlane2D.NormalizeOrIdentity(visual.Rotation);
-            float baseExtent = MathF.Max(0.12f, MathF.Max(MathF.Abs(visual.Scale.X), MathF.Max(MathF.Abs(visual.Scale.Y), MathF.Abs(visual.Scale.Z))) * 0.45f);
-            float radius = visual.VfxSpawnMode == PrefabVfxSpawnMode.Loop
-                ? baseExtent * 1.15f
-                : baseExtent * 0.9f;
-            Vector4 pulseColor = BlendSemanticColor(visual.Color, visual.EffectAssetId, 0.6f);
-            Vector4 shellColor = LerpColor(pulseColor, new Vector4(1f, 1f, 1f, pulseColor.W), 0.35f);
-
-            DrawPrototypeSphere(visual.Position, radius * 0.28f, pulseColor);
-            DrawRotatedRing(visual.Position, rotation, radius, 12, MultiplyColor(shellColor, 1f, 1f, 1f, 0.72f));
-            DrawRotatedRing(visual.Position, rotation * Quaternion.CreateFromAxisAngle(Vector3.UnitX, MathF.PI * 0.5f), radius * 0.82f, 10, MultiplyColor(shellColor, 0.92f, 1f, 1.1f, 0.64f));
-
-            Vector3 right = Vector3.Normalize(Vector3.Transform(Vector3.UnitX, rotation));
-            Vector3 up = Vector3.Normalize(Vector3.Transform(Vector3.UnitY, rotation));
-            Vector3 forward = Vector3.Normalize(Vector3.Transform(-Vector3.UnitZ, rotation));
-            Color beamColor = ToRaylibColor(MultiplyColor(pulseColor, 1.1f, 1.08f, 1.18f, 0.88f));
-            Rl.DrawLine3D(visual.Position - (right * radius), visual.Position + (right * radius), beamColor);
-            Rl.DrawLine3D(visual.Position - (up * radius * 0.8f), visual.Position + (up * radius * 0.8f), beamColor);
-            Rl.DrawLine3D(visual.Position - (forward * radius * 0.9f), visual.Position + (forward * radius * 0.9f), beamColor);
+            _vfxRenderer.Draw(in visual, meshes, timeSeconds);
         }
 
         private void DrawSurfaceVisual(in PrefabFinalizedVisual visual, Camera3D camera)
@@ -1664,6 +1756,12 @@ namespace Ludots.Client.Raylib.Rendering
             for (int i = 0; i < span.Length; i++)
             {
                 ref readonly var item = ref span[i];
+                if (item.AssetKind == AssetKind.VFX)
+                {
+                    throw new InvalidOperationException(
+                        $"{nameof(DrawInstanced)} cannot draw VFX primitives because it has no frame time. Use {nameof(Draw)} with timeSeconds.");
+                }
+
                 if (!meshes.TryGetPrimitiveKind(item.MeshAssetId, out var kind)) continue;
 
                 SubmitPrimitive(kind, item.Position, item.Rotation, item.Scale, item.Color);
@@ -1686,7 +1784,7 @@ namespace Ludots.Client.Raylib.Rendering
             LastInstancedMatrixCacheMisses = 0;
         }
 
-        public void DrawInstancedBucket(RaylibIsmRenderBridge.Bucket bucket, MeshAssetRegistry meshes, float scaleMul = 1f)
+        public void DrawInstancedBucket(RaylibIsmRenderBridge.Bucket bucket, MeshAssetRegistry meshes, float scaleMul = 1f, double timeSeconds = 0d)
         {
             if (bucket == null) throw new ArgumentNullException(nameof(bucket));
             if (meshes == null) throw new ArgumentNullException(nameof(meshes));
@@ -1707,6 +1805,11 @@ namespace Ludots.Client.Raylib.Rendering
             for (int i = 0; i < items.Count; i++)
             {
                 PrimitiveDrawItem item = items[i];
+                if (TryDrawDirectVfx(in item, default, meshes, scaleMul, timeSeconds))
+                {
+                    continue;
+                }
+
                 if (!meshes.TryGetDescriptor(item.MeshAssetId, out MeshAssetDescriptor descriptor))
                 {
                     continue;
@@ -1728,6 +1831,8 @@ namespace Ludots.Client.Raylib.Rendering
                             item.Color,
                             default,
                             meshes,
+                            item.StableId,
+                            timeSeconds,
                             new PrefabFinalizationContext(null));
                         break;
                 }
@@ -1738,6 +1843,14 @@ namespace Ludots.Client.Raylib.Rendering
 
         private bool TryDrawModelInstancedBucket(RaylibIsmRenderBridge.Bucket bucket, List<PrimitiveDrawItem> items, MeshAssetRegistry meshes, float scaleMul)
         {
+            for (int i = 0; i < items.Count; i++)
+            {
+                if (items[i].AssetKind != AssetKind.Mesh)
+                {
+                    return false;
+                }
+            }
+
             PrimitiveDrawItem first = items[0];
             if (!meshes.TryGetDescriptor(first.MeshAssetId, out MeshAssetDescriptor descriptor) ||
                 descriptor.Type != MeshAssetType.Model)

--- a/src/Client/Ludots.Client.Raylib/Rendering/RaylibPrimitiveRenderer.cs
+++ b/src/Client/Ludots.Client.Raylib/Rendering/RaylibPrimitiveRenderer.cs
@@ -86,6 +86,8 @@ namespace Ludots.Client.Raylib.Rendering
         public int TotalDecalVisualCount { get; private set; }
         public int TotalVfxVisualCount { get; private set; }
         public int TotalSurfaceVisualCount { get; private set; }
+        public int LastDrawnVfxEffectCount => _vfxRenderer.LastDrawnEffectCount;
+        public int TotalDrawnVfxEffectCount => _vfxRenderer.TotalDrawnEffectCount;
 
         public RaylibIsmRenderBridge IsmBridge => _ismBridge;
 
@@ -400,7 +402,7 @@ namespace Ludots.Client.Raylib.Rendering
             float scaleMul,
             double timeSeconds)
         {
-            if (!TryBuildDirectVfxVisual(in item, scaleMul, out PrefabFinalizedVisual visual))
+            if (!TryBuildDirectVfxVisual(in item, meshes, scaleMul, out PrefabFinalizedVisual visual))
             {
                 return false;
             }
@@ -416,7 +418,7 @@ namespace Ludots.Client.Raylib.Rendering
             float scaleMul,
             double timeSeconds)
         {
-            if (!TryBuildDirectVfxVisual(in item, scaleMul, out PrefabFinalizedVisual visual))
+            if (!TryBuildDirectVfxVisual(in item, meshes, scaleMul, out PrefabFinalizedVisual visual))
             {
                 return false;
             }
@@ -427,9 +429,15 @@ namespace Ludots.Client.Raylib.Rendering
 
         internal static bool TryBuildDirectVfxVisual(
             in PrimitiveDrawItem item,
+            MeshAssetRegistry meshes,
             float scaleMul,
             out PrefabFinalizedVisual visual)
         {
+            if (meshes == null)
+            {
+                throw new ArgumentNullException(nameof(meshes));
+            }
+
             if (item.AssetKind != AssetKind.VFX)
             {
                 visual = default;
@@ -448,6 +456,18 @@ namespace Ludots.Client.Raylib.Rendering
                     $"VFX primitive effectAssetId={item.MeshAssetId} requires a positive stableId.");
             }
 
+            if (!meshes.TryGetDescriptor(item.MeshAssetId, out MeshAssetDescriptor descriptor))
+            {
+                throw new InvalidOperationException(
+                    $"VFX primitive stableId={item.StableId} references unknown effect asset id {item.MeshAssetId}.");
+            }
+
+            if (!descriptor.VfxEffectData.IsValid)
+            {
+                throw new InvalidOperationException(
+                    $"VFX primitive stableId={item.StableId} effectAssetId={item.MeshAssetId} must declare vfx effect data.");
+            }
+
             visual = PrefabFinalizedVisual.Vfx(
                 item.StableId,
                 item.Position,
@@ -455,7 +475,7 @@ namespace Ludots.Client.Raylib.Rendering
                 item.Scale * scaleMul,
                 item.Color,
                 item.MeshAssetId,
-                PrefabVfxSpawnMode.Loop);
+                descriptor.VfxEffectData.SpawnMode);
             return true;
         }
 
@@ -758,7 +778,7 @@ namespace Ludots.Client.Raylib.Rendering
 
         public string BuildVisualKindDiagnosticSummary()
         {
-            return $"prefab-visual-counts lastFrame(mesh={LastMeshVisualCount},decal={LastDecalVisualCount},vfx={LastVfxVisualCount},surface={LastSurfaceVisualCount}) total(mesh={TotalMeshVisualCount},decal={TotalDecalVisualCount},vfx={TotalVfxVisualCount},surface={TotalSurfaceVisualCount})";
+            return $"prefab-visual-counts lastFrame(mesh={LastMeshVisualCount},decal={LastDecalVisualCount},vfx={LastVfxVisualCount},surface={LastSurfaceVisualCount}) total(mesh={TotalMeshVisualCount},decal={TotalDecalVisualCount},vfx={TotalVfxVisualCount},surface={TotalSurfaceVisualCount}) vfx-draws(last={_vfxRenderer.LastDrawnEffectCount},total={_vfxRenderer.TotalDrawnEffectCount})";
         }
 
         public string BuildPrimitiveLaneDiagnosticSummary(MeshAssetRegistry meshes)
@@ -2151,22 +2171,7 @@ namespace Ludots.Client.Raylib.Rendering
             if (_initialized) return;
 
             _cubeMesh = Rl.GenMeshCube(1f, 1f, 1f);
-            if (_cubeMesh.colors == null)
-            {
-                int bytes = _cubeMesh.vertexCount * 4;
-                _cubeMesh.colors = (byte*)Rl.MemAlloc(bytes);
-                for (int i = 0; i < bytes; i++) _cubeMesh.colors[i] = 255;
-            }
-            Rl.UploadMesh(ref _cubeMesh, false);
-
             _sphereMesh = Rl.GenMeshSphere(0.5f, 8, 8);
-            if (_sphereMesh.colors == null)
-            {
-                int bytes = _sphereMesh.vertexCount * 4;
-                _sphereMesh.colors = (byte*)Rl.MemAlloc(bytes);
-                for (int i = 0; i < bytes; i++) _sphereMesh.colors[i] = 255;
-            }
-            Rl.UploadMesh(ref _sphereMesh, false);
 
             string baseDir = AppContext.BaseDirectory;
             _shader = Rl.LoadShader(Path.Combine(baseDir, "instancing.vs"), Path.Combine(baseDir, "instancing.fs"));

--- a/src/Client/Ludots.Client.Raylib/Rendering/RaylibRenderEnvironmentConfig.cs
+++ b/src/Client/Ludots.Client.Raylib/Rendering/RaylibRenderEnvironmentConfig.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Numerics;
+using Raylib_cs;
+
+namespace Ludots.Client.Raylib.Rendering
+{
+    public sealed record RaylibRenderEnvironmentConfig(
+        RaylibLightingConfig Lighting,
+        RaylibSkyboxConfig Skybox,
+        RaylibWaterRenderConfig Water,
+        RaylibPostProcessConfig PostProcess)
+    {
+        public static RaylibRenderEnvironmentConfig CreateDefault()
+        {
+            return new RaylibRenderEnvironmentConfig(
+                RaylibLightingConfig.CreateDefault(),
+                RaylibSkyboxConfig.CreateDefault(),
+                RaylibWaterRenderConfig.CreateDefault(),
+                RaylibPostProcessConfig.CreateDefault()).NormalizeAndValidate();
+        }
+
+        public RaylibRenderEnvironmentConfig NormalizeAndValidate()
+        {
+            return this with
+            {
+                Lighting = Lighting.NormalizeAndValidate(),
+                Skybox = Skybox.Validate(),
+                Water = Water.Validate(),
+                PostProcess = PostProcess.Validate()
+            };
+        }
+
+        internal static void RequireFinite(float value, string name)
+        {
+            if (!float.IsFinite(value))
+            {
+                throw new ArgumentOutOfRangeException(name, $"{name} must be finite.");
+            }
+        }
+
+        internal static void RequirePositive(float value, string name)
+        {
+            RequireFinite(value, name);
+            if (value <= 0f)
+            {
+                throw new ArgumentOutOfRangeException(name, $"{name} must be greater than zero.");
+            }
+        }
+
+        internal static void RequireRange(float value, float min, float max, string name)
+        {
+            RequireFinite(value, name);
+            if (value < min || value > max)
+            {
+                throw new ArgumentOutOfRangeException(name, $"{name} must be between {min} and {max}.");
+            }
+        }
+
+        internal static Vector3 RequireUnitDirection(Vector3 value, string name)
+        {
+            RequireFinite(value, name);
+            float lengthSquared = value.LengthSquared();
+            if (!float.IsFinite(lengthSquared) || lengthSquared <= 0.000001f)
+            {
+                throw new ArgumentOutOfRangeException(name, $"{name} must be a non-zero vector.");
+            }
+
+            return Vector3.Normalize(value);
+        }
+
+        internal static void RequireFinite(Vector3 value, string name)
+        {
+            RequireFinite(value.X, $"{name}.X");
+            RequireFinite(value.Y, $"{name}.Y");
+            RequireFinite(value.Z, $"{name}.Z");
+        }
+
+        internal static void RequireColor(Vector3 value, string name)
+        {
+            RequireFinite(value, name);
+            RequireRange(value.X, 0f, 1f, $"{name}.X");
+            RequireRange(value.Y, 0f, 1f, $"{name}.Y");
+            RequireRange(value.Z, 0f, 1f, $"{name}.Z");
+        }
+    }
+
+    public readonly record struct RaylibLightingConfig(
+        Vector3 SunDirection,
+        Vector3 SunColor,
+        Vector3 AmbientColor,
+        float AmbientStrength,
+        float SunStrength,
+        Vector3 FogColor,
+        float FogNearMeters,
+        float FogFarMeters,
+        float FogDensity)
+    {
+        public static RaylibLightingConfig CreateDefault()
+        {
+            return new RaylibLightingConfig(
+                new Vector3(-0.36f, 0.82f, -0.44f),
+                new Vector3(1.0f, 0.93f, 0.78f),
+                new Vector3(0.50f, 0.62f, 0.74f),
+                0.38f,
+                0.92f,
+                new Vector3(0.62f, 0.72f, 0.82f),
+                700f,
+                4200f,
+                0.00018f);
+        }
+
+        public RaylibLightingConfig NormalizeAndValidate()
+        {
+            Vector3 sunDirection = RaylibRenderEnvironmentConfig.RequireUnitDirection(SunDirection, nameof(SunDirection));
+            RaylibRenderEnvironmentConfig.RequireColor(SunColor, nameof(SunColor));
+            RaylibRenderEnvironmentConfig.RequireColor(AmbientColor, nameof(AmbientColor));
+            RaylibRenderEnvironmentConfig.RequireRange(AmbientStrength, 0f, 4f, nameof(AmbientStrength));
+            RaylibRenderEnvironmentConfig.RequireRange(SunStrength, 0f, 8f, nameof(SunStrength));
+            RaylibRenderEnvironmentConfig.RequireColor(FogColor, nameof(FogColor));
+            RaylibRenderEnvironmentConfig.RequirePositive(FogNearMeters, nameof(FogNearMeters));
+            RaylibRenderEnvironmentConfig.RequirePositive(FogFarMeters, nameof(FogFarMeters));
+            if (FogFarMeters <= FogNearMeters)
+            {
+                throw new ArgumentOutOfRangeException(nameof(FogFarMeters), "FogFarMeters must be greater than FogNearMeters.");
+            }
+
+            RaylibRenderEnvironmentConfig.RequireRange(FogDensity, 0f, 0.02f, nameof(FogDensity));
+            return this with { SunDirection = sunDirection };
+        }
+    }
+
+    public readonly record struct RaylibSkyboxConfig(
+        bool Enabled,
+        float SizeMeters,
+        Vector3 ZenithColor,
+        Vector3 HorizonColor,
+        Vector3 GroundHazeColor,
+        Color ClearColor,
+        Color DeepClearColor)
+    {
+        public static RaylibSkyboxConfig CreateDefault()
+        {
+            return new RaylibSkyboxConfig(
+                Enabled: true,
+                SizeMeters: 9000f,
+                ZenithColor: new Vector3(0.16f, 0.36f, 0.62f),
+                HorizonColor: new Vector3(0.72f, 0.84f, 0.92f),
+                GroundHazeColor: new Vector3(0.52f, 0.64f, 0.66f),
+                ClearColor: new Color(84, 125, 158, 255),
+                DeepClearColor: new Color(6, 10, 16, 255));
+        }
+
+        public RaylibSkyboxConfig Validate()
+        {
+            RaylibRenderEnvironmentConfig.RequirePositive(SizeMeters, nameof(SizeMeters));
+            RaylibRenderEnvironmentConfig.RequireColor(ZenithColor, nameof(ZenithColor));
+            RaylibRenderEnvironmentConfig.RequireColor(HorizonColor, nameof(HorizonColor));
+            RaylibRenderEnvironmentConfig.RequireColor(GroundHazeColor, nameof(GroundHazeColor));
+            return this;
+        }
+    }
+
+    public readonly record struct RaylibWaterRenderConfig(
+        Vector3 ShallowColor,
+        Vector3 DeepColor,
+        float WaveAmplitudeMeters,
+        float WaveFrequency,
+        float WaveSpeed,
+        float FresnelStrength)
+    {
+        public static RaylibWaterRenderConfig CreateDefault()
+        {
+            return new RaylibWaterRenderConfig(
+                ShallowColor: new Vector3(0.18f, 0.56f, 0.72f),
+                DeepColor: new Vector3(0.02f, 0.17f, 0.36f),
+                WaveAmplitudeMeters: 0.045f,
+                WaveFrequency: 0.09f,
+                WaveSpeed: 0.72f,
+                FresnelStrength: 0.38f);
+        }
+
+        public RaylibWaterRenderConfig Validate()
+        {
+            RaylibRenderEnvironmentConfig.RequireColor(ShallowColor, nameof(ShallowColor));
+            RaylibRenderEnvironmentConfig.RequireColor(DeepColor, nameof(DeepColor));
+            RaylibRenderEnvironmentConfig.RequireRange(WaveAmplitudeMeters, 0f, 4f, nameof(WaveAmplitudeMeters));
+            RaylibRenderEnvironmentConfig.RequireRange(WaveFrequency, 0f, 16f, nameof(WaveFrequency));
+            RaylibRenderEnvironmentConfig.RequireRange(WaveSpeed, 0f, 16f, nameof(WaveSpeed));
+            RaylibRenderEnvironmentConfig.RequireRange(FresnelStrength, 0f, 2f, nameof(FresnelStrength));
+            return this;
+        }
+    }
+
+    public readonly record struct RaylibPostProcessConfig(
+        bool Enabled,
+        float Exposure,
+        float Contrast,
+        float Saturation,
+        float VignetteStrength)
+    {
+        public static RaylibPostProcessConfig CreateDefault()
+        {
+            return new RaylibPostProcessConfig(
+                Enabled: true,
+                Exposure: 1.03f,
+                Contrast: 1.06f,
+                Saturation: 1.05f,
+                VignetteStrength: 0.14f);
+        }
+
+        public RaylibPostProcessConfig Validate()
+        {
+            RaylibRenderEnvironmentConfig.RequireRange(Exposure, 0.05f, 8f, nameof(Exposure));
+            RaylibRenderEnvironmentConfig.RequireRange(Contrast, 0.05f, 8f, nameof(Contrast));
+            RaylibRenderEnvironmentConfig.RequireRange(Saturation, 0f, 8f, nameof(Saturation));
+            RaylibRenderEnvironmentConfig.RequireRange(VignetteStrength, 0f, 1f, nameof(VignetteStrength));
+            return this;
+        }
+    }
+}

--- a/src/Client/Ludots.Client.Raylib/Rendering/RaylibRenderEnvironmentRenderer.cs
+++ b/src/Client/Ludots.Client.Raylib/Rendering/RaylibRenderEnvironmentRenderer.cs
@@ -1,0 +1,60 @@
+using System;
+using Raylib_cs;
+
+namespace Ludots.Client.Raylib.Rendering
+{
+    public sealed class RaylibRenderEnvironmentRenderer : IDisposable
+    {
+        private readonly RaylibSkyboxRenderer _skyboxRenderer = new();
+        private readonly RaylibPostProcessRenderer _postProcessRenderer = new();
+        private RaylibRenderEnvironmentConfig _config;
+
+        public RaylibRenderEnvironmentRenderer(RaylibRenderEnvironmentConfig config)
+        {
+            _config = config?.NormalizeAndValidate() ?? throw new ArgumentNullException(nameof(config));
+        }
+
+        public RaylibRenderEnvironmentConfig Config
+        {
+            get => _config;
+            set => _config = value?.NormalizeAndValidate() ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        public void BeginWorldFrame(int width, int height, bool activeMapRequestsDeepBackground)
+        {
+            _postProcessRenderer.BeginWorldFrame(
+                width,
+                height,
+                ResolveClearColor(activeMapRequestsDeepBackground),
+                _config.PostProcess);
+        }
+
+        public void DrawSkybox(in Camera3D camera, double timeSeconds)
+        {
+            _skyboxRenderer.Draw(camera, timeSeconds, _config);
+        }
+
+        public void EndWorldFrame(double timeSeconds)
+        {
+            _postProcessRenderer.EndWorldFrame(timeSeconds, _config.PostProcess);
+        }
+
+        public void AbortWorldFrame()
+        {
+            _postProcessRenderer.AbortWorldFrame();
+        }
+
+        internal Color ResolveClearColor(bool activeMapRequestsDeepBackground)
+        {
+            return activeMapRequestsDeepBackground
+                ? _config.Skybox.DeepClearColor
+                : _config.Skybox.ClearColor;
+        }
+
+        public void Dispose()
+        {
+            _skyboxRenderer.Dispose();
+            _postProcessRenderer.Dispose();
+        }
+    }
+}

--- a/src/Client/Ludots.Client.Raylib/Rendering/RaylibShaderBindingGuard.cs
+++ b/src/Client/Ludots.Client.Raylib/Rendering/RaylibShaderBindingGuard.cs
@@ -1,0 +1,31 @@
+using System;
+using Raylib_cs;
+using Rl = Raylib_cs.Raylib;
+
+namespace Ludots.Client.Raylib.Rendering
+{
+    internal static class RaylibShaderBindingGuard
+    {
+        public static int RequireUniform(Shader shader, string name, string shaderLabel)
+        {
+            int location = Rl.GetShaderLocation(shader, name);
+            if (location < 0)
+            {
+                throw new InvalidOperationException($"{shaderLabel} shader uniform '{name}' was not found.");
+            }
+
+            return location;
+        }
+
+        public static int RequireAttribute(Shader shader, string name, string shaderLabel)
+        {
+            int location = Rl.GetShaderLocationAttrib(shader, name);
+            if (location < 0)
+            {
+                throw new InvalidOperationException($"{shaderLabel} shader attribute '{name}' was not found.");
+            }
+
+            return location;
+        }
+    }
+}

--- a/src/Client/Ludots.Client.Raylib/Rendering/RaylibSkyboxRenderer.cs
+++ b/src/Client/Ludots.Client.Raylib/Rendering/RaylibSkyboxRenderer.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using System.Numerics;
+using Raylib_cs;
+using Rl = Raylib_cs.Raylib;
+
+namespace Ludots.Client.Raylib.Rendering
+{
+    public sealed unsafe class RaylibSkyboxRenderer : IDisposable
+    {
+        private Shader _shader;
+        private Material _material;
+        private Mesh _cubeMesh;
+        private bool _initialized;
+        private int _locSunDirection;
+        private int _locSunColor;
+        private int _locZenithColor;
+        private int _locHorizonColor;
+        private int _locGroundHazeColor;
+        private int _locTime;
+
+        public void Draw(in Camera3D camera, double timeSeconds, RaylibRenderEnvironmentConfig config)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+
+            RaylibRenderEnvironmentConfig normalized = config.NormalizeAndValidate();
+            if (!normalized.Skybox.Enabled)
+            {
+                return;
+            }
+
+            EnsureInitialized();
+            UpdateUniforms(timeSeconds, normalized);
+
+            float size = normalized.Skybox.SizeMeters;
+            RaylibMatrix transform = RaylibMatrix.FromScaleTranslation(
+                camera.position.X,
+                camera.position.Y,
+                camera.position.Z,
+                size,
+                size,
+                size);
+
+            Rl.rlDisableDepthMask();
+            Rl.rlDisableBackfaceCulling();
+            Rl.DrawMesh(_cubeMesh, _material, transform);
+            Rl.rlEnableBackfaceCulling();
+            Rl.rlEnableDepthMask();
+        }
+
+        private void EnsureInitialized()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            _cubeMesh = Rl.GenMeshCube(1f, 1f, 1f);
+
+            string baseDir = AppContext.BaseDirectory;
+            _shader = Rl.LoadShader(Path.Combine(baseDir, "skybox.vs"), Path.Combine(baseDir, "skybox.fs"));
+            if (_shader.id == 0)
+            {
+                throw new InvalidOperationException("Failed to load skybox shader (shader.id == 0).");
+            }
+
+            _material = Rl.LoadMaterialDefault();
+            _material.shader = _shader;
+
+            int locMvp = RaylibShaderBindingGuard.RequireUniform(_shader, "mvp", "skybox");
+            int locMatModel = RaylibShaderBindingGuard.RequireUniform(_shader, "matModel", "skybox");
+            int locVertexPosition = RaylibShaderBindingGuard.RequireAttribute(_shader, "vertexPosition", "skybox");
+            _shader.locs[(int)Rl.ShaderLocationIndex.SHADER_LOC_VERTEX_POSITION] = locVertexPosition;
+            _shader.locs[(int)Rl.ShaderLocationIndex.SHADER_LOC_VERTEX_TEXCOORD01] = -1;
+            _shader.locs[(int)Rl.ShaderLocationIndex.SHADER_LOC_VERTEX_TEXCOORD02] = -1;
+            _shader.locs[(int)Rl.ShaderLocationIndex.SHADER_LOC_VERTEX_NORMAL] = -1;
+            _shader.locs[(int)Rl.ShaderLocationIndex.SHADER_LOC_VERTEX_TANGENT] = -1;
+            _shader.locs[(int)Rl.ShaderLocationIndex.SHADER_LOC_VERTEX_COLOR] = -1;
+            _shader.locs[(int)Rl.ShaderLocationIndex.SHADER_LOC_MATRIX_MVP] = locMvp;
+            _shader.locs[(int)Rl.ShaderLocationIndex.SHADER_LOC_MATRIX_MODEL] = locMatModel;
+
+            _locSunDirection = RaylibShaderBindingGuard.RequireUniform(_shader, "uSunDirection", "skybox");
+            _locSunColor = RaylibShaderBindingGuard.RequireUniform(_shader, "uSunColor", "skybox");
+            _locZenithColor = RaylibShaderBindingGuard.RequireUniform(_shader, "uZenithColor", "skybox");
+            _locHorizonColor = RaylibShaderBindingGuard.RequireUniform(_shader, "uHorizonColor", "skybox");
+            _locGroundHazeColor = RaylibShaderBindingGuard.RequireUniform(_shader, "uGroundHazeColor", "skybox");
+            _locTime = RaylibShaderBindingGuard.RequireUniform(_shader, "uTime", "skybox");
+            _initialized = true;
+        }
+
+        private void UpdateUniforms(double timeSeconds, RaylibRenderEnvironmentConfig config)
+        {
+            RaylibLightingConfig lighting = config.Lighting;
+            RaylibSkyboxConfig skybox = config.Skybox;
+            Vector3 sunDirection = lighting.SunDirection;
+            Vector3 sunColor = lighting.SunColor;
+            Vector3 zenithColor = skybox.ZenithColor;
+            Vector3 horizonColor = skybox.HorizonColor;
+            Vector3 groundHazeColor = skybox.GroundHazeColor;
+            float time = (float)(timeSeconds % 100000.0);
+
+            Rl.SetShaderValue(_shader, _locSunDirection, &sunDirection, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_shader, _locSunColor, &sunColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_shader, _locZenithColor, &zenithColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_shader, _locHorizonColor, &horizonColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_shader, _locGroundHazeColor, &groundHazeColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_shader, _locTime, &time, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+        }
+
+        public void Dispose()
+        {
+            if (!_initialized)
+            {
+                return;
+            }
+
+            if (_cubeMesh.vertexCount > 0)
+            {
+                Rl.UnloadMesh(_cubeMesh);
+            }
+
+            _material.shader = default;
+            Rl.UnloadMaterial(_material);
+            Rl.UnloadShader(_shader);
+            _initialized = false;
+        }
+    }
+}

--- a/src/Client/Ludots.Client.Raylib/Rendering/RaylibTerrainRenderer.cs
+++ b/src/Client/Ludots.Client.Raylib/Rendering/RaylibTerrainRenderer.cs
@@ -21,19 +21,39 @@ namespace Ludots.Client.Raylib.Rendering
 
         private Shader _terrainShader;
         private Material _terrainMaterial;
-        private int _locTerrainLightPos;
         private int _locTerrainViewPos;
+        private int _locTerrainSunDirection;
+        private int _locTerrainSunColor;
+        private int _locTerrainAmbientColor;
         private int _locTerrainAmbient;
         private int _locTerrainIntensity;
+        private int _locTerrainFogColor;
+        private int _locTerrainFogNear;
+        private int _locTerrainFogFar;
+        private int _locTerrainFogDensity;
 
         private Shader _waterShader;
         private Material _waterMaterial;
-        private int _locWaterLightPos;
         private int _locWaterViewPos;
+        private int _locWaterSunDirection;
+        private int _locWaterSunColor;
+        private int _locWaterAmbientColor;
         private int _locWaterAmbient;
         private int _locWaterIntensity;
+        private int _locWaterFogColor;
+        private int _locWaterFogNear;
+        private int _locWaterFogFar;
+        private int _locWaterFogDensity;
+        private int _locWaterTime;
+        private int _locWaterShallowColor;
+        private int _locWaterDeepColor;
+        private int _locWaterWaveAmplitude;
+        private int _locWaterWaveFrequency;
+        private int _locWaterWaveSpeed;
+        private int _locWaterFresnelStrength;
 
         private int _frameIndex;
+        private RaylibRenderEnvironmentConfig _environmentConfig = RaylibRenderEnvironmentConfig.CreateDefault();
 
         public int DrawnChunkCountLastFrame { get; private set; }
         public int BuiltChunkCountLastFrame { get; private set; }
@@ -45,18 +65,20 @@ namespace Ludots.Client.Raylib.Rendering
         public float VisibleRadius { get; set; } = 900f;
         public float SimplifiedCliffRadius { get; set; } = 350f;
 
-        public Vector3 LightPosition { get; set; } = new Vector3(50f, 200f, 100f);
-        public float Ambient { get; set; } = 0.8f;
-        public float LightIntensity { get; set; } = 1.0f;
+        public RaylibRenderEnvironmentConfig EnvironmentConfig
+        {
+            get => _environmentConfig;
+            set => _environmentConfig = value?.NormalizeAndValidate() ?? throw new ArgumentNullException(nameof(value));
+        }
 
         public float HeightScale { get; set; } = 2.0f;
 
-        public void Render(VertexMap map, in Camera3D camera)
+        public void Render(VertexMap map, in Camera3D camera, double timeSeconds)
         {
             if (map == null) return;
 
             EnsureInitialized(map);
-            UpdateUniforms(camera);
+            UpdateUniforms(camera, timeSeconds);
 
             _frameIndex++;
             DrawnChunkCountLastFrame = 0;
@@ -97,7 +119,9 @@ namespace Ludots.Client.Raylib.Rendering
                     Rl.DrawMesh(chunk.TerrainMesh, _terrainMaterial, identity);
                     if (chunk.WaterMesh.vertexCount > 0)
                     {
+                        Rl.BeginBlendMode(BlendMode.BLEND_ALPHA);
                         Rl.DrawMesh(chunk.WaterMesh, _waterMaterial, identity);
+                        Rl.EndBlendMode();
                         WaterVertexCountLastFrame += chunk.WaterMesh.vertexCount;
                     }
                     Rl.rlEnableBackfaceCulling();
@@ -120,40 +144,94 @@ namespace Ludots.Client.Raylib.Rendering
             _terrainMaterial = Rl.LoadMaterialDefault();
             _terrainMaterial.shader = _terrainShader;
 
-            _locTerrainLightPos = Rl.GetShaderLocation(_terrainShader, "uLightPos");
-            _locTerrainViewPos = Rl.GetShaderLocation(_terrainShader, "uViewPos");
-            _locTerrainAmbient = Rl.GetShaderLocation(_terrainShader, "uAmbient");
-            _locTerrainIntensity = Rl.GetShaderLocation(_terrainShader, "uLightIntensity");
+            _locTerrainViewPos = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uViewPos", "terrain");
+            _locTerrainSunDirection = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uSunDirection", "terrain");
+            _locTerrainSunColor = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uSunColor", "terrain");
+            _locTerrainAmbientColor = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uAmbientColor", "terrain");
+            _locTerrainAmbient = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uAmbient", "terrain");
+            _locTerrainIntensity = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uLightIntensity", "terrain");
+            _locTerrainFogColor = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uFogColor", "terrain");
+            _locTerrainFogNear = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uFogNear", "terrain");
+            _locTerrainFogFar = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uFogFar", "terrain");
+            _locTerrainFogDensity = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uFogDensity", "terrain");
 
             _waterShader = Rl.LoadShader(Path.Combine(baseDir, "water.vs"), Path.Combine(baseDir, "water.fs"));
             if (_waterShader.id == 0) throw new InvalidOperationException("Failed to load water shader (shader.id == 0).");
             _waterMaterial = Rl.LoadMaterialDefault();
             _waterMaterial.shader = _waterShader;
 
-            _locWaterLightPos = Rl.GetShaderLocation(_waterShader, "uLightPos");
-            _locWaterViewPos = Rl.GetShaderLocation(_waterShader, "uViewPos");
-            _locWaterAmbient = Rl.GetShaderLocation(_waterShader, "uAmbient");
-            _locWaterIntensity = Rl.GetShaderLocation(_waterShader, "uLightIntensity");
+            _locWaterViewPos = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uViewPos", "water");
+            _locWaterSunDirection = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uSunDirection", "water");
+            _locWaterSunColor = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uSunColor", "water");
+            _locWaterAmbientColor = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uAmbientColor", "water");
+            _locWaterAmbient = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uAmbient", "water");
+            _locWaterIntensity = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uLightIntensity", "water");
+            _locWaterFogColor = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uFogColor", "water");
+            _locWaterFogNear = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uFogNear", "water");
+            _locWaterFogFar = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uFogFar", "water");
+            _locWaterFogDensity = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uFogDensity", "water");
+            _locWaterTime = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uTime", "water");
+            _locWaterShallowColor = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uWaterShallowColor", "water");
+            _locWaterDeepColor = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uWaterDeepColor", "water");
+            _locWaterWaveAmplitude = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uWaveAmplitude", "water");
+            _locWaterWaveFrequency = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uWaveFrequency", "water");
+            _locWaterWaveSpeed = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uWaveSpeed", "water");
+            _locWaterFresnelStrength = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uFresnelStrength", "water");
 
             _initialized = true;
         }
 
-        private void UpdateUniforms(in Camera3D camera)
+        private void UpdateUniforms(in Camera3D camera, double timeSeconds)
         {
-            Vector3 lightPos = LightPosition;
+            RaylibRenderEnvironmentConfig config = EnvironmentConfig;
+            RaylibLightingConfig lighting = config.Lighting;
+            RaylibWaterRenderConfig water = config.Water;
             Vector3 viewPos = camera.position;
-            float ambient = Ambient;
-            float intensity = LightIntensity;
+            Vector3 sunDirection = lighting.SunDirection;
+            Vector3 sunColor = lighting.SunColor;
+            Vector3 ambientColor = lighting.AmbientColor;
+            Vector3 fogColor = lighting.FogColor;
+            float ambient = lighting.AmbientStrength;
+            float intensity = lighting.SunStrength;
+            float fogNear = lighting.FogNearMeters;
+            float fogFar = lighting.FogFarMeters;
+            float fogDensity = lighting.FogDensity;
+            float time = (float)(timeSeconds % 100000.0);
+            Vector3 waterShallowColor = water.ShallowColor;
+            Vector3 waterDeepColor = water.DeepColor;
+            float waveAmplitude = water.WaveAmplitudeMeters;
+            float waveFrequency = water.WaveFrequency;
+            float waveSpeed = water.WaveSpeed;
+            float fresnelStrength = water.FresnelStrength;
 
-            Rl.SetShaderValue(_terrainShader, _locTerrainLightPos, &lightPos, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
             Rl.SetShaderValue(_terrainShader, _locTerrainViewPos, &viewPos, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_terrainShader, _locTerrainSunDirection, &sunDirection, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_terrainShader, _locTerrainSunColor, &sunColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_terrainShader, _locTerrainAmbientColor, &ambientColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
             Rl.SetShaderValue(_terrainShader, _locTerrainAmbient, &ambient, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
             Rl.SetShaderValue(_terrainShader, _locTerrainIntensity, &intensity, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_terrainShader, _locTerrainFogColor, &fogColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_terrainShader, _locTerrainFogNear, &fogNear, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_terrainShader, _locTerrainFogFar, &fogFar, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_terrainShader, _locTerrainFogDensity, &fogDensity, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
 
-            Rl.SetShaderValue(_waterShader, _locWaterLightPos, &lightPos, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
             Rl.SetShaderValue(_waterShader, _locWaterViewPos, &viewPos, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_waterShader, _locWaterSunDirection, &sunDirection, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_waterShader, _locWaterSunColor, &sunColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_waterShader, _locWaterAmbientColor, &ambientColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
             Rl.SetShaderValue(_waterShader, _locWaterAmbient, &ambient, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
             Rl.SetShaderValue(_waterShader, _locWaterIntensity, &intensity, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_waterShader, _locWaterFogColor, &fogColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_waterShader, _locWaterFogNear, &fogNear, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_waterShader, _locWaterFogFar, &fogFar, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_waterShader, _locWaterFogDensity, &fogDensity, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_waterShader, _locWaterTime, &time, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_waterShader, _locWaterShallowColor, &waterShallowColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_waterShader, _locWaterDeepColor, &waterDeepColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_waterShader, _locWaterWaveAmplitude, &waveAmplitude, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_waterShader, _locWaterWaveFrequency, &waveFrequency, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_waterShader, _locWaterWaveSpeed, &waveSpeed, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_waterShader, _locWaterFresnelStrength, &fresnelStrength, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
         }
 
         private ref ChunkGpu GetOrCreateChunk(VertexMap map, int chunkX, int chunkY, bool simplifiedCliffs)

--- a/src/Client/Ludots.Client.Raylib/Rendering/RaylibVfxRenderer.cs
+++ b/src/Client/Ludots.Client.Raylib/Rendering/RaylibVfxRenderer.cs
@@ -22,6 +22,8 @@ namespace Ludots.Client.Raylib.Rendering
         float ParticleRadius,
         int ParticleCount,
         int RingSegments,
+        int ShellRingCount,
+        int BeamCount,
         float OrbitPhase,
         Vector4 CoreColor,
         Vector4 ShellColor,
@@ -35,9 +37,14 @@ namespace Ludots.Client.Raylib.Rendering
         private readonly HashSet<RaylibVfxEffectKey> _activeKeys = new();
         private readonly List<RaylibVfxEffectKey> _inactiveKeys = new();
 
+        public int LastDrawnEffectCount { get; private set; }
+
+        public int TotalDrawnEffectCount { get; private set; }
+
         public void BeginFrame()
         {
             _activeKeys.Clear();
+            LastDrawnEffectCount = 0;
         }
 
         public void Draw(in PrefabFinalizedVisual visual, MeshAssetRegistry effectAssets, double timeSeconds)
@@ -83,6 +90,8 @@ namespace Ludots.Client.Raylib.Rendering
             }
 
             Draw(in plan);
+            LastDrawnEffectCount++;
+            TotalDrawnEffectCount++;
         }
 
         public void EndFrame()
@@ -150,9 +159,10 @@ namespace Ludots.Client.Raylib.Rendering
                 ? 1f - life01
                 : 0.72f + (pulse01 * 0.28f);
 
-            Vector4 core = BlendSemanticColor(visual.Color, visual.EffectAssetId, 0.6f);
-            Vector4 shell = LerpColor(core, new Vector4(1f, 1f, 1f, core.W), 0.35f);
-            Vector4 particle = LerpColor(core, shell, 0.5f);
+            VfxEffectAssetData effect = effectDescriptor.VfxEffectData;
+            Vector4 core = ModulateColor(effect.CoreColor, visual.Color);
+            Vector4 shell = ModulateColor(effect.ShellColor, visual.Color);
+            Vector4 particle = ModulateColor(effect.ParticleColor, visual.Color);
             core.W *= alphaMultiplier;
             shell.W *= alphaMultiplier * 0.72f;
             particle.W *= alphaMultiplier * 0.9f;
@@ -176,6 +186,8 @@ namespace Ludots.Client.Raylib.Rendering
                 MathF.Max(0.012f, shellRadius * emitter.ParticleRadiusScale),
                 emitter.ParticleCount,
                 emitter.RingSegments,
+                emitter.ShellRingCount,
+                emitter.BeamCount,
                 age * emitter.OrbitSpeedRadPerSecond,
                 ClampColor(core),
                 ClampColor(shell),
@@ -185,21 +197,26 @@ namespace Ludots.Client.Raylib.Rendering
         private static void Draw(in RaylibVfxEmitterPlan plan)
         {
             DrawCore(in plan);
-            DrawRotatedRing(plan.Position, plan.Rotation, plan.ShellRadius, plan.RingSegments, plan.ShellColor);
-            DrawRotatedRing(
-                plan.Position,
-                plan.Rotation * Quaternion.CreateFromAxisAngle(Vector3.UnitX, MathF.PI * 0.5f),
-                plan.ShellRadius * 0.82f,
-                Math.Max(3, plan.RingSegments - 4),
-                MultiplyColor(plan.ShellColor, 0.92f, 1f, 1.1f, 0.8f));
+            DrawShellRings(in plan);
 
             Vector3 right = Vector3.Normalize(Vector3.Transform(Vector3.UnitX, plan.Rotation));
             Vector3 up = Vector3.Normalize(Vector3.Transform(Vector3.UnitY, plan.Rotation));
             Vector3 forward = Vector3.Normalize(Vector3.Transform(-Vector3.UnitZ, plan.Rotation));
             Color beamColor = ToRaylibColor(MultiplyColor(plan.CoreColor, 1.1f, 1.08f, 1.18f, 0.82f));
-            Rl.DrawLine3D(plan.Position - (right * plan.ShellRadius), plan.Position + (right * plan.ShellRadius), beamColor);
-            Rl.DrawLine3D(plan.Position - (up * plan.ShellRadius * 0.8f), plan.Position + (up * plan.ShellRadius * 0.8f), beamColor);
-            Rl.DrawLine3D(plan.Position - (forward * plan.ShellRadius * 0.9f), plan.Position + (forward * plan.ShellRadius * 0.9f), beamColor);
+            if (plan.BeamCount >= 1)
+            {
+                Rl.DrawLine3D(plan.Position - (right * plan.ShellRadius), plan.Position + (right * plan.ShellRadius), beamColor);
+            }
+
+            if (plan.BeamCount >= 2)
+            {
+                Rl.DrawLine3D(plan.Position - (up * plan.ShellRadius * 0.8f), plan.Position + (up * plan.ShellRadius * 0.8f), beamColor);
+            }
+
+            if (plan.BeamCount >= 3)
+            {
+                Rl.DrawLine3D(plan.Position - (forward * plan.ShellRadius * 0.9f), plan.Position + (forward * plan.ShellRadius * 0.9f), beamColor);
+            }
 
             DrawParticles(in plan);
         }
@@ -254,6 +271,30 @@ namespace Ludots.Client.Raylib.Rendering
             }
         }
 
+        private static void DrawShellRings(in RaylibVfxEmitterPlan plan)
+        {
+            for (int ring = 0; ring < plan.ShellRingCount; ring++)
+            {
+                Quaternion ringRotation = ring switch
+                {
+                    0 => plan.Rotation,
+                    1 => plan.Rotation * Quaternion.CreateFromAxisAngle(Vector3.UnitX, MathF.PI * 0.5f),
+                    _ => plan.Rotation * Quaternion.CreateFromAxisAngle(Vector3.UnitZ, ring * MathF.PI / Math.Max(1, plan.ShellRingCount)),
+                };
+                float radiusScale = ring == 0 ? 1f : MathF.Max(0.45f, 0.88f - (ring * 0.06f));
+                int segments = Math.Max(3, plan.RingSegments - (ring * 4));
+                Vector4 color = ring == 0
+                    ? plan.ShellColor
+                    : MultiplyColor(plan.ShellColor, 0.92f, 1f, 1.1f, MathF.Max(0.35f, 0.8f - (ring * 0.1f)));
+                DrawRotatedRing(
+                    plan.Position,
+                    ringRotation,
+                    plan.ShellRadius * radiusScale,
+                    segments,
+                    color);
+            }
+        }
+
         internal static RaylibVfxEffectKey ComposeEffectKey(int stableId, int effectAssetId)
         {
             return new RaylibVfxEffectKey(stableId, effectAssetId);
@@ -287,33 +328,6 @@ namespace Ludots.Client.Raylib.Rendering
             return origin + Vector3.Transform(local, WorldPlane2D.NormalizeOrIdentity(rotation));
         }
 
-        private static Vector4 BlendSemanticColor(Vector4 baseColor, int semanticId, float semanticWeight)
-        {
-            Vector4 semanticColor = ResolveSemanticColor(semanticId, baseColor.W);
-            Vector4 tinted = LerpColor(baseColor, semanticColor, semanticWeight);
-            tinted.W = Math.Max(baseColor.W, semanticColor.W * 0.8f);
-            return tinted;
-        }
-
-        private static Vector4 ResolveSemanticColor(int semanticId, float alpha)
-        {
-            uint seed = semanticId == 0 ? 0x9E3779B9u : Hash((uint)semanticId);
-            float r = 0.28f + (((seed >> 0) & 0xFF) / 255f) * 0.62f;
-            float g = 0.28f + (((seed >> 8) & 0xFF) / 255f) * 0.62f;
-            float b = 0.28f + (((seed >> 16) & 0xFF) / 255f) * 0.62f;
-            return new Vector4(r, g, b, Math.Clamp(alpha, 0.35f, 1f));
-        }
-
-        private static uint Hash(uint value)
-        {
-            value ^= value >> 16;
-            value *= 0x7FEB352Du;
-            value ^= value >> 15;
-            value *= 0x846CA68Bu;
-            value ^= value >> 16;
-            return value;
-        }
-
         private static Vector4 MultiplyColor(Vector4 color, float r, float g, float b, float a)
         {
             return new Vector4(
@@ -323,14 +337,13 @@ namespace Ludots.Client.Raylib.Rendering
                 Math.Clamp(color.W * a, 0f, 1f));
         }
 
-        private static Vector4 LerpColor(Vector4 from, Vector4 to, float t)
+        private static Vector4 ModulateColor(Vector4 authored, Vector4 tint)
         {
-            t = Math.Clamp(t, 0f, 1f);
             return new Vector4(
-                from.X + (to.X - from.X) * t,
-                from.Y + (to.Y - from.Y) * t,
-                from.Z + (to.Z - from.Z) * t,
-                from.W + (to.W - from.W) * t);
+                authored.X * tint.X,
+                authored.Y * tint.Y,
+                authored.Z * tint.Z,
+                authored.W * tint.W);
         }
 
         private static Vector4 ClampColor(Vector4 color)

--- a/src/Client/Ludots.Client.Raylib/Rendering/RaylibVfxRenderer.cs
+++ b/src/Client/Ludots.Client.Raylib/Rendering/RaylibVfxRenderer.cs
@@ -1,0 +1,350 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Presentation.Assets;
+using Raylib_cs;
+using Rl = Raylib_cs.Raylib;
+
+namespace Ludots.Client.Raylib.Rendering
+{
+    public readonly record struct RaylibVfxEmitterPlan(
+        int StableId,
+        int EffectAssetId,
+        VfxEmitterShape Shape,
+        PrefabVfxSpawnMode SpawnMode,
+        Vector3 Position,
+        Quaternion Rotation,
+        float AgeSeconds,
+        float Life01,
+        float ShellRadius,
+        float CoreRadius,
+        float ParticleRadius,
+        int ParticleCount,
+        int RingSegments,
+        float OrbitPhase,
+        Vector4 CoreColor,
+        Vector4 ShellColor,
+        Vector4 ParticleColor);
+
+    internal readonly record struct RaylibVfxEffectKey(int StableId, int EffectAssetId);
+
+    public sealed class RaylibVfxRenderer
+    {
+        private readonly Dictionary<RaylibVfxEffectKey, double> _effectStartSeconds = new();
+        private readonly HashSet<RaylibVfxEffectKey> _activeKeys = new();
+        private readonly List<RaylibVfxEffectKey> _inactiveKeys = new();
+
+        public void BeginFrame()
+        {
+            _activeKeys.Clear();
+        }
+
+        public void Draw(in PrefabFinalizedVisual visual, MeshAssetRegistry effectAssets, double timeSeconds)
+        {
+            if (effectAssets == null)
+            {
+                throw new ArgumentNullException(nameof(effectAssets));
+            }
+
+            if (visual.Kind != PrefabVisualPartKind.Vfx)
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(RaylibVfxRenderer)} can only draw finalized VFX visuals, but received '{visual.Kind}'.");
+            }
+
+            if (visual.StableId <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"VFX visual effectAssetId={visual.EffectAssetId} requires a positive stableId for renderer lifetime tracking.");
+            }
+
+            if (!effectAssets.TryGetDescriptor(visual.EffectAssetId, out MeshAssetDescriptor descriptor))
+            {
+                throw new InvalidOperationException(
+                    $"VFX visual stableId={visual.StableId} references unknown effect asset id {visual.EffectAssetId}.");
+            }
+
+            RaylibVfxEffectKey key = ComposeEffectKey(visual.StableId, visual.EffectAssetId);
+            _activeKeys.Add(key);
+            if (!_effectStartSeconds.TryGetValue(key, out double startSeconds))
+            {
+                startSeconds = timeSeconds;
+                _effectStartSeconds.Add(key, startSeconds);
+            }
+
+            double ageSeconds = Math.Max(0d, timeSeconds - startSeconds);
+            RaylibVfxEmitterPlan plan = BuildEmitterPlan(in visual, in descriptor, ageSeconds);
+            if (plan.CoreColor.W <= 0.001f &&
+                plan.ShellColor.W <= 0.001f &&
+                plan.ParticleColor.W <= 0.001f)
+            {
+                return;
+            }
+
+            Draw(in plan);
+        }
+
+        public void EndFrame()
+        {
+            if (_effectStartSeconds.Count == _activeKeys.Count)
+            {
+                return;
+            }
+
+            _inactiveKeys.Clear();
+            foreach (RaylibVfxEffectKey key in _effectStartSeconds.Keys)
+            {
+                if (!_activeKeys.Contains(key))
+                {
+                    _inactiveKeys.Add(key);
+                }
+            }
+
+            for (int i = 0; i < _inactiveKeys.Count; i++)
+            {
+                _effectStartSeconds.Remove(_inactiveKeys[i]);
+            }
+        }
+
+        public static RaylibVfxEmitterPlan BuildEmitterPlan(
+            in PrefabFinalizedVisual visual,
+            in MeshAssetDescriptor effectDescriptor,
+            double ageSeconds)
+        {
+            if (visual.Kind != PrefabVisualPartKind.Vfx)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot build a VFX emitter plan for finalized visual kind '{visual.Kind}'.");
+            }
+
+            if (visual.StableId <= 0)
+            {
+                throw new InvalidOperationException("VFX emitter plans require a positive stableId.");
+            }
+
+            if (visual.EffectAssetId <= 0)
+            {
+                throw new InvalidOperationException("VFX emitter plans require a positive effectAssetId.");
+            }
+
+            if (!effectDescriptor.VfxEffectData.IsValid)
+            {
+                throw new InvalidOperationException(
+                    $"VFX effect asset id {effectDescriptor.Id} must declare vfx emitter data.");
+            }
+
+            VfxEmitterDescriptor emitter = effectDescriptor.VfxEffectData.Emitter;
+            float age = Math.Max(0f, (float)ageSeconds);
+            float maxScale = MathF.Max(
+                MathF.Abs(visual.Scale.X),
+                MathF.Max(MathF.Abs(visual.Scale.Y), MathF.Abs(visual.Scale.Z)));
+            float baseExtent = MathF.Max(0.12f, maxScale * 0.45f);
+            float life01 = visual.VfxSpawnMode == PrefabVfxSpawnMode.Once
+                ? Math.Clamp(age / emitter.LifetimeSeconds, 0f, 1f)
+                : 0f;
+            float pulse01 = visual.VfxSpawnMode == PrefabVfxSpawnMode.Loop
+                ? (MathF.Sin(age * emitter.PulseSpeedRadPerSecond) * 0.5f) + 0.5f
+                : 1f - life01;
+            float alphaMultiplier = visual.VfxSpawnMode == PrefabVfxSpawnMode.Once
+                ? 1f - life01
+                : 0.72f + (pulse01 * 0.28f);
+
+            Vector4 core = BlendSemanticColor(visual.Color, visual.EffectAssetId, 0.6f);
+            Vector4 shell = LerpColor(core, new Vector4(1f, 1f, 1f, core.W), 0.35f);
+            Vector4 particle = LerpColor(core, shell, 0.5f);
+            core.W *= alphaMultiplier;
+            shell.W *= alphaMultiplier * 0.72f;
+            particle.W *= alphaMultiplier * 0.9f;
+
+            float burstScale = visual.VfxSpawnMode == PrefabVfxSpawnMode.Once
+                ? 0.85f + (life01 * 0.45f)
+                : 0.92f + (pulse01 * 0.12f);
+            float shellRadius = baseExtent * emitter.RadiusScale * burstScale;
+
+            return new RaylibVfxEmitterPlan(
+                visual.StableId,
+                visual.EffectAssetId,
+                emitter.Shape,
+                visual.VfxSpawnMode,
+                visual.Position,
+                WorldPlane2D.NormalizeOrIdentity(visual.Rotation),
+                age,
+                life01,
+                shellRadius,
+                MathF.Max(0.025f, shellRadius * emitter.CoreRadiusScale),
+                MathF.Max(0.012f, shellRadius * emitter.ParticleRadiusScale),
+                emitter.ParticleCount,
+                emitter.RingSegments,
+                age * emitter.OrbitSpeedRadPerSecond,
+                ClampColor(core),
+                ClampColor(shell),
+                ClampColor(particle));
+        }
+
+        private static void Draw(in RaylibVfxEmitterPlan plan)
+        {
+            DrawCore(in plan);
+            DrawRotatedRing(plan.Position, plan.Rotation, plan.ShellRadius, plan.RingSegments, plan.ShellColor);
+            DrawRotatedRing(
+                plan.Position,
+                plan.Rotation * Quaternion.CreateFromAxisAngle(Vector3.UnitX, MathF.PI * 0.5f),
+                plan.ShellRadius * 0.82f,
+                Math.Max(3, plan.RingSegments - 4),
+                MultiplyColor(plan.ShellColor, 0.92f, 1f, 1.1f, 0.8f));
+
+            Vector3 right = Vector3.Normalize(Vector3.Transform(Vector3.UnitX, plan.Rotation));
+            Vector3 up = Vector3.Normalize(Vector3.Transform(Vector3.UnitY, plan.Rotation));
+            Vector3 forward = Vector3.Normalize(Vector3.Transform(-Vector3.UnitZ, plan.Rotation));
+            Color beamColor = ToRaylibColor(MultiplyColor(plan.CoreColor, 1.1f, 1.08f, 1.18f, 0.82f));
+            Rl.DrawLine3D(plan.Position - (right * plan.ShellRadius), plan.Position + (right * plan.ShellRadius), beamColor);
+            Rl.DrawLine3D(plan.Position - (up * plan.ShellRadius * 0.8f), plan.Position + (up * plan.ShellRadius * 0.8f), beamColor);
+            Rl.DrawLine3D(plan.Position - (forward * plan.ShellRadius * 0.9f), plan.Position + (forward * plan.ShellRadius * 0.9f), beamColor);
+
+            DrawParticles(in plan);
+        }
+
+        private static void DrawCore(in RaylibVfxEmitterPlan plan)
+        {
+            Color color = ToRaylibColor(plan.CoreColor);
+            switch (plan.Shape)
+            {
+                case VfxEmitterShape.BillboardSprite:
+                    throw new InvalidOperationException(
+                        "Raylib VFX emitter shape 'BillboardSprite' requires a billboard texture renderer. Author PrimitiveSphere or PrimitiveCube until that renderer exists.");
+                case VfxEmitterShape.PrimitiveSphere:
+                    Rl.DrawSphere(plan.Position, plan.CoreRadius, color);
+                    break;
+                case VfxEmitterShape.PrimitiveCube:
+                    Vector3 size = new(plan.CoreRadius * 1.6f, plan.CoreRadius * 1.6f, plan.CoreRadius * 1.6f);
+                    Rl.DrawCube(plan.Position, size.X, size.Y, size.Z, color);
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Raylib VFX emitter shape '{plan.Shape}' is not supported.");
+            }
+        }
+
+        private static void DrawParticles(in RaylibVfxEmitterPlan plan)
+        {
+            const float goldenAngle = 2.3999631f;
+            for (int i = 0; i < plan.ParticleCount; i++)
+            {
+                float lane = i / (float)Math.Max(1, plan.ParticleCount - 1);
+                float angle = (i * goldenAngle) + plan.OrbitPhase;
+                float radius = plan.ShellRadius * (0.55f + (0.32f * MathF.Sin(plan.OrbitPhase * 0.7f + i)));
+                float y = plan.ShellRadius * (lane - 0.5f) * 0.9f;
+                Vector3 local = new(MathF.Cos(angle) * radius, y, MathF.Sin(angle) * radius);
+                Vector3 particlePosition = TransformLocal(plan.Position, plan.Rotation, local);
+                Vector4 color = MultiplyColor(
+                    plan.ParticleColor,
+                    1f,
+                    1f,
+                    1f,
+                    0.55f + (0.45f * MathF.Sin(plan.OrbitPhase + i)));
+                if (plan.Shape == VfxEmitterShape.PrimitiveCube)
+                {
+                    Vector3 size = new(plan.ParticleRadius * 1.55f, plan.ParticleRadius * 1.55f, plan.ParticleRadius * 1.55f);
+                    Rl.DrawCube(particlePosition, size.X, size.Y, size.Z, ToRaylibColor(color));
+                }
+                else
+                {
+                    Rl.DrawSphere(particlePosition, plan.ParticleRadius, ToRaylibColor(color));
+                }
+            }
+        }
+
+        internal static RaylibVfxEffectKey ComposeEffectKey(int stableId, int effectAssetId)
+        {
+            return new RaylibVfxEffectKey(stableId, effectAssetId);
+        }
+
+        private static void DrawRotatedRing(Vector3 center, Quaternion rotation, float radius, int segments, Vector4 color)
+        {
+            if (segments < 3 || radius <= 0f)
+            {
+                return;
+            }
+
+            Quaternion normalized = WorldPlane2D.NormalizeOrIdentity(rotation);
+            Color ringColor = ToRaylibColor(color);
+            float step = MathF.Tau / segments;
+            Vector3 previous = TransformLocal(center, normalized, new Vector3(radius, 0f, 0f));
+            for (int index = 1; index <= segments; index++)
+            {
+                float angle = index * step;
+                Vector3 current = TransformLocal(
+                    center,
+                    normalized,
+                    new Vector3(MathF.Cos(angle) * radius, 0f, MathF.Sin(angle) * radius));
+                Rl.DrawLine3D(previous, current, ringColor);
+                previous = current;
+            }
+        }
+
+        private static Vector3 TransformLocal(Vector3 origin, Quaternion rotation, Vector3 local)
+        {
+            return origin + Vector3.Transform(local, WorldPlane2D.NormalizeOrIdentity(rotation));
+        }
+
+        private static Vector4 BlendSemanticColor(Vector4 baseColor, int semanticId, float semanticWeight)
+        {
+            Vector4 semanticColor = ResolveSemanticColor(semanticId, baseColor.W);
+            Vector4 tinted = LerpColor(baseColor, semanticColor, semanticWeight);
+            tinted.W = Math.Max(baseColor.W, semanticColor.W * 0.8f);
+            return tinted;
+        }
+
+        private static Vector4 ResolveSemanticColor(int semanticId, float alpha)
+        {
+            uint seed = semanticId == 0 ? 0x9E3779B9u : Hash((uint)semanticId);
+            float r = 0.28f + (((seed >> 0) & 0xFF) / 255f) * 0.62f;
+            float g = 0.28f + (((seed >> 8) & 0xFF) / 255f) * 0.62f;
+            float b = 0.28f + (((seed >> 16) & 0xFF) / 255f) * 0.62f;
+            return new Vector4(r, g, b, Math.Clamp(alpha, 0.35f, 1f));
+        }
+
+        private static uint Hash(uint value)
+        {
+            value ^= value >> 16;
+            value *= 0x7FEB352Du;
+            value ^= value >> 15;
+            value *= 0x846CA68Bu;
+            value ^= value >> 16;
+            return value;
+        }
+
+        private static Vector4 MultiplyColor(Vector4 color, float r, float g, float b, float a)
+        {
+            return new Vector4(
+                Math.Clamp(color.X * r, 0f, 1f),
+                Math.Clamp(color.Y * g, 0f, 1f),
+                Math.Clamp(color.Z * b, 0f, 1f),
+                Math.Clamp(color.W * a, 0f, 1f));
+        }
+
+        private static Vector4 LerpColor(Vector4 from, Vector4 to, float t)
+        {
+            t = Math.Clamp(t, 0f, 1f);
+            return new Vector4(
+                from.X + (to.X - from.X) * t,
+                from.Y + (to.Y - from.Y) * t,
+                from.Z + (to.Z - from.Z) * t,
+                from.W + (to.W - from.W) * t);
+        }
+
+        private static Vector4 ClampColor(Vector4 color)
+        {
+            return new Vector4(
+                Math.Clamp(color.X, 0f, 1f),
+                Math.Clamp(color.Y, 0f, 1f),
+                Math.Clamp(color.Z, 0f, 1f),
+                Math.Clamp(color.W, 0f, 1f));
+        }
+
+        private static Color ToRaylibColor(in Vector4 color)
+        {
+            return RaylibColorUtil.ToRaylibColor(in color);
+        }
+    }
+}

--- a/src/Client/Ludots.Client.Raylib/Rendering/RaylibVisualHeightmapRenderer.cs
+++ b/src/Client/Ludots.Client.Raylib/Rendering/RaylibVisualHeightmapRenderer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Numerics;
+using System.Threading.Tasks;
 using Ludots.Core.Mathematics;
 using Ludots.Core.Navigation.GraphWorld;
 using Ludots.Core.Presentation.Terrain;
@@ -13,17 +14,59 @@ namespace Ludots.Client.Raylib.Rendering
 {
     public sealed unsafe class RaylibVisualHeightmapRenderer : IDisposable
     {
+        private const int OverviewTextureMinLongEdgePixels = 1024;
+        private const int OverviewTextureMaxLongEdgePixels = 3072;
+        private const int OverviewTextureScreenScale = 2;
+
         private readonly Dictionary<long, ChunkGpu> _chunks = new(1024);
         private readonly List<long> _evictKeys = new(256);
 
+        private OverviewGpu _overview;
+        private bool _overviewLoaded;
+        private Task<OverviewCpuData>? _overviewBuildTask;
+        private OverviewKey _overviewBuildKey;
+        private bool _overviewBuildInFlight;
+        private bool _overviewActive;
+
         private Shader _terrainShader;
         private Material _terrainMaterial;
-        private int _locTerrainLightPos;
         private int _locTerrainViewPos;
+        private int _locTerrainSunDirection;
+        private int _locTerrainSunColor;
+        private int _locTerrainAmbientColor;
         private int _locTerrainAmbient;
         private int _locTerrainIntensity;
+        private int _locTerrainFogColor;
+        private int _locTerrainFogNear;
+        private int _locTerrainFogFar;
+        private int _locTerrainFogDensity;
+        private int _locTerrainUseTexture;
+        private Shader _waterShader;
+        private Material _waterMaterial;
+        private int _locWaterViewPos;
+        private int _locWaterSunDirection;
+        private int _locWaterSunColor;
+        private int _locWaterAmbientColor;
+        private int _locWaterAmbient;
+        private int _locWaterIntensity;
+        private int _locWaterFogColor;
+        private int _locWaterFogNear;
+        private int _locWaterFogFar;
+        private int _locWaterFogDensity;
+        private int _locWaterTime;
+        private int _locWaterShallowColor;
+        private int _locWaterDeepColor;
+        private int _locWaterWaveAmplitude;
+        private int _locWaterWaveFrequency;
+        private int _locWaterWaveSpeed;
+        private int _locWaterFresnelStrength;
         private bool _initialized;
         private int _frameIndex;
+        private IVisualHeightmapRenderSource? _heightRangeSource;
+        private int _heightRangeRevision = int.MinValue;
+        private float _heightRangeMinCm;
+        private float _heightRangeMaxCm;
+        private RaylibRenderEnvironmentConfig _environmentConfig = RaylibRenderEnvironmentConfig.CreateDefault();
 
         public int DrawnChunkCountLastFrame { get; private set; }
 
@@ -33,19 +76,27 @@ namespace Ludots.Client.Raylib.Rendering
 
         public int TerrainVertexCountLastFrame { get; private set; }
 
+        public int WaterVertexCountLastFrame { get; private set; }
+
         public double ChunkBuildMsLastFrame { get; private set; }
 
         public int CachedChunkCount => _chunks.Count;
 
         public float VisibleRadiusCm { get; set; } = 120_000f;
 
-        public Vector3 LightPosition { get; set; } = new(50f, 200f, 100f);
+        public int OverviewMaxVertices { get; set; } = 60_000;
 
-        public float Ambient { get; set; } = 0.45f;
+        public float OverviewActivationMultiplier { get; set; } = 2.0f;
 
-        public float LightIntensity { get; set; } = 0.55f;
+        public float OverviewSwitchHysteresis { get; set; } = 0.18f;
 
-        public void Render(IVisualHeightmapRenderSource source, in Camera3D camera)
+        public RaylibRenderEnvironmentConfig EnvironmentConfig
+        {
+            get => _environmentConfig;
+            set => _environmentConfig = value?.NormalizeAndValidate() ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        public void Render(IVisualHeightmapRenderSource source, in Camera3D camera, double timeSeconds)
         {
             if (source == null)
             {
@@ -53,20 +104,74 @@ namespace Ludots.Client.Raylib.Rendering
             }
 
             EnsureInitialized();
-            UpdateUniforms(camera);
+            UpdateUniforms(camera, timeSeconds);
+            ResolveSourceHeightRange(source, out float minHeightCm, out float maxHeightCm);
+            VisualHeightmapRenderProfile renderProfile = source.RenderProfile.NormalizeAndValidate();
+            float effectiveSeaLevelCm = ResolveEffectiveSeaLevelCm(renderProfile, minHeightCm);
 
             _frameIndex++;
             DrawnChunkCountLastFrame = 0;
             BuiltChunkCountLastFrame = 0;
             MissingChunkCountLastFrame = 0;
             TerrainVertexCountLastFrame = 0;
+            WaterVertexCountLastFrame = 0;
             ChunkBuildMsLastFrame = 0d;
 
-            int minChunkX = ResolveChunkIndex((camera.target.X * 100f) - VisibleRadiusCm, source.Bounds.Left, source.Bounds.Width, source.ChunkColumns);
-            int maxChunkX = ResolveChunkIndex((camera.target.X * 100f) + VisibleRadiusCm, source.Bounds.Left, source.Bounds.Width, source.ChunkColumns);
-            int minChunkY = ResolveChunkIndex((camera.target.Z * 100f) - VisibleRadiusCm, source.Bounds.Top, source.Bounds.Height, source.ChunkRows);
-            int maxChunkY = ResolveChunkIndex((camera.target.Z * 100f) + VisibleRadiusCm, source.Bounds.Top, source.Bounds.Height, source.ChunkRows);
+            float aspect = MathF.Max(0.001f, Rl.GetScreenWidth() / (float)Math.Max(1, Rl.GetScreenHeight()));
+            if (ResolveOverviewActive(source, camera, aspect))
+            {
+                long overviewStart = Stopwatch.GetTimestamp();
+                if (TryGetOrCreateOverview(
+                    source,
+                    renderProfile,
+                    minHeightCm,
+                    maxHeightCm,
+                    effectiveSeaLevelCm,
+                    out OverviewGpu overview))
+                {
+                    ChunkBuildMsLastFrame += (Stopwatch.GetTimestamp() - overviewStart) * 1000d / Stopwatch.Frequency;
+                    RaylibMatrix identity = RaylibMatrix.Identity;
+                    SetTerrainTextureMode(overview.Texture, true);
+                    try
+                    {
+                        Rl.rlDisableBackfaceCulling();
+                        Rl.DrawMesh(overview.Mesh, _terrainMaterial, identity);
+                        if (overview.WaterMesh.vertexCount > 0)
+                        {
+                            Rl.BeginBlendMode(BlendMode.BLEND_ALPHA);
+                            Rl.DrawMesh(overview.WaterMesh, _waterMaterial, identity);
+                            Rl.EndBlendMode();
+                            WaterVertexCountLastFrame += overview.WaterMesh.vertexCount;
+                        }
 
+                        Rl.rlEnableBackfaceCulling();
+                    }
+                    finally
+                    {
+                        Rl.rlEnableBackfaceCulling();
+                        SetTerrainTextureMode(default, false);
+                    }
+
+                    DrawnChunkCountLastFrame = 1;
+                    TerrainVertexCountLastFrame = overview.Mesh.vertexCount;
+                    EvictUnusedChunks(30);
+                    return;
+                }
+
+                ChunkBuildMsLastFrame += (Stopwatch.GetTimestamp() - overviewStart) * 1000d / Stopwatch.Frequency;
+            }
+
+            float chunkWidthCm = source.Bounds.Width / (float)Math.Max(1, source.ChunkColumns);
+            float chunkHeightCm = source.Bounds.Height / (float)Math.Max(1, source.ChunkRows);
+            float visibleRadiusCm = MathF.Max(
+                VisibleRadiusCm,
+                MathF.Max(chunkWidthCm, chunkHeightCm) * 1.25f);
+            int minChunkX = ResolveChunkIndex((camera.target.X * 100f) - visibleRadiusCm, source.Bounds.Left, source.Bounds.Width, source.ChunkColumns);
+            int maxChunkX = ResolveChunkIndex((camera.target.X * 100f) + visibleRadiusCm, source.Bounds.Left, source.Bounds.Width, source.ChunkColumns);
+            int minChunkY = ResolveChunkIndex((camera.target.Z * 100f) - visibleRadiusCm, source.Bounds.Top, source.Bounds.Height, source.ChunkRows);
+            int maxChunkY = ResolveChunkIndex((camera.target.Z * 100f) + visibleRadiusCm, source.Bounds.Top, source.Bounds.Height, source.ChunkRows);
+
+            SetTerrainTextureMode(default, false);
             for (int y = minChunkY; y <= maxChunkY; y++)
             {
                 for (int x = minChunkX; x <= maxChunkX; x++)
@@ -77,11 +182,24 @@ namespace Ludots.Client.Raylib.Rendering
                         continue;
                     }
 
-                    ref ChunkGpu gpu = ref GetOrCreateChunk(in chunk);
+                    ref ChunkGpu gpu = ref GetOrCreateChunk(
+                        in chunk,
+                        source.Revision,
+                        minHeightCm,
+                        maxHeightCm,
+                        renderProfile,
+                        effectiveSeaLevelCm);
                     gpu.LastUsedFrame = _frameIndex;
                     RaylibMatrix identity = RaylibMatrix.Identity;
                     Rl.rlDisableBackfaceCulling();
                     Rl.DrawMesh(gpu.Mesh, _terrainMaterial, identity);
+                    if (gpu.WaterMesh.vertexCount > 0)
+                    {
+                        Rl.BeginBlendMode(BlendMode.BLEND_ALPHA);
+                        Rl.DrawMesh(gpu.WaterMesh, _waterMaterial, identity);
+                        Rl.EndBlendMode();
+                        WaterVertexCountLastFrame += gpu.WaterMesh.vertexCount;
+                    }
                     Rl.rlEnableBackfaceCulling();
 
                     DrawnChunkCountLastFrame++;
@@ -108,32 +226,146 @@ namespace Ludots.Client.Raylib.Rendering
 
             _terrainMaterial = Rl.LoadMaterialDefault();
             _terrainMaterial.shader = _terrainShader;
-            _locTerrainLightPos = Rl.GetShaderLocation(_terrainShader, "uLightPos");
-            _locTerrainViewPos = Rl.GetShaderLocation(_terrainShader, "uViewPos");
-            _locTerrainAmbient = Rl.GetShaderLocation(_terrainShader, "uAmbient");
-            _locTerrainIntensity = Rl.GetShaderLocation(_terrainShader, "uLightIntensity");
+            int locMapAlbedo = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "texture0", "visual heightmap terrain");
+            int locMvp = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "mvp", "visual heightmap terrain");
+            int locMatModel = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "matModel", "visual heightmap terrain");
+            int locVertexPosition = RaylibShaderBindingGuard.RequireAttribute(_terrainShader, "vertexPosition", "visual heightmap terrain");
+            int locVertexNormal = RaylibShaderBindingGuard.RequireAttribute(_terrainShader, "vertexNormal", "visual heightmap terrain");
+            int locVertexColor = RaylibShaderBindingGuard.RequireAttribute(_terrainShader, "vertexColor", "visual heightmap terrain");
+            int locVertexTexCoord = RaylibShaderBindingGuard.RequireAttribute(_terrainShader, "vertexTexCoord", "visual heightmap terrain");
+            _terrainShader.locs[(int)Rl.ShaderLocationIndex.SHADER_LOC_VERTEX_POSITION] = locVertexPosition;
+            _terrainShader.locs[(int)Rl.ShaderLocationIndex.SHADER_LOC_VERTEX_TEXCOORD01] = locVertexTexCoord;
+            _terrainShader.locs[(int)Rl.ShaderLocationIndex.SHADER_LOC_VERTEX_TEXCOORD02] = -1;
+            _terrainShader.locs[(int)Rl.ShaderLocationIndex.SHADER_LOC_VERTEX_NORMAL] = locVertexNormal;
+            _terrainShader.locs[(int)Rl.ShaderLocationIndex.SHADER_LOC_VERTEX_TANGENT] = -1;
+            _terrainShader.locs[(int)Rl.ShaderLocationIndex.SHADER_LOC_VERTEX_COLOR] = locVertexColor;
+            _terrainShader.locs[(int)Rl.ShaderLocationIndex.SHADER_LOC_MATRIX_MVP] = locMvp;
+            _terrainShader.locs[(int)Rl.ShaderLocationIndex.SHADER_LOC_MATRIX_MODEL] = locMatModel;
+            _terrainShader.locs[(int)Rl.ShaderLocationIndex.SHADER_LOC_MAP_ALBEDO] = locMapAlbedo;
+            _locTerrainViewPos = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uViewPos", "visual heightmap terrain");
+            _locTerrainSunDirection = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uSunDirection", "visual heightmap terrain");
+            _locTerrainSunColor = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uSunColor", "visual heightmap terrain");
+            _locTerrainAmbientColor = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uAmbientColor", "visual heightmap terrain");
+            _locTerrainAmbient = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uAmbient", "visual heightmap terrain");
+            _locTerrainIntensity = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uLightIntensity", "visual heightmap terrain");
+            _locTerrainFogColor = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uFogColor", "visual heightmap terrain");
+            _locTerrainFogNear = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uFogNear", "visual heightmap terrain");
+            _locTerrainFogFar = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uFogFar", "visual heightmap terrain");
+            _locTerrainFogDensity = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uFogDensity", "visual heightmap terrain");
+            _locTerrainUseTexture = RaylibShaderBindingGuard.RequireUniform(_terrainShader, "uUseTexture", "visual heightmap terrain");
+
+            _waterShader = Rl.LoadShader(Path.Combine(baseDir, "water.vs"), Path.Combine(baseDir, "water.fs"));
+            if (_waterShader.id == 0)
+            {
+                throw new InvalidOperationException("Failed to load visual heightmap water shader (shader.id == 0).");
+            }
+
+            _waterMaterial = Rl.LoadMaterialDefault();
+            _waterMaterial.shader = _waterShader;
+            _locWaterViewPos = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uViewPos", "visual heightmap water");
+            _locWaterSunDirection = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uSunDirection", "visual heightmap water");
+            _locWaterSunColor = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uSunColor", "visual heightmap water");
+            _locWaterAmbientColor = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uAmbientColor", "visual heightmap water");
+            _locWaterAmbient = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uAmbient", "visual heightmap water");
+            _locWaterIntensity = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uLightIntensity", "visual heightmap water");
+            _locWaterFogColor = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uFogColor", "visual heightmap water");
+            _locWaterFogNear = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uFogNear", "visual heightmap water");
+            _locWaterFogFar = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uFogFar", "visual heightmap water");
+            _locWaterFogDensity = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uFogDensity", "visual heightmap water");
+            _locWaterTime = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uTime", "visual heightmap water");
+            _locWaterShallowColor = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uWaterShallowColor", "visual heightmap water");
+            _locWaterDeepColor = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uWaterDeepColor", "visual heightmap water");
+            _locWaterWaveAmplitude = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uWaveAmplitude", "visual heightmap water");
+            _locWaterWaveFrequency = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uWaveFrequency", "visual heightmap water");
+            _locWaterWaveSpeed = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uWaveSpeed", "visual heightmap water");
+            _locWaterFresnelStrength = RaylibShaderBindingGuard.RequireUniform(_waterShader, "uFresnelStrength", "visual heightmap water");
             _initialized = true;
         }
 
-        private void UpdateUniforms(in Camera3D camera)
+        private void UpdateUniforms(in Camera3D camera, double timeSeconds)
         {
-            Vector3 lightPos = LightPosition;
+            RaylibRenderEnvironmentConfig config = EnvironmentConfig;
+            RaylibLightingConfig lighting = config.Lighting;
+            RaylibWaterRenderConfig water = config.Water;
             Vector3 viewPos = camera.position;
-            float ambient = Ambient;
-            float intensity = LightIntensity;
+            Vector3 sunDirection = lighting.SunDirection;
+            Vector3 sunColor = lighting.SunColor;
+            Vector3 ambientColor = lighting.AmbientColor;
+            Vector3 fogColor = lighting.FogColor;
+            float ambient = lighting.AmbientStrength;
+            float intensity = lighting.SunStrength;
+            float fogNear = lighting.FogNearMeters;
+            float fogFar = lighting.FogFarMeters;
+            float fogDensity = lighting.FogDensity;
+            float time = (float)(timeSeconds % 100000.0);
+            Vector3 waterShallowColor = water.ShallowColor;
+            Vector3 waterDeepColor = water.DeepColor;
+            float waveAmplitude = water.WaveAmplitudeMeters;
+            float waveFrequency = water.WaveFrequency;
+            float waveSpeed = water.WaveSpeed;
+            float fresnelStrength = water.FresnelStrength;
 
-            Rl.SetShaderValue(_terrainShader, _locTerrainLightPos, &lightPos, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
             Rl.SetShaderValue(_terrainShader, _locTerrainViewPos, &viewPos, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_terrainShader, _locTerrainSunDirection, &sunDirection, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_terrainShader, _locTerrainSunColor, &sunColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_terrainShader, _locTerrainAmbientColor, &ambientColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
             Rl.SetShaderValue(_terrainShader, _locTerrainAmbient, &ambient, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
             Rl.SetShaderValue(_terrainShader, _locTerrainIntensity, &intensity, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_terrainShader, _locTerrainFogColor, &fogColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_terrainShader, _locTerrainFogNear, &fogNear, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_terrainShader, _locTerrainFogFar, &fogFar, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_terrainShader, _locTerrainFogDensity, &fogDensity, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+
+            Rl.SetShaderValue(_waterShader, _locWaterViewPos, &viewPos, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_waterShader, _locWaterSunDirection, &sunDirection, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_waterShader, _locWaterSunColor, &sunColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_waterShader, _locWaterAmbientColor, &ambientColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_waterShader, _locWaterAmbient, &ambient, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_waterShader, _locWaterIntensity, &intensity, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_waterShader, _locWaterFogColor, &fogColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_waterShader, _locWaterFogNear, &fogNear, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_waterShader, _locWaterFogFar, &fogFar, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_waterShader, _locWaterFogDensity, &fogDensity, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_waterShader, _locWaterTime, &time, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_waterShader, _locWaterShallowColor, &waterShallowColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_waterShader, _locWaterDeepColor, &waterDeepColor, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_VEC3);
+            Rl.SetShaderValue(_waterShader, _locWaterWaveAmplitude, &waveAmplitude, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_waterShader, _locWaterWaveFrequency, &waveFrequency, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_waterShader, _locWaterWaveSpeed, &waveSpeed, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
+            Rl.SetShaderValue(_waterShader, _locWaterFresnelStrength, &fresnelStrength, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_FLOAT);
         }
 
-        private ref ChunkGpu GetOrCreateChunk(in VisualHeightmapRenderChunk chunk)
+        private void SetTerrainTextureMode(Texture2D texture, bool useTexture)
+        {
+            int enabled = useTexture ? 1 : 0;
+            Rl.SetShaderValue(_terrainShader, _locTerrainUseTexture, &enabled, (int)Rl.ShaderUniformDataType.SHADER_UNIFORM_INT);
+            if (!useTexture)
+            {
+                return;
+            }
+
+            int albedoIndex = (int)Rl.MaterialMapIndex.MATERIAL_MAP_ALBEDO;
+            _terrainMaterial.maps[albedoIndex].texture = texture;
+            _terrainMaterial.maps[albedoIndex].color = Color.WHITE;
+        }
+
+        private ref ChunkGpu GetOrCreateChunk(
+            in VisualHeightmapRenderChunk chunk,
+            int sourceRevision,
+            float minHeightCm,
+            float maxHeightCm,
+            VisualHeightmapRenderProfile renderProfile,
+            float effectiveSeaLevelCm)
         {
             long key = GraphChunkKey.Pack(chunk.ChunkX, chunk.ChunkY);
             if (_chunks.TryGetValue(key, out ChunkGpu existing))
             {
-                if (existing.Revision == chunk.Revision)
+                if (existing.Revision == chunk.Revision &&
+                    existing.SourceRevision == sourceRevision &&
+                    existing.WaterEnabled == renderProfile.WaterEnabled &&
+                    MathF.Abs(existing.SeaLevelCm - renderProfile.SeaLevelCm) <= 0.001f &&
+                    MathF.Abs(existing.DisplayHeightScale - renderProfile.DisplayHeightScale) <= 0.0001f &&
+                    MathF.Abs(existing.ColorContrast - renderProfile.ColorContrast) <= 0.0001f)
                 {
                     _chunks[key] = existing;
                     return ref _chunks.GetValueRefOrNullRef(key);
@@ -146,8 +378,22 @@ namespace Ludots.Client.Raylib.Rendering
             long buildStart = Stopwatch.GetTimestamp();
             ChunkGpu gpu = new()
             {
-                Mesh = CreateChunkMesh(in chunk),
+                Mesh = CreateChunkMesh(
+                    in chunk,
+                    minHeightCm,
+                    maxHeightCm,
+                    effectiveSeaLevelCm,
+                    renderProfile.DisplayHeightScale,
+                    renderProfile.ColorContrast),
+                WaterMesh = renderProfile.WaterEnabled
+                    ? CreateWaterMesh(in chunk, renderProfile.SeaLevelCm, renderProfile.DisplayHeightScale)
+                    : default,
                 Revision = chunk.Revision,
+                SourceRevision = sourceRevision,
+                WaterEnabled = renderProfile.WaterEnabled,
+                SeaLevelCm = renderProfile.SeaLevelCm,
+                DisplayHeightScale = renderProfile.DisplayHeightScale,
+                ColorContrast = renderProfile.ColorContrast,
                 LastUsedFrame = _frameIndex,
             };
             BuiltChunkCountLastFrame++;
@@ -156,10 +402,17 @@ namespace Ludots.Client.Raylib.Rendering
             return ref _chunks.GetValueRefOrNullRef(key);
         }
 
-        private static Mesh CreateChunkMesh(in VisualHeightmapRenderChunk chunk)
+        private static Mesh CreateChunkMesh(
+            in VisualHeightmapRenderChunk chunk,
+            float minHeightCm,
+            float maxHeightCm,
+            float effectiveSeaLevelCm,
+            float displayHeightScale,
+            float colorContrast)
         {
-            int columns = chunk.SampleColumns;
-            int rows = chunk.SampleRows;
+            int sampleStride = ResolveChunkSampleStride(chunk.SampleColumns, chunk.SampleRows);
+            int columns = ResolveChunkSampleAxisPointCount(chunk.SampleColumns, sampleStride);
+            int rows = ResolveChunkSampleAxisPointCount(chunk.SampleRows, sampleStride);
             int vertexCount = checked(columns * rows);
             int indexCount = checked((columns - 1) * (rows - 1) * 6);
             if (vertexCount > ushort.MaxValue)
@@ -176,36 +429,50 @@ namespace Ludots.Client.Raylib.Rendering
 
             int vertexFloatCount = vertexCount * 3;
             int colorByteCount = vertexCount * 4;
+            int uvFloatCount = vertexCount * 2;
             mesh.vertices = (float*)Rl.MemAlloc(sizeof(float) * vertexFloatCount);
             mesh.normals = (float*)Rl.MemAlloc(sizeof(float) * vertexFloatCount);
+            mesh.texcoords = (float*)Rl.MemAlloc(sizeof(float) * uvFloatCount);
             mesh.colors = (byte*)Rl.MemAlloc(sizeof(byte) * colorByteCount);
             mesh.indices = (ushort*)Rl.MemAlloc(sizeof(ushort) * indexCount);
 
             float stepXCm = chunk.SampleStepXCm;
             float stepYCm = chunk.SampleStepYCm;
-            ResolveChunkHeightRange(in chunk, out float minHeightCm, out float maxHeightCm);
-            float heightRangeCm = MathF.Max(1f, maxHeightCm - minHeightCm);
             for (int y = 0; y < rows; y++)
             {
+                int sourceY = ResolveChunkSourceSampleIndex(y, chunk.SampleRows, sampleStride);
                 for (int x = 0; x < columns; x++)
                 {
+                    int sourceX = ResolveChunkSourceSampleIndex(x, chunk.SampleColumns, sampleStride);
                     int vertex = (y * columns) + x;
-                    float worldXCm = chunk.Bounds.Left + (x * stepXCm);
-                    float worldYCm = chunk.Bounds.Top + (y * stepYCm);
-                    chunk.TryReadHeightCm(x, y, out float heightCm);
-                    Vector3 normal = ComputeNormal(in chunk, x, y, stepXCm, stepYCm);
+                    float worldXCm = chunk.Bounds.Left + (sourceX * stepXCm);
+                    float worldYCm = chunk.Bounds.Top + (sourceY * stepYCm);
+                    float heightCm = ReadRequiredHeightCm(in chunk, sourceX, sourceY);
+                    Vector3 normal = ComputeNormal(in chunk, sourceX, sourceY, stepXCm, stepYCm, displayHeightScale);
                     int f = vertex * 3;
                     mesh.vertices[f + 0] = worldXCm * 0.01f;
-                    mesh.vertices[f + 1] = heightCm * 0.01f;
+                    mesh.vertices[f + 1] = heightCm * displayHeightScale * 0.01f;
                     mesh.vertices[f + 2] = worldYCm * 0.01f;
                     mesh.normals[f + 0] = normal.X;
                     mesh.normals[f + 1] = normal.Y;
                     mesh.normals[f + 2] = normal.Z;
 
+                    int uv = vertex * 2;
+                    mesh.texcoords[uv + 0] = columns > 1 ? x / (float)(columns - 1) : 0f;
+                    mesh.texcoords[uv + 1] = rows > 1 ? y / (float)(rows - 1) : 0f;
+
                     int c = vertex * 4;
-                    float heightBand = Math.Clamp((heightCm - minHeightCm) / heightRangeCm, 0f, 1f);
                     float slope = Math.Clamp(1f - normal.Y, 0f, 1f);
-                    ResolveTerrainColor(heightBand, slope, out byte red, out byte green, out byte blue);
+                    ResolveTerrainColor(
+                        heightCm,
+                        minHeightCm,
+                        maxHeightCm,
+                        effectiveSeaLevelCm,
+                        slope,
+                        colorContrast,
+                        out byte red,
+                        out byte green,
+                        out byte blue);
                     mesh.colors[c + 0] = red;
                     mesh.colors[c + 1] = green;
                     mesh.colors[c + 2] = blue;
@@ -236,10 +503,78 @@ namespace Ludots.Client.Raylib.Rendering
             return mesh;
         }
 
-        private static void ResolveChunkHeightRange(in VisualHeightmapRenderChunk chunk, out float minHeightCm, out float maxHeightCm)
+        internal static int ResolveChunkSampleStride(int sampleColumns, int sampleRows)
         {
+            if (sampleColumns < 2) throw new ArgumentOutOfRangeException(nameof(sampleColumns));
+            if (sampleRows < 2) throw new ArgumentOutOfRangeException(nameof(sampleRows));
+
+            int stride = 1;
+            while (checked(ResolveChunkSampleAxisPointCount(sampleColumns, stride) * ResolveChunkSampleAxisPointCount(sampleRows, stride)) > ushort.MaxValue)
+            {
+                stride++;
+            }
+
+            return stride;
+        }
+
+        internal static int ResolveChunkSampleAxisPointCount(int sampleCount, int stride)
+        {
+            if (sampleCount < 2) throw new ArgumentOutOfRangeException(nameof(sampleCount));
+            if (stride <= 0) throw new ArgumentOutOfRangeException(nameof(stride));
+
+            return ((sampleCount - 2) / stride) + 2;
+        }
+
+        internal static int ResolveChunkSourceSampleIndex(int pointIndex, int sampleCount, int stride)
+        {
+            int pointCount = ResolveChunkSampleAxisPointCount(sampleCount, stride);
+            if ((uint)pointIndex >= (uint)pointCount) throw new ArgumentOutOfRangeException(nameof(pointIndex));
+
+            return pointIndex == pointCount - 1
+                ? sampleCount - 1
+                : pointIndex * stride;
+        }
+
+        private void ResolveSourceHeightRange(IVisualHeightmapRenderSource source, out float minHeightCm, out float maxHeightCm)
+        {
+            if (ReferenceEquals(_heightRangeSource, source) && _heightRangeRevision == source.Revision)
+            {
+                minHeightCm = _heightRangeMinCm;
+                maxHeightCm = _heightRangeMaxCm;
+                return;
+            }
+
             minHeightCm = float.PositiveInfinity;
             maxHeightCm = float.NegativeInfinity;
+            int validChunkCount = 0;
+            for (int chunkY = 0; chunkY < source.ChunkRows; chunkY++)
+            {
+                for (int chunkX = 0; chunkX < source.ChunkColumns; chunkX++)
+                {
+                    if (!source.TryGetChunk(chunkX, chunkY, out VisualHeightmapRenderChunk chunk))
+                    {
+                        continue;
+                    }
+
+                    validChunkCount++;
+                    ResolveChunkHeightRange(in chunk, ref minHeightCm, ref maxHeightCm);
+                }
+            }
+
+            if (validChunkCount <= 0 || !float.IsFinite(minHeightCm) || !float.IsFinite(maxHeightCm))
+            {
+                throw new InvalidOperationException(
+                    $"Raylib visual heightmap renderer could not resolve a finite height range for source revision={source.Revision} chunks={source.ChunkColumns}x{source.ChunkRows}.");
+            }
+
+            _heightRangeSource = source;
+            _heightRangeRevision = source.Revision;
+            _heightRangeMinCm = minHeightCm;
+            _heightRangeMaxCm = maxHeightCm;
+        }
+
+        private static void ResolveChunkHeightRange(in VisualHeightmapRenderChunk chunk, ref float minHeightCm, ref float maxHeightCm)
+        {
             int columns = chunk.SampleColumns;
             int rows = chunk.SampleRows;
             for (int y = 0; y < rows; y++)
@@ -248,55 +583,883 @@ namespace Ludots.Client.Raylib.Rendering
                 {
                     if (!chunk.TryReadHeightCm(x, y, out float heightCm))
                     {
-                        continue;
+                        throw new InvalidOperationException(
+                            $"Raylib visual heightmap renderer failed to read height sample chunk=({chunk.ChunkX},{chunk.ChunkY}) sample=({x},{y}).");
+                    }
+
+                    if (!float.IsFinite(heightCm))
+                    {
+                        throw new InvalidOperationException(
+                            $"Raylib visual heightmap renderer read non-finite height sample chunk=({chunk.ChunkX},{chunk.ChunkY}) sample=({x},{y}) heightCm={heightCm}.");
                     }
 
                     minHeightCm = MathF.Min(minHeightCm, heightCm);
                     maxHeightCm = MathF.Max(maxHeightCm, heightCm);
                 }
             }
+        }
 
-            if (!float.IsFinite(minHeightCm) || !float.IsFinite(maxHeightCm))
+        private static Mesh CreateWaterMesh(in VisualHeightmapRenderChunk chunk, float seaLevelCm, float displayHeightScale)
+        {
+            int sampleStride = ResolveChunkSampleStride(chunk.SampleColumns, chunk.SampleRows);
+            int columns = ResolveChunkSampleAxisPointCount(chunk.SampleColumns, sampleStride);
+            int rows = ResolveChunkSampleAxisPointCount(chunk.SampleRows, sampleStride);
+            int waterCellCount = CountChunkWaterCells(in chunk, seaLevelCm, columns, rows, sampleStride);
+            if (waterCellCount <= 0)
             {
-                minHeightCm = 0f;
-                maxHeightCm = 1f;
+                return default;
+            }
+
+            int vertexCount = checked(columns * rows);
+            int indexCount = checked(waterCellCount * 6);
+            Mesh mesh = new()
+            {
+                vertexCount = vertexCount,
+                triangleCount = indexCount / 3,
+            };
+
+            int vertexFloatCount = vertexCount * 3;
+            int colorByteCount = vertexCount * 4;
+            mesh.vertices = (float*)Rl.MemAlloc(sizeof(float) * vertexFloatCount);
+            mesh.normals = (float*)Rl.MemAlloc(sizeof(float) * vertexFloatCount);
+            mesh.colors = (byte*)Rl.MemAlloc(sizeof(byte) * colorByteCount);
+            mesh.indices = (ushort*)Rl.MemAlloc(sizeof(ushort) * indexCount);
+
+            float y = seaLevelCm * displayHeightScale * 0.01f;
+            for (int row = 0; row < rows; row++)
+            {
+                int sourceY = ResolveChunkSourceSampleIndex(row, chunk.SampleRows, sampleStride);
+                float worldYCm = chunk.Bounds.Top + (sourceY * chunk.SampleStepYCm);
+                for (int column = 0; column < columns; column++)
+                {
+                    int sourceX = ResolveChunkSourceSampleIndex(column, chunk.SampleColumns, sampleStride);
+                    float worldXCm = chunk.Bounds.Left + (sourceX * chunk.SampleStepXCm);
+                    int vertex = (row * columns) + column;
+                    WriteWaterVertex(mesh, vertex, worldXCm * 0.01f, y, worldYCm * 0.01f);
+                }
+            }
+
+            int cursor = 0;
+            for (int row = 0; row < rows - 1; row++)
+            {
+                int sourceY0 = ResolveChunkSourceSampleIndex(row, chunk.SampleRows, sampleStride);
+                int sourceY1 = ResolveChunkSourceSampleIndex(row + 1, chunk.SampleRows, sampleStride);
+                for (int column = 0; column < columns - 1; column++)
+                {
+                    int sourceX0 = ResolveChunkSourceSampleIndex(column, chunk.SampleColumns, sampleStride);
+                    int sourceX1 = ResolveChunkSourceSampleIndex(column + 1, chunk.SampleColumns, sampleStride);
+                    if (!ChunkCellHasWater(in chunk, sourceX0, sourceY0, sourceX1, sourceY1, seaLevelCm))
+                    {
+                        continue;
+                    }
+
+                    int p00 = (row * columns) + column;
+                    int p10 = p00 + 1;
+                    int p01 = p00 + columns;
+                    int p11 = p01 + 1;
+                    mesh.indices[cursor++] = checked((ushort)p00);
+                    mesh.indices[cursor++] = checked((ushort)p01);
+                    mesh.indices[cursor++] = checked((ushort)p10);
+                    mesh.indices[cursor++] = checked((ushort)p11);
+                    mesh.indices[cursor++] = checked((ushort)p10);
+                    mesh.indices[cursor++] = checked((ushort)p01);
+                }
+            }
+
+            Rl.UploadMesh(ref mesh, false);
+            return mesh;
+        }
+
+        private static void WriteWaterVertex(Mesh mesh, int vertexIndex, float x, float y, float z)
+        {
+            int f = vertexIndex * 3;
+            mesh.vertices[f + 0] = x;
+            mesh.vertices[f + 1] = y;
+            mesh.vertices[f + 2] = z;
+            mesh.normals[f + 0] = 0f;
+            mesh.normals[f + 1] = 1f;
+            mesh.normals[f + 2] = 0f;
+
+            int c = vertexIndex * 4;
+            mesh.colors[c + 0] = 255;
+            mesh.colors[c + 1] = 255;
+            mesh.colors[c + 2] = 255;
+            mesh.colors[c + 3] = 142;
+        }
+
+        private static int CountChunkWaterCells(
+            in VisualHeightmapRenderChunk chunk,
+            float seaLevelCm,
+            int columns,
+            int rows,
+            int sampleStride)
+        {
+            int count = 0;
+            for (int row = 0; row < rows - 1; row++)
+            {
+                int sourceY0 = ResolveChunkSourceSampleIndex(row, chunk.SampleRows, sampleStride);
+                int sourceY1 = ResolveChunkSourceSampleIndex(row + 1, chunk.SampleRows, sampleStride);
+                for (int column = 0; column < columns - 1; column++)
+                {
+                    int sourceX0 = ResolveChunkSourceSampleIndex(column, chunk.SampleColumns, sampleStride);
+                    int sourceX1 = ResolveChunkSourceSampleIndex(column + 1, chunk.SampleColumns, sampleStride);
+                    if (ChunkCellHasWater(in chunk, sourceX0, sourceY0, sourceX1, sourceY1, seaLevelCm))
+                    {
+                        count++;
+                    }
+                }
+            }
+
+            return count;
+        }
+
+        private static bool ChunkCellHasWater(
+            in VisualHeightmapRenderChunk chunk,
+            int x0,
+            int y0,
+            int x1,
+            int y1,
+            float seaLevelCm)
+        {
+            return ReadRequiredHeightCm(in chunk, x0, y0) <= seaLevelCm ||
+                   ReadRequiredHeightCm(in chunk, x1, y0) <= seaLevelCm ||
+                   ReadRequiredHeightCm(in chunk, x0, y1) <= seaLevelCm ||
+                   ReadRequiredHeightCm(in chunk, x1, y1) <= seaLevelCm;
+        }
+
+        private static void ResolveTerrainColor(
+            float heightCm,
+            float minHeightCm,
+            float maxHeightCm,
+            float seaLevelCm,
+            float slope,
+            float colorContrast,
+            out byte red,
+            out byte green,
+            out byte blue)
+        {
+            Vector3 color = VisualHeightmapColorRamp.ResolveColorRanged(
+                heightCm,
+                slope,
+                minHeightCm,
+                maxHeightCm,
+                seaLevelCm,
+                colorContrast);
+            red = ClampToByte(color.X * 255f);
+            green = ClampToByte(color.Y * 255f);
+            blue = ClampToByte(color.Z * 255f);
+        }
+
+        private bool TryGetOrCreateOverview(
+            IVisualHeightmapRenderSource source,
+            VisualHeightmapRenderProfile renderProfile,
+            float minHeightCm,
+            float maxHeightCm,
+            float effectiveSeaLevelCm,
+            out OverviewGpu overview)
+        {
+            int maxVertices = Math.Clamp(OverviewMaxVertices, 4, ushort.MaxValue);
+            ResolveOverviewTextureSize(
+                source.Bounds,
+                Rl.GetScreenWidth(),
+                Rl.GetScreenHeight(),
+                out int textureWidth,
+                out int textureHeight);
+
+            var key = new OverviewKey(
+                source.Bounds,
+                source.ChunkColumns,
+                source.ChunkRows,
+                source.SamplesPerChunkColumn,
+                source.SamplesPerChunkRow,
+                source.DefaultLayerIndex,
+                source.Revision,
+                maxVertices,
+                renderProfile.WaterEnabled,
+                renderProfile.SeaLevelCm,
+                effectiveSeaLevelCm,
+                renderProfile.DisplayHeightScale,
+                renderProfile.ColorContrast,
+                minHeightCm,
+                maxHeightCm,
+                textureWidth,
+                textureHeight);
+
+            if (_overviewLoaded && _overview.Key == key)
+            {
+                overview = _overview;
+                return true;
+            }
+
+            PumpOverviewBuild(source, maxVertices, textureWidth, textureHeight, renderProfile, minHeightCm, maxHeightCm, effectiveSeaLevelCm, in key);
+            if (_overviewLoaded)
+            {
+                overview = _overview;
+                return true;
+            }
+
+            overview = default;
+            return false;
+        }
+
+        private void PumpOverviewBuild(
+            IVisualHeightmapRenderSource source,
+            int maxVertices,
+            int textureWidth,
+            int textureHeight,
+            VisualHeightmapRenderProfile renderProfile,
+            float minHeightCm,
+            float maxHeightCm,
+            float effectiveSeaLevelCm,
+            in OverviewKey key)
+        {
+            if (_overviewBuildTask != null && _overviewBuildTask.IsCompleted)
+            {
+                Task<OverviewCpuData> completed = _overviewBuildTask;
+                _overviewBuildTask = null;
+                _overviewBuildInFlight = false;
+
+                if (completed.IsFaulted)
+                {
+                    throw new InvalidOperationException("Raylib visual heightmap overview build failed.", completed.Exception);
+                }
+
+                OverviewCpuData cpu = completed.Result;
+                if (cpu.Key == key)
+                {
+                    if (_overviewLoaded)
+                    {
+                        _overview.Dispose();
+                        _overview = default;
+                        _overviewLoaded = false;
+                    }
+
+                    if (TryUploadOverview(cpu, out OverviewGpu uploaded))
+                    {
+                        _overview = uploaded;
+                        _overviewLoaded = true;
+                        BuiltChunkCountLastFrame++;
+                    }
+                }
+            }
+
+            if (!_overviewBuildInFlight && (!_overviewLoaded || _overview.Key != key))
+            {
+                if (_overviewBuildKey != key || _overviewBuildTask == null)
+                {
+                    _overviewBuildKey = key;
+                    _overviewBuildInFlight = true;
+                    VisualHeightmapRenderProfile capturedProfile = renderProfile.Clone();
+                    OverviewKey capturedKey = key;
+                    _overviewBuildTask = Task.Run(() => BuildOverviewCpu(
+                        source,
+                        maxVertices,
+                        textureWidth,
+                        textureHeight,
+                        capturedProfile,
+                        minHeightCm,
+                        maxHeightCm,
+                        effectiveSeaLevelCm,
+                        capturedKey));
+                }
             }
         }
 
-        private static void ResolveTerrainColor(float heightBand, float slope, out byte red, out byte green, out byte blue)
+        private static OverviewCpuData BuildOverviewCpu(
+            IVisualHeightmapRenderSource source,
+            int maxVertices,
+            int textureWidth,
+            int textureHeight,
+            VisualHeightmapRenderProfile renderProfile,
+            float minHeightCm,
+            float maxHeightCm,
+            float effectiveSeaLevelCm,
+            OverviewKey key)
         {
-            Vector3 low = new(35f, 86f, 88f);
-            Vector3 mid = new(82f, 143f, 84f);
-            Vector3 high = new(190f, 174f, 108f);
-            Vector3 peak = new(226f, 220f, 184f);
-            Vector3 color = heightBand < 0.50f
-                ? Vector3.Lerp(low, mid, heightBand * 2f)
-                : heightBand < 0.82f
-                    ? Vector3.Lerp(mid, high, (heightBand - 0.50f) / 0.32f)
-                    : Vector3.Lerp(high, peak, (heightBand - 0.82f) / 0.18f);
-            float shade = 1f - Math.Clamp(slope * 0.42f, 0f, 0.42f);
-            red = ClampToByte(color.X * shade);
-            green = ClampToByte(color.Y * shade);
-            blue = ClampToByte(color.Z * shade);
+            BuildOverviewMeshesCpu(
+                source,
+                maxVertices,
+                renderProfile,
+                minHeightCm,
+                maxHeightCm,
+                effectiveSeaLevelCm,
+                out OverviewMeshCpu terrainMesh,
+                out OverviewMeshCpu waterMesh);
+            OverviewTextureCpu texture = BuildOverviewTextureCpu(
+                source,
+                textureWidth,
+                textureHeight,
+                renderProfile,
+                minHeightCm,
+                maxHeightCm,
+                effectiveSeaLevelCm);
+            return new OverviewCpuData(key, terrainMesh, waterMesh, texture);
         }
 
-        private static Vector3 ComputeNormal(in VisualHeightmapRenderChunk chunk, int x, int y, float stepXCm, float stepYCm)
+        private static void BuildOverviewMeshesCpu(
+            IVisualHeightmapRenderSource source,
+            int maxVertices,
+            VisualHeightmapRenderProfile renderProfile,
+            float minHeightCm,
+            float maxHeightCm,
+            float effectiveSeaLevelCm,
+            out OverviewMeshCpu terrainMesh,
+            out OverviewMeshCpu waterMesh)
+        {
+            int stepChunks = ResolveOverviewStepChunks(source.ChunkColumns, source.ChunkRows, maxVertices);
+            int columns = ResolveOverviewAxisPointCount(source.ChunkColumns, stepChunks);
+            int rows = ResolveOverviewAxisPointCount(source.ChunkRows, stepChunks);
+            int vertexCount = checked(columns * rows);
+            if (vertexCount > ushort.MaxValue)
+            {
+                throw new InvalidOperationException(
+                    $"Raylib visual heightmap overview has {vertexCount} vertices, exceeding the platform mesh index limit.");
+            }
+
+            int indexCount = checked((columns - 1) * (rows - 1) * 6);
+            var worldXCm = new float[columns];
+            var worldYCm = new float[rows];
+            var heightsCm = new float[vertexCount];
+
+            for (int x = 0; x < columns; x++)
+            {
+                int boundaryX = ResolveOverviewBoundaryChunk(x, source.ChunkColumns, stepChunks);
+                worldXCm[x] = source.Bounds.Left + (source.Bounds.Width * (boundaryX / (float)source.ChunkColumns));
+            }
+
+            for (int y = 0; y < rows; y++)
+            {
+                int boundaryY = ResolveOverviewBoundaryChunk(y, source.ChunkRows, stepChunks);
+                worldYCm[y] = source.Bounds.Top + (source.Bounds.Height * (boundaryY / (float)source.ChunkRows));
+            }
+
+            for (int y = 0; y < rows; y++)
+            {
+                int boundaryY = ResolveOverviewBoundaryChunk(y, source.ChunkRows, stepChunks);
+                for (int x = 0; x < columns; x++)
+                {
+                    int boundaryX = ResolveOverviewBoundaryChunk(x, source.ChunkColumns, stepChunks);
+                    heightsCm[(y * columns) + x] = ReadOverviewHeightCm(source, boundaryX, boundaryY);
+                }
+            }
+
+            float heightScale = renderProfile.DisplayHeightScale;
+            int vertexFloatCount = vertexCount * 3;
+            int colorByteCount = vertexCount * 4;
+            int uvFloatCount = vertexCount * 2;
+            float[] vertices = new float[vertexFloatCount];
+            float[] normals = new float[vertexFloatCount];
+            float[] texcoords = new float[uvFloatCount];
+            byte[] colors = new byte[colorByteCount];
+            ushort[] indices = new ushort[indexCount];
+
+            for (int y = 0; y < rows; y++)
+            {
+                for (int x = 0; x < columns; x++)
+                {
+                    int vertex = (y * columns) + x;
+                    int f = vertex * 3;
+                    float heightCm = heightsCm[vertex];
+                    Vector3 normal = ComputeOverviewNormal(worldXCm, worldYCm, heightsCm, columns, rows, x, y, heightScale);
+                    vertices[f + 0] = worldXCm[x] * 0.01f;
+                    vertices[f + 1] = heightCm * heightScale * 0.01f;
+                    vertices[f + 2] = worldYCm[y] * 0.01f;
+                    normals[f + 0] = normal.X;
+                    normals[f + 1] = normal.Y;
+                    normals[f + 2] = normal.Z;
+
+                    int uv = vertex * 2;
+                    texcoords[uv + 0] = columns > 1 ? x / (float)(columns - 1) : 0f;
+                    texcoords[uv + 1] = rows > 1 ? y / (float)(rows - 1) : 0f;
+
+                    int c = vertex * 4;
+                    float slope = Math.Clamp(1f - normal.Y, 0f, 1f);
+                    ResolveTerrainColor(
+                        heightCm,
+                        minHeightCm,
+                        maxHeightCm,
+                        effectiveSeaLevelCm,
+                        slope,
+                        renderProfile.ColorContrast,
+                        out byte red,
+                        out byte green,
+                        out byte blue);
+                    colors[c + 0] = red;
+                    colors[c + 1] = green;
+                    colors[c + 2] = blue;
+                    colors[c + 3] = 255;
+                }
+            }
+
+            int cursor = 0;
+            for (int y = 0; y < rows - 1; y++)
+            {
+                for (int x = 0; x < columns - 1; x++)
+                {
+                    int p00 = (y * columns) + x;
+                    int p10 = p00 + 1;
+                    int p01 = p00 + columns;
+                    int p11 = p01 + 1;
+                    indices[cursor++] = checked((ushort)p00);
+                    indices[cursor++] = checked((ushort)p01);
+                    indices[cursor++] = checked((ushort)p10);
+                    indices[cursor++] = checked((ushort)p11);
+                    indices[cursor++] = checked((ushort)p10);
+                    indices[cursor++] = checked((ushort)p01);
+                }
+            }
+
+            terrainMesh = new OverviewMeshCpu(vertexCount, indexCount / 3, vertices, normals, texcoords, colors, indices);
+            waterMesh = renderProfile.WaterEnabled
+                ? BuildOverviewWaterMeshCpu(worldXCm, worldYCm, heightsCm, columns, rows, renderProfile.SeaLevelCm, heightScale)
+                : default;
+        }
+
+        private static OverviewMeshCpu BuildOverviewWaterMeshCpu(
+            float[] worldXCm,
+            float[] worldYCm,
+            float[] heightsCm,
+            int columns,
+            int rows,
+            float seaLevelCm,
+            float displayHeightScale)
+        {
+            int waterCellCount = CountOverviewWaterCells(heightsCm, columns, rows, seaLevelCm);
+            if (waterCellCount <= 0)
+            {
+                return default;
+            }
+
+            int vertexCount = checked(columns * rows);
+            int vertexFloatCount = vertexCount * 3;
+            int colorByteCount = vertexCount * 4;
+            int indexCount = checked(waterCellCount * 6);
+            float[] vertices = new float[vertexFloatCount];
+            float[] normals = new float[vertexFloatCount];
+            float[] texcoords = new float[vertexCount * 2];
+            byte[] colors = new byte[colorByteCount];
+            ushort[] indices = new ushort[indexCount];
+            float waterY = seaLevelCm * displayHeightScale * 0.01f;
+
+            for (int y = 0; y < rows; y++)
+            {
+                for (int x = 0; x < columns; x++)
+                {
+                    int vertex = (y * columns) + x;
+                    int f = vertex * 3;
+                    vertices[f + 0] = worldXCm[x] * 0.01f;
+                    vertices[f + 1] = waterY;
+                    vertices[f + 2] = worldYCm[y] * 0.01f;
+                    normals[f + 0] = 0f;
+                    normals[f + 1] = 1f;
+                    normals[f + 2] = 0f;
+
+                    int uv = vertex * 2;
+                    texcoords[uv + 0] = columns > 1 ? x / (float)(columns - 1) : 0f;
+                    texcoords[uv + 1] = rows > 1 ? y / (float)(rows - 1) : 0f;
+
+                    int c = vertex * 4;
+                    colors[c + 0] = 255;
+                    colors[c + 1] = 255;
+                    colors[c + 2] = 255;
+                    colors[c + 3] = 142;
+                }
+            }
+
+            int cursor = 0;
+            for (int y = 0; y < rows - 1; y++)
+            {
+                for (int x = 0; x < columns - 1; x++)
+                {
+                    if (!OverviewCellHasWater(heightsCm, columns, x, y, seaLevelCm))
+                    {
+                        continue;
+                    }
+
+                    int p00 = (y * columns) + x;
+                    int p10 = p00 + 1;
+                    int p01 = p00 + columns;
+                    int p11 = p01 + 1;
+                    indices[cursor++] = checked((ushort)p00);
+                    indices[cursor++] = checked((ushort)p01);
+                    indices[cursor++] = checked((ushort)p10);
+                    indices[cursor++] = checked((ushort)p11);
+                    indices[cursor++] = checked((ushort)p10);
+                    indices[cursor++] = checked((ushort)p01);
+                }
+            }
+
+            return new OverviewMeshCpu(vertexCount, indexCount / 3, vertices, normals, texcoords, colors, indices);
+        }
+
+        private static OverviewTextureCpu BuildOverviewTextureCpu(
+            IVisualHeightmapRenderSource source,
+            int textureWidth,
+            int textureHeight,
+            VisualHeightmapRenderProfile renderProfile,
+            float minHeightCm,
+            float maxHeightCm,
+            float effectiveSeaLevelCm)
+        {
+            if (textureWidth <= 0) throw new ArgumentOutOfRangeException(nameof(textureWidth));
+            if (textureHeight <= 0) throw new ArgumentOutOfRangeException(nameof(textureHeight));
+
+            int sampleCount = checked(textureWidth * textureHeight);
+            var heightsCm = new float[sampleCount];
+            for (int y = 0; y < textureHeight; y++)
+            {
+                float sampleY = textureHeight > 1
+                    ? y / (float)(textureHeight - 1)
+                    : 0f;
+                for (int x = 0; x < textureWidth; x++)
+                {
+                    float sampleX = textureWidth > 1
+                        ? x / (float)(textureWidth - 1)
+                        : 0f;
+                    heightsCm[(y * textureWidth) + x] = SampleOverviewTextureHeightCm(source, sampleX, sampleY);
+                }
+            }
+
+            float heightScale = renderProfile.DisplayHeightScale;
+            byte[] pixels = new byte[checked(sampleCount * 4)];
+            float stepXCm = source.Bounds.Width / (float)Math.Max(1, textureWidth - 1);
+            float stepYCm = source.Bounds.Height / (float)Math.Max(1, textureHeight - 1);
+            for (int y = 0; y < textureHeight; y++)
+            {
+                int top = Math.Max(0, y - 1);
+                int bottom = Math.Min(textureHeight - 1, y + 1);
+                for (int x = 0; x < textureWidth; x++)
+                {
+                    int left = Math.Max(0, x - 1);
+                    int right = Math.Min(textureWidth - 1, x + 1);
+                    int index = (y * textureWidth) + x;
+                    float hLeft = heightsCm[(y * textureWidth) + left];
+                    float hRight = heightsCm[(y * textureWidth) + right];
+                    float hTop = heightsCm[(top * textureWidth) + x];
+                    float hBottom = heightsCm[(bottom * textureWidth) + x];
+                    float dx = MathF.Max(1f, (right - left) * stepXCm);
+                    float dz = MathF.Max(1f, (bottom - top) * stepYCm);
+                    Vector3 normal = Vector3.Normalize(new Vector3(
+                        -((hRight - hLeft) * heightScale) / dx,
+                        1f,
+                        -((hBottom - hTop) * heightScale) / dz));
+                    if (!float.IsFinite(normal.X) || !float.IsFinite(normal.Y) || !float.IsFinite(normal.Z))
+                    {
+                        normal = Vector3.UnitY;
+                    }
+
+                    float slope = Math.Clamp(1f - normal.Y, 0f, 1f);
+                    ResolveTerrainColor(
+                        heightsCm[index],
+                        minHeightCm,
+                        maxHeightCm,
+                        effectiveSeaLevelCm,
+                        slope,
+                        renderProfile.ColorContrast,
+                        out byte red,
+                        out byte green,
+                        out byte blue);
+                    int pixel = index * 4;
+                    pixels[pixel + 0] = red;
+                    pixels[pixel + 1] = green;
+                    pixels[pixel + 2] = blue;
+                    pixels[pixel + 3] = 255;
+                }
+            }
+
+            return new OverviewTextureCpu(textureWidth, textureHeight, pixels);
+        }
+
+        private static float ReadOverviewHeightCm(
+            IVisualHeightmapRenderSource source,
+            int boundaryChunkX,
+            int boundaryChunkY)
+        {
+            int chunkX = boundaryChunkX == 0 ? 0 : boundaryChunkX - 1;
+            int chunkY = boundaryChunkY == 0 ? 0 : boundaryChunkY - 1;
+            chunkX = Math.Clamp(chunkX, 0, source.ChunkColumns - 1);
+            chunkY = Math.Clamp(chunkY, 0, source.ChunkRows - 1);
+            if (!source.TryGetChunk(chunkX, chunkY, out VisualHeightmapRenderChunk chunk))
+            {
+                throw new InvalidOperationException(
+                    $"Raylib visual heightmap overview could not read chunk=({chunkX},{chunkY}).");
+            }
+
+            int sampleX = boundaryChunkX == 0 ? 0 : chunk.SampleColumns - 1;
+            int sampleY = boundaryChunkY == 0 ? 0 : chunk.SampleRows - 1;
+            return ReadRequiredHeightCm(in chunk, sampleX, sampleY);
+        }
+
+        private static float SampleOverviewTextureHeightCm(
+            IVisualHeightmapRenderSource source,
+            float normalizedX,
+            float normalizedY)
+        {
+            int sampleColumns = checked(source.ChunkColumns * (source.SamplesPerChunkColumn - 1) + 1);
+            int sampleRows = checked(source.ChunkRows * (source.SamplesPerChunkRow - 1) + 1);
+            float sampleX = Math.Clamp(normalizedX, 0f, 1f) * (sampleColumns - 1);
+            float sampleY = Math.Clamp(normalizedY, 0f, 1f) * (sampleRows - 1);
+            int x0 = Math.Clamp((int)MathF.Floor(sampleX), 0, sampleColumns - 1);
+            int y0 = Math.Clamp((int)MathF.Floor(sampleY), 0, sampleRows - 1);
+            int x1 = Math.Min(sampleColumns - 1, x0 + 1);
+            int y1 = Math.Min(sampleRows - 1, y0 + 1);
+            float tx = sampleX - x0;
+            float ty = sampleY - y0;
+
+            float h00 = ReadOverviewTextureSampleHeightCm(source, x0, y0, sampleColumns, sampleRows);
+            float h10 = ReadOverviewTextureSampleHeightCm(source, x1, y0, sampleColumns, sampleRows);
+            float h01 = ReadOverviewTextureSampleHeightCm(source, x0, y1, sampleColumns, sampleRows);
+            float h11 = ReadOverviewTextureSampleHeightCm(source, x1, y1, sampleColumns, sampleRows);
+            float hx0 = Lerp(h00, h10, tx);
+            float hx1 = Lerp(h01, h11, tx);
+            return Lerp(hx0, hx1, ty);
+        }
+
+        private static float ReadOverviewTextureSampleHeightCm(
+            IVisualHeightmapRenderSource source,
+            int globalX,
+            int globalY,
+            int sampleColumns,
+            int sampleRows)
+        {
+            int stepX = source.SamplesPerChunkColumn - 1;
+            int stepY = source.SamplesPerChunkRow - 1;
+            int chunkX = globalX >= sampleColumns - 1 ? source.ChunkColumns - 1 : globalX / stepX;
+            int chunkY = globalY >= sampleRows - 1 ? source.ChunkRows - 1 : globalY / stepY;
+            int localX = globalX >= sampleColumns - 1 ? source.SamplesPerChunkColumn - 1 : globalX - (chunkX * stepX);
+            int localY = globalY >= sampleRows - 1 ? source.SamplesPerChunkRow - 1 : globalY - (chunkY * stepY);
+            if (!source.TryGetChunk(chunkX, chunkY, out VisualHeightmapRenderChunk chunk))
+            {
+                throw new InvalidOperationException(
+                    $"Raylib visual heightmap overview texture could not read chunk=({chunkX},{chunkY}).");
+            }
+
+            return ReadRequiredHeightCm(in chunk, localX, localY);
+        }
+
+        private static int CountOverviewWaterCells(float[] heightsCm, int columns, int rows, float seaLevelCm)
+        {
+            int count = 0;
+            for (int y = 0; y < rows - 1; y++)
+            {
+                for (int x = 0; x < columns - 1; x++)
+                {
+                    if (OverviewCellHasWater(heightsCm, columns, x, y, seaLevelCm))
+                    {
+                        count++;
+                    }
+                }
+            }
+
+            return count;
+        }
+
+        private static bool OverviewCellHasWater(float[] heightsCm, int columns, int x, int y, float seaLevelCm)
+        {
+            int p00 = (y * columns) + x;
+            int p10 = p00 + 1;
+            int p01 = p00 + columns;
+            int p11 = p01 + 1;
+            return heightsCm[p00] <= seaLevelCm ||
+                   heightsCm[p10] <= seaLevelCm ||
+                   heightsCm[p01] <= seaLevelCm ||
+                   heightsCm[p11] <= seaLevelCm;
+        }
+
+        private bool ResolveOverviewActive(IVisualHeightmapRenderSource source, in Camera3D camera, float aspect)
+        {
+            float hysteresis = Math.Clamp(OverviewSwitchHysteresis, 0f, 0.9f);
+            float multiplier = _overviewActive
+                ? OverviewActivationMultiplier * (1f - hysteresis)
+                : OverviewActivationMultiplier * (1f + hysteresis);
+            _overviewActive = ShouldUseOverviewMesh(source, camera, aspect, VisibleRadiusCm, multiplier);
+            return _overviewActive;
+        }
+
+        internal static bool ShouldUseOverviewMesh(
+            IVisualHeightmapRenderSource source,
+            in Camera3D camera,
+            float aspect,
+            float detailVisibleRadiusCm,
+            float activationMultiplier)
+        {
+            if (source == null)
+            {
+                return false;
+            }
+
+            if (source.ChunkColumns <= 0 || source.ChunkRows <= 0)
+            {
+                return false;
+            }
+
+            float chunkWidthCm = source.Bounds.Width / (float)source.ChunkColumns;
+            float chunkHeightCm = source.Bounds.Height / (float)source.ChunkRows;
+            float detailRadiusCm = MathF.Max(
+                MathF.Max(1f, detailVisibleRadiusCm),
+                MathF.Max(chunkWidthCm, chunkHeightCm) * 1.25f);
+            float activationRadiusCm = detailRadiusCm * MathF.Max(1f, activationMultiplier);
+            return ComputeCameraFootprintRadiusCm(camera, aspect) > activationRadiusCm;
+        }
+
+        internal static float ComputeCameraFootprintRadiusCm(in Camera3D camera, float aspect)
+        {
+            float distanceMeters = Vector3.Distance(camera.position, camera.target);
+            if (!float.IsFinite(distanceMeters) || distanceMeters <= 0f)
+            {
+                return 0f;
+            }
+
+            float fovyRad = camera.fovy * (MathF.PI / 180f);
+            float clampedFovyRad = Math.Clamp(fovyRad, 0.001f, MathF.PI - 0.001f);
+            float halfHeightMeters = distanceMeters * MathF.Tan(clampedFovyRad * 0.5f);
+            float halfWidthMeters = halfHeightMeters * MathF.Max(0.001f, aspect);
+            float radiusMeters = MathF.Sqrt((halfWidthMeters * halfWidthMeters) + (halfHeightMeters * halfHeightMeters));
+            return radiusMeters * 100f;
+        }
+
+        internal static void ResolveOverviewTextureSize(
+            WorldAabbCm bounds,
+            int screenWidth,
+            int screenHeight,
+            out int textureWidth,
+            out int textureHeight)
+        {
+            int screenLongEdge = Math.Max(1, Math.Max(screenWidth, screenHeight));
+            int longEdge = Math.Clamp(
+                checked(screenLongEdge * OverviewTextureScreenScale),
+                OverviewTextureMinLongEdgePixels,
+                OverviewTextureMaxLongEdgePixels);
+            float aspect = MathF.Max(0.001f, bounds.Width / (float)Math.Max(1, bounds.Height));
+            if (aspect >= 1f)
+            {
+                textureWidth = longEdge;
+                textureHeight = Math.Clamp((int)MathF.Round(longEdge / aspect), 1, OverviewTextureMaxLongEdgePixels);
+                return;
+            }
+
+            textureHeight = longEdge;
+            textureWidth = Math.Clamp((int)MathF.Round(longEdge * aspect), 1, OverviewTextureMaxLongEdgePixels);
+        }
+
+        internal static int ResolveOverviewStepChunks(int chunkColumns, int chunkRows, int maxVertices)
+        {
+            if (chunkColumns <= 0) throw new ArgumentOutOfRangeException(nameof(chunkColumns));
+            if (chunkRows <= 0) throw new ArgumentOutOfRangeException(nameof(chunkRows));
+
+            int vertexLimit = Math.Clamp(maxVertices, 4, ushort.MaxValue);
+            int step = 1;
+            while (checked(ResolveOverviewAxisPointCount(chunkColumns, step) * ResolveOverviewAxisPointCount(chunkRows, step)) > vertexLimit)
+            {
+                step++;
+            }
+
+            return step;
+        }
+
+        internal static int ResolveOverviewAxisPointCount(int chunkCount, int stepChunks)
+        {
+            if (chunkCount <= 0) throw new ArgumentOutOfRangeException(nameof(chunkCount));
+            if (stepChunks <= 0) throw new ArgumentOutOfRangeException(nameof(stepChunks));
+
+            return ((chunkCount + stepChunks - 1) / stepChunks) + 1;
+        }
+
+        private static int ResolveOverviewBoundaryChunk(int pointIndex, int chunkCount, int stepChunks)
+        {
+            int pointCount = ResolveOverviewAxisPointCount(chunkCount, stepChunks);
+            return pointIndex == pointCount - 1
+                ? chunkCount
+                : Math.Min(chunkCount, pointIndex * stepChunks);
+        }
+
+        private static Vector3 ComputeOverviewNormal(
+            float[] worldXCm,
+            float[] worldYCm,
+            float[] heightsCm,
+            int columns,
+            int rows,
+            int x,
+            int y,
+            float heightScale)
+        {
+            int left = Math.Max(0, x - 1);
+            int right = Math.Min(columns - 1, x + 1);
+            int top = Math.Max(0, y - 1);
+            int bottom = Math.Min(rows - 1, y + 1);
+            float hLeft = heightsCm[(y * columns) + left] * heightScale;
+            float hRight = heightsCm[(y * columns) + right] * heightScale;
+            float hTop = heightsCm[(top * columns) + x] * heightScale;
+            float hBottom = heightsCm[(bottom * columns) + x] * heightScale;
+            float dx = MathF.Max(1f, worldXCm[right] - worldXCm[left]);
+            float dz = MathF.Max(1f, worldYCm[bottom] - worldYCm[top]);
+            Vector3 normal = Vector3.Normalize(new Vector3(-(hRight - hLeft) / dx, 1f, -(hBottom - hTop) / dz));
+            return float.IsFinite(normal.X) && float.IsFinite(normal.Y) && float.IsFinite(normal.Z)
+                ? normal
+                : Vector3.UnitY;
+        }
+
+        private static Vector3 ComputeNormal(
+            in VisualHeightmapRenderChunk chunk,
+            int x,
+            int y,
+            float stepXCm,
+            float stepYCm,
+            float displayHeightScale)
         {
             int left = Math.Max(0, x - 1);
             int right = Math.Min(chunk.SampleColumns - 1, x + 1);
             int top = Math.Max(0, y - 1);
             int bottom = Math.Min(chunk.SampleRows - 1, y + 1);
-            chunk.TryReadHeightCm(left, y, out float hLeft);
-            chunk.TryReadHeightCm(right, y, out float hRight);
-            chunk.TryReadHeightCm(x, top, out float hTop);
-            chunk.TryReadHeightCm(x, bottom, out float hBottom);
+            float hLeft = ReadRequiredHeightCm(in chunk, left, y);
+            float hRight = ReadRequiredHeightCm(in chunk, right, y);
+            float hTop = ReadRequiredHeightCm(in chunk, x, top);
+            float hBottom = ReadRequiredHeightCm(in chunk, x, bottom);
 
             float dx = MathF.Max(1f, (right - left) * stepXCm);
             float dz = MathF.Max(1f, (bottom - top) * stepYCm);
-            Vector3 normal = Vector3.Normalize(new Vector3(-(hRight - hLeft) / dx, 1f, -(hBottom - hTop) / dz));
+            Vector3 normal = Vector3.Normalize(new Vector3(
+                -((hRight - hLeft) * displayHeightScale) / dx,
+                1f,
+                -((hBottom - hTop) * displayHeightScale) / dz));
             return float.IsFinite(normal.X) && float.IsFinite(normal.Y) && float.IsFinite(normal.Z)
                 ? normal
                 : Vector3.UnitY;
+        }
+
+        private static float ReadRequiredHeightCm(in VisualHeightmapRenderChunk chunk, int sampleX, int sampleY)
+        {
+            if (!chunk.TryReadHeightCm(sampleX, sampleY, out float heightCm))
+            {
+                throw new InvalidOperationException(
+                    $"Raylib visual heightmap renderer failed to read height sample chunk=({chunk.ChunkX},{chunk.ChunkY}) sample=({sampleX},{sampleY}).");
+            }
+
+            if (!float.IsFinite(heightCm))
+            {
+                throw new InvalidOperationException(
+                    $"Raylib visual heightmap renderer read non-finite height sample chunk=({chunk.ChunkX},{chunk.ChunkY}) sample=({sampleX},{sampleY}) heightCm={heightCm}.");
+            }
+
+            return heightCm;
+        }
+
+        internal static float ResolveEffectiveSeaLevelCm(VisualHeightmapRenderProfile renderProfile, float minHeightCm)
+        {
+            if (renderProfile == null)
+            {
+                throw new ArgumentNullException(nameof(renderProfile));
+            }
+
+            VisualHeightmapRenderProfile normalized = renderProfile.NormalizeAndValidate();
+            if (!float.IsFinite(minHeightCm))
+            {
+                throw new ArgumentOutOfRangeException(nameof(minHeightCm));
+            }
+
+            return normalized.WaterEnabled
+                ? normalized.SeaLevelCm
+                : minHeightCm - 1f;
         }
 
         private void EvictUnusedChunks(int maxAgeFrames)
@@ -338,14 +1501,132 @@ namespace Ludots.Client.Raylib.Rendering
             return (byte)Math.Clamp((int)MathF.Round(value), 0, 255);
         }
 
+        private static float Lerp(float a, float b, float t)
+        {
+            return a + ((b - a) * t);
+        }
+
+        private bool TryUploadOverview(OverviewCpuData cpu, out OverviewGpu overview)
+        {
+            overview = default;
+            Mesh mesh = UploadOverviewMesh(cpu.Mesh);
+            Mesh waterMesh = cpu.WaterMesh.VertexCount > 0
+                ? UploadOverviewMesh(cpu.WaterMesh)
+                : default;
+            Texture2D texture = default;
+            try
+            {
+                Image image = Rl.GenImageColor(cpu.Texture.Width, cpu.Texture.Height, Color.BLANK);
+                texture = Rl.LoadTextureFromImage(image);
+                Rl.UnloadImage(image);
+                if (texture.id == 0)
+                {
+                    return false;
+                }
+
+                fixed (byte* ptr = cpu.Texture.Pixels)
+                {
+                    Rl.UpdateTexture(texture, ptr);
+                }
+
+                Rl.SetTextureFilter(texture, Rl.TextureFilter.TEXTURE_FILTER_POINT);
+                overview = new OverviewGpu(mesh, waterMesh, texture, cpu.Key);
+                mesh = default;
+                waterMesh = default;
+                texture = default;
+                return true;
+            }
+            finally
+            {
+                if (mesh.vertexCount > 0)
+                {
+                    Rl.UnloadMesh(mesh);
+                }
+
+                if (waterMesh.vertexCount > 0)
+                {
+                    Rl.UnloadMesh(waterMesh);
+                }
+
+                if (texture.id != 0)
+                {
+                    Rl.UnloadTexture(texture);
+                }
+            }
+        }
+
+        private static Mesh UploadOverviewMesh(OverviewMeshCpu meshCpu)
+        {
+            Mesh mesh = new()
+            {
+                vertexCount = meshCpu.VertexCount,
+                triangleCount = meshCpu.TriangleCount,
+            };
+
+            int vertexFloatCount = meshCpu.VertexCount * 3;
+            int colorByteCount = meshCpu.VertexCount * 4;
+            int uvFloatCount = meshCpu.VertexCount * 2;
+            mesh.vertices = (float*)Rl.MemAlloc(sizeof(float) * vertexFloatCount);
+            mesh.normals = (float*)Rl.MemAlloc(sizeof(float) * vertexFloatCount);
+            mesh.texcoords = (float*)Rl.MemAlloc(sizeof(float) * uvFloatCount);
+            mesh.colors = (byte*)Rl.MemAlloc(sizeof(byte) * colorByteCount);
+            mesh.indices = (ushort*)Rl.MemAlloc(sizeof(ushort) * meshCpu.Indices.Length);
+
+            for (int i = 0; i < vertexFloatCount; i++)
+            {
+                mesh.vertices[i] = meshCpu.Vertices[i];
+                mesh.normals[i] = meshCpu.Normals[i];
+            }
+
+            for (int i = 0; i < uvFloatCount; i++)
+            {
+                mesh.texcoords[i] = meshCpu.Texcoords[i];
+            }
+
+            for (int i = 0; i < colorByteCount; i++)
+            {
+                mesh.colors[i] = meshCpu.Colors[i];
+            }
+
+            for (int i = 0; i < meshCpu.Indices.Length; i++)
+            {
+                mesh.indices[i] = meshCpu.Indices[i];
+            }
+
+            Rl.UploadMesh(ref mesh, false);
+            return mesh;
+        }
+
         public void Dispose()
         {
+            if (_overviewBuildTask != null)
+            {
+                try
+                {
+                    _overviewBuildTask.Wait();
+                }
+                catch
+                {
+                    // Renderer teardown must release GPU resources even if a superseded overview build failed.
+                }
+
+                _overviewBuildTask = null;
+                _overviewBuildInFlight = false;
+            }
+
             foreach (var kvp in _chunks)
             {
                 kvp.Value.Dispose();
             }
 
             _chunks.Clear();
+            if (_overviewLoaded)
+            {
+                _overview.Dispose();
+                _overview = default;
+                _overviewLoaded = false;
+            }
+
             if (!_initialized)
             {
                 return;
@@ -354,13 +1635,22 @@ namespace Ludots.Client.Raylib.Rendering
             _terrainMaterial.shader = default;
             Rl.UnloadMaterial(_terrainMaterial);
             Rl.UnloadShader(_terrainShader);
+            _waterMaterial.shader = default;
+            Rl.UnloadMaterial(_waterMaterial);
+            Rl.UnloadShader(_waterShader);
             _initialized = false;
         }
 
         private struct ChunkGpu : IDisposable
         {
             public Mesh Mesh;
+            public Mesh WaterMesh;
             public int Revision;
+            public int SourceRevision;
+            public bool WaterEnabled;
+            public float SeaLevelCm;
+            public float DisplayHeightScale;
+            public float ColorContrast;
             public int LastUsedFrame;
 
             public void Dispose()
@@ -368,6 +1658,138 @@ namespace Ludots.Client.Raylib.Rendering
                 if (Mesh.vertexCount > 0)
                 {
                     Rl.UnloadMesh(Mesh);
+                }
+
+                if (WaterMesh.vertexCount > 0)
+                {
+                    Rl.UnloadMesh(WaterMesh);
+                }
+            }
+        }
+
+        private sealed class OverviewCpuData
+        {
+            public OverviewCpuData(
+                OverviewKey key,
+                OverviewMeshCpu mesh,
+                OverviewMeshCpu waterMesh,
+                OverviewTextureCpu texture)
+            {
+                Key = key;
+                Mesh = mesh;
+                WaterMesh = waterMesh;
+                Texture = texture;
+            }
+
+            public OverviewKey Key { get; }
+
+            public OverviewMeshCpu Mesh { get; }
+
+            public OverviewMeshCpu WaterMesh { get; }
+
+            public OverviewTextureCpu Texture { get; }
+        }
+
+        private readonly struct OverviewMeshCpu
+        {
+            public OverviewMeshCpu(
+                int vertexCount,
+                int triangleCount,
+                float[] vertices,
+                float[] normals,
+                float[] texcoords,
+                byte[] colors,
+                ushort[] indices)
+            {
+                VertexCount = vertexCount;
+                TriangleCount = triangleCount;
+                Vertices = vertices;
+                Normals = normals;
+                Texcoords = texcoords;
+                Colors = colors;
+                Indices = indices;
+            }
+
+            public int VertexCount { get; }
+
+            public int TriangleCount { get; }
+
+            public float[] Vertices { get; }
+
+            public float[] Normals { get; }
+
+            public float[] Texcoords { get; }
+
+            public byte[] Colors { get; }
+
+            public ushort[] Indices { get; }
+        }
+
+        private readonly struct OverviewTextureCpu
+        {
+            public OverviewTextureCpu(int width, int height, byte[] pixels)
+            {
+                Width = width;
+                Height = height;
+                Pixels = pixels;
+            }
+
+            public int Width { get; }
+
+            public int Height { get; }
+
+            public byte[] Pixels { get; }
+        }
+
+        private readonly record struct OverviewKey(
+            WorldAabbCm Bounds,
+            int ChunkColumns,
+            int ChunkRows,
+            int SamplesPerChunkColumn,
+            int SamplesPerChunkRow,
+            int DefaultLayerIndex,
+            int Revision,
+            int MaxVertices,
+            bool WaterEnabled,
+            float SeaLevelCm,
+            float EffectiveSeaLevelCm,
+            float DisplayHeightScale,
+            float ColorContrast,
+            float MinHeightCm,
+            float MaxHeightCm,
+            int TextureWidth,
+            int TextureHeight);
+
+        private struct OverviewGpu : IDisposable
+        {
+            public OverviewGpu(Mesh mesh, Mesh waterMesh, Texture2D texture, OverviewKey key)
+            {
+                Mesh = mesh;
+                WaterMesh = waterMesh;
+                Texture = texture;
+                Key = key;
+            }
+
+            public Mesh Mesh;
+            public Mesh WaterMesh;
+            public Texture2D Texture;
+            public OverviewKey Key;
+
+            public void Dispose()
+            {
+                if (Mesh.vertexCount > 0)
+                {
+                    Rl.UnloadMesh(Mesh);
+                }
+
+                if (WaterMesh.vertexCount > 0)
+                {
+                    Rl.UnloadMesh(WaterMesh);
+                }
+
+                if (Texture.id != 0)
+                {
+                    Rl.UnloadTexture(Texture);
                 }
             }
         }

--- a/src/Core/Engine/GameEngine.cs
+++ b/src/Core/Engine/GameEngine.cs
@@ -1204,7 +1204,7 @@ namespace Ludots.Core.Engine
                     AssetKind.Mesh => meshAssets.GetId(key),
                     AssetKind.SkinnedMesh => meshAssets.GetId(key),
                     AssetKind.Decal => meshAssets.GetId(key),
-                    AssetKind.VFX => meshAssets.GetId(key),
+                    AssetKind.VFX => ResolveVfxEffectAssetId(key),
                     AssetKind.Spline => meshAssets.GetId(key),
                     AssetKind.Surface => meshAssets.GetId(key),
                     AssetKind.Sound => meshAssets.GetId(key),
@@ -1214,6 +1214,25 @@ namespace Ludots.Core.Engine
                 },
                 instancedBatchAssets.GetId,
                 entityCollectionKeyRegistry.Register).Load(ConfigCatalog, ConfigConflictReport);
+
+            int ResolveVfxEffectAssetId(string key)
+            {
+                int assetId = meshAssets.GetId(key);
+                if (assetId <= 0)
+                {
+                    return 0;
+                }
+
+                if (!meshAssets.TryGetDescriptor(assetId, out MeshAssetDescriptor descriptor) ||
+                    !descriptor.VfxEffectData.IsValid)
+                {
+                    throw new InvalidOperationException(
+                        $"Performer behavior VFX asset '{key}' must declare vfx emitter data.");
+                }
+
+                return assetId;
+            }
+
             performerDefinitions.RebuildCompiledViews();
             MapLoader.SetPresentationRuntime(
                 presentationStableIds,

--- a/src/Core/Gameplay/Camera/Behaviors/ZoomBehavior.cs
+++ b/src/Core/Gameplay/Camera/Behaviors/ZoomBehavior.cs
@@ -7,12 +7,14 @@ namespace Ludots.Core.Gameplay.Camera.Behaviors
         private readonly float _cmPerWheel;
         private readonly float _minDistanceCm;
         private readonly float _maxDistanceCm;
+        private readonly float _factorPerWheel;
 
-        public ZoomBehavior(float cmPerWheel, float minDistanceCm, float maxDistanceCm)
+        public ZoomBehavior(float cmPerWheel, float minDistanceCm, float maxDistanceCm, float factorPerWheel = 0f)
         {
             _cmPerWheel = cmPerWheel;
             _minDistanceCm = minDistanceCm;
             _maxDistanceCm = maxDistanceCm;
+            _factorPerWheel = factorPerWheel;
         }
 
         public void Update(CameraState state, CameraBehaviorContext ctx, float dt)
@@ -20,7 +22,15 @@ namespace Ludots.Core.Gameplay.Camera.Behaviors
             float zoom = ctx.BehaviorInput.Zoom;
             if (MathF.Abs(zoom) < 0.0001f) return;
 
-            state.DistanceCm -= zoom * _cmPerWheel;
+            if (_factorPerWheel > 0f)
+            {
+                state.DistanceCm *= MathF.Pow(_factorPerWheel, -zoom);
+            }
+            else
+            {
+                state.DistanceCm -= zoom * _cmPerWheel;
+            }
+
             state.DistanceCm = Math.Clamp(state.DistanceCm, _minDistanceCm, _maxDistanceCm);
         }
     }

--- a/src/Core/Gameplay/Camera/CameraControllerFactory.cs
+++ b/src/Core/Gameplay/Camera/CameraControllerFactory.cs
@@ -14,7 +14,9 @@ namespace Ludots.Core.Gameplay.Camera
             {
                 behaviors.Add(new ZoomBehavior(
                     definition.ZoomCmPerWheel,
-                    definition.MinDistanceCm, definition.MaxDistanceCm));
+                    definition.MinDistanceCm,
+                    definition.MaxDistanceCm,
+                    definition.ZoomFactorPerWheel));
             }
 
             switch (definition.PanMode)

--- a/src/Core/Gameplay/Camera/VirtualCameraDefinition.cs
+++ b/src/Core/Gameplay/Camera/VirtualCameraDefinition.cs
@@ -40,6 +40,7 @@ namespace Ludots.Core.Gameplay.Camera
         public float RotateDegPerSecond { get; set; } = 90f;
         public bool EnableZoom { get; set; } = true;
         public float ZoomCmPerWheel { get; set; } = 2000f;
+        public float ZoomFactorPerWheel { get; set; }
         public CameraFollowMode FollowMode { get; set; } = CameraFollowMode.None;
         public CameraFollowTargetKind FollowTargetKind { get; set; } = CameraFollowTargetKind.None;
         public string FollowCollectionKey { get; set; } = string.Empty;

--- a/src/Core/Gameplay/Camera/VirtualCameraDefinitionLoader.cs
+++ b/src/Core/Gameplay/Camera/VirtualCameraDefinitionLoader.cs
@@ -95,6 +95,7 @@ namespace Ludots.Core.Gameplay.Camera
                         RotateDegPerSecond = config.RotateDegPerSecond,
                         EnableZoom = enableZoom,
                         ZoomCmPerWheel = config.ZoomCmPerWheel,
+                        ZoomFactorPerWheel = config.ZoomFactorPerWheel,
                         FollowMode = config.FollowMode,
                         FollowTargetKind = config.FollowTargetKind,
                         FollowCollectionKey = config.FollowCollectionKey,
@@ -475,6 +476,7 @@ namespace Ludots.Core.Gameplay.Camera
             public float RotateDegPerSecond { get; set; } = 90f;
             public bool? EnableZoom { get; set; }
             public float ZoomCmPerWheel { get; set; } = 2000f;
+            public float ZoomFactorPerWheel { get; set; }
             public CameraFollowMode FollowMode { get; set; } = CameraFollowMode.None;
             public CameraFollowTargetKind FollowTargetKind { get; set; } = CameraFollowTargetKind.None;
             public string FollowCollectionKey { get; set; } = string.Empty;

--- a/src/Core/Map/MapManager.cs
+++ b/src/Core/Map/MapManager.cs
@@ -194,7 +194,24 @@ namespace Ludots.Core.Map
         private void MergeMapConfig(MapConfig target, MapConfig source)
         {
             if (!string.IsNullOrEmpty(source.ParentId)) target.ParentId = source.ParentId;
-            if (!string.IsNullOrWhiteSpace(source.VisualHeightmapAsset)) target.VisualHeightmapAsset = source.VisualHeightmapAsset;
+            if (!string.IsNullOrWhiteSpace(source.VisualHeightmapAsset))
+            {
+                target.VisualHeightmapAsset = source.VisualHeightmapAsset;
+                if (target.VisualHeightmap != null && source.VisualHeightmap == null)
+                {
+                    target.VisualHeightmap.Asset = string.Empty;
+                }
+            }
+
+            if (source.VisualHeightmap != null)
+            {
+                target.VisualHeightmap = source.VisualHeightmap.Clone();
+                if (!string.IsNullOrWhiteSpace(target.VisualHeightmap.Asset))
+                {
+                    target.VisualHeightmapAsset = target.VisualHeightmap.Asset;
+                }
+            }
+
             if (!string.IsNullOrWhiteSpace(source.StructureCollisionAsset)) target.StructureCollisionAsset = source.StructureCollisionAsset;
             if (source.StructureAwareGrounding) target.StructureAwareGrounding = true;
             if (source.StructureAwareNavigation) target.StructureAwareNavigation = true;

--- a/src/Core/Presentation/Assets/MeshAssetDescriptor.cs
+++ b/src/Core/Presentation/Assets/MeshAssetDescriptor.cs
@@ -8,6 +8,7 @@ namespace Ludots.Core.Presentation.Assets
         public string[] SourceUris;
         public PrefabPart[] PrefabParts;
         public ProceduralMeshAssetData ProceduralMeshData;
+        public VfxEffectAssetData VfxEffectData;
 
         public static MeshAssetDescriptor Primitive(int id, PrimitiveMeshKind kind)
         {

--- a/src/Core/Presentation/Assets/PrefabFinalizationPipeline.cs
+++ b/src/Core/Presentation/Assets/PrefabFinalizationPipeline.cs
@@ -316,6 +316,25 @@ namespace Ludots.Core.Presentation.Assets
 
                 case PrefabVisualPartKind.Vfx:
                     ValidatePartContract(part, stableId);
+                    if (!meshes.TryGetDescriptor(part.EffectAssetId, out MeshAssetDescriptor effectDescriptor))
+                    {
+                        throw new InvalidOperationException(
+                            $"Prefab VFX part stableId={stableId} references unknown effectAssetId={part.EffectAssetId}.");
+                    }
+
+                    if (!effectDescriptor.VfxEffectData.IsValid)
+                    {
+                        throw new InvalidOperationException(
+                            $"Prefab VFX part stableId={stableId} references effectAssetId={part.EffectAssetId} without valid VFX effect data.");
+                    }
+
+                    if (part.VfxSpawnModeAuthored &&
+                        part.VfxSpawnMode != effectDescriptor.VfxEffectData.SpawnMode)
+                    {
+                        throw new InvalidOperationException(
+                            $"Prefab VFX part stableId={stableId} declares spawnMode={part.VfxSpawnMode}, but effectAssetId={part.EffectAssetId} declares spawnMode={effectDescriptor.VfxEffectData.SpawnMode}. VFX spawn mode must be authored on the effect asset only.");
+                    }
+
                     output.Add(PrefabFinalizedVisual.Vfx(
                         stableId,
                         position,
@@ -323,7 +342,7 @@ namespace Ludots.Core.Presentation.Assets
                         scale,
                         color,
                         part.EffectAssetId,
-                        part.VfxSpawnMode));
+                        effectDescriptor.VfxEffectData.SpawnMode));
                     return;
 
                 case PrefabVisualPartKind.Surface:

--- a/src/Core/Presentation/Assets/PrefabPart.cs
+++ b/src/Core/Presentation/Assets/PrefabPart.cs
@@ -17,6 +17,7 @@ namespace Ludots.Core.Presentation.Assets
         public bool AlignToSurface;
         public bool TerrainFacing;
         public PrefabVfxSpawnMode VfxSpawnMode;
+        public bool VfxSpawnModeAuthored;
         public PrefabPartGrounding Grounding;
 
         public static PrefabPart Default(int meshAssetId)
@@ -36,6 +37,7 @@ namespace Ludots.Core.Presentation.Assets
                 AlignToSurface = false,
                 TerrainFacing = false,
                 VfxSpawnMode = PrefabVfxSpawnMode.Once,
+                VfxSpawnModeAuthored = false,
                 Grounding = PrefabPartGrounding.None,
             };
         }

--- a/src/Core/Presentation/Assets/VfxEffectAssetData.cs
+++ b/src/Core/Presentation/Assets/VfxEffectAssetData.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 
 namespace Ludots.Core.Presentation.Assets
 {
@@ -21,7 +22,9 @@ namespace Ludots.Core.Presentation.Assets
             float particleRadiusScale,
             float lifetimeSeconds,
             float pulseSpeedRadPerSecond,
-            float orbitSpeedRadPerSecond)
+            float orbitSpeedRadPerSecond,
+            int shellRingCount,
+            int beamCount)
         {
             if (shape == VfxEmitterShape.None)
             {
@@ -44,6 +47,15 @@ namespace Ludots.Core.Presentation.Assets
             ValidatePositive(lifetimeSeconds, nameof(lifetimeSeconds));
             ValidateNonNegative(pulseSpeedRadPerSecond, nameof(pulseSpeedRadPerSecond));
             ValidateNonNegative(orbitSpeedRadPerSecond, nameof(orbitSpeedRadPerSecond));
+            if (shellRingCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(shellRingCount));
+            }
+
+            if (beamCount < 0 || beamCount > 3)
+            {
+                throw new ArgumentOutOfRangeException(nameof(beamCount));
+            }
 
             Shape = shape;
             ParticleCount = particleCount;
@@ -54,6 +66,8 @@ namespace Ludots.Core.Presentation.Assets
             LifetimeSeconds = lifetimeSeconds;
             PulseSpeedRadPerSecond = pulseSpeedRadPerSecond;
             OrbitSpeedRadPerSecond = orbitSpeedRadPerSecond;
+            ShellRingCount = shellRingCount;
+            BeamCount = beamCount;
         }
 
         public VfxEmitterShape Shape { get; }
@@ -74,6 +88,10 @@ namespace Ludots.Core.Presentation.Assets
 
         public float OrbitSpeedRadPerSecond { get; }
 
+        public int ShellRingCount { get; }
+
+        public int BeamCount { get; }
+
         public bool IsValid =>
             Shape != VfxEmitterShape.None &&
             ParticleCount > 0 &&
@@ -83,7 +101,9 @@ namespace Ludots.Core.Presentation.Assets
             ParticleRadiusScale > 0f &&
             LifetimeSeconds > 0f &&
             PulseSpeedRadPerSecond >= 0f &&
-            OrbitSpeedRadPerSecond >= 0f;
+            OrbitSpeedRadPerSecond >= 0f &&
+            ShellRingCount >= 0 &&
+            BeamCount is >= 0 and <= 3;
 
         private static void ValidatePositive(float value, string name)
         {
@@ -104,18 +124,70 @@ namespace Ludots.Core.Presentation.Assets
 
     public readonly struct VfxEffectAssetData
     {
-        public VfxEffectAssetData(in VfxEmitterDescriptor emitter)
+        public VfxEffectAssetData(
+            in VfxEmitterDescriptor emitter,
+            PrefabVfxSpawnMode spawnMode,
+            in Vector4 coreColor,
+            in Vector4 shellColor,
+            in Vector4 particleColor)
         {
             if (!emitter.IsValid)
             {
                 throw new ArgumentException("VFX effect assets require a valid emitter descriptor.", nameof(emitter));
             }
 
+            if (!Enum.IsDefined(typeof(PrefabVfxSpawnMode), spawnMode))
+            {
+                throw new ArgumentOutOfRangeException(nameof(spawnMode));
+            }
+
+            ValidateColor(in coreColor, nameof(coreColor));
+            ValidateColor(in shellColor, nameof(shellColor));
+            ValidateColor(in particleColor, nameof(particleColor));
+
             Emitter = emitter;
+            SpawnMode = spawnMode;
+            CoreColor = coreColor;
+            ShellColor = shellColor;
+            ParticleColor = particleColor;
         }
 
         public VfxEmitterDescriptor Emitter { get; }
 
-        public bool IsValid => Emitter.IsValid;
+        public PrefabVfxSpawnMode SpawnMode { get; }
+
+        public Vector4 CoreColor { get; }
+
+        public Vector4 ShellColor { get; }
+
+        public Vector4 ParticleColor { get; }
+
+        public bool IsValid =>
+            Emitter.IsValid &&
+            Enum.IsDefined(typeof(PrefabVfxSpawnMode), SpawnMode) &&
+            IsValidColor(CoreColor) &&
+            IsValidColor(ShellColor) &&
+            IsValidColor(ParticleColor);
+
+        private static void ValidateColor(in Vector4 value, string name)
+        {
+            if (!IsValidColor(value))
+            {
+                throw new ArgumentOutOfRangeException(name);
+            }
+        }
+
+        private static bool IsValidColor(Vector4 value)
+        {
+            return IsUnit(value.X) &&
+                   IsUnit(value.Y) &&
+                   IsUnit(value.Z) &&
+                   IsUnit(value.W);
+        }
+
+        private static bool IsUnit(float value)
+        {
+            return float.IsFinite(value) && value >= 0f && value <= 1f;
+        }
     }
 }

--- a/src/Core/Presentation/Assets/VfxEffectAssetData.cs
+++ b/src/Core/Presentation/Assets/VfxEffectAssetData.cs
@@ -1,0 +1,121 @@
+using System;
+
+namespace Ludots.Core.Presentation.Assets
+{
+    public enum VfxEmitterShape : byte
+    {
+        None = 0,
+        BillboardSprite = 1,
+        PrimitiveCube = 2,
+        PrimitiveSphere = 3,
+    }
+
+    public readonly struct VfxEmitterDescriptor
+    {
+        public VfxEmitterDescriptor(
+            VfxEmitterShape shape,
+            int particleCount,
+            int ringSegments,
+            float radiusScale,
+            float coreRadiusScale,
+            float particleRadiusScale,
+            float lifetimeSeconds,
+            float pulseSpeedRadPerSecond,
+            float orbitSpeedRadPerSecond)
+        {
+            if (shape == VfxEmitterShape.None)
+            {
+                throw new ArgumentOutOfRangeException(nameof(shape));
+            }
+
+            if (particleCount <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(particleCount));
+            }
+
+            if (ringSegments < 3)
+            {
+                throw new ArgumentOutOfRangeException(nameof(ringSegments));
+            }
+
+            ValidatePositive(radiusScale, nameof(radiusScale));
+            ValidatePositive(coreRadiusScale, nameof(coreRadiusScale));
+            ValidatePositive(particleRadiusScale, nameof(particleRadiusScale));
+            ValidatePositive(lifetimeSeconds, nameof(lifetimeSeconds));
+            ValidateNonNegative(pulseSpeedRadPerSecond, nameof(pulseSpeedRadPerSecond));
+            ValidateNonNegative(orbitSpeedRadPerSecond, nameof(orbitSpeedRadPerSecond));
+
+            Shape = shape;
+            ParticleCount = particleCount;
+            RingSegments = ringSegments;
+            RadiusScale = radiusScale;
+            CoreRadiusScale = coreRadiusScale;
+            ParticleRadiusScale = particleRadiusScale;
+            LifetimeSeconds = lifetimeSeconds;
+            PulseSpeedRadPerSecond = pulseSpeedRadPerSecond;
+            OrbitSpeedRadPerSecond = orbitSpeedRadPerSecond;
+        }
+
+        public VfxEmitterShape Shape { get; }
+
+        public int ParticleCount { get; }
+
+        public int RingSegments { get; }
+
+        public float RadiusScale { get; }
+
+        public float CoreRadiusScale { get; }
+
+        public float ParticleRadiusScale { get; }
+
+        public float LifetimeSeconds { get; }
+
+        public float PulseSpeedRadPerSecond { get; }
+
+        public float OrbitSpeedRadPerSecond { get; }
+
+        public bool IsValid =>
+            Shape != VfxEmitterShape.None &&
+            ParticleCount > 0 &&
+            RingSegments >= 3 &&
+            RadiusScale > 0f &&
+            CoreRadiusScale > 0f &&
+            ParticleRadiusScale > 0f &&
+            LifetimeSeconds > 0f &&
+            PulseSpeedRadPerSecond >= 0f &&
+            OrbitSpeedRadPerSecond >= 0f;
+
+        private static void ValidatePositive(float value, string name)
+        {
+            if (!float.IsFinite(value) || value <= 0f)
+            {
+                throw new ArgumentOutOfRangeException(name);
+            }
+        }
+
+        private static void ValidateNonNegative(float value, string name)
+        {
+            if (!float.IsFinite(value) || value < 0f)
+            {
+                throw new ArgumentOutOfRangeException(name);
+            }
+        }
+    }
+
+    public readonly struct VfxEffectAssetData
+    {
+        public VfxEffectAssetData(in VfxEmitterDescriptor emitter)
+        {
+            if (!emitter.IsValid)
+            {
+                throw new ArgumentException("VFX effect assets require a valid emitter descriptor.", nameof(emitter));
+            }
+
+            Emitter = emitter;
+        }
+
+        public VfxEmitterDescriptor Emitter { get; }
+
+        public bool IsValid => Emitter.IsValid;
+    }
+}

--- a/src/Core/Presentation/Config/InstancedBatchAssetConfigLoader.cs
+++ b/src/Core/Presentation/Config/InstancedBatchAssetConfigLoader.cs
@@ -598,10 +598,16 @@ namespace Ludots.Core.Presentation.Config
                 node,
                 $"Instanced batch '{batchKey}' behavior '{behaviorKey}' target.effectAssetId");
             int effectAssetId = _meshes.GetId(effectKey);
-            if (effectAssetId <= 0 || !_meshes.TryGetDescriptor(effectAssetId, out _))
+            if (effectAssetId <= 0 || !_meshes.TryGetDescriptor(effectAssetId, out MeshAssetDescriptor descriptor))
             {
                 throw new InvalidOperationException(
                     $"Instanced batch '{batchKey}' behavior '{behaviorKey}' references unknown effect asset '{effectKey}'.");
+            }
+
+            if (!descriptor.VfxEffectData.IsValid)
+            {
+                throw new InvalidOperationException(
+                    $"Instanced batch '{batchKey}' behavior '{behaviorKey}' references effect asset '{effectKey}' without vfx emitter data.");
             }
 
             return effectAssetId;

--- a/src/Core/Presentation/Config/MeshAssetConfigLoader.cs
+++ b/src/Core/Presentation/Config/MeshAssetConfigLoader.cs
@@ -206,6 +206,7 @@ namespace Ludots.Core.Presentation.Config
                 part.Tiling = ParseVector2WithDefault(p?["tiling"], part.Tiling == Vector2.Zero ? Vector2.One : part.Tiling);
                 part.AlignToSurface = p?["alignToSurface"]?.GetValue<bool>() ?? part.AlignToSurface;
                 part.TerrainFacing = p?["terrainFacing"]?.GetValue<bool>() ?? part.TerrainFacing;
+                part.VfxSpawnModeAuthored = kind == PrefabVisualPartKind.Vfx && p?["spawnMode"] != null;
 
                 parts[j] = part;
             }
@@ -247,7 +248,11 @@ namespace Ludots.Core.Presentation.Config
             ValidateObjectFields(
                 obj,
                 $"Presentation/mesh_assets.json asset '{key}' vfx",
-                "emitter");
+                "emitter",
+                "spawnMode",
+                "coreColor",
+                "shellColor",
+                "particleColor");
 
             if (obj["emitter"] is not JsonObject emitter)
             {
@@ -266,7 +271,9 @@ namespace Ludots.Core.Presentation.Config
                 "particleRadiusScale",
                 "lifetimeSeconds",
                 "pulseSpeedRadPerSecond",
-                "orbitSpeedRadPerSecond");
+                "orbitSpeedRadPerSecond",
+                "shellRingCount",
+                "beamCount");
 
             string shapeLabel = $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.shape";
             VfxEmitterShape shape = ReadRequiredEnum<VfxEmitterShape>(emitter["shape"], shapeLabel);
@@ -275,16 +282,25 @@ namespace Ludots.Core.Presentation.Config
                 throw new InvalidOperationException($"{shapeLabel} must not be None.");
             }
 
-            return new VfxEffectAssetData(new VfxEmitterDescriptor(
-                shape,
-                ReadRequiredPositiveInt(emitter["particleCount"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.particleCount"),
-                ReadRequiredMinInt(emitter["ringSegments"], 3, $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.ringSegments"),
-                ReadRequiredPositiveFloat(emitter["radiusScale"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.radiusScale"),
-                ReadRequiredPositiveFloat(emitter["coreRadiusScale"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.coreRadiusScale"),
-                ReadRequiredPositiveFloat(emitter["particleRadiusScale"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.particleRadiusScale"),
-                ReadRequiredPositiveFloat(emitter["lifetimeSeconds"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.lifetimeSeconds"),
-                ReadRequiredNonNegativeFloat(emitter["pulseSpeedRadPerSecond"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.pulseSpeedRadPerSecond"),
-                ReadRequiredNonNegativeFloat(emitter["orbitSpeedRadPerSecond"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.orbitSpeedRadPerSecond")));
+            string assetLabel = $"Presentation/mesh_assets.json asset '{key}' vfx";
+            PrefabVfxSpawnMode spawnMode = ReadRequiredEnum<PrefabVfxSpawnMode>(obj["spawnMode"], $"{assetLabel}.spawnMode");
+            return new VfxEffectAssetData(
+                new VfxEmitterDescriptor(
+                    shape,
+                    ReadRequiredPositiveInt(emitter["particleCount"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.particleCount"),
+                    ReadRequiredMinInt(emitter["ringSegments"], 3, $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.ringSegments"),
+                    ReadRequiredPositiveFloat(emitter["radiusScale"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.radiusScale"),
+                    ReadRequiredPositiveFloat(emitter["coreRadiusScale"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.coreRadiusScale"),
+                    ReadRequiredPositiveFloat(emitter["particleRadiusScale"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.particleRadiusScale"),
+                    ReadRequiredPositiveFloat(emitter["lifetimeSeconds"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.lifetimeSeconds"),
+                    ReadRequiredNonNegativeFloat(emitter["pulseSpeedRadPerSecond"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.pulseSpeedRadPerSecond"),
+                    ReadRequiredNonNegativeFloat(emitter["orbitSpeedRadPerSecond"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.orbitSpeedRadPerSecond"),
+                    ReadRequiredMinInt(emitter["shellRingCount"], 0, $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.shellRingCount"),
+                    ReadRequiredIntRange(emitter["beamCount"], 0, 3, $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.beamCount")),
+                spawnMode,
+                ReadRequiredColor(obj["coreColor"], $"{assetLabel}.coreColor"),
+                ReadRequiredColor(obj["shellColor"], $"{assetLabel}.shellColor"),
+                ReadRequiredColor(obj["particleColor"], $"{assetLabel}.particleColor"));
         }
 
         private static PrefabVfxSpawnMode ParseSpawnMode(string? spawnModeText)
@@ -416,6 +432,46 @@ namespace Ludots.Core.Presentation.Config
             if (!float.IsFinite(value) || value < 0f)
             {
                 throw new InvalidOperationException($"{label} must be a finite number greater than or equal to 0.");
+            }
+
+            return value;
+        }
+
+        private static int ReadRequiredIntRange(JsonNode? node, int min, int max, string label)
+        {
+            int value = ReadRequiredMinInt(node, min, label);
+            if (value > max)
+            {
+                throw new InvalidOperationException($"{label} must be less than or equal to {max}.");
+            }
+
+            return value;
+        }
+
+        private static Vector4 ReadRequiredColor(JsonNode? node, string label)
+        {
+            if (node is not JsonArray arr || arr.Count != 4)
+            {
+                throw new InvalidOperationException($"{label} must be an array of exactly four normalized numbers.");
+            }
+
+            return new Vector4(
+                ReadColorChannel(arr[0], $"{label}[0]"),
+                ReadColorChannel(arr[1], $"{label}[1]"),
+                ReadColorChannel(arr[2], $"{label}[2]"),
+                ReadColorChannel(arr[3], $"{label}[3]"));
+        }
+
+        private static float ReadColorChannel(JsonNode? node, string label)
+        {
+            if (node is not JsonValue valueNode || !valueNode.TryGetValue(out float value))
+            {
+                throw new InvalidOperationException($"{label} must be a finite number between 0 and 1.");
+            }
+
+            if (!float.IsFinite(value) || value < 0f || value > 1f)
+            {
+                throw new InvalidOperationException($"{label} must be between 0 and 1.");
             }
 
             return value;

--- a/src/Core/Presentation/Config/MeshAssetConfigLoader.cs
+++ b/src/Core/Presentation/Config/MeshAssetConfigLoader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Numerics;
 using System.Text.Json.Nodes;
 using Ludots.Core.Config;
@@ -103,23 +104,30 @@ namespace Ludots.Core.Presentation.Config
 
         private MeshAssetDescriptor ParseDescriptor(JsonNode node, string key)
         {
-            string typeStr = node["type"]?.GetValue<string>();
-            if (!Enum.TryParse<MeshAssetType>(typeStr, ignoreCase: false, out var type))
+            MeshAssetType type = ReadRequiredEnum<MeshAssetType>(
+                node["type"],
+                $"Presentation/mesh_assets.json asset '{key}' type");
+            if (type == MeshAssetType.None)
             {
-                throw new InvalidOperationException($"Presentation/mesh_assets.json asset '{key}' has invalid or missing type '{typeStr}'.");
+                throw new InvalidOperationException($"Presentation/mesh_assets.json asset '{key}' type must not be None.");
             }
 
             switch (type)
             {
                 case MeshAssetType.Primitive:
                 {
-                    string kindStr = node["primitiveKind"]?.GetValue<string>();
-                    if (!Enum.TryParse<PrimitiveMeshKind>(kindStr, ignoreCase: false, out var kind))
+                    PrimitiveMeshKind kind = ReadRequiredEnum<PrimitiveMeshKind>(
+                        node["primitiveKind"],
+                        $"Presentation/mesh_assets.json primitive asset '{key}' primitiveKind");
+                    if (kind == PrimitiveMeshKind.None)
                     {
-                        throw new InvalidOperationException($"Presentation/mesh_assets.json primitive asset '{key}' has invalid or missing primitiveKind '{kindStr}'.");
+                        throw new InvalidOperationException(
+                            $"Presentation/mesh_assets.json primitive asset '{key}' primitiveKind must not be None.");
                     }
 
-                    return MeshAssetDescriptor.Primitive(0, kind);
+                    var descriptor = MeshAssetDescriptor.Primitive(0, kind);
+                    descriptor.VfxEffectData = ParseVfxEffectData(node["vfx"], key);
+                    return descriptor;
                 }
                 case MeshAssetType.Model:
                 case MeshAssetType.Billboard:
@@ -130,14 +138,18 @@ namespace Ludots.Core.Presentation.Config
                             $"Presentation/mesh_assets.json asset '{key}' declares sourceUris. Platform paths belong in Presentation/host_assets.json.");
                     }
 
-                    return type == MeshAssetType.Billboard
+                    var descriptor = type == MeshAssetType.Billboard
                         ? MeshAssetDescriptor.Billboard(0, Array.Empty<string>())
                         : MeshAssetDescriptor.Model(0, Array.Empty<string>());
+                    descriptor.VfxEffectData = ParseVfxEffectData(node["vfx"], key);
+                    return descriptor;
                 }
                 case MeshAssetType.Prefab:
                 {
                     var parts = ParseParts(node["parts"]);
-                    return MeshAssetDescriptor.Prefab(0, parts);
+                    var descriptor = MeshAssetDescriptor.Prefab(0, parts);
+                    descriptor.VfxEffectData = ParseVfxEffectData(node["vfx"], key);
+                    return descriptor;
                 }
                 default:
                     throw new InvalidOperationException($"Presentation/mesh_assets.json asset '{key}' uses unsupported mesh asset type '{type}'.");
@@ -159,10 +171,9 @@ namespace Ludots.Core.Presentation.Config
                     throw new InvalidOperationException($"Prefab part at index {j} must declare an explicit kind.");
                 }
 
-                if (!Enum.TryParse(kindText, ignoreCase: false, out PrefabVisualPartKind kind))
-                {
-                    throw new InvalidOperationException($"Prefab part has invalid kind '{kindText}'.");
-                }
+                PrefabVisualPartKind kind = ParseRequiredEnumText<PrefabVisualPartKind>(
+                    kindText,
+                    $"Prefab part at index {j} kind");
 
                 string meshRef = p?["meshAssetId"]?.GetValue<string>();
                 int meshId = 0;
@@ -175,7 +186,7 @@ namespace Ludots.Core.Presentation.Config
                         p?["materialId"]?.GetValue<int>() ?? 0,
                         ParseVector2WithDefault(p?["size"], Vector2.One)),
                     PrefabVisualPartKind.Vfx => PrefabPart.Vfx(
-                        p?["effectAssetId"]?.GetValue<int>() ?? 0,
+                        ResolveEffectAssetId(p?["effectAssetId"], $"Prefab part at index {j}"),
                         ParseSpawnMode(p?["spawnMode"]?.GetValue<string>())),
                     PrefabVisualPartKind.Surface => PrefabPart.Surface(
                         meshId,
@@ -191,7 +202,6 @@ namespace Ludots.Core.Presentation.Config
                 part.ColorTint = ParseVector4WithDefault(p?["colorTint"], Vector4.One);
                 part.Grounding = ParseGrounding(p?["grounding"]);
                 part.MaterialId = p?["materialId"]?.GetValue<int>() ?? part.MaterialId;
-                part.EffectAssetId = p?["effectAssetId"]?.GetValue<int>() ?? part.EffectAssetId;
                 part.Size = ParseVector2WithDefault(p?["size"], part.Size == Vector2.Zero ? Vector2.One : part.Size);
                 part.Tiling = ParseVector2WithDefault(p?["tiling"], part.Tiling == Vector2.Zero ? Vector2.One : part.Tiling);
                 part.AlignToSurface = p?["alignToSurface"]?.GetValue<bool>() ?? part.AlignToSurface;
@@ -202,17 +212,89 @@ namespace Ludots.Core.Presentation.Config
             return parts;
         }
 
+        private int ResolveEffectAssetId(JsonNode? node, string partLabel)
+        {
+            string effectKey = ReadRequiredString(node, $"{partLabel} effectAssetId");
+            int effectAssetId = _meshRegistry.GetId(effectKey);
+            if (effectAssetId <= 0 || !_meshRegistry.TryGetDescriptor(effectAssetId, out MeshAssetDescriptor descriptor))
+            {
+                throw new InvalidOperationException(
+                    $"{partLabel} references unknown VFX effect asset '{effectKey}'.");
+            }
+
+            if (!descriptor.VfxEffectData.IsValid)
+            {
+                throw new InvalidOperationException(
+                    $"{partLabel} references VFX effect asset '{effectKey}' without vfx emitter data.");
+            }
+
+            return effectAssetId;
+        }
+
+        private static VfxEffectAssetData ParseVfxEffectData(JsonNode? node, string key)
+        {
+            if (node == null)
+            {
+                return default;
+            }
+
+            if (node is not JsonObject obj)
+            {
+                throw new InvalidOperationException(
+                    $"Presentation/mesh_assets.json asset '{key}' vfx must be an object.");
+            }
+
+            ValidateObjectFields(
+                obj,
+                $"Presentation/mesh_assets.json asset '{key}' vfx",
+                "emitter");
+
+            if (obj["emitter"] is not JsonObject emitter)
+            {
+                throw new InvalidOperationException(
+                    $"Presentation/mesh_assets.json asset '{key}' vfx.emitter must be an object.");
+            }
+
+            ValidateObjectFields(
+                emitter,
+                $"Presentation/mesh_assets.json asset '{key}' vfx.emitter",
+                "shape",
+                "particleCount",
+                "ringSegments",
+                "radiusScale",
+                "coreRadiusScale",
+                "particleRadiusScale",
+                "lifetimeSeconds",
+                "pulseSpeedRadPerSecond",
+                "orbitSpeedRadPerSecond");
+
+            string shapeLabel = $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.shape";
+            VfxEmitterShape shape = ReadRequiredEnum<VfxEmitterShape>(emitter["shape"], shapeLabel);
+            if (shape == VfxEmitterShape.None)
+            {
+                throw new InvalidOperationException($"{shapeLabel} must not be None.");
+            }
+
+            return new VfxEffectAssetData(new VfxEmitterDescriptor(
+                shape,
+                ReadRequiredPositiveInt(emitter["particleCount"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.particleCount"),
+                ReadRequiredMinInt(emitter["ringSegments"], 3, $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.ringSegments"),
+                ReadRequiredPositiveFloat(emitter["radiusScale"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.radiusScale"),
+                ReadRequiredPositiveFloat(emitter["coreRadiusScale"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.coreRadiusScale"),
+                ReadRequiredPositiveFloat(emitter["particleRadiusScale"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.particleRadiusScale"),
+                ReadRequiredPositiveFloat(emitter["lifetimeSeconds"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.lifetimeSeconds"),
+                ReadRequiredNonNegativeFloat(emitter["pulseSpeedRadPerSecond"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.pulseSpeedRadPerSecond"),
+                ReadRequiredNonNegativeFloat(emitter["orbitSpeedRadPerSecond"], $"Presentation/mesh_assets.json asset '{key}' vfx.emitter.orbitSpeedRadPerSecond")));
+        }
+
         private static PrefabVfxSpawnMode ParseSpawnMode(string? spawnModeText)
         {
             string resolved = string.IsNullOrWhiteSpace(spawnModeText)
                 ? nameof(PrefabVfxSpawnMode.Once)
                 : spawnModeText;
-            if (!Enum.TryParse(resolved, ignoreCase: false, out PrefabVfxSpawnMode spawnMode))
-            {
-                throw new InvalidOperationException($"Prefab part VFX spawnMode has invalid value '{resolved}'.");
-            }
-
-            return spawnMode;
+            return ParseRequiredEnumText<PrefabVfxSpawnMode>(
+                resolved,
+                "Prefab part VFX spawnMode");
         }
 
         private static PrefabPartGrounding ParseGrounding(JsonNode node)
@@ -228,10 +310,9 @@ namespace Ludots.Core.Presentation.Config
             }
 
             string modeText = obj["mode"]?.GetValue<string>() ?? nameof(PrefabPartGroundingMode.None);
-            if (!Enum.TryParse(modeText, ignoreCase: false, out PrefabPartGroundingMode mode))
-            {
-                throw new InvalidOperationException($"Prefab part grounding has invalid mode '{modeText}'.");
-            }
+            PrefabPartGroundingMode mode = ParseRequiredEnumText<PrefabPartGroundingMode>(
+                modeText,
+                "Prefab part grounding mode");
 
             int layerIndex = obj["layerIndex"]?.GetValue<int>() ?? 0;
             if (layerIndex < 0)
@@ -244,6 +325,122 @@ namespace Ludots.Core.Presentation.Config
                 obj["verticalOffsetMeters"]?.GetValue<float>() ?? 0f,
                 obj["alignToGroundNormal"]?.GetValue<bool>() ?? false,
                 layerIndex);
+        }
+
+        private static string ReadRequiredString(JsonNode? node, string label)
+        {
+            if (node is not JsonValue valueNode || !valueNode.TryGetValue(out string? value))
+            {
+                throw new InvalidOperationException($"{label} must be a non-empty asset key.");
+            }
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new InvalidOperationException($"{label} must be a non-empty asset key.");
+            }
+
+            if (!string.Equals(value, value.Trim(), StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"{label} must not include leading or trailing whitespace.");
+            }
+
+            return value;
+        }
+
+        private static T ReadRequiredEnum<T>(JsonNode? node, string label)
+            where T : struct, Enum
+        {
+            string value = ReadRequiredString(node, label);
+            return ParseRequiredEnumText<T>(value, label);
+        }
+
+        private static T ParseRequiredEnumText<T>(string value, string label)
+            where T : struct, Enum
+        {
+            if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+            {
+                throw new InvalidOperationException($"{label} has invalid value '{value}'. Use the enum name, not a numeric string.");
+            }
+
+            if (!Enum.TryParse(value, ignoreCase: false, out T parsed) ||
+                !Enum.IsDefined(typeof(T), parsed))
+            {
+                throw new InvalidOperationException($"{label} has invalid value '{value}'.");
+            }
+
+            return parsed;
+        }
+
+        private static int ReadRequiredPositiveInt(JsonNode? node, string label)
+        {
+            return ReadRequiredMinInt(node, 1, label);
+        }
+
+        private static int ReadRequiredMinInt(JsonNode? node, int min, string label)
+        {
+            if (node is not JsonValue valueNode || !valueNode.TryGetValue(out int value))
+            {
+                throw new InvalidOperationException($"{label} must be an integer greater than or equal to {min}.");
+            }
+
+            if (value < min)
+            {
+                throw new InvalidOperationException($"{label} must be greater than or equal to {min}.");
+            }
+
+            return value;
+        }
+
+        private static float ReadRequiredPositiveFloat(JsonNode? node, string label)
+        {
+            if (node is not JsonValue valueNode || !valueNode.TryGetValue(out float value))
+            {
+                throw new InvalidOperationException($"{label} must be a finite number greater than 0.");
+            }
+
+            if (!float.IsFinite(value) || value <= 0f)
+            {
+                throw new InvalidOperationException($"{label} must be a finite number greater than 0.");
+            }
+
+            return value;
+        }
+
+        private static float ReadRequiredNonNegativeFloat(JsonNode? node, string label)
+        {
+            if (node is not JsonValue valueNode || !valueNode.TryGetValue(out float value))
+            {
+                throw new InvalidOperationException($"{label} must be a finite number greater than or equal to 0.");
+            }
+
+            if (!float.IsFinite(value) || value < 0f)
+            {
+                throw new InvalidOperationException($"{label} must be a finite number greater than or equal to 0.");
+            }
+
+            return value;
+        }
+
+        private static void ValidateObjectFields(JsonObject obj, string context, params string[] allowedFields)
+        {
+            foreach (var property in obj)
+            {
+                bool allowed = false;
+                for (int i = 0; i < allowedFields.Length; i++)
+                {
+                    if (string.Equals(property.Key, allowedFields[i], StringComparison.Ordinal))
+                    {
+                        allowed = true;
+                        break;
+                    }
+                }
+
+                if (!allowed)
+                {
+                    throw new InvalidOperationException(
+                        $"{context} uses unsupported field '{property.Key}'.");
+                }
+            }
         }
 
         private static Vector3 ParseVector3(JsonNode node)

--- a/src/Core/Presentation/Terrain/ChunkedVisualHeightmapRuntime.cs
+++ b/src/Core/Presentation/Terrain/ChunkedVisualHeightmapRuntime.cs
@@ -13,11 +13,21 @@ namespace Ludots.Core.Presentation.Terrain
     {
         private readonly ChunkedVisualHeightmapDescriptor _descriptor;
         private readonly ChunkedVisualHeightmapStore _store;
+        private readonly VisualHeightmapRenderProfile _renderProfile;
 
         public ChunkedVisualHeightmapRuntime(ChunkedVisualHeightmapDescriptor descriptor, ChunkedVisualHeightmapStore store)
+            : this(descriptor, store, VisualHeightmapRenderProfile.CreateDefault())
+        {
+        }
+
+        public ChunkedVisualHeightmapRuntime(
+            ChunkedVisualHeightmapDescriptor descriptor,
+            ChunkedVisualHeightmapStore store,
+            VisualHeightmapRenderProfile renderProfile)
         {
             _descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
             _store = store ?? throw new ArgumentNullException(nameof(store));
+            _renderProfile = (renderProfile ?? throw new ArgumentNullException(nameof(renderProfile))).NormalizeAndValidate();
         }
 
         public ChunkedVisualHeightmapDescriptor Descriptor => _descriptor;
@@ -37,6 +47,8 @@ namespace Ludots.Core.Presentation.Terrain
         public int DefaultLayerIndex => _descriptor.DefaultLayerIndex;
 
         public int Revision => _store.Revision;
+
+        public VisualHeightmapRenderProfile RenderProfile => _renderProfile;
 
         public bool TryGetChunk(int chunkX, int chunkY, out VisualHeightmapRenderChunk chunk)
         {

--- a/src/Core/Presentation/Terrain/IVisualHeightmapRenderSource.cs
+++ b/src/Core/Presentation/Terrain/IVisualHeightmapRenderSource.cs
@@ -22,6 +22,8 @@ namespace Ludots.Core.Presentation.Terrain
 
         int Revision { get; }
 
+        VisualHeightmapRenderProfile RenderProfile { get; }
+
         bool TryGetChunk(int chunkX, int chunkY, out VisualHeightmapRenderChunk chunk);
     }
 }

--- a/src/Core/Presentation/Terrain/MapVisualHeightmapLoader.cs
+++ b/src/Core/Presentation/Terrain/MapVisualHeightmapLoader.cs
@@ -30,12 +30,12 @@ namespace Ludots.Core.Presentation.Terrain
 
             using Stream stream = OpenDeclaredAsset(vfs, loadedModIds, assetPath);
             VisualHeightmapAsset asset = VisualHeightmapBinary.Read(stream);
-            return new VisualHeightmapRuntime(asset);
+            return new VisualHeightmapRuntime(asset, ResolveRenderProfile(mapConfig));
         }
 
         public static string? ResolveDeclaredAssetPath(MapConfig mapConfig)
         {
-            string? resolved = MapDeclaredAssetResolver.NormalizeDeclaredAssetPath(mapConfig.VisualHeightmapAsset);
+            string? resolved = ResolveMapLevelDeclaredAssetPath(mapConfig);
 
             if (mapConfig.Boards == null)
             {
@@ -65,6 +65,32 @@ namespace Ludots.Core.Presentation.Terrain
             }
 
             return resolved;
+        }
+
+        public static VisualHeightmapRenderProfile ResolveRenderProfile(MapConfig mapConfig)
+        {
+            if (mapConfig == null)
+            {
+                throw new ArgumentNullException(nameof(mapConfig));
+            }
+
+            return (mapConfig.VisualHeightmap?.RenderProfile ?? VisualHeightmapRenderProfile.CreateDefault())
+                .NormalizeAndValidate();
+        }
+
+        private static string? ResolveMapLevelDeclaredAssetPath(MapConfig mapConfig)
+        {
+            string? legacy = MapDeclaredAssetResolver.NormalizeDeclaredAssetPath(mapConfig.VisualHeightmapAsset);
+            string? binding = MapDeclaredAssetResolver.NormalizeDeclaredAssetPath(mapConfig.VisualHeightmap?.Asset);
+            if (legacy != null &&
+                binding != null &&
+                !string.Equals(legacy, binding, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Map '{mapConfig.Id}' declares conflicting visual heightmap assets. visualHeightmapAsset and visualHeightmap.asset must resolve to the same asset path.");
+            }
+
+            return binding ?? legacy;
         }
 
         private static Stream OpenDeclaredAsset(IVirtualFileSystem vfs, IEnumerable<string>? loadedModIds, string assetPath)

--- a/src/Core/Presentation/Terrain/VisualHeightmapBindingConfig.cs
+++ b/src/Core/Presentation/Terrain/VisualHeightmapBindingConfig.cs
@@ -20,6 +20,11 @@ namespace Ludots.Core.Presentation.Terrain
         /// </summary>
         public int DefaultLayerIndex { get; set; } = -1;
 
+        /// <summary>
+        /// Presentation-only render profile for adapters. This never changes sampling truth.
+        /// </summary>
+        public VisualHeightmapRenderProfile RenderProfile { get; set; } = VisualHeightmapRenderProfile.CreateDefault();
+
         public VisualHeightmapBindingConfig Clone()
         {
             return new VisualHeightmapBindingConfig
@@ -27,6 +32,7 @@ namespace Ludots.Core.Presentation.Terrain
                 Asset = Asset,
                 BoardName = BoardName,
                 DefaultLayerIndex = DefaultLayerIndex,
+                RenderProfile = (RenderProfile ?? VisualHeightmapRenderProfile.CreateDefault()).NormalizeAndValidate(),
             };
         }
     }

--- a/src/Core/Presentation/Terrain/VisualHeightmapColorRamp.cs
+++ b/src/Core/Presentation/Terrain/VisualHeightmapColorRamp.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Numerics;
+
+namespace Ludots.Core.Presentation.Terrain
+{
+    public static class VisualHeightmapColorRamp
+    {
+        public static float ResolveHeightBandContrast(float heightBand, float colorContrast)
+        {
+            if (!float.IsFinite(heightBand)) throw new ArgumentOutOfRangeException(nameof(heightBand));
+            if (!float.IsFinite(colorContrast) || colorContrast <= 0f) throw new ArgumentOutOfRangeException(nameof(colorContrast));
+
+            float clampedBand = Math.Clamp(heightBand, 0f, 1f);
+            float clampedContrast = Math.Clamp(colorContrast, 0.01f, 16f);
+            return Math.Clamp(((clampedBand - 0.5f) * clampedContrast) + 0.5f, 0f, 1f);
+        }
+
+        public static Vector3 ResolveColorRanged(
+            float heightCm,
+            float slope,
+            float minHeightCm,
+            float maxHeightCm,
+            float seaLevelCm,
+            float colorContrast)
+        {
+            if (!float.IsFinite(heightCm)) throw new ArgumentOutOfRangeException(nameof(heightCm));
+            if (!float.IsFinite(slope)) throw new ArgumentOutOfRangeException(nameof(slope));
+            if (!float.IsFinite(minHeightCm)) throw new ArgumentOutOfRangeException(nameof(minHeightCm));
+            if (!float.IsFinite(maxHeightCm)) throw new ArgumentOutOfRangeException(nameof(maxHeightCm));
+            if (!float.IsFinite(seaLevelCm)) throw new ArgumentOutOfRangeException(nameof(seaLevelCm));
+            if (maxHeightCm < minHeightCm) throw new ArgumentOutOfRangeException(nameof(maxHeightCm));
+
+            bool water = heightCm <= seaLevelCm;
+            float band = water
+                ? ResolveWaterBand(heightCm, minHeightCm, maxHeightCm, seaLevelCm)
+                : ResolveLandBand(heightCm, minHeightCm, maxHeightCm, seaLevelCm);
+            band = ResolveHeightBandContrast(band, colorContrast);
+            return ResolveSplitBandColor(water, band, slope);
+        }
+
+        public static Vector3 ResolveGrayscale(float heightBand)
+        {
+            if (!float.IsFinite(heightBand)) throw new ArgumentOutOfRangeException(nameof(heightBand));
+
+            float value = Math.Clamp(heightBand, 0f, 1f);
+            return new Vector3(value, value, value);
+        }
+
+        private static float ResolveWaterBand(float heightCm, float minHeightCm, float maxHeightCm, float seaLevelCm)
+        {
+            float deepCm = MathF.Min(minHeightCm, seaLevelCm);
+            float shallowCm = MathF.Min(maxHeightCm, seaLevelCm);
+            float span = MathF.Max(1f, shallowCm - deepCm);
+            return Math.Clamp((heightCm - deepCm) / span, 0f, 1f);
+        }
+
+        private static float ResolveLandBand(float heightCm, float minHeightCm, float maxHeightCm, float seaLevelCm)
+        {
+            float lowlandCm = MathF.Max(minHeightCm, seaLevelCm);
+            float highlandCm = MathF.Max(maxHeightCm, lowlandCm + 1f);
+            float span = MathF.Max(1f, highlandCm - lowlandCm);
+            return Math.Clamp((heightCm - lowlandCm) / span, 0f, 1f);
+        }
+
+        private static Vector3 ResolveSplitBandColor(bool water, float band, float slope)
+        {
+            band = Math.Clamp(band, 0f, 1f);
+            if (water)
+            {
+                Vector3 deep = new(12f / 255f, 34f / 255f, 66f / 255f);
+                Vector3 shallow = new(48f / 255f, 104f / 255f, 154f / 255f);
+                return Vector3.Lerp(deep, shallow, band);
+            }
+
+            Vector3 lowland = new(58f / 255f, 120f / 255f, 62f / 255f);
+            Vector3 mid = new(120f / 255f, 150f / 255f, 74f / 255f);
+            Vector3 high = new(176f / 255f, 148f / 255f, 96f / 255f);
+            Vector3 peak = new(232f / 255f, 232f / 255f, 224f / 255f);
+            Vector3 color = band < 0.45f
+                ? Vector3.Lerp(lowland, mid, band / 0.45f)
+                : band < 0.80f
+                    ? Vector3.Lerp(mid, high, (band - 0.45f) / 0.35f)
+                    : Vector3.Lerp(high, peak, (band - 0.80f) / 0.20f);
+            float shade = 1f - Math.Clamp(Math.Clamp(slope, 0f, 1f) * 0.42f, 0f, 0.42f);
+            return Vector3.Clamp(color * shade, Vector3.Zero, Vector3.One);
+        }
+    }
+}

--- a/src/Core/Presentation/Terrain/VisualHeightmapRenderProfile.cs
+++ b/src/Core/Presentation/Terrain/VisualHeightmapRenderProfile.cs
@@ -1,0 +1,77 @@
+using System;
+
+namespace Ludots.Core.Presentation.Terrain
+{
+    /// <summary>
+    /// Map-owned presentation profile for visual heightmap rendering.
+    /// Height samples remain the gameplay truth; this profile controls how adapters display them.
+    /// </summary>
+    public sealed class VisualHeightmapRenderProfile
+    {
+        public const float DefaultSeaLevelCm = 0f;
+        public const float DefaultDisplayHeightScale = 1f;
+        public const float DefaultColorContrast = 1f;
+        public const float MinDisplayHeightScale = 0.01f;
+        public const float MaxDisplayHeightScale = 5000f;
+        public const float MinColorContrast = 0.01f;
+        public const float MaxColorContrast = 16f;
+
+        public bool WaterEnabled { get; set; }
+
+        public float SeaLevelCm { get; set; } = DefaultSeaLevelCm;
+
+        public float DisplayHeightScale { get; set; } = DefaultDisplayHeightScale;
+
+        public float ColorContrast { get; set; } = DefaultColorContrast;
+
+        public static VisualHeightmapRenderProfile CreateDefault()
+        {
+            return new VisualHeightmapRenderProfile();
+        }
+
+        public VisualHeightmapRenderProfile Clone()
+        {
+            return new VisualHeightmapRenderProfile
+            {
+                WaterEnabled = WaterEnabled,
+                SeaLevelCm = SeaLevelCm,
+                DisplayHeightScale = DisplayHeightScale,
+                ColorContrast = ColorContrast,
+            };
+        }
+
+        public VisualHeightmapRenderProfile NormalizeAndValidate()
+        {
+            RequireFinite(SeaLevelCm, nameof(SeaLevelCm));
+            RequireRange(
+                DisplayHeightScale,
+                MinDisplayHeightScale,
+                MaxDisplayHeightScale,
+                nameof(DisplayHeightScale));
+            RequireRange(
+                ColorContrast,
+                MinColorContrast,
+                MaxColorContrast,
+                nameof(ColorContrast));
+
+            return Clone();
+        }
+
+        private static void RequireFinite(float value, string name)
+        {
+            if (!float.IsFinite(value))
+            {
+                throw new ArgumentOutOfRangeException(name, $"{name} must be finite.");
+            }
+        }
+
+        private static void RequireRange(float value, float min, float max, string name)
+        {
+            RequireFinite(value, name);
+            if (value < min || value > max)
+            {
+                throw new ArgumentOutOfRangeException(name, $"{name} must be between {min} and {max}.");
+            }
+        }
+    }
+}

--- a/src/Core/Presentation/Terrain/VisualHeightmapRuntime.cs
+++ b/src/Core/Presentation/Terrain/VisualHeightmapRuntime.cs
@@ -8,14 +8,21 @@ namespace Ludots.Core.Presentation.Terrain
     {
         private const int PreferredRenderChunkSampleSpan = 33;
         private readonly VisualHeightmapAsset _asset;
+        private readonly VisualHeightmapRenderProfile _renderProfile;
         private readonly int _renderChunkColumns;
         private readonly int _renderChunkRows;
         private readonly int _renderChunkStepColumns;
         private readonly int _renderChunkStepRows;
 
         public VisualHeightmapRuntime(VisualHeightmapAsset asset)
+            : this(asset, VisualHeightmapRenderProfile.CreateDefault())
+        {
+        }
+
+        public VisualHeightmapRuntime(VisualHeightmapAsset asset, VisualHeightmapRenderProfile renderProfile)
         {
             _asset = asset ?? throw new ArgumentNullException(nameof(asset));
+            _renderProfile = (renderProfile ?? throw new ArgumentNullException(nameof(renderProfile))).NormalizeAndValidate();
             _renderChunkColumns = ResolveRenderChunkCount(_asset.SampleColumns);
             _renderChunkRows = ResolveRenderChunkCount(_asset.SampleRows);
             _renderChunkStepColumns = ResolveRenderChunkStep(_asset.SampleColumns, _renderChunkColumns);
@@ -37,6 +44,8 @@ namespace Ludots.Core.Presentation.Terrain
         public int DefaultLayerIndex => _asset.DefaultLayerIndex;
 
         public int Revision => 0;
+
+        public VisualHeightmapRenderProfile RenderProfile => _renderProfile;
 
         public bool TryGetChunk(int chunkX, int chunkY, out VisualHeightmapRenderChunk chunk)
         {

--- a/src/Libraries/Arch/src/Arch/Core/Events/World.Events.cs
+++ b/src/Libraries/Arch/src/Arch/Core/Events/World.Events.cs
@@ -55,7 +55,11 @@ public partial class World
     /// <param name="handler">The delegate to call.</param>
     public void SubscribeEntityDestroyed(EntityDestroyedHandler handler)
     {
-        ArgumentNullException.ThrowIfNull(handler);
+        if (handler == null)
+        {
+            throw new ArgumentNullException(nameof(handler));
+        }
+
         lock (_entityDestroyedHandlersWriteLock)
         {
             EntityDestroyedHandler[] current = Volatile.Read(ref _entityDestroyedHandlers);

--- a/src/Libraries/Raylib-cs/Raylib.cs
+++ b/src/Libraries/Raylib-cs/Raylib.cs
@@ -594,6 +594,16 @@ namespace Raylib_cs
             MATERIAL_MAP_BRDF
         }
 
+        public enum TextureFilter
+        {
+            TEXTURE_FILTER_POINT = 0,
+            TEXTURE_FILTER_BILINEAR,
+            TEXTURE_FILTER_TRILINEAR,
+            TEXTURE_FILTER_ANISOTROPIC_4X,
+            TEXTURE_FILTER_ANISOTROPIC_8X,
+            TEXTURE_FILTER_ANISOTROPIC_16X
+        }
+
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern unsafe Image GenImageColor(int width, int height, Color color);
 
@@ -619,6 +629,9 @@ namespace Raylib_cs
         public static extern unsafe void UpdateTextureRec(Texture2D texture, Rectangle rec, void* pixels);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SetTextureFilter(Texture2D texture, TextureFilter filter);
+
+        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void DrawTexture(Texture2D texture, int posX, int posY, Color tint);
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl)]
@@ -638,6 +651,12 @@ namespace Raylib_cs
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void DrawTexturePro(Texture2D texture, Rectangle source, Rectangle dest, Vector2 origin, float rotation, Color tint);
+
+        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void BeginShaderMode(Shader shader);
+
+        [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void EndShaderMode();
 
         [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl)]
         public static extern void BeginBlendMode(BlendMode mode);

--- a/src/Platforms/Desktop/postprocess.fs
+++ b/src/Platforms/Desktop/postprocess.fs
@@ -1,0 +1,34 @@
+#version 330
+
+in vec2 fragTexCoord;
+in vec4 fragColor;
+
+uniform sampler2D texture0;
+uniform vec2 uResolution;
+uniform float uTime;
+uniform float uExposure;
+uniform float uContrast;
+uniform float uSaturation;
+uniform float uVignetteStrength;
+
+out vec4 finalColor;
+
+void main()
+{
+    vec4 source = texture(texture0, fragTexCoord) * fragColor;
+    vec3 color = source.rgb * uExposure;
+    color = ((color - 0.5) * uContrast) + 0.5;
+
+    float luma = dot(color, vec3(0.2126, 0.7152, 0.0722));
+    color = mix(vec3(luma), color, uSaturation);
+
+    vec2 uv = (fragTexCoord * 2.0) - 1.0;
+    uv.x *= uResolution.x / max(uResolution.y, 1.0);
+    float vignette = 1.0 - smoothstep(0.18, 1.85, dot(uv, uv));
+    color *= mix(1.0, vignette, uVignetteStrength);
+
+    float grain = fract(sin(dot(fragTexCoord * uResolution + uTime, vec2(12.9898, 78.233))) * 43758.5453);
+    color += (grain - 0.5) * 0.006;
+
+    finalColor = vec4(clamp(color, 0.0, 1.0), source.a);
+}

--- a/src/Platforms/Desktop/skybox.fs
+++ b/src/Platforms/Desktop/skybox.fs
@@ -1,0 +1,29 @@
+#version 330
+
+in vec3 fragDirection;
+
+uniform vec3 uSunDirection;
+uniform vec3 uSunColor;
+uniform vec3 uZenithColor;
+uniform vec3 uHorizonColor;
+uniform vec3 uGroundHazeColor;
+uniform float uTime;
+
+out vec4 finalColor;
+
+void main()
+{
+    vec3 direction = normalize(fragDirection);
+    vec3 sunDirection = normalize(uSunDirection);
+    float skyBand = smoothstep(-0.10, 0.85, direction.y);
+    vec3 sky = mix(uHorizonColor, uZenithColor, skyBand);
+    float groundBand = 1.0 - smoothstep(-0.22, 0.12, direction.y);
+    sky = mix(sky, uGroundHazeColor, groundBand * 0.42);
+
+    float sunDot = max(dot(direction, sunDirection), 0.0);
+    float sunDisk = pow(sunDot, 720.0);
+    float sunGlow = pow(sunDot, 22.0) * 0.34;
+    float airShimmer = sin((direction.x + direction.z + uTime * 0.012) * 18.0) * 0.006;
+    vec3 color = sky + (uSunColor * (sunGlow + sunDisk * 2.4)) + vec3(airShimmer);
+    finalColor = vec4(clamp(color, 0.0, 1.0), 1.0);
+}

--- a/src/Platforms/Desktop/skybox.vs
+++ b/src/Platforms/Desktop/skybox.vs
@@ -1,0 +1,16 @@
+#version 330
+
+in vec3 vertexPosition;
+
+uniform mat4 mvp;
+uniform mat4 matModel;
+
+out vec3 fragDirection;
+
+void main()
+{
+    vec4 worldPos = matModel * vec4(vertexPosition, 1.0);
+    vec3 worldOrigin = vec3(matModel[3][0], matModel[3][1], matModel[3][2]);
+    fragDirection = normalize(worldPos.xyz - worldOrigin);
+    gl_Position = mvp * vec4(vertexPosition, 1.0);
+}

--- a/src/Platforms/Desktop/terrain.fs
+++ b/src/Platforms/Desktop/terrain.fs
@@ -3,20 +3,36 @@
 in vec3 fragPos;
 in vec3 fragNormal;
 in vec4 fragColor;
+in vec2 fragTexCoord;
 
-uniform vec3 uLightPos;
 uniform vec3 uViewPos;
+uniform vec3 uSunDirection;
+uniform vec3 uSunColor;
+uniform vec3 uAmbientColor;
 uniform float uAmbient;
 uniform float uLightIntensity;
+uniform vec3 uFogColor;
+uniform float uFogNear;
+uniform float uFogFar;
+uniform float uFogDensity;
+uniform sampler2D texture0;
+uniform int uUseTexture;
 
 out vec4 finalColor;
 
 void main()
 {
     vec3 N = normalize(fragNormal);
-    vec3 L = normalize(uLightPos - fragPos);
-    float ndl = abs(dot(N, L));
-    vec3 lit = fragColor.rgb * (uAmbient + uLightIntensity * ndl);
-    finalColor = vec4(clamp(lit, 0.0, 1.0), fragColor.a);
-}
+    vec3 L = normalize(uSunDirection);
+    vec4 baseColor = uUseTexture == 1 ? texture(texture0, fragTexCoord) : fragColor;
+    float wrappedDiffuse = clamp(dot(N, L) * 0.5 + 0.5, 0.0, 1.0);
+    float directLight = wrappedDiffuse * wrappedDiffuse;
+    vec3 lit = baseColor.rgb * ((uAmbientColor * uAmbient) + (uSunColor * uLightIntensity * directLight));
 
+    float viewDistance = length(uViewPos - fragPos);
+    float linearFog = smoothstep(uFogNear, uFogFar, viewDistance);
+    float distanceFog = 1.0 - exp(-max(viewDistance - uFogNear, 0.0) * uFogDensity);
+    float fog = clamp(max(linearFog, distanceFog), 0.0, 1.0);
+    vec3 color = mix(clamp(lit, 0.0, 1.0), uFogColor, fog);
+    finalColor = vec4(color, baseColor.a);
+}

--- a/src/Platforms/Desktop/terrain.vs
+++ b/src/Platforms/Desktop/terrain.vs
@@ -3,6 +3,7 @@
 in vec3 vertexPosition;
 in vec3 vertexNormal;
 in vec4 vertexColor;
+in vec2 vertexTexCoord;
 
 uniform mat4 mvp;
 uniform mat4 matModel;
@@ -10,6 +11,7 @@ uniform mat4 matModel;
 out vec3 fragPos;
 out vec3 fragNormal;
 out vec4 fragColor;
+out vec2 fragTexCoord;
 
 void main()
 {
@@ -17,6 +19,7 @@ void main()
     fragPos = worldPos.xyz;
     fragNormal = normalize(mat3(matModel) * vertexNormal);
     fragColor = vertexColor;
+    fragTexCoord = vertexTexCoord;
     gl_Position = mvp * vec4(vertexPosition, 1.0);
 }
 

--- a/src/Platforms/Desktop/water.fs
+++ b/src/Platforms/Desktop/water.fs
@@ -3,26 +3,45 @@
 in vec3 fragPos;
 in vec3 fragNormal;
 in vec4 fragColor;
+in float fragWave;
 
-uniform vec3 uLightPos;
 uniform vec3 uViewPos;
+uniform vec3 uSunDirection;
+uniform vec3 uSunColor;
+uniform vec3 uAmbientColor;
 uniform float uAmbient;
 uniform float uLightIntensity;
+uniform vec3 uFogColor;
+uniform float uFogNear;
+uniform float uFogFar;
+uniform float uFogDensity;
+uniform vec3 uWaterShallowColor;
+uniform vec3 uWaterDeepColor;
+uniform float uFresnelStrength;
 
 out vec4 finalColor;
 
 void main()
 {
     vec3 N = normalize(fragNormal);
-    vec3 L = normalize(uLightPos - fragPos);
+    vec3 L = normalize(uSunDirection);
     vec3 V = normalize(uViewPos - fragPos);
     vec3 H = normalize(L + V);
 
-    float ndl = abs(dot(N, L));
-    float spec = pow(max(dot(N, H), 0.0), 48.0) * 0.08;
+    float ndl = clamp(dot(N, L) * 0.5 + 0.5, 0.0, 1.0);
+    float spec = pow(max(dot(N, H), 0.0), 96.0) * 0.22;
+    float fresnel = pow(1.0 - clamp(dot(N, V), 0.0, 1.0), 3.0) * uFresnelStrength;
 
-    vec3 base = fragColor.rgb;
-    vec3 lit = base * (uAmbient + uLightIntensity * ndl) + vec3(spec);
-    finalColor = vec4(clamp(lit, 0.0, 1.0), fragColor.a);
+    float waterBand = clamp(fragWave * 0.5 + 0.5, 0.0, 1.0);
+    vec3 base = mix(uWaterDeepColor, uWaterShallowColor, waterBand);
+    vec3 lit = base * ((uAmbientColor * uAmbient) + (uSunColor * uLightIntensity * ndl));
+    lit += uSunColor * (spec + fresnel * 0.24);
+
+    float viewDistance = length(uViewPos - fragPos);
+    float linearFog = smoothstep(uFogNear, uFogFar, viewDistance);
+    float distanceFog = 1.0 - exp(-max(viewDistance - uFogNear, 0.0) * uFogDensity);
+    float fog = clamp(max(linearFog, distanceFog), 0.0, 1.0);
+    vec3 color = mix(clamp(lit, 0.0, 1.0), uFogColor, fog);
+    float alpha = clamp(fragColor.a + fresnel, 0.42, 0.82);
+    finalColor = vec4(color, alpha);
 }
-

--- a/src/Platforms/Desktop/water.vs
+++ b/src/Platforms/Desktop/water.vs
@@ -6,17 +6,31 @@ in vec4 vertexColor;
 
 uniform mat4 mvp;
 uniform mat4 matModel;
+uniform float uTime;
+uniform float uWaveAmplitude;
+uniform float uWaveFrequency;
+uniform float uWaveSpeed;
 
 out vec3 fragPos;
 out vec3 fragNormal;
 out vec4 fragColor;
+out float fragWave;
 
 void main()
 {
-    vec4 worldPos = matModel * vec4(vertexPosition, 1.0);
-    fragPos = worldPos.xyz;
-    fragNormal = normalize(mat3(matModel) * vertexNormal);
-    fragColor = vertexColor;
-    gl_Position = mvp * vec4(vertexPosition, 1.0);
-}
+    float phaseA = (vertexPosition.x * uWaveFrequency) + (uTime * uWaveSpeed);
+    float phaseB = ((vertexPosition.z + vertexPosition.x * 0.37) * uWaveFrequency * 0.73) - (uTime * uWaveSpeed * 1.31);
+    float wave = (sin(phaseA) + cos(phaseB)) * 0.5;
+    vec3 displaced = vertexPosition + vec3(0.0, wave * uWaveAmplitude, 0.0);
 
+    float dx = cos(phaseA) * uWaveFrequency * uWaveAmplitude * 0.5;
+    float dz = -sin(phaseB) * uWaveFrequency * 0.73 * uWaveAmplitude * 0.5;
+    vec3 waveNormal = normalize(vec3(-dx, 1.0, -dz));
+
+    vec4 worldPos = matModel * vec4(displaced, 1.0);
+    fragPos = worldPos.xyz;
+    fragNormal = normalize(mat3(matModel) * waveNormal);
+    fragColor = vertexColor;
+    fragWave = wave;
+    gl_Position = mvp * vec4(displaced, 1.0);
+}

--- a/src/Tests/ArchitectureTests/PresentationBehaviorAndPrefabConfigContractTests.cs
+++ b/src/Tests/ArchitectureTests/PresentationBehaviorAndPrefabConfigContractTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using Ludots.Core.Config;
 using Ludots.Core.Engine;
 using Ludots.Core.EntityCollections;
@@ -55,6 +56,240 @@ namespace Ludots.Tests.Architecture
             var ex = Assert.Throws<InvalidOperationException>(() =>
                 new MeshAssetConfigLoader(pipeline, meshes, prefabs).Load(catalog));
             Assert.That(ex!.Message, Does.Contain("must declare an explicit kind"));
+        }
+
+        [Test]
+        public void MeshAssetConfigLoader_PrefabVfxEffectAssetId_ResolvesMeshAssetKey()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "Ludots_PresentationVfxConfigContracts", Guid.NewGuid().ToString("N"));
+            string core = Path.Combine(root, "Core");
+            Directory.CreateDirectory(Path.Combine(core, "Configs", "Presentation"));
+            WriteCatalog(core, "Presentation/mesh_assets.json", "ArrayById", "id", "Presentation/prefabs.json", "ArrayById", "id");
+            File.WriteAllText(Path.Combine(core, "Configs", "Presentation", "mesh_assets.json"), """
+[
+  { "id": "cube", "type": "Primitive", "primitiveKind": "Cube" },
+  {
+    "id": "effect.spark",
+    "type": "Primitive",
+    "primitiveKind": "Sphere",
+    "vfx": {
+      "emitter": {
+        "shape": "PrimitiveSphere",
+        "particleCount": 24,
+        "ringSegments": 20,
+        "radiusScale": 1.15,
+        "coreRadiusScale": 0.28,
+        "particleRadiusScale": 0.085,
+        "lifetimeSeconds": 0.75,
+        "pulseSpeedRadPerSecond": 5.2,
+        "orbitSpeedRadPerSecond": 1.7
+      }
+    }
+  }
+]
+""");
+            File.WriteAllText(Path.Combine(core, "Configs", "Presentation", "prefabs.json"), """
+[
+  {
+    "id": "prefab.vfx",
+    "parts": [
+      {
+        "kind": "Vfx",
+        "effectAssetId": "effect.spark",
+        "spawnMode": "Loop"
+      }
+    ]
+  }
+]
+""");
+
+            var vfs = new VirtualFileSystem();
+            vfs.Mount("Core", core);
+            var pipeline = new ConfigPipeline(vfs, modLoader: null!);
+            var catalog = ConfigCatalogLoader.Load(pipeline);
+            var meshes = new MeshAssetRegistry();
+            var prefabs = new PrefabRegistry();
+
+            new MeshAssetConfigLoader(pipeline, meshes, prefabs).Load(catalog);
+
+            int prefabMeshId = meshes.GetId("prefab.vfx");
+            Assert.That(meshes.TryGetDescriptor(prefabMeshId, out MeshAssetDescriptor descriptor), Is.True);
+            Assert.That(descriptor.PrefabParts[0].EffectAssetId, Is.EqualTo(meshes.GetId("effect.spark")));
+            Assert.That(descriptor.PrefabParts[0].VfxSpawnMode, Is.EqualTo(PrefabVfxSpawnMode.Loop));
+        }
+
+        [Test]
+        public void MeshAssetConfigLoader_PrefabVfxEffectAssetId_RejectsRawNumber()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "Ludots_PresentationVfxConfigContracts", Guid.NewGuid().ToString("N"));
+            string core = Path.Combine(root, "Core");
+            Directory.CreateDirectory(Path.Combine(core, "Configs", "Presentation"));
+            WriteCatalog(core, "Presentation/mesh_assets.json", "ArrayById", "id", "Presentation/prefabs.json", "ArrayById", "id");
+            File.WriteAllText(Path.Combine(core, "Configs", "Presentation", "mesh_assets.json"), """
+[
+  { "id": "cube", "type": "Primitive", "primitiveKind": "Cube" }
+]
+""");
+            File.WriteAllText(Path.Combine(core, "Configs", "Presentation", "prefabs.json"), """
+[
+  {
+    "id": "prefab.bad.vfx",
+    "parts": [
+      {
+        "kind": "Vfx",
+        "effectAssetId": 201
+      }
+    ]
+  }
+]
+""");
+
+            var vfs = new VirtualFileSystem();
+            vfs.Mount("Core", core);
+            var pipeline = new ConfigPipeline(vfs, modLoader: null!);
+            var catalog = ConfigCatalogLoader.Load(pipeline);
+            var meshes = new MeshAssetRegistry();
+            var prefabs = new PrefabRegistry();
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                new MeshAssetConfigLoader(pipeline, meshes, prefabs).Load(catalog));
+            Assert.That(ex!.Message, Does.Contain("effectAssetId must be a non-empty asset key"));
+        }
+
+        [Test]
+        public void MeshAssetConfigLoader_PrefabVfxEffectAssetId_RejectsAssetWithoutVfxEmitterData()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "Ludots_PresentationVfxConfigContracts", Guid.NewGuid().ToString("N"));
+            string core = Path.Combine(root, "Core");
+            Directory.CreateDirectory(Path.Combine(core, "Configs", "Presentation"));
+            WriteCatalog(core, "Presentation/mesh_assets.json", "ArrayById", "id", "Presentation/prefabs.json", "ArrayById", "id");
+            File.WriteAllText(Path.Combine(core, "Configs", "Presentation", "mesh_assets.json"), """
+[
+  { "id": "effect.spark", "type": "Billboard" }
+]
+""");
+            File.WriteAllText(Path.Combine(core, "Configs", "Presentation", "prefabs.json"), """
+[
+  {
+    "id": "prefab.bad.vfx",
+    "parts": [
+      {
+        "kind": "Vfx",
+        "effectAssetId": "effect.spark"
+      }
+    ]
+  }
+]
+""");
+
+            var vfs = new VirtualFileSystem();
+            vfs.Mount("Core", core);
+            var pipeline = new ConfigPipeline(vfs, modLoader: null!);
+            var catalog = ConfigCatalogLoader.Load(pipeline);
+            var meshes = new MeshAssetRegistry();
+            var prefabs = new PrefabRegistry();
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                new MeshAssetConfigLoader(pipeline, meshes, prefabs).Load(catalog));
+            Assert.That(ex!.Message, Does.Contain("without vfx emitter data"));
+        }
+
+        [Test]
+        public void MeshAssetConfigLoader_VfxEmitterShape_RejectsNumericString()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "Ludots_PresentationVfxConfigContracts", Guid.NewGuid().ToString("N"));
+            string core = Path.Combine(root, "Core");
+            Directory.CreateDirectory(Path.Combine(core, "Configs", "Presentation"));
+            WriteCatalog(core, "Presentation/mesh_assets.json", "ArrayById", "id");
+            File.WriteAllText(Path.Combine(core, "Configs", "Presentation", "mesh_assets.json"), """
+[
+  {
+    "id": "effect.spark",
+    "type": "Billboard",
+    "vfx": {
+      "emitter": {
+        "shape": "99",
+        "particleCount": 24,
+        "ringSegments": 20,
+        "radiusScale": 1.15,
+        "coreRadiusScale": 0.28,
+        "particleRadiusScale": 0.085,
+        "lifetimeSeconds": 0.75,
+        "pulseSpeedRadPerSecond": 5.2,
+        "orbitSpeedRadPerSecond": 1.7
+      }
+    }
+  }
+]
+""");
+
+            var vfs = new VirtualFileSystem();
+            vfs.Mount("Core", core);
+            var pipeline = new ConfigPipeline(vfs, modLoader: null!);
+            var catalog = ConfigCatalogLoader.Load(pipeline);
+            var meshes = new MeshAssetRegistry();
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                new MeshAssetConfigLoader(pipeline, meshes).Load(catalog));
+            Assert.That(ex!.Message, Does.Contain("vfx.emitter.shape"));
+            Assert.That(ex.Message, Does.Contain("not a numeric string"));
+        }
+
+        [Test]
+        public void MeshAssetConfigLoader_PrefabVfxSpawnMode_RejectsNumericString()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "Ludots_PresentationVfxConfigContracts", Guid.NewGuid().ToString("N"));
+            string core = Path.Combine(root, "Core");
+            Directory.CreateDirectory(Path.Combine(core, "Configs", "Presentation"));
+            WriteCatalog(core, "Presentation/mesh_assets.json", "ArrayById", "id", "Presentation/prefabs.json", "ArrayById", "id");
+            File.WriteAllText(Path.Combine(core, "Configs", "Presentation", "mesh_assets.json"), """
+[
+  {
+    "id": "effect.spark",
+    "type": "Primitive",
+    "primitiveKind": "Sphere",
+    "vfx": {
+      "emitter": {
+        "shape": "PrimitiveSphere",
+        "particleCount": 24,
+        "ringSegments": 20,
+        "radiusScale": 1.15,
+        "coreRadiusScale": 0.28,
+        "particleRadiusScale": 0.085,
+        "lifetimeSeconds": 0.75,
+        "pulseSpeedRadPerSecond": 5.2,
+        "orbitSpeedRadPerSecond": 1.7
+      }
+    }
+  }
+]
+""");
+            File.WriteAllText(Path.Combine(core, "Configs", "Presentation", "prefabs.json"), """
+[
+  {
+    "id": "prefab.bad.spawn",
+    "parts": [
+      {
+        "kind": "Vfx",
+        "effectAssetId": "effect.spark",
+        "spawnMode": "99"
+      }
+    ]
+  }
+]
+""");
+
+            var vfs = new VirtualFileSystem();
+            vfs.Mount("Core", core);
+            var pipeline = new ConfigPipeline(vfs, modLoader: null!);
+            var catalog = ConfigCatalogLoader.Load(pipeline);
+            var meshes = new MeshAssetRegistry();
+            var prefabs = new PrefabRegistry();
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                new MeshAssetConfigLoader(pipeline, meshes, prefabs).Load(catalog));
+            Assert.That(ex!.Message, Does.Contain("VFX spawnMode"));
+            Assert.That(ex.Message, Does.Contain("not a numeric string"));
         }
 
         [Test]
@@ -113,6 +348,33 @@ namespace Ludots.Tests.Architecture
 
             Assert.That(engine.GetService(CoreServiceKeys.PresentationBehaviorRegistry), Is.Not.Null);
             Assert.That(engine.GetService(CoreServiceKeys.PresentationBehaviorResolver), Is.Not.Null);
+        }
+
+        [Test]
+        public void BlacksmithSmokeShowcases_AuthorVfxEmitterWithoutRaylibHostTexture()
+        {
+            string repoRoot = FindRepoRoot();
+
+            AssertSmokeAssetIsPrimitiveVfx(
+                repoRoot,
+                Path.Combine(
+                    "mods",
+                    "showcases",
+                    "performer_blacksmith",
+                    "PerformerBlacksmithShowcaseMod",
+                    "assets",
+                    "Presentation"),
+                "blacksmith.smoke.billboard");
+            AssertSmokeAssetIsPrimitiveVfx(
+                repoRoot,
+                Path.Combine(
+                    "mods",
+                    "showcases",
+                    "capability_standard",
+                    "CapabilityStandardStaticPerformer30kMod",
+                    "assets",
+                    "Presentation"),
+                "capability_static_performer.smoke.billboard");
         }
 
         [Test]
@@ -1217,11 +1479,15 @@ namespace Ludots.Tests.Architecture
                 color: System.Numerics.Vector4.One,
                 output);
 
-            PrefabVisualPartKind[] kinds = output.GetSpan().ToArray().Select(static visual => visual.Kind).ToArray();
+            PrefabFinalizedVisual[] visuals = output.GetSpan().ToArray();
+            PrefabVisualPartKind[] kinds = visuals.Select(static visual => visual.Kind).ToArray();
             Assert.That(kinds, Does.Contain(PrefabVisualPartKind.Mesh));
             Assert.That(kinds, Does.Contain(PrefabVisualPartKind.Decal));
             Assert.That(kinds, Does.Contain(PrefabVisualPartKind.Vfx));
             Assert.That(kinds, Does.Contain(PrefabVisualPartKind.Surface));
+            Assert.That(
+                visuals.Single(static visual => visual.Kind == PrefabVisualPartKind.Vfx).EffectAssetId,
+                Is.EqualTo(meshes.GetId("effect.camera.projection_cue")));
         }
 
         private static string FindRepoRoot()
@@ -1239,6 +1505,51 @@ namespace Ludots.Tests.Architecture
             }
 
             throw new DirectoryNotFoundException("Could not locate repo root containing src/Core/Ludots.Core.csproj");
+        }
+
+        private static void AssertSmokeAssetIsPrimitiveVfx(
+            string repoRoot,
+            string presentationRelativeDirectory,
+            string smokeAssetId)
+        {
+            string presentationDirectory = Path.Combine(repoRoot, presentationRelativeDirectory);
+            JsonObject meshAsset = RequireJsonObjectById(
+                Path.Combine(presentationDirectory, "mesh_assets.json"),
+                smokeAssetId);
+
+            Assert.That(meshAsset["type"]?.GetValue<string>(), Is.EqualTo("Primitive"));
+            Assert.That(meshAsset["primitiveKind"]?.GetValue<string>(), Is.EqualTo("Sphere"));
+            Assert.That(meshAsset["vfx"]?["emitter"]?["shape"]?.GetValue<string>(), Is.EqualTo("PrimitiveSphere"));
+            Assert.That(meshAsset["vfx"]?["emitter"]?["particleCount"]?.GetValue<int>(), Is.GreaterThan(0));
+
+            JsonArray hostAssets = ReadJsonArray(Path.Combine(presentationDirectory, "host_assets.json"));
+            foreach (JsonNode? node in hostAssets)
+            {
+                Assert.That(
+                    node?["assetId"]?.GetValue<string>(),
+                    Is.Not.EqualTo(smokeAssetId),
+                    "Raylib host texture registration must not target authored Primitive VFX smoke.");
+            }
+        }
+
+        private static JsonObject RequireJsonObjectById(string path, string id)
+        {
+            foreach (JsonNode? node in ReadJsonArray(path))
+            {
+                if (node is JsonObject candidate &&
+                    string.Equals(candidate["id"]?.GetValue<string>(), id, StringComparison.Ordinal))
+                {
+                    return candidate;
+                }
+            }
+
+            throw new InvalidOperationException($"Config object '{id}' was not found in '{path}'.");
+        }
+
+        private static JsonArray ReadJsonArray(string path)
+        {
+            return JsonNode.Parse(File.ReadAllText(path))?.AsArray()
+                ?? throw new InvalidOperationException($"Config file '{path}' must contain a JSON array.");
         }
 
         private static void WriteCatalog(string coreRoot, params string[] triples)

--- a/src/Tests/ArchitectureTests/PresentationBehaviorAndPrefabConfigContractTests.cs
+++ b/src/Tests/ArchitectureTests/PresentationBehaviorAndPrefabConfigContractTests.cs
@@ -82,8 +82,14 @@ namespace Ludots.Tests.Architecture
         "particleRadiusScale": 0.085,
         "lifetimeSeconds": 0.75,
         "pulseSpeedRadPerSecond": 5.2,
-        "orbitSpeedRadPerSecond": 1.7
-      }
+        "orbitSpeedRadPerSecond": 1.7,
+        "shellRingCount": 2,
+        "beamCount": 3
+      },
+      "spawnMode": "Loop",
+      "coreColor": [0.2, 0.85, 1, 0.88],
+      "shellColor": [0.55, 0.95, 1, 0.62],
+      "particleColor": [1, 0.92, 0.32, 0.86]
     }
   }
 ]
@@ -216,8 +222,14 @@ namespace Ludots.Tests.Architecture
         "particleRadiusScale": 0.085,
         "lifetimeSeconds": 0.75,
         "pulseSpeedRadPerSecond": 5.2,
-        "orbitSpeedRadPerSecond": 1.7
-      }
+        "orbitSpeedRadPerSecond": 1.7,
+        "shellRingCount": 2,
+        "beamCount": 3
+      },
+      "spawnMode": "Loop",
+      "coreColor": [0.2, 0.85, 1, 0.88],
+      "shellColor": [0.55, 0.95, 1, 0.62],
+      "particleColor": [1, 0.92, 0.32, 0.86]
     }
   }
 ]
@@ -258,8 +270,14 @@ namespace Ludots.Tests.Architecture
         "particleRadiusScale": 0.085,
         "lifetimeSeconds": 0.75,
         "pulseSpeedRadPerSecond": 5.2,
-        "orbitSpeedRadPerSecond": 1.7
-      }
+        "orbitSpeedRadPerSecond": 1.7,
+        "shellRingCount": 2,
+        "beamCount": 3
+      },
+      "spawnMode": "Loop",
+      "coreColor": [0.2, 0.85, 1, 0.88],
+      "shellColor": [0.55, 0.95, 1, 0.62],
+      "particleColor": [1, 0.92, 0.32, 0.86]
     }
   }
 ]
@@ -1521,6 +1539,12 @@ namespace Ludots.Tests.Architecture
             Assert.That(meshAsset["primitiveKind"]?.GetValue<string>(), Is.EqualTo("Sphere"));
             Assert.That(meshAsset["vfx"]?["emitter"]?["shape"]?.GetValue<string>(), Is.EqualTo("PrimitiveSphere"));
             Assert.That(meshAsset["vfx"]?["emitter"]?["particleCount"]?.GetValue<int>(), Is.GreaterThan(0));
+            Assert.That(meshAsset["vfx"]?["emitter"]?["shellRingCount"]?.GetValue<int>(), Is.GreaterThanOrEqualTo(0));
+            Assert.That(meshAsset["vfx"]?["emitter"]?["beamCount"]?.GetValue<int>(), Is.GreaterThanOrEqualTo(0));
+            Assert.That(meshAsset["vfx"]?["spawnMode"]?.GetValue<string>(), Is.EqualTo("Loop"));
+            Assert.That(meshAsset["vfx"]?["coreColor"], Is.TypeOf<JsonArray>());
+            Assert.That(meshAsset["vfx"]?["shellColor"], Is.TypeOf<JsonArray>());
+            Assert.That(meshAsset["vfx"]?["particleColor"], Is.TypeOf<JsonArray>());
 
             JsonArray hostAssets = ReadJsonArray(Path.Combine(presentationDirectory, "host_assets.json"));
             foreach (JsonNode? node in hostAssets)

--- a/src/Tests/GasTests/Map/MapVisualHeightmapContractTests.cs
+++ b/src/Tests/GasTests/Map/MapVisualHeightmapContractTests.cs
@@ -132,6 +132,37 @@ namespace Ludots.Tests.Gas
         }
 
         [Test]
+        public void LoadMap_BindsVisualHeightmapRenderProfileThroughRenderSource()
+        {
+            WriteHeightmap("outer.vhtm", -75);
+            WriteMap("outer_map", """
+            {
+              "id": "outer_map",
+              "visualHeightmap": {
+                "asset": "assets/terrain/outer.vhtm",
+                "renderProfile": {
+                  "waterEnabled": true,
+                  "seaLevelCm": 0,
+                  "displayHeightScale": 500,
+                  "colorContrast": 1.4
+                }
+              }
+            }
+            """);
+
+            using var engine = CreateEngine();
+            engine.LoadMap("outer_map");
+
+            IVisualHeightmap heightmap = engine.GetService(CoreServiceKeys.VisualHeightmap);
+            Assert.That(heightmap, Is.AssignableTo<IVisualHeightmapRenderSource>());
+            var renderSource = (IVisualHeightmapRenderSource)heightmap;
+            Assert.That(renderSource.RenderProfile.WaterEnabled, Is.True);
+            Assert.That(renderSource.RenderProfile.SeaLevelCm, Is.EqualTo(0f));
+            Assert.That(renderSource.RenderProfile.DisplayHeightScale, Is.EqualTo(500f));
+            Assert.That(renderSource.RenderProfile.ColorContrast, Is.EqualTo(1.4f));
+        }
+
+        [Test]
         public void LoadMap_WhenDeclaredVisualHeightmapMissing_ThrowsExplicitly()
         {
             WriteMap("outer_map", """

--- a/src/Tests/PresentationTests/Core/PresentationFoundationTests.cs
+++ b/src/Tests/PresentationTests/Core/PresentationFoundationTests.cs
@@ -1624,13 +1624,32 @@ namespace Ludots.Tests.Presentation
             var meshes = new MeshAssetRegistry();
 
             int cubeId = meshes.GetId(WellKnownMeshKeys.Cube);
+            MeshAssetDescriptor effectDescriptor = MeshAssetDescriptor.Primitive(0, PrimitiveMeshKind.Sphere);
+            effectDescriptor.VfxEffectData = new VfxEffectAssetData(
+                new VfxEmitterDescriptor(
+                    VfxEmitterShape.PrimitiveSphere,
+                    particleCount: 6,
+                    ringSegments: 8,
+                    radiusScale: 1f,
+                    coreRadiusScale: 0.35f,
+                    particleRadiusScale: 0.18f,
+                    lifetimeSeconds: 1.2f,
+                    pulseSpeedRadPerSecond: 2f,
+                    orbitSpeedRadPerSecond: 1f,
+                    shellRingCount: 1,
+                    beamCount: 1),
+                PrefabVfxSpawnMode.Loop,
+                new Vector4(0.8f, 0.9f, 1f, 1f),
+                new Vector4(0.3f, 0.6f, 1f, 0.55f),
+                new Vector4(1f, 0.85f, 0.35f, 0.9f));
+            int effectId = meshes.Register("test.prefab.typed_root.effect", in effectDescriptor);
             int typedPrefabMeshId = meshes.Register(
                 "test.prefab.typed_root",
                 MeshAssetDescriptor.Prefab(
                     0,
                     PrefabPart.Default(cubeId),
                     PrefabPart.Decal(materialId: 17, size: new Vector2(2f, 3f)),
-                    PrefabPart.Vfx(effectAssetId: 23, spawnMode: PrefabVfxSpawnMode.Loop),
+                    PrefabPart.Vfx(effectAssetId: effectId, spawnMode: PrefabVfxSpawnMode.Once),
                     PrefabPart.Surface(cubeId, materialId: 31, tiling: new Vector2(2f, 2f))));
             int prefabId = prefabs.Register(
                 "test.prefab.typed_root",

--- a/src/Tests/PresentationTests/Performer/BlacksmithPerformerUatTests.cs
+++ b/src/Tests/PresentationTests/Performer/BlacksmithPerformerUatTests.cs
@@ -140,6 +140,7 @@ namespace Ludots.Tests.Presentation
                 "src",
                 "Tests",
                 "PresentationTests",
+                "Performer",
                 "BlacksmithPerformerUatTests.cs");
 
             string source = File.ReadAllText(sourcePath);
@@ -584,12 +585,31 @@ namespace Ludots.Tests.Presentation
                 {
                     return kind switch
                     {
-                        AssetKind.Mesh or AssetKind.SkinnedMesh or AssetKind.VFX => meshAssets.GetId(key),
+                        AssetKind.Mesh or AssetKind.SkinnedMesh => meshAssets.GetId(key),
+                        AssetKind.VFX => ResolveVfxFixtureAssetId(key),
                         AssetKind.Spline when string.Equals(key, PatrolSplineAssetKey, StringComparison.Ordinal) => PatrolSplineAssetId,
                         AssetKind.Sound when string.Equals(key, HammerSoundAssetKey, StringComparison.Ordinal) => HammerSoundAssetId,
                         _ => throw new InvalidOperationException(
                             $"Blacksmith performer UAT has no fixture asset registered for {kind} '{key}'."),
                     };
+                }
+
+                int ResolveVfxFixtureAssetId(string key)
+                {
+                    int assetId = meshAssets.GetId(key);
+                    if (assetId <= 0)
+                    {
+                        return 0;
+                    }
+
+                    if (!meshAssets.TryGetDescriptor(assetId, out MeshAssetDescriptor descriptor) ||
+                        !descriptor.VfxEffectData.IsValid)
+                    {
+                        throw new InvalidOperationException(
+                            $"Blacksmith performer UAT VFX fixture asset '{key}' must declare vfx emitter data.");
+                    }
+
+                    return assetId;
                 }
 
                 int ResolveUnsupportedEffectTemplateId(string key)
@@ -612,7 +632,7 @@ namespace Ludots.Tests.Presentation
                 RegisterPrimitiveMesh(meshAssets, WorkshopDamagedAssetKey);
                 RegisterPrimitiveMesh(meshAssets, WorkshopRuinedAssetKey);
                 RegisterPrimitiveMesh(meshAssets, FurnaceAssetKey);
-                RegisterPrimitiveMesh(meshAssets, SmokeAssetKey);
+                RegisterVfxEffect(meshAssets, SmokeAssetKey);
                 RegisterPrimitiveMesh(meshAssets, WorkerAssetKey);
                 materialAssets.Register(
                     BrickNorthMaterialKey,
@@ -629,6 +649,22 @@ namespace Ludots.Tests.Presentation
             private static void RegisterPrimitiveMesh(MeshAssetRegistry meshAssets, string key)
             {
                 MeshAssetDescriptor descriptor = MeshAssetDescriptor.Primitive(0, PrimitiveMeshKind.Cube);
+                meshAssets.Register(key, in descriptor);
+            }
+
+            private static void RegisterVfxEffect(MeshAssetRegistry meshAssets, string key)
+            {
+                MeshAssetDescriptor descriptor = MeshAssetDescriptor.Primitive(0, PrimitiveMeshKind.Sphere);
+                descriptor.VfxEffectData = new VfxEffectAssetData(new VfxEmitterDescriptor(
+                    VfxEmitterShape.PrimitiveSphere,
+                    particleCount: 24,
+                    ringSegments: 20,
+                    radiusScale: 1.15f,
+                    coreRadiusScale: 0.28f,
+                    particleRadiusScale: 0.085f,
+                    lifetimeSeconds: 0.75f,
+                    pulseSpeedRadPerSecond: 5.2f,
+                    orbitSpeedRadPerSecond: 1.7f));
                 meshAssets.Register(key, in descriptor);
             }
 

--- a/src/Tests/PresentationTests/Performer/BlacksmithPerformerUatTests.cs
+++ b/src/Tests/PresentationTests/Performer/BlacksmithPerformerUatTests.cs
@@ -655,16 +655,23 @@ namespace Ludots.Tests.Presentation
             private static void RegisterVfxEffect(MeshAssetRegistry meshAssets, string key)
             {
                 MeshAssetDescriptor descriptor = MeshAssetDescriptor.Primitive(0, PrimitiveMeshKind.Sphere);
-                descriptor.VfxEffectData = new VfxEffectAssetData(new VfxEmitterDescriptor(
-                    VfxEmitterShape.PrimitiveSphere,
-                    particleCount: 24,
-                    ringSegments: 20,
-                    radiusScale: 1.15f,
-                    coreRadiusScale: 0.28f,
-                    particleRadiusScale: 0.085f,
-                    lifetimeSeconds: 0.75f,
-                    pulseSpeedRadPerSecond: 5.2f,
-                    orbitSpeedRadPerSecond: 1.7f));
+                descriptor.VfxEffectData = new VfxEffectAssetData(
+                    new VfxEmitterDescriptor(
+                        VfxEmitterShape.PrimitiveSphere,
+                        particleCount: 24,
+                        ringSegments: 20,
+                        radiusScale: 1.15f,
+                        coreRadiusScale: 0.28f,
+                        particleRadiusScale: 0.085f,
+                        lifetimeSeconds: 0.75f,
+                        pulseSpeedRadPerSecond: 5.2f,
+                        orbitSpeedRadPerSecond: 1.7f,
+                        shellRingCount: 2,
+                        beamCount: 0),
+                    PrefabVfxSpawnMode.Loop,
+                    new Vector4(0.42f, 0.43f, 0.39f, 0.48f),
+                    new Vector4(0.72f, 0.72f, 0.67f, 0.32f),
+                    new Vector4(0.86f, 0.83f, 0.74f, 0.42f));
                 meshAssets.Register(key, in descriptor);
             }
 

--- a/src/Tests/PresentationTests/Performer/PerformerBlacksmithShowcaseRuntimeTests.cs
+++ b/src/Tests/PresentationTests/Performer/PerformerBlacksmithShowcaseRuntimeTests.cs
@@ -85,6 +85,27 @@ namespace Ludots.Tests.Presentation
             return count;
         }
 
+        private static int CountVisiblePrimitivesByMeshAndKind(
+            Ludots.Core.Engine.GameEngine engine,
+            int meshAssetId,
+            AssetKind assetKind)
+        {
+            var primitives = engine.GetService(CoreServiceKeys.PresentationPrimitiveDrawBuffer)
+                ?? throw new InvalidOperationException("PrimitiveDrawBuffer missing.");
+            int count = 0;
+            foreach (ref readonly PrimitiveDrawItem item in primitives.GetSpan())
+            {
+                if (item.Visibility == VisualVisibility.Visible &&
+                    item.MeshAssetId == meshAssetId &&
+                    item.AssetKind == assetKind)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
         private static int CountVisibleSkinnedByMesh(Ludots.Core.Engine.GameEngine engine, int meshAssetId)
         {
             var skinned = engine.GetService(CoreServiceKeys.PresentationSkinnedVisualBatchBuffer)
@@ -245,6 +266,10 @@ namespace Ludots.Tests.Presentation
 
             int smokeMeshId = ResolveMeshAssetId(engine, "blacksmith.smoke.billboard");
             int workerMeshId = ResolveMeshAssetId(engine, "blacksmith.worker.knight");
+            var meshes = engine.GetService(CoreServiceKeys.PresentationMeshAssetRegistry)
+                ?? throw new InvalidOperationException("MeshAssetRegistry missing.");
+            Assert.That(meshes.TryGetDescriptor(smokeMeshId, out MeshAssetDescriptor smokeDescriptor), Is.True);
+            Assert.That(smokeDescriptor.VfxEffectData.IsValid, Is.True, "Blacksmith smoke must be an authored VFX effect asset, not a plain billboard fallback.");
             int smokeDefId = ResolvePerformerDefId(engine, PerformerBlacksmithShowcaseIds.SmokeDefinitionId);
             int workerDefId = ResolvePerformerDefId(engine, PerformerBlacksmithShowcaseIds.WorkerDefinitionId);
             var sounds = engine.GetService(CoreServiceKeys.SoundRequestBuffer)
@@ -265,6 +290,7 @@ namespace Ludots.Tests.Presentation
             PerformerBlacksmithShowcaseTestHarness.Tick(engine, 8);
 
             Assert.That(CountVisiblePrimitivesByMesh(engine, smokeMeshId), Is.GreaterThanOrEqualTo(1), "Smoke should become visible when working.");
+            Assert.That(CountVisiblePrimitivesByMeshAndKind(engine, smokeMeshId, AssetKind.VFX), Is.GreaterThanOrEqualTo(1), "Smoke should enter the VFX renderer path.");
             Assert.That(CountVisibleSkinnedByMesh(engine, workerMeshId), Is.GreaterThanOrEqualTo(1), "Worker should become visible when working.");
             Assert.That(sounds.Count, Is.GreaterThanOrEqualTo(1), "Worker sound loop should emit when working.");
             Assert.That((engine.World.Get<PerformerState>(smokeEntity).BehaviorActiveMask & (1u << 0)) != 0u, Is.True, "Smoke asset binding slot should be active.");

--- a/src/Tests/PresentationTests/Performer/PerformerDynamicWorkerBenchmarkTests.cs
+++ b/src/Tests/PresentationTests/Performer/PerformerDynamicWorkerBenchmarkTests.cs
@@ -140,7 +140,12 @@ namespace Ludots.Tests.Presentation
             const string expectedHeightmapAsset = "assets/terrain/performer_blacksmith_minimap_marker_large_world_relief.vhtm";
             Assert.That(engine.CurrentMapSession?.MapConfig.VisualHeightmapAsset, Is.EqualTo(expectedHeightmapAsset));
             Assert.That(engine.CurrentMapSession?.MapConfig.DefaultCamera?.VirtualCameraId, Is.EqualTo("PerformerBlacksmith.Camera.LargeWorldHeightmap"));
-            Assert.That(engine.GetService(CoreServiceKeys.VisualHeightmap), Is.AssignableTo<IVisualHeightmapRenderSource>());
+            IVisualHeightmapRenderSource renderSource = engine.GetService(CoreServiceKeys.VisualHeightmap) as IVisualHeightmapRenderSource
+                ?? throw new InvalidOperationException("VisualHeightmap render source missing.");
+            Assert.That(renderSource.RenderProfile.WaterEnabled, Is.True);
+            Assert.That(renderSource.RenderProfile.SeaLevelCm, Is.EqualTo(0f));
+            Assert.That(renderSource.RenderProfile.DisplayHeightScale, Is.EqualTo(1.25f));
+            Assert.That(renderSource.RenderProfile.ColorContrast, Is.EqualTo(1.35f));
 
             VirtualCameraRegistry cameraRegistry = engine.GetService(CoreServiceKeys.VirtualCameraRegistry)
                 ?? throw new InvalidOperationException("VirtualCameraRegistry missing.");

--- a/src/Tests/PresentationTests/Rendering/InstancedBatchContractTests.cs
+++ b/src/Tests/PresentationTests/Rendering/InstancedBatchContractTests.cs
@@ -1415,7 +1415,7 @@ namespace Ludots.Tests.Presentation
             registry = new InstancedBatchAssetRegistry();
 
             meshes.Register("mesh.unit", MeshAssetDescriptor.Model(0));
-            meshes.Register("effect.batch.spark", MeshAssetDescriptor.Billboard(0));
+            meshes.Register("effect.batch.spark", CreateEffectDescriptor());
 
             materials.Register("material.unit", MaterialAssetDomain.Surface, Array.Empty<string>(), MaterialAssetFlags.None);
             return new InstancedBatchAssetConfigLoader(
@@ -1433,6 +1433,22 @@ namespace Ludots.Tests.Presentation
             return eventKind == PresentationEventKind.EffectApplied
                 ? EffectTemplateIdRegistry.GetId(key)
                 : AbilityIdRegistry.GetId(key);
+        }
+
+        private static MeshAssetDescriptor CreateEffectDescriptor()
+        {
+            MeshAssetDescriptor descriptor = MeshAssetDescriptor.Primitive(0, PrimitiveMeshKind.Sphere);
+            descriptor.VfxEffectData = new VfxEffectAssetData(new VfxEmitterDescriptor(
+                VfxEmitterShape.PrimitiveSphere,
+                particleCount: 24,
+                ringSegments: 20,
+                radiusScale: 1.15f,
+                coreRadiusScale: 0.28f,
+                particleRadiusScale: 0.085f,
+                lifetimeSeconds: 0.75f,
+                pulseSpeedRadPerSecond: 5.2f,
+                orbitSpeedRadPerSecond: 1.7f));
+            return descriptor;
         }
 
         private static int ResolvePresentationEventKey(PresentationEventKind eventKind, string key)

--- a/src/Tests/PresentationTests/Rendering/InstancedBatchContractTests.cs
+++ b/src/Tests/PresentationTests/Rendering/InstancedBatchContractTests.cs
@@ -1438,16 +1438,23 @@ namespace Ludots.Tests.Presentation
         private static MeshAssetDescriptor CreateEffectDescriptor()
         {
             MeshAssetDescriptor descriptor = MeshAssetDescriptor.Primitive(0, PrimitiveMeshKind.Sphere);
-            descriptor.VfxEffectData = new VfxEffectAssetData(new VfxEmitterDescriptor(
-                VfxEmitterShape.PrimitiveSphere,
-                particleCount: 24,
-                ringSegments: 20,
-                radiusScale: 1.15f,
-                coreRadiusScale: 0.28f,
-                particleRadiusScale: 0.085f,
-                lifetimeSeconds: 0.75f,
-                pulseSpeedRadPerSecond: 5.2f,
-                orbitSpeedRadPerSecond: 1.7f));
+            descriptor.VfxEffectData = new VfxEffectAssetData(
+                new VfxEmitterDescriptor(
+                    VfxEmitterShape.PrimitiveSphere,
+                    particleCount: 24,
+                    ringSegments: 20,
+                    radiusScale: 1.15f,
+                    coreRadiusScale: 0.28f,
+                    particleRadiusScale: 0.085f,
+                    lifetimeSeconds: 0.75f,
+                    pulseSpeedRadPerSecond: 5.2f,
+                    orbitSpeedRadPerSecond: 1.7f,
+                    shellRingCount: 2,
+                    beamCount: 0),
+                PrefabVfxSpawnMode.Loop,
+                new Vector4(0.42f, 0.43f, 0.39f, 0.48f),
+                new Vector4(0.72f, 0.72f, 0.67f, 0.32f),
+                new Vector4(0.86f, 0.83f, 0.74f, 0.42f));
             return descriptor;
         }
 

--- a/src/Tests/PresentationTests/Rendering/PrefabFinalizationAndVisualHeightmapTests.cs
+++ b/src/Tests/PresentationTests/Rendering/PrefabFinalizationAndVisualHeightmapTests.cs
@@ -231,13 +231,14 @@ namespace Ludots.Tests.Presentation
         {
             var meshes = new MeshAssetRegistry();
             int cubeId = meshes.GetId(WellKnownMeshKeys.Cube);
+            int effectId = RegisterVfxEffect(meshes, "prefab.mixed_visuals.effect", PrefabVfxSpawnMode.Loop);
             int prefabId = meshes.Register(
                 "prefab.mixed_visuals",
                 MeshAssetDescriptor.Prefab(
                     0,
                     PrefabPart.Default(cubeId),
                     PrefabPart.Decal(materialId: 22, size: new Vector2(4f, 5f)),
-                    PrefabPart.Vfx(effectAssetId: 33, spawnMode: PrefabVfxSpawnMode.Loop),
+                    PrefabPart.Vfx(effectAssetId: effectId, spawnMode: PrefabVfxSpawnMode.Once),
                     PrefabPart.Surface(cubeId, materialId: 44, tiling: new Vector2(2f, 3f))));
 
             var output = new PrefabFinalizedVisualBuffer();
@@ -264,7 +265,7 @@ namespace Ludots.Tests.Presentation
             Assert.That(visuals[1].AlignToSurface, Is.True);
 
             Assert.That(visuals[2].Kind, Is.EqualTo(PrefabVisualPartKind.Vfx));
-            Assert.That(visuals[2].EffectAssetId, Is.EqualTo(33));
+            Assert.That(visuals[2].EffectAssetId, Is.EqualTo(effectId));
             Assert.That(visuals[2].VfxSpawnMode, Is.EqualTo(PrefabVfxSpawnMode.Loop));
 
             Assert.That(visuals[3].Kind, Is.EqualTo(PrefabVisualPartKind.Surface));
@@ -272,6 +273,33 @@ namespace Ludots.Tests.Presentation
             Assert.That(visuals[3].MaterialId, Is.EqualTo(44));
             Assert.That(visuals[3].Tiling, Is.EqualTo(new Vector2(2f, 3f)));
             Assert.That(visuals[3].TerrainFacing, Is.True);
+        }
+
+        [Test]
+        public void PrefabFinalizationPipeline_WhenAuthoredPrefabVfxSpawnModeConflictsWithEffectAsset_ThrowsExplicitly()
+        {
+            var meshes = new MeshAssetRegistry();
+            int effectId = RegisterVfxEffect(meshes, "prefab.conflicting_vfx.effect", PrefabVfxSpawnMode.Loop);
+            PrefabPart vfxPart = PrefabPart.Vfx(effectAssetId: effectId, spawnMode: PrefabVfxSpawnMode.Once);
+            vfxPart.VfxSpawnModeAuthored = true;
+            int prefabId = meshes.Register(
+                "prefab.conflicting_vfx",
+                MeshAssetDescriptor.Prefab(0, vfxPart));
+
+            var output = new PrefabFinalizedVisualBuffer();
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                PrefabFinalizationPipeline.FinalizeVisuals(
+                    meshes,
+                    prefabId,
+                    stableId: 31,
+                    position: Vector3.Zero,
+                    rotation: Quaternion.Identity,
+                    scale: Vector3.One,
+                    color: Vector4.One,
+                    output));
+
+            Assert.That(ex!.Message, Does.Contain("VFX spawn mode must be authored on the effect asset only"));
         }
 
         [Test]
@@ -1124,6 +1152,29 @@ namespace Ludots.Tests.Presentation
             }
 
             return new ChunkedVisualHeightmapRuntime(descriptor, store);
+        }
+
+        private static int RegisterVfxEffect(MeshAssetRegistry meshes, string key, PrefabVfxSpawnMode spawnMode)
+        {
+            MeshAssetDescriptor descriptor = MeshAssetDescriptor.Primitive(0, PrimitiveMeshKind.Sphere);
+            descriptor.VfxEffectData = new VfxEffectAssetData(
+                new VfxEmitterDescriptor(
+                    VfxEmitterShape.PrimitiveSphere,
+                    particleCount: 6,
+                    ringSegments: 8,
+                    radiusScale: 1f,
+                    coreRadiusScale: 0.35f,
+                    particleRadiusScale: 0.18f,
+                    lifetimeSeconds: 1.2f,
+                    pulseSpeedRadPerSecond: 2f,
+                    orbitSpeedRadPerSecond: 1f,
+                    shellRingCount: 1,
+                    beamCount: 1),
+                spawnMode,
+                new Vector4(0.8f, 0.9f, 1f, 1f),
+                new Vector4(0.3f, 0.6f, 1f, 0.55f),
+                new Vector4(1f, 0.85f, 0.35f, 0.9f));
+            return meshes.Register(key, in descriptor);
         }
 
         private sealed class CountingGroundProjector : IVisualGroundProjector

--- a/src/Tests/PresentationTests/Rendering/VisualHeightmapColorRampTests.cs
+++ b/src/Tests/PresentationTests/Rendering/VisualHeightmapColorRampTests.cs
@@ -1,0 +1,38 @@
+using Ludots.Core.Presentation.Terrain;
+using NUnit.Framework;
+
+namespace Ludots.Tests.Presentation.Rendering;
+
+[TestFixture]
+public sealed class VisualHeightmapColorRampTests
+{
+    [Test]
+    public void ResolveColorRanged_KeepsLowLandGreenWhenDeepSeaDominatesRange()
+    {
+        var land = VisualHeightmapColorRamp.ResolveColorRanged(
+            heightCm: 120f,
+            slope: 0f,
+            minHeightCm: -6000f,
+            maxHeightCm: 1800f,
+            seaLevelCm: 0f,
+            colorContrast: 1f);
+
+        Assert.That(land.Y, Is.GreaterThan(land.X));
+        Assert.That(land.Y, Is.GreaterThan(land.Z));
+    }
+
+    [Test]
+    public void ResolveColorRanged_ShadesDeepWaterBlue()
+    {
+        var water = VisualHeightmapColorRamp.ResolveColorRanged(
+            heightCm: -5200f,
+            slope: 0f,
+            minHeightCm: -6000f,
+            maxHeightCm: 1800f,
+            seaLevelCm: 0f,
+            colorContrast: 1f);
+
+        Assert.That(water.Z, Is.GreaterThan(water.X));
+        Assert.That(water.Z, Is.GreaterThan(water.Y));
+    }
+}

--- a/src/Tests/PresentationTests/Rendering/VisualTerrainEditorRuntimeConsistencyTests.cs
+++ b/src/Tests/PresentationTests/Rendering/VisualTerrainEditorRuntimeConsistencyTests.cs
@@ -39,16 +39,64 @@ public sealed class VisualTerrainEditorRuntimeConsistencyTests
         for (int chunkX = 0; chunkX < 2; chunkX++)
         {
             Assert.That(document.TryGetChunkProceduralMesh(chunkX, 0, out var proceduralMesh), Is.True);
+            Vector3 chunkCenterMeters = ChunkCenterMeters(document.Asset, chunkX, 0);
             for (int vertexIndex = 0; vertexIndex < proceduralMesh.VertexCount; vertexIndex++)
             {
                 Vector3 position = ReadPosition(proceduralMesh, vertexIndex);
-                float worldXCm = position.X * 100f;
-                float worldYCm = position.Z * 100f;
+                float worldXCm = (chunkCenterMeters.X + position.X) * 100f;
+                float worldYCm = (chunkCenterMeters.Z + position.Z) * 100f;
 
                 Assert.That(runtime.TrySampleHeightCm(worldXCm, worldYCm, out float heightCm), Is.True, $"chunk={chunkX} vertex={vertexIndex} position={position}");
                 Assert.That(position.Y, Is.EqualTo(heightCm * 0.01f).Within(0.001f), $"chunk={chunkX} vertex={vertexIndex} position={position}");
+
+                Vector4 tangent = ReadTangent(proceduralMesh, vertexIndex);
+                Assert.That(float.IsFinite(tangent.X), Is.True, $"chunk={chunkX} vertex={vertexIndex} tangent={tangent}");
+                Assert.That(float.IsFinite(tangent.Y), Is.True, $"chunk={chunkX} vertex={vertexIndex} tangent={tangent}");
+                Assert.That(float.IsFinite(tangent.Z), Is.True, $"chunk={chunkX} vertex={vertexIndex} tangent={tangent}");
+                Assert.That(float.IsFinite(tangent.W), Is.True, $"chunk={chunkX} vertex={vertexIndex} tangent={tangent}");
+                Assert.That(new Vector3(tangent.X, tangent.Y, tangent.Z).LengthSquared(), Is.GreaterThan(1e-10f), $"chunk={chunkX} vertex={vertexIndex} tangent={tangent}");
+                Assert.That(tangent.W, Is.EqualTo(1f).Within(0.001f), $"chunk={chunkX} vertex={vertexIndex} tangent={tangent}");
             }
         }
+    }
+
+    [Test]
+    public void VisualTerrainEditor_ProceduralMeshEdgesMeetInWorldCoordinates()
+    {
+        using var document = new VisualTerrainEditorDocument(
+            new VisualTerrainAssetDescriptor(
+                id: $"visual_terrain_editor_world_mesh_{Guid.NewGuid():N}",
+                displayName: "World Mesh",
+                bounds: new WorldAabbCm(-10_000, -5_000, 20_000, 10_000),
+                chunkColumns: 2,
+                chunkRows: 1,
+                samplesPerChunkColumn: 9,
+                samplesPerChunkRow: 9,
+                renderColumnsPerChunk: 9,
+                renderRowsPerChunk: 9,
+                defaultHeight01: 0.45f),
+            defaultMaterialAssetId: 1);
+
+        document.SetViewMode(TerrainViewMode.Base);
+        document.EnsureChunkWindowLoaded(centerChunkX: 0, centerChunkY: 0, radius: 1);
+        document.Update();
+
+        Assert.That(document.TryGetChunkProceduralMesh(0, 0, out var leftChunk), Is.True);
+        Assert.That(document.TryGetChunkProceduralMesh(1, 0, out var rightChunk), Is.True);
+
+        Assert.That(leftChunk.LocalBounds.Center.X, Is.EqualTo(0f).Within(0.001f));
+        Assert.That(leftChunk.LocalBounds.Center.Z, Is.EqualTo(0f).Within(0.001f));
+        Assert.That(rightChunk.LocalBounds.Center.X, Is.EqualTo(0f).Within(0.001f));
+        Assert.That(rightChunk.LocalBounds.Center.Z, Is.EqualTo(0f).Within(0.001f));
+
+        Vector3 leftEastEdge = ReadPosition(leftChunk, 8);
+        Vector3 rightWestEdge = ReadPosition(rightChunk, 0);
+        Vector3 leftCenterMeters = ChunkCenterMeters(document.Asset, 0, 0);
+        Vector3 rightCenterMeters = ChunkCenterMeters(document.Asset, 1, 0);
+
+        Assert.That(leftEastEdge.X, Is.EqualTo(50f).Within(0.001f));
+        Assert.That(rightWestEdge.X, Is.EqualTo(-50f).Within(0.001f));
+        Assert.That(leftCenterMeters.X + leftEastEdge.X, Is.EqualTo(rightCenterMeters.X + rightWestEdge.X).Within(0.001f));
     }
 
     [Test]
@@ -127,5 +175,22 @@ public sealed class VisualTerrainEditorRuntimeConsistencyTests
             proceduralMesh.Positions[floatOffset + 0],
             proceduralMesh.Positions[floatOffset + 1],
             proceduralMesh.Positions[floatOffset + 2]);
+    }
+
+    private static Vector4 ReadTangent(Ludots.Core.Presentation.Assets.ProceduralMeshAssetData proceduralMesh, int vertexIndex)
+    {
+        int floatOffset = vertexIndex * 4;
+        return new Vector4(
+            proceduralMesh.Tangents[floatOffset + 0],
+            proceduralMesh.Tangents[floatOffset + 1],
+            proceduralMesh.Tangents[floatOffset + 2],
+            proceduralMesh.Tangents[floatOffset + 3]);
+    }
+
+    private static Vector3 ChunkCenterMeters(VisualTerrainAssetDescriptor asset, int chunkX, int chunkY)
+    {
+        float centerXCm = asset.Bounds.Left + ((chunkX + 0.5f) * asset.ChunkWorldWidthCm);
+        float centerYCm = asset.Bounds.Top + ((chunkY + 0.5f) * asset.ChunkWorldHeightCm);
+        return new Vector3(centerXCm * 0.01f, 0f, centerYCm * 0.01f);
     }
 }

--- a/src/Tests/RaylibAdapterTests/RaylibAdapterTests.csproj
+++ b/src/Tests/RaylibAdapterTests/RaylibAdapterTests.csproj
@@ -5,6 +5,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <SkiaNativeRid Condition="'$(SkiaNativeRid)' == '' and '$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</SkiaNativeRid>
+    <SkiaNativeRid Condition="'$(SkiaNativeRid)' == '' and '$(OS)' == 'Windows_NT'">win-x64</SkiaNativeRid>
+    <SkiaNativeRid Condition="'$(SkiaNativeRid)' == '' and '$([MSBuild]::IsOSPlatform(`Linux`))' == 'true'">linux-x64</SkiaNativeRid>
+    <SkiaNativeRid Condition="'$(SkiaNativeRid)' == '' and '$([MSBuild]::IsOSPlatform(`OSX`))' == 'true'">osx</SkiaNativeRid>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,5 +21,24 @@
     <ProjectReference Include="..\..\Adapters\Raylib\Ludots.Adapter.Raylib\Ludots.Adapter.Raylib.csproj" />
     <ProjectReference Include="..\..\Libraries\Ludots.UI.Browser\Ludots.UI.Browser.csproj" />
     <ProjectReference Include="..\..\Libraries\Ludots.UI\Ludots.UI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\Libraries\SkiaSharp\runtimes\**\*.*" Link="runtimes\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(SkiaNativeRid)' != ''">
+    <None Include="..\..\Libraries\SkiaSharp\runtimes\$(SkiaNativeRid)\native\libSkiaSharp.dll"
+          Link="libSkiaSharp.dll"
+          CopyToOutputDirectory="PreserveNewest"
+          Condition="Exists('..\..\Libraries\SkiaSharp\runtimes\$(SkiaNativeRid)\native\libSkiaSharp.dll')" />
+    <None Include="..\..\Libraries\SkiaSharp\runtimes\$(SkiaNativeRid)\native\libSkiaSharp.so"
+          Link="libSkiaSharp.so"
+          CopyToOutputDirectory="PreserveNewest"
+          Condition="Exists('..\..\Libraries\SkiaSharp\runtimes\$(SkiaNativeRid)\native\libSkiaSharp.so')" />
+    <None Include="..\..\Libraries\SkiaSharp\runtimes\$(SkiaNativeRid)\native\libSkiaSharp.dylib"
+          Link="libSkiaSharp.dylib"
+          CopyToOutputDirectory="PreserveNewest"
+          Condition="Exists('..\..\Libraries\SkiaSharp\runtimes\$(SkiaNativeRid)\native\libSkiaSharp.dylib')" />
   </ItemGroup>
 </Project>

--- a/src/Tests/RaylibAdapterTests/RaylibFrameRendererTests.cs
+++ b/src/Tests/RaylibAdapterTests/RaylibFrameRendererTests.cs
@@ -22,13 +22,17 @@ public sealed class RaylibFrameRendererTests
                 HasGroundOverlays: true,
                 HasRoadSplines: true,
                 DrawDebugDraw: true,
-                DrawSkiaUi: true),
+                DrawSkiaUi: true,
+                DrawEnvironment: true,
+                UsePostProcess: true),
             passes);
 
         Assert.That(passes[..count].ToArray(), Is.EqualTo(new[]
         {
             RaylibFramePass.Clear,
+            RaylibFramePass.BeginWorldTexture,
             RaylibFramePass.BeginWorld3D,
+            RaylibFramePass.Skybox,
             RaylibFramePass.DebugGuides,
             RaylibFramePass.Terrain,
             RaylibFramePass.GlobalField,
@@ -38,6 +42,7 @@ public sealed class RaylibFrameRendererTests
             RaylibFramePass.RoadSpline,
             RaylibFramePass.DebugDraw,
             RaylibFramePass.EndWorld3D,
+            RaylibFramePass.PostProcessComposite,
             RaylibFramePass.BrowserLayer,
             RaylibFramePass.OverlayComposite,
         }));
@@ -59,7 +64,9 @@ public sealed class RaylibFrameRendererTests
                 HasGroundOverlays: false,
                 HasRoadSplines: false,
                 DrawDebugDraw: false,
-                DrawSkiaUi: false),
+                DrawSkiaUi: false,
+                DrawEnvironment: false,
+                UsePostProcess: false),
             passes);
 
         Assert.That(passes[..count].ToArray(), Is.EqualTo(new[]
@@ -89,9 +96,11 @@ public sealed class RaylibFrameRendererTests
                     HasBenchmarkRenderer: true,
                     DrawPrimitives: true,
                     HasGroundOverlays: true,
-                    HasRoadSplines: true,
-                    DrawDebugDraw: true,
-                    DrawSkiaUi: true),
+                HasRoadSplines: true,
+                DrawDebugDraw: true,
+                DrawSkiaUi: true,
+                DrawEnvironment: true,
+                UsePostProcess: true),
                 passes);
         }
         catch (InvalidOperationException ex)

--- a/src/Tests/RaylibAdapterTests/RaylibFrameRendererTests.cs
+++ b/src/Tests/RaylibAdapterTests/RaylibFrameRendererTests.cs
@@ -1,0 +1,104 @@
+using Ludots.Adapter.Raylib;
+using NUnit.Framework;
+
+namespace Ludots.Tests.RaylibAdapter;
+
+[TestFixture]
+public sealed class RaylibFrameRendererTests
+{
+    [Test]
+    public void BuildPassPlan_KeepsWorldPassesBeforeUiComposite()
+    {
+        Span<RaylibFramePass> passes = stackalloc RaylibFramePass[16];
+        int count = RaylibFrameRenderer.BuildPassPlan(
+            new RaylibFramePassPlanInput(
+                DrawDebugGuides: true,
+                DrawTerrain: true,
+                DrawVisualHeightmap: false,
+                HasGlobalFieldBuffer: true,
+                DrawFieldOverlays: true,
+                HasBenchmarkRenderer: true,
+                DrawPrimitives: true,
+                HasGroundOverlays: true,
+                HasRoadSplines: true,
+                DrawDebugDraw: true,
+                DrawSkiaUi: true),
+            passes);
+
+        Assert.That(passes[..count].ToArray(), Is.EqualTo(new[]
+        {
+            RaylibFramePass.Clear,
+            RaylibFramePass.BeginWorld3D,
+            RaylibFramePass.DebugGuides,
+            RaylibFramePass.Terrain,
+            RaylibFramePass.GlobalField,
+            RaylibFramePass.BenchmarkScene,
+            RaylibFramePass.PrimitiveVisuals,
+            RaylibFramePass.GroundOverlay,
+            RaylibFramePass.RoadSpline,
+            RaylibFramePass.DebugDraw,
+            RaylibFramePass.EndWorld3D,
+            RaylibFramePass.BrowserLayer,
+            RaylibFramePass.OverlayComposite,
+        }));
+    }
+
+    [Test]
+    public void BuildPassPlan_CanSuppressOptionalPassesWithoutMovingOverlay()
+    {
+        Span<RaylibFramePass> passes = stackalloc RaylibFramePass[16];
+        int count = RaylibFrameRenderer.BuildPassPlan(
+            new RaylibFramePassPlanInput(
+                DrawDebugGuides: false,
+                DrawTerrain: false,
+                DrawVisualHeightmap: false,
+                HasGlobalFieldBuffer: false,
+                DrawFieldOverlays: true,
+                HasBenchmarkRenderer: false,
+                DrawPrimitives: false,
+                HasGroundOverlays: false,
+                HasRoadSplines: false,
+                DrawDebugDraw: false,
+                DrawSkiaUi: false),
+            passes);
+
+        Assert.That(passes[..count].ToArray(), Is.EqualTo(new[]
+        {
+            RaylibFramePass.Clear,
+            RaylibFramePass.BeginWorld3D,
+            RaylibFramePass.EndWorld3D,
+            RaylibFramePass.OverlayComposite,
+        }));
+    }
+
+    [Test]
+    public void BuildPassPlan_FailsFastWhenOutputSpanIsTooSmall()
+    {
+        Span<RaylibFramePass> passes = stackalloc RaylibFramePass[1];
+
+        InvalidOperationException? error = null;
+        try
+        {
+            RaylibFrameRenderer.BuildPassPlan(
+                new RaylibFramePassPlanInput(
+                    DrawDebugGuides: true,
+                    DrawTerrain: true,
+                    DrawVisualHeightmap: true,
+                    HasGlobalFieldBuffer: true,
+                    DrawFieldOverlays: true,
+                    HasBenchmarkRenderer: true,
+                    DrawPrimitives: true,
+                    HasGroundOverlays: true,
+                    HasRoadSplines: true,
+                    DrawDebugDraw: true,
+                    DrawSkiaUi: true),
+                passes);
+        }
+        catch (InvalidOperationException ex)
+        {
+            error = ex;
+        }
+
+        Assert.That(error, Is.Not.Null);
+    }
+}

--- a/src/Tests/RaylibAdapterTests/RaylibRenderEnvironmentConfigTests.cs
+++ b/src/Tests/RaylibAdapterTests/RaylibRenderEnvironmentConfigTests.cs
@@ -1,0 +1,101 @@
+using System.Numerics;
+using Ludots.Client.Raylib.Rendering;
+using Ludots.Core.Presentation.Terrain;
+using NUnit.Framework;
+using Raylib_cs;
+
+namespace Ludots.Tests.RaylibAdapter;
+
+[TestFixture]
+public sealed class RaylibRenderEnvironmentConfigTests
+{
+    [Test]
+    public void CreateDefault_ProvidesNormalizedLightingAndEnabledWorldPostProcess()
+    {
+        RaylibRenderEnvironmentConfig config = RaylibRenderEnvironmentConfig.CreateDefault();
+
+        Assert.That(config.Skybox.Enabled, Is.True);
+        Assert.That(config.PostProcess.Enabled, Is.True);
+        Assert.That(config.Lighting.SunDirection.Length(), Is.EqualTo(1f).Within(0.0001f));
+        Assert.That(config.Lighting.FogFarMeters, Is.GreaterThan(config.Lighting.FogNearMeters));
+        Assert.That(config.Water.WaveAmplitudeMeters, Is.GreaterThan(0f));
+    }
+
+    [Test]
+    public void NormalizeAndValidate_RejectsInvertedFogRange()
+    {
+        RaylibRenderEnvironmentConfig config = RaylibRenderEnvironmentConfig.CreateDefault() with
+        {
+            Lighting = RaylibLightingConfig.CreateDefault() with
+            {
+                FogNearMeters = 2000f,
+                FogFarMeters = 1000f
+            }
+        };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => config.NormalizeAndValidate());
+    }
+
+    [Test]
+    public void VisualHeightmapRenderProfile_DisablesWaterByDefaultForFlatShowcaseMaps()
+    {
+        VisualHeightmapRenderProfile profile = VisualHeightmapRenderProfile.CreateDefault();
+
+        float effectiveSeaLevelCm = RaylibVisualHeightmapRenderer.ResolveEffectiveSeaLevelCm(profile, minHeightCm: 0f);
+
+        Assert.That(profile.WaterEnabled, Is.False);
+        Assert.That(effectiveSeaLevelCm, Is.LessThan(0f));
+    }
+
+    [Test]
+    public void VisualHeightmapRenderProfile_WhenWaterEnabled_UsesAuthoredSeaLevel()
+    {
+        var profile = new VisualHeightmapRenderProfile
+        {
+            WaterEnabled = true,
+            SeaLevelCm = 125f,
+            DisplayHeightScale = 250f,
+            ColorContrast = 1.35f
+        };
+
+        float effectiveSeaLevelCm = RaylibVisualHeightmapRenderer.ResolveEffectiveSeaLevelCm(profile, minHeightCm: -600f);
+
+        Assert.That(effectiveSeaLevelCm, Is.EqualTo(125f));
+    }
+
+    [Test]
+    public void VisualHeightmapRenderProfile_RejectsDisplayScaleOutsideCoreRange()
+    {
+        var profile = new VisualHeightmapRenderProfile
+        {
+            DisplayHeightScale = VisualHeightmapRenderProfile.MaxDisplayHeightScale + 1f
+        };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => profile.NormalizeAndValidate());
+    }
+
+    [Test]
+    public void BuildTextureSourceRectangle_FlipsRenderTextureForWindowComposite()
+    {
+        Texture2D texture = new()
+        {
+            width = 1280,
+            height = 720
+        };
+
+        Rectangle source = RaylibPostProcessRenderer.BuildTextureSourceRectangle(texture);
+
+        Assert.That(source.x, Is.EqualTo(0f));
+        Assert.That(source.y, Is.EqualTo(0f));
+        Assert.That(source.width, Is.EqualTo(1280f));
+        Assert.That(source.height, Is.EqualTo(-720f));
+    }
+
+    [Test]
+    public void NeedsRenderTargetResize_TracksWindowSizeExactly()
+    {
+        Assert.That(RaylibPostProcessRenderer.NeedsRenderTargetResize(false, 0, 0, 1280, 720), Is.True);
+        Assert.That(RaylibPostProcessRenderer.NeedsRenderTargetResize(true, 1280, 720, 1280, 720), Is.False);
+        Assert.That(RaylibPostProcessRenderer.NeedsRenderTargetResize(true, 1280, 720, 1600, 900), Is.True);
+    }
+}

--- a/src/Tests/RaylibAdapterTests/RaylibScreenshotEvidenceTests.cs
+++ b/src/Tests/RaylibAdapterTests/RaylibScreenshotEvidenceTests.cs
@@ -1,0 +1,130 @@
+using Ludots.Adapter.Raylib;
+using NUnit.Framework;
+using SkiaSharp;
+
+namespace Ludots.Tests.RaylibAdapter;
+
+[TestFixture]
+public sealed class RaylibScreenshotEvidenceTests
+{
+    [Test]
+    public void ValidateRuntimeScreenshotEvidence_AcceptsPngWithExpectedDimensions()
+    {
+        string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"raylib-screenshot-{Guid.NewGuid():N}.png");
+        try
+        {
+            WritePng(path, width: 1280, height: 720, flat: false);
+
+            RaylibHostLoop.ValidateRuntimeScreenshotEvidence(path, expectedWidth: 1280, expectedHeight: 720);
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Test]
+    public void ValidateRuntimeScreenshotEvidence_RejectsMissingFile()
+    {
+        string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"missing-raylib-screenshot-{Guid.NewGuid():N}.png");
+
+        Assert.That(
+            () => RaylibHostLoop.ValidateRuntimeScreenshotEvidence(path, expectedWidth: 1280, expectedHeight: 720),
+            Throws.InvalidOperationException.With.Message.Contains("was not written"));
+    }
+
+    [Test]
+    public void ValidateRuntimeScreenshotEvidence_RejectsDimensionMismatch()
+    {
+        string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"raylib-screenshot-mismatch-{Guid.NewGuid():N}.png");
+        try
+        {
+            WritePng(path, width: 640, height: 360, flat: false);
+
+            Assert.That(
+                () => RaylibHostLoop.ValidateRuntimeScreenshotEvidence(path, expectedWidth: 1280, expectedHeight: 720),
+                Throws.InvalidOperationException.With.Message.Contains("dimensions mismatch"));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Test]
+    public void ValidateRuntimeScreenshotEvidence_RejectsUndecodableHeaderOnlyPng()
+    {
+        string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"raylib-screenshot-corrupt-{Guid.NewGuid():N}.png");
+        try
+        {
+            File.WriteAllBytes(path, new byte[]
+            {
+                137, 80, 78, 71, 13, 10, 26, 10,
+                0, 0, 0, 13,
+                (byte)'I', (byte)'H', (byte)'D', (byte)'R',
+                0, 0, 5, 0,
+                0, 0, 2, 208,
+            });
+
+            Assert.That(
+                () => RaylibHostLoop.ValidateRuntimeScreenshotEvidence(path, expectedWidth: 1280, expectedHeight: 720),
+                Throws.InvalidOperationException.With.Message.Contains("decodable PNG"));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Test]
+    public void ValidateRuntimeScreenshotEvidence_RejectsVisuallyFlatPng()
+    {
+        string path = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"raylib-screenshot-flat-{Guid.NewGuid():N}.png");
+        try
+        {
+            WritePng(path, width: 1280, height: 720, flat: true);
+
+            Assert.That(
+                () => RaylibHostLoop.ValidateRuntimeScreenshotEvidence(path, expectedWidth: 1280, expectedHeight: 720),
+                Throws.InvalidOperationException.With.Message.Contains("visually flat"));
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    private static void WritePng(string path, int width, int height, bool flat)
+    {
+        using var bitmap = new SKBitmap(width, height);
+        bitmap.Erase(new SKColor(20, 30, 40, 255));
+        if (!flat)
+        {
+            for (int y = 0; y < height; y++)
+            {
+                byte shade = (byte)(40 + (y * 140 / Math.Max(1, height - 1)));
+                for (int x = 0; x < width; x++)
+                {
+                    bitmap.SetPixel(x, y, new SKColor((byte)(shade / 2), shade, (byte)(120 + (x % 80)), 255));
+                }
+            }
+        }
+
+        using SKImage image = SKImage.FromBitmap(bitmap);
+        using SKData data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using Stream stream = File.Open(path, FileMode.Create, FileAccess.Write, FileShare.None);
+        data.SaveTo(stream);
+    }
+}

--- a/src/Tests/RaylibAdapterTests/RaylibVfxRendererTests.cs
+++ b/src/Tests/RaylibAdapterTests/RaylibVfxRendererTests.cs
@@ -12,11 +12,14 @@ namespace Ludots.Tests.RaylibAdapter;
 public sealed class RaylibVfxRendererTests
 {
     [Test]
-    public void TryBuildDirectVfxVisual_PerformerVfxPrimitive_BuildsLoopEffectVisual()
+    public void TryBuildDirectVfxVisual_PerformerVfxPrimitive_UsesAuthoredEffectSpawnMode()
     {
+        var meshes = new MeshAssetRegistry();
+        MeshAssetDescriptor descriptor = CreateSphereEffectDescriptor(0, PrefabVfxSpawnMode.Loop);
+        int effectAssetId = meshes.Register("effect.looping.smoke", in descriptor);
         var primitive = new PrimitiveDrawItem
         {
-            MeshAssetId = 42,
+            MeshAssetId = effectAssetId,
             Position = new Vector3(1f, 2f, 3f),
             Rotation = Quaternion.Identity,
             Scale = new Vector3(2f, 3f, 4f),
@@ -30,13 +33,14 @@ public sealed class RaylibVfxRendererTests
 
         bool handled = RaylibPrimitiveRenderer.TryBuildDirectVfxVisual(
             in primitive,
+            meshes,
             scaleMul: 0.5f,
             out PrefabFinalizedVisual visual);
 
         Assert.That(handled, Is.True);
         Assert.That(visual.Kind, Is.EqualTo(PrefabVisualPartKind.Vfx));
         Assert.That(visual.StableId, Is.EqualTo(99));
-        Assert.That(visual.EffectAssetId, Is.EqualTo(42));
+        Assert.That(visual.EffectAssetId, Is.EqualTo(effectAssetId));
         Assert.That(visual.VfxSpawnMode, Is.EqualTo(PrefabVfxSpawnMode.Loop));
         Assert.That(visual.Scale, Is.EqualTo(new Vector3(1f, 1.5f, 2f)));
     }
@@ -63,7 +67,7 @@ public sealed class RaylibVfxRendererTests
             color: new Vector4(0.35f, 0.95f, 1f, 0.85f),
             effectAssetId: 42,
             spawnMode: PrefabVfxSpawnMode.Loop);
-        MeshAssetDescriptor descriptor = CreateSphereEffectDescriptor(42);
+        MeshAssetDescriptor descriptor = CreateSphereEffectDescriptor(42, PrefabVfxSpawnMode.Loop);
 
         RaylibVfxEmitterPlan plan = RaylibVfxRenderer.BuildEmitterPlan(
             in visual,
@@ -74,6 +78,8 @@ public sealed class RaylibVfxRendererTests
         Assert.That(plan.SpawnMode, Is.EqualTo(PrefabVfxSpawnMode.Loop));
         Assert.That(plan.ParticleCount, Is.EqualTo(24));
         Assert.That(plan.RingSegments, Is.EqualTo(20));
+        Assert.That(plan.ShellRingCount, Is.EqualTo(2));
+        Assert.That(plan.BeamCount, Is.EqualTo(3));
         Assert.That(plan.ShellRadius, Is.GreaterThan(0f));
         Assert.That(plan.OrbitPhase, Is.GreaterThan(0f));
         Assert.That(plan.CoreColor.W, Is.GreaterThan(0f));
@@ -91,7 +97,7 @@ public sealed class RaylibVfxRendererTests
             color: Vector4.One,
             effectAssetId: 77,
             spawnMode: PrefabVfxSpawnMode.Once);
-        MeshAssetDescriptor descriptor = CreateSphereEffectDescriptor(77);
+        MeshAssetDescriptor descriptor = CreateSphereEffectDescriptor(77, PrefabVfxSpawnMode.Once);
 
         RaylibVfxEmitterPlan plan = RaylibVfxRenderer.BuildEmitterPlan(
             in visual,
@@ -134,8 +140,9 @@ public sealed class RaylibVfxRendererTests
             effectAssetId: 91,
             spawnMode: PrefabVfxSpawnMode.Loop);
         MeshAssetDescriptor descriptor = MeshAssetDescriptor.Primitive(91, PrimitiveMeshKind.Cube);
-        descriptor.VfxEffectData = new VfxEffectAssetData(new VfxEmitterDescriptor(
+        descriptor.VfxEffectData = CreateEffectData(
             VfxEmitterShape.PrimitiveCube,
+            PrefabVfxSpawnMode.Loop,
             particleCount: 9,
             ringSegments: 11,
             radiusScale: 0.8f,
@@ -143,7 +150,9 @@ public sealed class RaylibVfxRendererTests
             particleRadiusScale: 0.06f,
             lifetimeSeconds: 0.5f,
             pulseSpeedRadPerSecond: 3.2f,
-            orbitSpeedRadPerSecond: 1.1f));
+            orbitSpeedRadPerSecond: 1.1f,
+            shellRingCount: 1,
+            beamCount: 2);
 
         RaylibVfxEmitterPlan plan = RaylibVfxRenderer.BuildEmitterPlan(
             in visual,
@@ -153,13 +162,16 @@ public sealed class RaylibVfxRendererTests
         Assert.That(plan.Shape, Is.EqualTo(VfxEmitterShape.PrimitiveCube));
         Assert.That(plan.ParticleCount, Is.EqualTo(9));
         Assert.That(plan.RingSegments, Is.EqualTo(11));
+        Assert.That(plan.ShellRingCount, Is.EqualTo(1));
+        Assert.That(plan.BeamCount, Is.EqualTo(2));
     }
 
-    private static MeshAssetDescriptor CreateSphereEffectDescriptor(int id)
+    private static MeshAssetDescriptor CreateSphereEffectDescriptor(int id, PrefabVfxSpawnMode spawnMode)
     {
         MeshAssetDescriptor descriptor = MeshAssetDescriptor.Primitive(id, PrimitiveMeshKind.Sphere);
-        descriptor.VfxEffectData = new VfxEffectAssetData(new VfxEmitterDescriptor(
+        descriptor.VfxEffectData = CreateEffectData(
             VfxEmitterShape.PrimitiveSphere,
+            spawnMode,
             particleCount: 24,
             ringSegments: 20,
             radiusScale: 1.15f,
@@ -167,7 +179,42 @@ public sealed class RaylibVfxRendererTests
             particleRadiusScale: 0.085f,
             lifetimeSeconds: 0.75f,
             pulseSpeedRadPerSecond: 5.2f,
-            orbitSpeedRadPerSecond: 1.7f));
+            orbitSpeedRadPerSecond: 1.7f,
+            shellRingCount: 2,
+            beamCount: 3);
         return descriptor;
+    }
+
+    private static VfxEffectAssetData CreateEffectData(
+        VfxEmitterShape shape,
+        PrefabVfxSpawnMode spawnMode,
+        int particleCount,
+        int ringSegments,
+        float radiusScale,
+        float coreRadiusScale,
+        float particleRadiusScale,
+        float lifetimeSeconds,
+        float pulseSpeedRadPerSecond,
+        float orbitSpeedRadPerSecond,
+        int shellRingCount,
+        int beamCount)
+    {
+        return new VfxEffectAssetData(
+            new VfxEmitterDescriptor(
+                shape,
+                particleCount,
+                ringSegments,
+                radiusScale,
+                coreRadiusScale,
+                particleRadiusScale,
+                lifetimeSeconds,
+                pulseSpeedRadPerSecond,
+                orbitSpeedRadPerSecond,
+                shellRingCount,
+                beamCount),
+            spawnMode,
+            new Vector4(0.20f, 0.85f, 1.00f, 0.88f),
+            new Vector4(0.55f, 0.95f, 1.00f, 0.62f),
+            new Vector4(1.00f, 0.92f, 0.32f, 0.86f));
     }
 }

--- a/src/Tests/RaylibAdapterTests/RaylibVfxRendererTests.cs
+++ b/src/Tests/RaylibAdapterTests/RaylibVfxRendererTests.cs
@@ -1,0 +1,173 @@
+using System.Numerics;
+using Ludots.Client.Raylib.Rendering;
+using Ludots.Core.Presentation.Assets;
+using Ludots.Core.Presentation.Components;
+using Ludots.Core.Presentation.Performers;
+using Ludots.Core.Presentation.Rendering;
+using NUnit.Framework;
+
+namespace Ludots.Tests.RaylibAdapter;
+
+[TestFixture]
+public sealed class RaylibVfxRendererTests
+{
+    [Test]
+    public void TryBuildDirectVfxVisual_PerformerVfxPrimitive_BuildsLoopEffectVisual()
+    {
+        var primitive = new PrimitiveDrawItem
+        {
+            MeshAssetId = 42,
+            Position = new Vector3(1f, 2f, 3f),
+            Rotation = Quaternion.Identity,
+            Scale = new Vector3(2f, 3f, 4f),
+            Color = new Vector4(0.3f, 0.4f, 0.5f, 0.6f),
+            StableId = 99,
+            RenderPath = VisualRenderPath.StaticMesh,
+            AssetKind = AssetKind.VFX,
+            Mobility = VisualMobility.Movable,
+            Visibility = VisualVisibility.Visible,
+        };
+
+        bool handled = RaylibPrimitiveRenderer.TryBuildDirectVfxVisual(
+            in primitive,
+            scaleMul: 0.5f,
+            out PrefabFinalizedVisual visual);
+
+        Assert.That(handled, Is.True);
+        Assert.That(visual.Kind, Is.EqualTo(PrefabVisualPartKind.Vfx));
+        Assert.That(visual.StableId, Is.EqualTo(99));
+        Assert.That(visual.EffectAssetId, Is.EqualTo(42));
+        Assert.That(visual.VfxSpawnMode, Is.EqualTo(PrefabVfxSpawnMode.Loop));
+        Assert.That(visual.Scale, Is.EqualTo(new Vector3(1f, 1.5f, 2f)));
+    }
+
+    [Test]
+    public void ComposeEffectKey_UsesFullStableAndEffectIdentity()
+    {
+        RaylibVfxEffectKey first = RaylibVfxRenderer.ComposeEffectKey(17, 42);
+        RaylibVfxEffectKey same = RaylibVfxRenderer.ComposeEffectKey(17, 42);
+        RaylibVfxEffectKey differentEffect = RaylibVfxRenderer.ComposeEffectKey(17, 43);
+
+        Assert.That(first, Is.EqualTo(same));
+        Assert.That(first, Is.Not.EqualTo(differentEffect));
+    }
+
+    [Test]
+    public void BuildEmitterPlan_PrimitiveSphereLoop_ProducesAnimatedParticlePlan()
+    {
+        PrefabFinalizedVisual visual = PrefabFinalizedVisual.Vfx(
+            stableId: 17,
+            position: new Vector3(1f, 2f, 3f),
+            rotation: Quaternion.Identity,
+            scale: new Vector3(2f, 1f, 1f),
+            color: new Vector4(0.35f, 0.95f, 1f, 0.85f),
+            effectAssetId: 42,
+            spawnMode: PrefabVfxSpawnMode.Loop);
+        MeshAssetDescriptor descriptor = CreateSphereEffectDescriptor(42);
+
+        RaylibVfxEmitterPlan plan = RaylibVfxRenderer.BuildEmitterPlan(
+            in visual,
+            in descriptor,
+            ageSeconds: 1.25d);
+
+        Assert.That(plan.Shape, Is.EqualTo(VfxEmitterShape.PrimitiveSphere));
+        Assert.That(plan.SpawnMode, Is.EqualTo(PrefabVfxSpawnMode.Loop));
+        Assert.That(plan.ParticleCount, Is.EqualTo(24));
+        Assert.That(plan.RingSegments, Is.EqualTo(20));
+        Assert.That(plan.ShellRadius, Is.GreaterThan(0f));
+        Assert.That(plan.OrbitPhase, Is.GreaterThan(0f));
+        Assert.That(plan.CoreColor.W, Is.GreaterThan(0f));
+        Assert.That(plan.Life01, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void BuildEmitterPlan_Once_FadesOutByLifetime()
+    {
+        PrefabFinalizedVisual visual = PrefabFinalizedVisual.Vfx(
+            stableId: 23,
+            position: Vector3.Zero,
+            rotation: Quaternion.Identity,
+            scale: Vector3.One,
+            color: Vector4.One,
+            effectAssetId: 77,
+            spawnMode: PrefabVfxSpawnMode.Once);
+        MeshAssetDescriptor descriptor = CreateSphereEffectDescriptor(77);
+
+        RaylibVfxEmitterPlan plan = RaylibVfxRenderer.BuildEmitterPlan(
+            in visual,
+            in descriptor,
+            ageSeconds: 1.0d);
+
+        Assert.That(plan.Life01, Is.EqualTo(1f));
+        Assert.That(plan.CoreColor.W, Is.EqualTo(0f));
+        Assert.That(plan.ShellColor.W, Is.EqualTo(0f));
+        Assert.That(plan.ParticleColor.W, Is.EqualTo(0f));
+    }
+
+    [Test]
+    public void BuildEmitterPlan_RejectsEffectAssetWithoutEmitterData()
+    {
+        PrefabFinalizedVisual visual = PrefabFinalizedVisual.Vfx(
+            stableId: 31,
+            position: Vector3.Zero,
+            rotation: Quaternion.Identity,
+            scale: Vector3.One,
+            color: Vector4.One,
+            effectAssetId: 88,
+            spawnMode: PrefabVfxSpawnMode.Loop);
+        MeshAssetDescriptor descriptor = MeshAssetDescriptor.Billboard(88);
+
+        Assert.That(
+            () => RaylibVfxRenderer.BuildEmitterPlan(in visual, in descriptor, ageSeconds: 0d),
+            Throws.InvalidOperationException.With.Message.Contains("must declare vfx emitter data"));
+    }
+
+    [Test]
+    public void BuildEmitterPlan_PrimitiveCube_UsesAuthoredShapeAndParticleBudget()
+    {
+        PrefabFinalizedVisual visual = PrefabFinalizedVisual.Vfx(
+            stableId: 41,
+            position: Vector3.Zero,
+            rotation: Quaternion.Identity,
+            scale: Vector3.One,
+            color: Vector4.One,
+            effectAssetId: 91,
+            spawnMode: PrefabVfxSpawnMode.Loop);
+        MeshAssetDescriptor descriptor = MeshAssetDescriptor.Primitive(91, PrimitiveMeshKind.Cube);
+        descriptor.VfxEffectData = new VfxEffectAssetData(new VfxEmitterDescriptor(
+            VfxEmitterShape.PrimitiveCube,
+            particleCount: 9,
+            ringSegments: 11,
+            radiusScale: 0.8f,
+            coreRadiusScale: 0.2f,
+            particleRadiusScale: 0.06f,
+            lifetimeSeconds: 0.5f,
+            pulseSpeedRadPerSecond: 3.2f,
+            orbitSpeedRadPerSecond: 1.1f));
+
+        RaylibVfxEmitterPlan plan = RaylibVfxRenderer.BuildEmitterPlan(
+            in visual,
+            in descriptor,
+            ageSeconds: 0.2d);
+
+        Assert.That(plan.Shape, Is.EqualTo(VfxEmitterShape.PrimitiveCube));
+        Assert.That(plan.ParticleCount, Is.EqualTo(9));
+        Assert.That(plan.RingSegments, Is.EqualTo(11));
+    }
+
+    private static MeshAssetDescriptor CreateSphereEffectDescriptor(int id)
+    {
+        MeshAssetDescriptor descriptor = MeshAssetDescriptor.Primitive(id, PrimitiveMeshKind.Sphere);
+        descriptor.VfxEffectData = new VfxEffectAssetData(new VfxEmitterDescriptor(
+            VfxEmitterShape.PrimitiveSphere,
+            particleCount: 24,
+            ringSegments: 20,
+            radiusScale: 1.15f,
+            coreRadiusScale: 0.28f,
+            particleRadiusScale: 0.085f,
+            lifetimeSeconds: 0.75f,
+            pulseSpeedRadPerSecond: 5.2f,
+            orbitSpeedRadPerSecond: 1.7f));
+        return descriptor;
+    }
+}

--- a/src/Tests/RaylibAdapterTests/RaylibVisualHeightmapRendererTests.cs
+++ b/src/Tests/RaylibAdapterTests/RaylibVisualHeightmapRendererTests.cs
@@ -1,0 +1,141 @@
+using System;
+using Ludots.Client.Raylib.Rendering;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Presentation.Terrain;
+using NUnit.Framework;
+using Raylib_cs;
+
+namespace Ludots.Tests.RaylibAdapter;
+
+[TestFixture]
+public sealed class RaylibVisualHeightmapRendererTests
+{
+    [Test]
+    public void ShouldUseOverviewMesh_WhenCameraFramesEastAsiaScaleTerrain()
+    {
+        var source = new FakeVisualHeightmapRenderSource(
+            new WorldAabbCm(-450_326_016, -257_329_152, 900_652_032, 514_658_304),
+            chunkColumns: 224,
+            chunkRows: 128);
+        var camera = new Camera3D
+        {
+            position = new System.Numerics.Vector3(0f, 6_750_000f, 0f),
+            target = System.Numerics.Vector3.Zero,
+            fovy = 55f,
+            projection = CameraProjection.CAMERA_PERSPECTIVE
+        };
+
+        bool useOverview = RaylibVisualHeightmapRenderer.ShouldUseOverviewMesh(
+            source,
+            in camera,
+            aspect: 16f / 9f,
+            detailVisibleRadiusCm: 140_000f,
+            activationMultiplier: 2f);
+
+        Assert.That(useOverview, Is.True);
+    }
+
+    [Test]
+    public void ShouldUseOverviewMesh_WhenCameraIsNearTerrain_ReturnsFalse()
+    {
+        var source = new FakeVisualHeightmapRenderSource(
+            new WorldAabbCm(-450_326_016, -257_329_152, 900_652_032, 514_658_304),
+            chunkColumns: 224,
+            chunkRows: 128);
+        var camera = new Camera3D
+        {
+            position = new System.Numerics.Vector3(0f, 1_000f, 0f),
+            target = System.Numerics.Vector3.Zero,
+            fovy = 55f,
+            projection = CameraProjection.CAMERA_PERSPECTIVE
+        };
+
+        bool useOverview = RaylibVisualHeightmapRenderer.ShouldUseOverviewMesh(
+            source,
+            in camera,
+            aspect: 16f / 9f,
+            detailVisibleRadiusCm: 140_000f,
+            activationMultiplier: 2f);
+
+        Assert.That(useOverview, Is.False);
+    }
+
+    [Test]
+    public void ResolveOverviewStepChunks_KeepsLargeMapOverviewUnderRaylibVertexLimit()
+    {
+        int step = RaylibVisualHeightmapRenderer.ResolveOverviewStepChunks(
+            chunkColumns: 1024,
+            chunkRows: 1024,
+            maxVertices: 60_000);
+
+        int columns = RaylibVisualHeightmapRenderer.ResolveOverviewAxisPointCount(1024, step);
+        int rows = RaylibVisualHeightmapRenderer.ResolveOverviewAxisPointCount(1024, step);
+
+        Assert.That(columns * rows, Is.LessThanOrEqualTo(60_000));
+        Assert.That(columns * rows, Is.LessThanOrEqualTo(ushort.MaxValue));
+    }
+
+    [Test]
+    public void ResolveOverviewTextureSize_UsesScreenScaledResolutionForEastAsiaEditing()
+    {
+        RaylibVisualHeightmapRenderer.ResolveOverviewTextureSize(
+            new WorldAabbCm(-450_326_016, -257_329_152, 900_652_032, 514_658_304),
+            screenWidth: 1600,
+            screenHeight: 900,
+            out int textureWidth,
+            out int textureHeight);
+
+        Assert.That(textureWidth, Is.EqualTo(3072));
+        Assert.That(textureHeight, Is.EqualTo(1755));
+        Assert.That(textureWidth, Is.GreaterThan(112 * 8));
+        Assert.That(textureHeight, Is.GreaterThan(64 * 8));
+    }
+
+    [Test]
+    public void ResolveChunkSampleStride_KeepsImportedEditorChunkUnderRaylibVertexLimit()
+    {
+        int stride = RaylibVisualHeightmapRenderer.ResolveChunkSampleStride(
+            sampleColumns: 257,
+            sampleRows: 257);
+
+        int columns = RaylibVisualHeightmapRenderer.ResolveChunkSampleAxisPointCount(257, stride);
+        int rows = RaylibVisualHeightmapRenderer.ResolveChunkSampleAxisPointCount(257, stride);
+
+        Assert.That(stride, Is.EqualTo(2));
+        Assert.That(columns, Is.EqualTo(129));
+        Assert.That(rows, Is.EqualTo(129));
+        Assert.That(columns * rows, Is.LessThanOrEqualTo(ushort.MaxValue));
+        Assert.That(RaylibVisualHeightmapRenderer.ResolveChunkSourceSampleIndex(columns - 1, 257, stride), Is.EqualTo(256));
+    }
+
+    private sealed class FakeVisualHeightmapRenderSource : IVisualHeightmapRenderSource
+    {
+        public FakeVisualHeightmapRenderSource(WorldAabbCm bounds, int chunkColumns, int chunkRows)
+        {
+            Bounds = bounds;
+            ChunkColumns = chunkColumns;
+            ChunkRows = chunkRows;
+        }
+
+        public WorldAabbCm Bounds { get; }
+
+        public int ChunkColumns { get; }
+
+        public int ChunkRows { get; }
+
+        public int SamplesPerChunkColumn => 33;
+
+        public int SamplesPerChunkRow => 33;
+
+        public int DefaultLayerIndex => 0;
+
+        public int Revision => 0;
+
+        public VisualHeightmapRenderProfile RenderProfile { get; } = VisualHeightmapRenderProfile.CreateDefault();
+
+        public bool TryGetChunk(int chunkX, int chunkY, out VisualHeightmapRenderChunk chunk)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}


### PR DESCRIPTION
## 概述
把 Raylib 从基础绘制路径提升到可用于正式 Showcase 的地形环境渲染：地形、海水、天空、光照、雾和后处理拥有完整的帧内管线，并补齐大地图远景与证据验证。

## 主要改动
- 新增 Raylib 天空盒、光照/雾、透明水面波动、Fresnel 和后处理合成。
- 新增 Core `VisualHeightmapRenderProfile`，地图可以声明海平面、水体开关、显示高度夸张和颜色对比度。
- 大地图地形新增异步总览网格/纹理、远近 LOD 和切换迟滞；超大 chunk 自动降采样，避免 Raylib 索引上限。
- 海陆颜色按地图范围分别归一化，海底深度连续，水面按水域单元生成。
- VFX 的 spawn mode 冲突改成显式失败，截图证据改成完整 PNG 解码、尺寸和视觉平坦检查。
- Blacksmith / Visual Terrain Editor / 30K showcase 的资产和 smoke 入口同步更新。

## 验证
- Raylib 应用构建通过，0 error。
- Raylib adapter focused tests: 26/26 passed。
- Presentation focused tests: 47/47 passed。
- Gas visual-heightmap contract tests: 8/8 passed。
- `git diff --check` 通过。
- 标准 Blacksmith Raylib direct smoke：退出码 0，截图有效，VFX `last=1,total=176`。
- Blacksmith 大世界 terrain/water smoke：截图有效，地形 chunk `12`，远景和 minimap 运行正常。

## 说明
大世界场景当前仍是 30K 标记压力 Showcase，画面信息密度较高；本 PR 验收重点是正式地形环境管线和大地图稳定渲染，不改变该 Showcase 的业务展示布局。