### PR TITLE
Align launcher evidence with current camera batch contract

### DIFF
--- a/src/Libraries/Arch/src/Arch/Core/Events/World.Events.cs
+++ b/src/Libraries/Arch/src/Arch/Core/Events/World.Events.cs
@@ -55,7 +55,10 @@ public partial class World
     /// <param name="handler">The delegate to call.</param>
     public void SubscribeEntityDestroyed(EntityDestroyedHandler handler)
     {
-        ArgumentNullException.ThrowIfNull(handler);
+        if (handler is null)
+        {
+            throw new ArgumentNullException(nameof(handler));
+        }
         lock (_entityDestroyedHandlersWriteLock)
         {
             EntityDestroyedHandler[] current = Volatile.Read(ref _entityDestroyedHandlers);

--- a/src/Tests/ArchitectureTests/LauncherBootstrapContractTests.cs
+++ b/src/Tests/ArchitectureTests/LauncherBootstrapContractTests.cs
@@ -41,7 +41,12 @@ namespace Ludots.Tests.Architecture
                     outputDrainTimeoutMs: 250);
                 stopwatch.Stop();
 
-                Assert.That(result.ExitCode, Is.Zero);
+                Assert.That(result.ProcessExitCode, Is.Zero);
+                Assert.That(result.WorkflowExitCode, Is.EqualTo(-3));
+                Assert.That(result.Status, Is.EqualTo(ProcessRunStatus.OutputDrainFailed));
+                Assert.That(result.ProcessExited, Is.True);
+                Assert.That(result.ProcessTreeExitConfirmed, Is.False);
+                Assert.That(result.OutputComplete, Is.False);
                 Assert.That(result.Output, Does.Contain("parent-done"));
                 Assert.That(result.Output, Does.Contain("Redirected output remained open"));
                 Assert.That(stopwatch.Elapsed, Is.LessThan(TimeSpan.FromSeconds(2)));

--- a/src/Tests/ArchitectureTests/LauncherProcessRunnerContractTests.cs
+++ b/src/Tests/ArchitectureTests/LauncherProcessRunnerContractTests.cs
@@ -1,0 +1,469 @@
+using System.Diagnostics;
+using System.Globalization;
+using Ludots.Launcher.Backend;
+using NUnit.Framework;
+
+namespace Ludots.Tests.Architecture;
+
+[TestFixture]
+[NonParallelizable]
+public sealed class LauncherProcessRunnerContractTests
+{
+    [Test]
+    public async Task RunProcessAsync_PreservesExitCodeAndOutput_ForNormalExit()
+    {
+        RequireWindows();
+
+        ProcessRunResult result = await LauncherService.RunProcessAsync(
+            "cmd.exe",
+            "/d /c \"echo stdout-line & echo stderr-line 1>&2\"",
+            Path.GetTempPath(),
+            timeoutMs: 5_000);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Status, Is.EqualTo(ProcessRunStatus.Success));
+            Assert.That(result.WorkflowExitCode, Is.Zero);
+            Assert.That(result.ProcessExitCode, Is.Zero);
+            Assert.That(result.Output, Does.Contain("stdout-line"));
+            Assert.That(result.Output, Does.Contain("stderr-line"));
+            Assert.That(result.TimedOut, Is.False);
+            Assert.That(result.ProcessExited, Is.True);
+            Assert.That(result.ProcessTreeExitConfirmed, Is.False);
+            Assert.That(result.OutputComplete, Is.True);
+            Assert.That(result.Failures, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task RunProcessAsync_PreservesNonZeroExitCode_ForProcessFailure()
+    {
+        RequireWindows();
+
+        ProcessRunResult result = await LauncherService.RunProcessAsync(
+            "cmd.exe",
+            "/d /c \"echo failed-output & exit /b 7\"",
+            Path.GetTempPath(),
+            timeoutMs: 5_000);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Status, Is.EqualTo(ProcessRunStatus.ProcessFailed));
+            Assert.That(result.WorkflowExitCode, Is.EqualTo(7));
+            Assert.That(result.ProcessExitCode, Is.EqualTo(7));
+            Assert.That(result.Output, Does.Contain("failed-output"));
+            Assert.That(result.TimedOut, Is.False);
+            Assert.That(result.ProcessExited, Is.True);
+            Assert.That(result.ProcessTreeExitConfirmed, Is.False);
+            Assert.That(result.OutputComplete, Is.True);
+            Assert.That(result.Failures, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task RunProcessAsync_ReturnsTimedOutCleanly_AfterEntireProcessTreeExits()
+    {
+        RequireWindows();
+
+        using var fixture = BlockingProcessFixture.Create(startChild: true);
+        ProcessRunOperations operations = CreateOperationsWaitingForReady(fixture.ReadyPath);
+
+        ProcessRunResult result = await LauncherService.RunProcessAsync(
+            WindowsPowerShellPath,
+            fixture.ParentArguments,
+            fixture.DirectoryPath,
+            timeoutMs: 5_000,
+            outputDrainTimeoutMs: 2_000,
+            terminationTimeoutMs: 5_000,
+            operations);
+        fixture.CaptureProcessIds(result);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Status, Is.EqualTo(ProcessRunStatus.TimedOutCleanly));
+            Assert.That(result.WorkflowExitCode, Is.EqualTo(-1));
+            Assert.That(result.ProcessExitCode, Is.Not.Null);
+            Assert.That(result.TimedOut, Is.True);
+            Assert.That(result.ProcessExited, Is.True);
+            Assert.That(result.ProcessTreeExitConfirmed, Is.True);
+            Assert.That(result.OutputComplete, Is.True);
+            Assert.That(result.Failures, Is.Empty);
+            AssertProcessExited(result.ProcessId);
+            AssertProcessExited(fixture.ChildProcessId);
+        });
+    }
+
+    [Test]
+    public async Task RunProcessAsync_ReturnsTerminationFailed_WhenKillThrows()
+    {
+        RequireWindows();
+
+        using var fixture = BlockingProcessFixture.Create(startChild: false);
+        ProcessRunOperations defaults = ProcessRunOperations.Default;
+        var operations = new ProcessRunOperations(
+            process =>
+            {
+                WaitForReadyOrThrow(fixture.ReadyPath);
+                throw new InvalidOperationException("synthetic kill failure");
+            },
+            defaults.ConfirmProcessExitAsync,
+            defaults.CancelStandardOutputRead,
+            defaults.CancelStandardErrorRead);
+
+        ProcessRunResult result = await LauncherService.RunProcessAsync(
+            WindowsPowerShellPath,
+            fixture.ParentArguments,
+            fixture.DirectoryPath,
+            timeoutMs: 250,
+            outputDrainTimeoutMs: 100,
+            terminationTimeoutMs: 100,
+            operations);
+        fixture.CaptureProcessIds(result);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Status, Is.EqualTo(ProcessRunStatus.TerminationFailed));
+            Assert.That(result.WorkflowExitCode, Is.EqualTo(-2));
+            Assert.That(result.ProcessExitCode, Is.Null);
+            Assert.That(result.ProcessExited, Is.False);
+            Assert.That(result.ProcessTreeExitConfirmed, Is.False);
+            Assert.That(result.Failures.Any(failure =>
+                failure.Stage == ProcessRunFailureStage.TerminateProcessTree &&
+                failure.Exception is InvalidOperationException &&
+                failure.Exception.Message == "synthetic kill failure"), Is.True);
+            Assert.That(result.Failures.Any(failure =>
+                failure.Stage == ProcessRunFailureStage.ConfirmProcessTreeExit), Is.True);
+            Assert.That(result.Output, Does.Contain(nameof(ProcessRunFailureStage.TerminateProcessTree)));
+            Assert.That(result.Output, Does.Contain(typeof(InvalidOperationException).FullName));
+            Assert.That(result.Output, Does.Contain("synthetic kill failure"));
+            Assert.That(result.Output, Does.Contain(result.ProcessId.ToString(CultureInfo.InvariantCulture)));
+            Assert.That(result.Output, Does.Contain(WindowsPowerShellPath));
+        });
+    }
+
+    [Test]
+    public async Task RunProcessAsync_ReturnsTerminationFailed_WhenKillDoesNotExitProcess()
+    {
+        RequireWindows();
+
+        using var fixture = BlockingProcessFixture.Create(startChild: false);
+        ProcessRunOperations defaults = ProcessRunOperations.Default;
+        var operations = new ProcessRunOperations(
+            _ => WaitForReadyOrThrow(fixture.ReadyPath),
+            defaults.ConfirmProcessExitAsync,
+            defaults.CancelStandardOutputRead,
+            defaults.CancelStandardErrorRead);
+
+        ProcessRunResult result = await LauncherService.RunProcessAsync(
+            WindowsPowerShellPath,
+            fixture.ParentArguments,
+            fixture.DirectoryPath,
+            timeoutMs: 250,
+            outputDrainTimeoutMs: 100,
+            terminationTimeoutMs: 100,
+            operations);
+        fixture.CaptureProcessIds(result);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Status, Is.EqualTo(ProcessRunStatus.TerminationFailed));
+            Assert.That(result.WorkflowExitCode, Is.EqualTo(-2));
+            Assert.That(result.ProcessExited, Is.False);
+            Assert.That(result.ProcessTreeExitConfirmed, Is.False);
+            Assert.That(result.Failures.Any(failure =>
+                failure.Stage == ProcessRunFailureStage.TerminateProcessTree), Is.False);
+            Assert.That(result.Failures.Any(failure =>
+                failure.Stage == ProcessRunFailureStage.ConfirmProcessTreeExit &&
+                failure.Exception is TimeoutException), Is.True);
+        });
+    }
+
+    [Test]
+    public async Task RunProcessAsync_MarksOutputIncomplete_WhenDescendantKeepsRedirectedOutputOpen()
+    {
+        RequireWindows();
+
+        using var fixture = BlockingProcessFixture.Create(startChild: true, parentExitsAfterReady: true);
+        ProcessRunResult result = await LauncherService.RunProcessAsync(
+            WindowsPowerShellPath,
+            fixture.ParentArguments,
+            fixture.DirectoryPath,
+            timeoutMs: 5_000,
+            outputDrainTimeoutMs: 250);
+        fixture.CaptureProcessIds(result);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Status, Is.EqualTo(ProcessRunStatus.OutputDrainFailed));
+            Assert.That(result.WorkflowExitCode, Is.EqualTo(-3));
+            Assert.That(result.ProcessExitCode, Is.Zero);
+            Assert.That(result.Output, Does.Contain("parent-done"));
+            Assert.That(result.Output, Does.Contain("Redirected output remained open"));
+            Assert.That(result.ProcessExited, Is.True);
+            Assert.That(result.ProcessTreeExitConfirmed, Is.False);
+            Assert.That(result.OutputComplete, Is.False);
+            Assert.That(result.Failures.Select(failure => failure.Stage),
+                Is.EqualTo(new[] { ProcessRunFailureStage.DrainOutput }));
+        });
+    }
+
+    [TestCase(nameof(ProcessRunFailureStage.CancelStandardOutputRead))]
+    [TestCase(nameof(ProcessRunFailureStage.CancelStandardErrorRead))]
+    public async Task RunProcessAsync_ReturnsOutputDrainFailed_WhenOutputCancellationFails(
+        string failingStageName)
+    {
+        RequireWindows();
+        var failingStage = Enum.Parse<ProcessRunFailureStage>(failingStageName);
+
+        using var fixture = BlockingProcessFixture.Create(startChild: true, parentExitsAfterReady: true);
+        ProcessRunOperations defaults = ProcessRunOperations.Default;
+        var operations = new ProcessRunOperations(
+            defaults.KillProcessTree,
+            defaults.ConfirmProcessExitAsync,
+            process =>
+            {
+                defaults.CancelStandardOutputRead(process);
+                if (failingStage == ProcessRunFailureStage.CancelStandardOutputRead)
+                {
+                    throw new InvalidOperationException("synthetic stdout cancellation failure");
+                }
+            },
+            process =>
+            {
+                defaults.CancelStandardErrorRead(process);
+                if (failingStage == ProcessRunFailureStage.CancelStandardErrorRead)
+                {
+                    throw new InvalidOperationException("synthetic stderr cancellation failure");
+                }
+            });
+
+        ProcessRunResult result = await LauncherService.RunProcessAsync(
+            WindowsPowerShellPath,
+            fixture.ParentArguments,
+            fixture.DirectoryPath,
+            timeoutMs: 5_000,
+            outputDrainTimeoutMs: 250,
+            operations: operations);
+        fixture.CaptureProcessIds(result);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Status, Is.EqualTo(ProcessRunStatus.OutputDrainFailed));
+            Assert.That(result.WorkflowExitCode, Is.EqualTo(-3));
+            Assert.That(result.ProcessExitCode, Is.Zero);
+            Assert.That(result.ProcessExited, Is.True);
+            Assert.That(result.ProcessTreeExitConfirmed, Is.False);
+            Assert.That(result.OutputComplete, Is.False);
+            Assert.That(result.Failures.Any(failure =>
+                failure.Stage == failingStage &&
+                failure.Exception is InvalidOperationException), Is.True);
+            Assert.That(result.Output, Does.Contain(failingStage.ToString()));
+            Assert.That(result.Output, Does.Contain("cancellation failure"));
+        });
+    }
+
+    private static string WindowsPowerShellPath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.Windows),
+        "System32",
+        "WindowsPowerShell",
+        "v1.0",
+        "powershell.exe");
+
+    private static void RequireWindows()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("Launcher process-tree cleanup is implemented through the Windows entireProcessTree contract.");
+        }
+    }
+
+    private static ProcessRunOperations CreateOperationsWaitingForReady(string readyPath)
+    {
+        ProcessRunOperations defaults = ProcessRunOperations.Default;
+        return new ProcessRunOperations(
+            process =>
+            {
+                WaitForReadyOrThrow(readyPath);
+                defaults.KillProcessTree(process);
+            },
+            defaults.ConfirmProcessExitAsync,
+            defaults.CancelStandardOutputRead,
+            defaults.CancelStandardErrorRead);
+    }
+
+    private static void WaitForReadyOrThrow(string readyPath)
+    {
+        if (!WaitForFile(readyPath, TimeSpan.FromSeconds(5)))
+        {
+            throw new TimeoutException($"Child process did not publish ready signal: {readyPath}");
+        }
+    }
+
+    private static bool WaitForFile(string path, TimeSpan timeout)
+    {
+        if (File.Exists(path))
+        {
+            return true;
+        }
+
+        string directory = Path.GetDirectoryName(path)
+            ?? throw new InvalidOperationException($"File signal path has no directory: {path}");
+        string fileName = Path.GetFileName(path);
+        var signal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var watcher = new FileSystemWatcher(directory, fileName)
+        {
+            NotifyFilter = NotifyFilters.FileName | NotifyFilters.CreationTime
+        };
+        FileSystemEventHandler handler = (_, _) => signal.TrySetResult(true);
+        RenamedEventHandler renamedHandler = (_, eventArgs) =>
+        {
+            if (string.Equals(eventArgs.Name, fileName, StringComparison.OrdinalIgnoreCase))
+            {
+                signal.TrySetResult(true);
+            }
+        };
+        watcher.Created += handler;
+        watcher.Renamed += renamedHandler;
+        watcher.EnableRaisingEvents = true;
+
+        if (File.Exists(path))
+        {
+            return true;
+        }
+
+        return signal.Task.Wait(timeout);
+    }
+
+    private static void AssertProcessExited(int processId)
+    {
+        try
+        {
+            using Process process = Process.GetProcessById(processId);
+            Assert.That(process.WaitForExit(5_000), Is.True, $"Process {processId} remained alive.");
+        }
+        catch (ArgumentException)
+        {
+        }
+    }
+
+    private sealed class BlockingProcessFixture : IDisposable
+    {
+        private readonly List<int> _processIds = new();
+
+        private BlockingProcessFixture(
+            string directoryPath,
+            string readyPath,
+            string childPidPath,
+            string parentArguments)
+        {
+            DirectoryPath = directoryPath;
+            ReadyPath = readyPath;
+            ChildPidPath = childPidPath;
+            ParentArguments = parentArguments;
+        }
+
+        public string DirectoryPath { get; }
+
+        public string ReadyPath { get; }
+
+        public string ChildPidPath { get; }
+
+        public string ParentArguments { get; }
+
+        public int ChildProcessId => ReadProcessId(ChildPidPath);
+
+        public static BlockingProcessFixture Create(bool startChild, bool parentExitsAfterReady = false)
+        {
+            string directoryPath = Path.Combine(Path.GetTempPath(), $"ludots-launcher-process-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(directoryPath);
+            string readyPath = Path.Combine(directoryPath, "ready.txt");
+            string childPidPath = Path.Combine(directoryPath, "child.pid");
+            string blockingScriptPath = Path.Combine(directoryPath, "block.ps1");
+            File.WriteAllText(
+                blockingScriptPath,
+                "param([string]$ReadyPath, [string]$PidPath)\r\n" +
+                "[IO.File]::WriteAllText($PidPath, [string]$PID)\r\n" +
+                "[IO.File]::WriteAllText($ReadyPath, 'ready')\r\n" +
+                "$gate = [Threading.ManualResetEventSlim]::new($false)\r\n" +
+                "$gate.Wait()\r\n");
+
+            string parentScriptPath;
+            if (startChild)
+            {
+                parentScriptPath = Path.Combine(directoryPath, "parent.ps1");
+                File.WriteAllText(
+                    parentScriptPath,
+                    "param([string]$ChildScript, [string]$ReadyPath, [string]$ChildPidPath, [string]$ExitAfterReady)\r\n" +
+                    "$powershell = (Get-Process -Id $PID).Path\r\n" +
+                    "$childArgs = @('-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', ('\"' + $ChildScript + '\"'), ('\"' + $ReadyPath + '\"'), ('\"' + $ChildPidPath + '\"'))\r\n" +
+                    "$child = Start-Process -FilePath $powershell -ArgumentList $childArgs -PassThru -NoNewWindow\r\n" +
+                    "$deadline = [Diagnostics.Stopwatch]::StartNew()\r\n" +
+                    "while (-not (Test-Path -LiteralPath $ReadyPath)) {\r\n" +
+                    "  if ($deadline.ElapsedMilliseconds -ge 5000) { throw 'Child did not become ready.' }\r\n" +
+                    "  [Threading.Thread]::Yield() | Out-Null\r\n" +
+                    "}\r\n" +
+                    "if ($ExitAfterReady -eq 'true') { Write-Output 'parent-done'; exit 0 }\r\n" +
+                    "$child.WaitForExit()\r\n");
+            }
+            else
+            {
+                parentScriptPath = blockingScriptPath;
+                childPidPath = Path.Combine(directoryPath, "parent.pid");
+            }
+
+            string parentArguments = startChild
+                ? $"-NoProfile -NonInteractive -ExecutionPolicy Bypass -File {Quote(parentScriptPath)} {Quote(blockingScriptPath)} {Quote(readyPath)} {Quote(childPidPath)} {parentExitsAfterReady.ToString().ToLowerInvariant()}"
+                : $"-NoProfile -NonInteractive -ExecutionPolicy Bypass -File {Quote(blockingScriptPath)} {Quote(readyPath)} {Quote(childPidPath)}";
+            return new BlockingProcessFixture(directoryPath, readyPath, childPidPath, parentArguments);
+        }
+
+        public void CaptureProcessIds(ProcessRunResult result)
+        {
+            _processIds.Add(result.ProcessId);
+            if (File.Exists(ChildPidPath))
+            {
+                _processIds.Add(ReadProcessId(ChildPidPath));
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (int processId in _processIds.Distinct())
+            {
+                KillProcessTreeIfRunning(processId);
+            }
+
+            if (Directory.Exists(DirectoryPath))
+            {
+                Directory.Delete(DirectoryPath, recursive: true);
+            }
+        }
+
+        private static int ReadProcessId(string path)
+        {
+            WaitForReadyOrThrow(path);
+            return int.Parse(File.ReadAllText(path), CultureInfo.InvariantCulture);
+        }
+
+        private static void KillProcessTreeIfRunning(int processId)
+        {
+            try
+            {
+                using Process process = Process.GetProcessById(processId);
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                    process.WaitForExit(5_000);
+                }
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        private static string Quote(string value) => $"\"{value.Replace("\"", "\\\"")}\"";
+    }
+}

--- a/src/Tools/Ludots.Launcher.Backend/LauncherService.cs
+++ b/src/Tools/Ludots.Launcher.Backend/LauncherService.cs
@@ -9,6 +9,65 @@ using Ludots.Core.Modding;
 
 namespace Ludots.Launcher.Backend;
 
+internal enum ProcessRunStatus
+{
+    Success,
+    ProcessFailed,
+    TimedOutCleanly,
+    TerminationFailed,
+    OutputDrainFailed
+}
+
+internal enum ProcessRunFailureStage
+{
+    CaptureProcessTree,
+    TerminateProcessTree,
+    ConfirmProcessTreeExit,
+    DrainOutput,
+    CancelStandardOutputRead,
+    CancelStandardErrorRead
+}
+
+internal sealed record ProcessRunFailure(ProcessRunFailureStage Stage, Exception Exception);
+
+internal sealed record ProcessRunResult(
+    ProcessRunStatus Status,
+    int? ProcessExitCode,
+    string Output,
+    bool TimedOut,
+    bool ProcessExited,
+    bool ProcessTreeExitConfirmed,
+    bool OutputComplete,
+    int ProcessId,
+    string FileName,
+    string Arguments,
+    IReadOnlyList<ProcessRunFailure> Failures)
+{
+    public bool Succeeded => Status == ProcessRunStatus.Success;
+
+    public int WorkflowExitCode => Status switch
+    {
+        ProcessRunStatus.Success or ProcessRunStatus.ProcessFailed => ProcessExitCode ?? -4,
+        ProcessRunStatus.TimedOutCleanly => -1,
+        ProcessRunStatus.TerminationFailed => -2,
+        ProcessRunStatus.OutputDrainFailed => -3,
+        _ => -4
+    };
+}
+
+internal sealed record ProcessRunOperations(
+    Action<Process> KillProcessTree,
+    Func<Task, TimeSpan, Task> ConfirmProcessExitAsync,
+    Action<Process> CancelStandardOutputRead,
+    Action<Process> CancelStandardErrorRead)
+{
+    public static ProcessRunOperations Default { get; } = new(
+        process => process.Kill(entireProcessTree: true),
+        (processExited, timeout) => processExited.WaitAsync(timeout),
+        process => process.CancelOutputRead(),
+        process => process.CancelErrorRead());
+}
+
 public sealed class LauncherService
 {
     private const int LaunchGraphSchemaVersion = 1;
@@ -309,17 +368,17 @@ public sealed class LauncherService
             {
                 var install = await RunNodePackageCommandAsync("ci", profile.ClientProjectDirectory, timeoutMs: 300_000);
                 output.AppendLine(install.Output);
-                if (install.ExitCode != 0)
+                if (!install.Succeeded)
                 {
-                    return new LauncherBuildResult(platformId, false, install.ExitCode, output.ToString());
+                    return new LauncherBuildResult(platformId, false, install.WorkflowExitCode, output.ToString());
                 }
             }
 
             var clientBuild = await RunNodePackageCommandAsync("run build", profile.ClientProjectDirectory, timeoutMs: 300_000);
             output.AppendLine(clientBuild.Output);
-            if (clientBuild.ExitCode != 0)
+            if (!clientBuild.Succeeded)
             {
-                return new LauncherBuildResult(platformId, false, clientBuild.ExitCode, output.ToString());
+                return new LauncherBuildResult(platformId, false, clientBuild.WorkflowExitCode, output.ToString());
             }
         }
 
@@ -328,7 +387,7 @@ public sealed class LauncherService
             _repoRoot,
             timeoutMs: 300_000);
         output.AppendLine(dotnetBuild.Output);
-        return new LauncherBuildResult(platformId, dotnetBuild.ExitCode == 0, dotnetBuild.ExitCode, output.ToString());
+        return new LauncherBuildResult(platformId, dotnetBuild.Succeeded, dotnetBuild.WorkflowExitCode, output.ToString());
     }
 
     public string WriteGameJson(string platformId, IEnumerable<string> modIds)
@@ -450,7 +509,7 @@ public sealed class LauncherService
         var solutionPath = Path.Combine(entry.Info.RootPath, $"{entry.Info.Id}.sln");
 
         var create = await RunDotnetAsync($"new sln -n {entry.Info.Id} --force", entry.Info.RootPath, timeoutMs: 30_000);
-        if (create.ExitCode != 0)
+        if (!create.Succeeded)
         {
             throw new InvalidOperationException(create.Output);
         }
@@ -458,7 +517,10 @@ public sealed class LauncherService
         var projectPath = EnsureProjectFile(entry, config);
         if (File.Exists(projectPath))
         {
-            await RunDotnetAsync($"sln \"{solutionPath}\" add \"{projectPath}\"", entry.Info.RootPath, timeoutMs: 30_000);
+            await RunDotnetOrThrowAsync(
+                $"sln \"{solutionPath}\" add \"{projectPath}\"",
+                entry.Info.RootPath,
+                timeoutMs: 30_000);
         }
 
         foreach (var dependencyId in entry.Manifest.Dependencies.Keys.OrderBy(id => id, StringComparer.OrdinalIgnoreCase))
@@ -467,14 +529,20 @@ public sealed class LauncherService
             var dependencyProjectPath = ResolveBuildProjectPath(config, dependency.Info.RootPath, dependency.Info.Id, dependency.Info.ProjectPath);
             if (!string.IsNullOrWhiteSpace(dependencyProjectPath) && File.Exists(dependencyProjectPath))
             {
-                await RunDotnetAsync($"sln \"{solutionPath}\" add \"{dependencyProjectPath}\"", entry.Info.RootPath, timeoutMs: 30_000);
+                await RunDotnetOrThrowAsync(
+                    $"sln \"{solutionPath}\" add \"{dependencyProjectPath}\"",
+                    entry.Info.RootPath,
+                    timeoutMs: 30_000);
             }
         }
 
         var coreProjectPath = Path.Combine(_repoRoot, "src", "Core", "Ludots.Core.csproj");
         if (File.Exists(coreProjectPath))
         {
-            await RunDotnetAsync($"sln \"{solutionPath}\" add \"{coreProjectPath}\"", entry.Info.RootPath, timeoutMs: 30_000);
+            await RunDotnetOrThrowAsync(
+                $"sln \"{solutionPath}\" add \"{coreProjectPath}\"",
+                entry.Info.RootPath,
+                timeoutMs: 30_000);
         }
 
         return solutionPath;
@@ -1547,9 +1615,9 @@ public sealed class LauncherService
             projectDirectory,
             timeoutMs: 300_000);
         output.AppendLine(publish.Output);
-        if (publish.ExitCode != 0)
+        if (!publish.Succeeded)
         {
-            return new[] { new LauncherBuildResult(resultId, false, publish.ExitCode, output.ToString()) };
+            return new[] { new LauncherBuildResult(resultId, false, publish.WorkflowExitCode, output.ToString()) };
         }
 
         if (!ValidateBrowserRuntimePackage(browserRuntime, out string packageValidationMessage))
@@ -1676,9 +1744,9 @@ public sealed class LauncherService
             projectDirectory,
             timeoutMs: 300_000);
         output.AppendLine(build.Output);
-        if (build.ExitCode != 0)
+        if (!build.Succeeded)
         {
-            return new LauncherBuildResult(entry.Info.Id, false, build.ExitCode, output.ToString());
+            return new LauncherBuildResult(entry.Info.Id, false, build.WorkflowExitCode, output.ToString());
         }
 
         var referenceExportPath = ExportReferenceAssembly(entry.Info, projectDirectory);
@@ -2179,17 +2247,31 @@ public sealed class LauncherService
         return latest;
     }
 
-    internal static async Task<(int ExitCode, string Output)> RunProcessAsync(
+    internal static async Task<ProcessRunResult> RunProcessAsync(
         string fileName,
         string arguments,
         string workingDirectory,
         int timeoutMs,
-        int outputDrainTimeoutMs = 5_000)
+        int outputDrainTimeoutMs = 5_000,
+        int terminationTimeoutMs = 10_000,
+        ProcessRunOperations? operations = null)
     {
+        if (timeoutMs <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeoutMs), timeoutMs, "Process timeout must be positive.");
+        }
+
         if (outputDrainTimeoutMs <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(outputDrainTimeoutMs), outputDrainTimeoutMs, "Output drain timeout must be positive.");
         }
+
+        if (terminationTimeoutMs <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(terminationTimeoutMs), terminationTimeoutMs, "Termination timeout must be positive.");
+        }
+
+        operations ??= ProcessRunOperations.Default;
 
         var startInfo = new ProcessStartInfo(fileName, arguments)
         {
@@ -2203,20 +2285,16 @@ public sealed class LauncherService
         };
 
         using var process = Process.Start(startInfo) ?? throw new InvalidOperationException($"Failed to start process '{fileName}'.");
+        int processId = process.Id;
+        long processStartTimeUtcTicks = process.StartTime.ToUniversalTime().Ticks;
         var processExited = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        process.Exited += (_, _) => processExited.TrySetResult(true);
-        process.EnableRaisingEvents = true;
-        if (process.HasExited)
-        {
-            processExited.TrySetResult(true);
-        }
-
+        EventHandler processExitedHandler = (_, _) => processExited.TrySetResult(true);
         var outputGate = new object();
         var stdout = new StringBuilder();
         var stderr = new StringBuilder();
         var stdoutClosed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var stderrClosed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        process.OutputDataReceived += (_, eventArgs) =>
+        DataReceivedEventHandler stdoutHandler = (_, eventArgs) =>
         {
             if (eventArgs.Data is null)
             {
@@ -2229,7 +2307,7 @@ public sealed class LauncherService
                 stdout.AppendLine(eventArgs.Data);
             }
         };
-        process.ErrorDataReceived += (_, eventArgs) =>
+        DataReceivedEventHandler stderrHandler = (_, eventArgs) =>
         {
             if (eventArgs.Data is null)
             {
@@ -2242,115 +2320,199 @@ public sealed class LauncherService
                 stderr.AppendLine(eventArgs.Data);
             }
         };
-        process.BeginOutputReadLine();
-        process.BeginErrorReadLine();
-
-        using var timeoutSource = new CancellationTokenSource(timeoutMs);
-        bool timedOut = false;
-        bool timedOutProcessTerminated = false;
-        var cleanupFailures = new List<string>();
+        process.Exited += processExitedHandler;
+        process.OutputDataReceived += stdoutHandler;
+        process.ErrorDataReceived += stderrHandler;
         try
         {
-            await processExited.Task.WaitAsync(timeoutSource.Token);
-        }
-        catch (OperationCanceledException)
-        {
-            timedOut = true;
+            process.EnableRaisingEvents = true;
+            if (process.HasExited)
+            {
+                processExited.TrySetResult(true);
+            }
+
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            using var timeoutSource = new CancellationTokenSource(timeoutMs);
+            var failures = new List<ProcessRunFailure>();
+            bool timedOut = false;
+            bool rootProcessExited = false;
+            bool processTreeExitConfirmed = false;
             try
             {
-                if (!process.HasExited)
-                {
-                    process.Kill(entireProcessTree: true);
-                }
-
-                await processExited.Task.WaitAsync(TimeSpan.FromSeconds(10));
-                timedOutProcessTerminated = process.HasExited;
+                await processExited.Task.WaitAsync(timeoutSource.Token);
+                rootProcessExited = true;
             }
-            catch (Exception ex)
+            catch (OperationCanceledException) when (timeoutSource.IsCancellationRequested)
             {
-                if (process.HasExited)
+                timedOut = true;
+                DateTime terminationDeadlineUtc = DateTime.UtcNow.AddMilliseconds(terminationTimeoutMs);
+                WindowsProcessTreeSnapshot? processTreeSnapshot = null;
+
+                try
                 {
-                    timedOutProcessTerminated = true;
+                    processTreeSnapshot = WindowsProcessTreeSnapshot.Capture(processId, processStartTimeUtcTicks);
                 }
-                else
+                catch (Exception ex)
                 {
-                    cleanupFailures.Add(
-                        $"[launcher] Timed-out process could not be confirmed stopped: {ex.GetType().Name}: {ex.Message}");
+                    failures.Add(new ProcessRunFailure(ProcessRunFailureStage.CaptureProcessTree, ex));
+                }
+
+                try
+                {
+                    if (!process.HasExited)
+                    {
+                        operations.KillProcessTree(process);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    failures.Add(new ProcessRunFailure(ProcessRunFailureStage.TerminateProcessTree, ex));
+                }
+
+                try
+                {
+                    await operations.ConfirmProcessExitAsync(
+                        processExited.Task,
+                        GetRemainingTerminationTime(terminationDeadlineUtc, processId));
+                    rootProcessExited = process.HasExited;
+                    if (!rootProcessExited)
+                    {
+                        throw new TimeoutException($"Process {processId} remained alive after process-tree termination completed.");
+                    }
+
+                    if (processTreeSnapshot == null)
+                    {
+                        throw new InvalidOperationException(
+                            $"Process tree rooted at {processId} could not be captured before termination.");
+                    }
+
+                    await processTreeSnapshot.ConfirmExitedAsync(
+                        GetRemainingTerminationTime(terminationDeadlineUtc, processId));
+                    processTreeExitConfirmed = true;
+                }
+                catch (Exception ex)
+                {
+                    failures.Add(new ProcessRunFailure(ProcessRunFailureStage.ConfirmProcessTreeExit, ex));
                 }
             }
-        }
 
-        bool outputClosed = false;
-        try
-        {
-            await Task.WhenAll(stdoutClosed.Task, stderrClosed.Task).WaitAsync(TimeSpan.FromMilliseconds(outputDrainTimeoutMs));
-            outputClosed = true;
-        }
-        catch (TimeoutException)
-        {
+            bool outputComplete = false;
             try
             {
-                process.CancelOutputRead();
+                await Task.WhenAll(stdoutClosed.Task, stderrClosed.Task).WaitAsync(TimeSpan.FromMilliseconds(outputDrainTimeoutMs));
+                outputComplete = true;
             }
-            catch (Exception ex)
+            catch (TimeoutException ex)
             {
-                cleanupFailures.Add(
-                    $"[launcher] Failed to cancel stdout capture after drain timeout: {ex.GetType().Name}: {ex.Message}");
+                failures.Add(new ProcessRunFailure(ProcessRunFailureStage.DrainOutput, ex));
+
+                if (!stdoutClosed.Task.IsCompleted)
+                {
+                    try
+                    {
+                        operations.CancelStandardOutputRead(process);
+                    }
+                    catch (Exception cancelException)
+                    {
+                        failures.Add(new ProcessRunFailure(ProcessRunFailureStage.CancelStandardOutputRead, cancelException));
+                    }
+                }
+
+                if (!stderrClosed.Task.IsCompleted)
+                {
+                    try
+                    {
+                        operations.CancelStandardErrorRead(process);
+                    }
+                    catch (Exception cancelException)
+                    {
+                        failures.Add(new ProcessRunFailure(ProcessRunFailureStage.CancelStandardErrorRead, cancelException));
+                    }
+                }
             }
 
-            try
+            string capturedStdout;
+            string capturedStderr;
+            lock (outputGate)
             {
-                process.CancelErrorRead();
+                capturedStdout = stdout.ToString().TrimEnd();
+                capturedStderr = stderr.ToString().TrimEnd();
             }
-            catch (Exception ex)
+
+            var outputParts = new List<string>(3);
+            if (timedOut)
             {
-                cleanupFailures.Add(
-                    $"[launcher] Failed to cancel stderr capture after drain timeout: {ex.GetType().Name}: {ex.Message}");
+                outputParts.Add($"Process timed out after {timeoutMs} ms.");
             }
-        }
 
-        string capturedStdout;
-        string capturedStderr;
-        lock (outputGate)
-        {
-            capturedStdout = stdout.ToString().TrimEnd();
-            capturedStderr = stderr.ToString().TrimEnd();
-        }
-
-        var outputParts = new List<string>(3);
-        if (timedOut)
-        {
-            outputParts.Add($"Process timed out after {timeoutMs} ms.");
-            if (!timedOutProcessTerminated)
+            if (!string.IsNullOrWhiteSpace(capturedStdout))
             {
-                outputParts.Add("[launcher] Timed-out process did not confirm termination; build outputs may still be changing.");
+                outputParts.Add(capturedStdout);
             }
-        }
 
-        if (!string.IsNullOrWhiteSpace(capturedStdout))
+            if (!string.IsNullOrWhiteSpace(capturedStderr))
+            {
+                outputParts.Add(capturedStderr);
+            }
+
+            if (!outputComplete)
+            {
+                outputParts.Add($"[launcher] Redirected output remained open for {outputDrainTimeoutMs} ms after process exit; capture was stopped explicitly.");
+            }
+
+            foreach (ProcessRunFailure failure in failures)
+            {
+                outputParts.Add($"[launcher] {failure.Stage} failed for process {processId} ({fileName} {arguments}): {failure.Exception.GetType().FullName}: {failure.Exception.Message}");
+            }
+
+            int? processExitCode = rootProcessExited ? process.ExitCode : null;
+            bool terminationFailed = timedOut &&
+                (!rootProcessExited || !processTreeExitConfirmed || failures.Any(failure =>
+                    failure.Stage is ProcessRunFailureStage.CaptureProcessTree or
+                        ProcessRunFailureStage.TerminateProcessTree or
+                        ProcessRunFailureStage.ConfirmProcessTreeExit));
+            ProcessRunStatus status = terminationFailed
+                ? ProcessRunStatus.TerminationFailed
+                : !outputComplete
+                    ? ProcessRunStatus.OutputDrainFailed
+                    : timedOut
+                        ? ProcessRunStatus.TimedOutCleanly
+                        : processExitCode == 0
+                            ? ProcessRunStatus.Success
+                            : ProcessRunStatus.ProcessFailed;
+
+            return new ProcessRunResult(
+                status,
+                processExitCode,
+                string.Join(Environment.NewLine, outputParts),
+                timedOut,
+                rootProcessExited,
+                processTreeExitConfirmed,
+                outputComplete,
+                processId,
+                fileName,
+                arguments,
+                failures.ToArray());
+        }
+        finally
         {
-            outputParts.Add(capturedStdout);
+            process.Exited -= processExitedHandler;
+            process.OutputDataReceived -= stdoutHandler;
+            process.ErrorDataReceived -= stderrHandler;
         }
+    }
 
-        if (!string.IsNullOrWhiteSpace(capturedStderr))
+    private static TimeSpan GetRemainingTerminationTime(DateTime deadlineUtc, int processId)
+    {
+        TimeSpan remaining = deadlineUtc - DateTime.UtcNow;
+        if (remaining <= TimeSpan.Zero)
         {
-            outputParts.Add(capturedStderr);
+            throw new TimeoutException($"Process tree rooted at {processId} exceeded its termination deadline.");
         }
 
-        if (!outputClosed)
-        {
-            outputParts.Add($"[launcher] Redirected output remained open for {outputDrainTimeoutMs} ms after process exit; capture was stopped explicitly.");
-        }
-
-        if (cleanupFailures.Count > 0)
-        {
-            outputParts.AddRange(cleanupFailures);
-        }
-
-        int exitCode = timedOut
-            ? (timedOutProcessTerminated && cleanupFailures.Count == 0 ? -1 : -2)
-            : process.ExitCode;
-        return (exitCode, string.Join(Environment.NewLine, outputParts));
+        return remaining;
     }
 
     private static string ResolveDotnetCommand()
@@ -2387,9 +2549,18 @@ public sealed class LauncherService
                string.Equals(fileName, "dotnet.exe", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static Task<(int ExitCode, string Output)> RunDotnetAsync(string arguments, string workingDirectory, int timeoutMs)
+    private static Task<ProcessRunResult> RunDotnetAsync(string arguments, string workingDirectory, int timeoutMs)
     {
         return RunProcessAsync(ResolveDotnetCommand(), arguments, workingDirectory, timeoutMs);
+    }
+
+    private static async Task RunDotnetOrThrowAsync(string arguments, string workingDirectory, int timeoutMs)
+    {
+        ProcessRunResult result = await RunDotnetAsync(arguments, workingDirectory, timeoutMs);
+        if (!result.Succeeded)
+        {
+            throw new InvalidOperationException(result.Output);
+        }
     }
 
     private string GetLudotsToolProjectPath()
@@ -2415,9 +2586,9 @@ public sealed class LauncherService
             output.AppendLine(build.Output);
         }
 
-        if (build.ExitCode != 0)
+        if (!build.Succeeded)
         {
-            return (build.ExitCode, output.ToString());
+            return (build.WorkflowExitCode, output.ToString());
         }
 
         var toolAssemblyPath = GetLudotsToolAssemblyPath();
@@ -2436,10 +2607,10 @@ public sealed class LauncherService
             output.AppendLine(run.Output);
         }
 
-        return (run.ExitCode, output.ToString());
+        return (run.WorkflowExitCode, output.ToString());
     }
 
-    private static Task<(int ExitCode, string Output)> RunNodePackageCommandAsync(string arguments, string workingDirectory, int timeoutMs)
+    private static Task<ProcessRunResult> RunNodePackageCommandAsync(string arguments, string workingDirectory, int timeoutMs)
     {
         if (OperatingSystem.IsWindows())
         {

--- a/src/Tools/Ludots.Launcher.Backend/WindowsProcessTreeSnapshot.cs
+++ b/src/Tools/Ludots.Launcher.Backend/WindowsProcessTreeSnapshot.cs
@@ -1,0 +1,276 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace Ludots.Launcher.Backend;
+
+internal sealed class WindowsProcessTreeSnapshot
+{
+    private const uint SnapshotProcesses = 0x00000002;
+    private const int ErrorNoMoreFiles = 18;
+    private readonly int _rootProcessId;
+    private readonly Dictionary<int, long> _processStartTimesUtcTicks;
+
+    private WindowsProcessTreeSnapshot(
+        int rootProcessId,
+        Dictionary<int, long> processStartTimesUtcTicks)
+    {
+        _rootProcessId = rootProcessId;
+        _processStartTimesUtcTicks = processStartTimesUtcTicks;
+    }
+
+    public static WindowsProcessTreeSnapshot Capture(int rootProcessId, long rootStartTimeUtcTicks)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            throw new PlatformNotSupportedException(
+                "Process-tree exit confirmation currently requires the Windows process snapshot API.");
+        }
+
+        var identities = new Dictionary<int, long>
+        {
+            [rootProcessId] = rootStartTimeUtcTicks
+        };
+        AddLiveDescendants(rootProcessId, identities);
+        return new WindowsProcessTreeSnapshot(rootProcessId, identities);
+    }
+
+    public async Task ConfirmExitedAsync(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Process-tree confirmation timeout must be positive.");
+        }
+
+        DateTime deadlineUtc = DateTime.UtcNow + timeout;
+        while (true)
+        {
+            AddLiveDescendants(_rootProcessId, _processStartTimesUtcTicks);
+            List<Process> liveProcesses = OpenLiveProcesses();
+            if (liveProcesses.Count == 0)
+            {
+                AddLiveDescendants(_rootProcessId, _processStartTimesUtcTicks);
+                liveProcesses = OpenLiveProcesses();
+                if (liveProcesses.Count == 0)
+                {
+                    return;
+                }
+            }
+
+            TimeSpan remaining = deadlineUtc - DateTime.UtcNow;
+            if (remaining <= TimeSpan.Zero)
+            {
+                DisposeProcesses(liveProcesses);
+                throw CreateTimeoutException(timeout);
+            }
+
+            using var timeoutSource = new CancellationTokenSource(remaining);
+            try
+            {
+                await Task.WhenAll(liveProcesses.Select(process => process.WaitForExitAsync(timeoutSource.Token)));
+            }
+            catch (OperationCanceledException) when (timeoutSource.IsCancellationRequested)
+            {
+                throw CreateTimeoutException(timeout);
+            }
+            finally
+            {
+                DisposeProcesses(liveProcesses);
+            }
+        }
+    }
+
+    private static void AddLiveDescendants(
+        int rootProcessId,
+        Dictionary<int, long> identities)
+    {
+        Dictionary<int, int> parentByProcessId = CaptureParentMap();
+        var relatedProcessIds = new HashSet<int>(identities.Keys)
+        {
+            rootProcessId
+        };
+
+        bool added;
+        do
+        {
+            added = false;
+            foreach ((int processId, int parentProcessId) in parentByProcessId)
+            {
+                if (!relatedProcessIds.Contains(parentProcessId) || !relatedProcessIds.Add(processId))
+                {
+                    continue;
+                }
+
+                added = true;
+            }
+        }
+        while (added);
+
+        foreach (int processId in relatedProcessIds)
+        {
+            if (identities.ContainsKey(processId) || !TryGetStartTimeUtcTicks(processId, out long startTimeUtcTicks))
+            {
+                continue;
+            }
+
+            identities.Add(processId, startTimeUtcTicks);
+        }
+    }
+
+    private List<Process> OpenLiveProcesses()
+    {
+        var processes = new List<Process>(_processStartTimesUtcTicks.Count);
+        try
+        {
+            foreach ((int processId, long startTimeUtcTicks) in _processStartTimesUtcTicks)
+            {
+                Process? process = TryOpenMatchingProcess(processId, startTimeUtcTicks);
+                if (process != null)
+                {
+                    processes.Add(process);
+                }
+            }
+
+            return processes;
+        }
+        catch
+        {
+            DisposeProcesses(processes);
+            throw;
+        }
+    }
+
+    private static Process? TryOpenMatchingProcess(int processId, long startTimeUtcTicks)
+    {
+        try
+        {
+            Process process = Process.GetProcessById(processId);
+            if (process.HasExited || process.StartTime.ToUniversalTime().Ticks != startTimeUtcTicks)
+            {
+                process.Dispose();
+                return null;
+            }
+
+            return process;
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    private static bool TryGetStartTimeUtcTicks(int processId, out long startTimeUtcTicks)
+    {
+        try
+        {
+            using Process process = Process.GetProcessById(processId);
+            if (process.HasExited)
+            {
+                startTimeUtcTicks = 0;
+                return false;
+            }
+
+            startTimeUtcTicks = process.StartTime.ToUniversalTime().Ticks;
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            startTimeUtcTicks = 0;
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            startTimeUtcTicks = 0;
+            return false;
+        }
+    }
+
+    private static Dictionary<int, int> CaptureParentMap()
+    {
+        using SafeFileHandle snapshotHandle = CreateToolhelp32Snapshot(SnapshotProcesses, 0);
+        if (snapshotHandle.IsInvalid)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to capture the Windows process list.");
+        }
+
+        var parentByProcessId = new Dictionary<int, int>();
+        var entry = new ProcessEntry32
+        {
+            Size = (uint)Marshal.SizeOf<ProcessEntry32>(),
+            ExecutableFile = string.Empty
+        };
+
+        if (!Process32First(snapshotHandle, ref entry))
+        {
+            int error = Marshal.GetLastWin32Error();
+            if (error == ErrorNoMoreFiles)
+            {
+                return parentByProcessId;
+            }
+
+            throw new Win32Exception(error, "Failed to read the first Windows process snapshot entry.");
+        }
+
+        do
+        {
+            parentByProcessId[checked((int)entry.ProcessId)] = checked((int)entry.ParentProcessId);
+        }
+        while (Process32Next(snapshotHandle, ref entry));
+
+        int finalError = Marshal.GetLastWin32Error();
+        if (finalError != ErrorNoMoreFiles)
+        {
+            throw new Win32Exception(finalError, "Failed while enumerating the Windows process snapshot.");
+        }
+
+        return parentByProcessId;
+    }
+
+    private TimeoutException CreateTimeoutException(TimeSpan timeout)
+    {
+        string processIds = string.Join(", ", _processStartTimesUtcTicks.Keys.OrderBy(processId => processId));
+        return new TimeoutException(
+            $"Process tree rooted at {_rootProcessId} did not exit within {timeout.TotalMilliseconds:F0} ms. Tracked process ids: {processIds}.");
+    }
+
+    private static void DisposeProcesses(IEnumerable<Process> processes)
+    {
+        foreach (Process process in processes)
+        {
+            process.Dispose();
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct ProcessEntry32
+    {
+        public uint Size;
+        public uint UsageCount;
+        public uint ProcessId;
+        public nint DefaultHeapId;
+        public uint ModuleId;
+        public uint ThreadCount;
+        public uint ParentProcessId;
+        public int BasePriority;
+        public uint Flags;
+
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+        public string ExecutableFile;
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern SafeFileHandle CreateToolhelp32Snapshot(uint flags, uint processId);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool Process32First(SafeFileHandle snapshotHandle, ref ProcessEntry32 entry);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool Process32Next(SafeFileHandle snapshotHandle, ref ProcessEntry32 entry);
+}

--- a/src/Tools/Ludots.Launcher.Evidence/LauncherEvidenceRecorder.cs
+++ b/src/Tools/Ludots.Launcher.Evidence/LauncherEvidenceRecorder.cs
@@ -996,10 +996,11 @@ public static class LauncherEvidenceRecorder
 
         var failures = new List<string>();
 
-        AddAcceptanceCheck(markerLive.DummyCount == start.DummyCount + 1,
-            $"Projection click should spawn one Dummy by the live capture, but count moved {start.DummyCount} -> {markerLive.DummyCount}.", failures);
+        int expectedDummyCount = start.DummyCount + CameraAcceptanceIds.ProjectionSpawnCountDefault;
+        AddAcceptanceCheck(markerLive.DummyCount == expectedDummyCount,
+            $"Projection click should spawn the configured projection batch by the live capture, but count moved {start.DummyCount} -> {markerLive.DummyCount}.", failures);
 
-        CameraSnapshot spawnedSnapshot = markerLive.DummyCount > 0 ? markerLive : markerExpired;
+        CameraSnapshot spawnedSnapshot = markerLive.DummyCount > start.DummyCount ? markerLive : markerExpired;
         if (spawnedSnapshot.ClickTargetWorldCm.HasValue)
         {
             Vector2 click = spawnedSnapshot.ClickTargetWorldCm.Value;


### PR DESCRIPTION
﻿This post-merge audit updates the launcher evidence and process runner to match the current PR658-era contracts.

What changed:
- Launcher backend now distinguishes process failure, timeout cleanup, termination failure, and output-drain failure.
- Launcher bootstrap tests lock the workflow/process exit split.
- Arch netstandard2.1 event helpers compile without introducing fallback behavior.
- Camera acceptance recording now matches the current projection scenario contract (default batch = 100) instead of the obsolete +1 assumption.

Verification:
- dotnet build src/Tools/Ludots.Launcher.Evidence/Ludots.Launcher.Evidence.csproj --no-restore -c Release
- .\scripts\run-mod-launcher.cmd cli launch camera_acceptance --adapter raylib --record artifacts/acceptance/recheck-camera-20260805-v3
- dotnet test src/Tests/ThreeCTests/ThreeCTests.csproj -c Release --filter "FullyQualifiedName~CameraAcceptanceMod_ProjectionMap_ClickGround_SpawnsConfiguredRandomBatch_AndEmitsCueMarkerThenExpires"

Out of scope for this PR: #708, #720, and PR #721.
