### PR TITLE
Add minimal Core GraphVM loop

### DIFF
--- a/src/Benchmarks/GraphRuntimeBenchmarks/GraphRuntimeBenchmarks.csproj
+++ b/src/Benchmarks/GraphRuntimeBenchmarks/GraphRuntimeBenchmarks.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Ludots.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Benchmarks/GraphRuntimeBenchmarks/GraphVmBenchmarkGraphs.cs
+++ b/src/Benchmarks/GraphRuntimeBenchmarks/GraphVmBenchmarkGraphs.cs
@@ -1,0 +1,150 @@
+using Ludots.Core.GraphRuntime;
+
+namespace Ludots.Benchmarks.GraphRuntime;
+
+internal static class GraphVmBenchmarkGraphs
+{
+    public static GraphVmDocument CreateCountedLoopGraph(int limit)
+    {
+        return new GraphVmDocument
+        {
+            Id = "bench.graphvm.counted-loop",
+            Entry = "zeroI",
+            Nodes = new List<GraphVmNode>
+            {
+                new() { Id = "zeroI", Op = nameof(GraphVmOpcode.ConstInt), IntValue = 0 },
+                new() { Id = "storeI", Op = nameof(GraphVmOpcode.StoreInt), Slot = 0 },
+                new() { Id = "zeroSum", Op = nameof(GraphVmOpcode.ConstInt), IntValue = 0 },
+                new() { Id = "storeSum", Op = nameof(GraphVmOpcode.StoreInt), Slot = 1 },
+                new() { Id = "limit", Op = nameof(GraphVmOpcode.ConstInt), IntValue = limit },
+                new() { Id = "storeLimit", Op = nameof(GraphVmOpcode.StoreInt), Slot = 2 },
+                new() { Id = "one", Op = nameof(GraphVmOpcode.ConstInt), IntValue = 1 },
+                new() { Id = "storeOne", Op = nameof(GraphVmOpcode.StoreInt), Slot = 3 },
+                new() { Id = "loadIForCheck", Op = nameof(GraphVmOpcode.LoadInt), Slot = 0 },
+                new() { Id = "loadLimit", Op = nameof(GraphVmOpcode.LoadInt), Slot = 2 },
+                new() { Id = "iBelowLimit", Op = nameof(GraphVmOpcode.LessThanInt) },
+                new() { Id = "branchLoop", Op = nameof(GraphVmOpcode.BranchBool) },
+                new() { Id = "loadSum", Op = nameof(GraphVmOpcode.LoadInt), Slot = 1 },
+                new() { Id = "loadIForAdd", Op = nameof(GraphVmOpcode.LoadInt), Slot = 0 },
+                new() { Id = "addIToSum", Op = nameof(GraphVmOpcode.AddInt) },
+                new() { Id = "storeNewSum", Op = nameof(GraphVmOpcode.StoreInt), Slot = 1 },
+                new() { Id = "loadIForInc", Op = nameof(GraphVmOpcode.LoadInt), Slot = 0 },
+                new() { Id = "loadOne", Op = nameof(GraphVmOpcode.LoadInt), Slot = 3 },
+                new() { Id = "incI", Op = nameof(GraphVmOpcode.AddInt) },
+                new() { Id = "storeNewI", Op = nameof(GraphVmOpcode.StoreInt), Slot = 0 },
+                new() { Id = "jumpCheck", Op = nameof(GraphVmOpcode.Jump) },
+                new() { Id = "loadSumForReturn", Op = nameof(GraphVmOpcode.LoadInt), Slot = 1 },
+                new() { Id = "done", Op = nameof(GraphVmOpcode.ReturnInt) }
+            },
+            ControlEdges = new List<GraphVmControlEdge>
+            {
+                new("zeroI", GraphVmControlPorts.Next, "storeI"),
+                new("storeI", GraphVmControlPorts.Next, "zeroSum"),
+                new("zeroSum", GraphVmControlPorts.Next, "storeSum"),
+                new("storeSum", GraphVmControlPorts.Next, "limit"),
+                new("limit", GraphVmControlPorts.Next, "storeLimit"),
+                new("storeLimit", GraphVmControlPorts.Next, "one"),
+                new("one", GraphVmControlPorts.Next, "storeOne"),
+                new("storeOne", GraphVmControlPorts.Next, "loadIForCheck"),
+                new("loadIForCheck", GraphVmControlPorts.Next, "loadLimit"),
+                new("loadLimit", GraphVmControlPorts.Next, "iBelowLimit"),
+                new("iBelowLimit", GraphVmControlPorts.Next, "branchLoop"),
+                new("branchLoop", GraphVmControlPorts.True, "loadSum"),
+                new("branchLoop", GraphVmControlPorts.False, "loadSumForReturn"),
+                new("loadSum", GraphVmControlPorts.Next, "loadIForAdd"),
+                new("loadIForAdd", GraphVmControlPorts.Next, "addIToSum"),
+                new("addIToSum", GraphVmControlPorts.Next, "storeNewSum"),
+                new("storeNewSum", GraphVmControlPorts.Next, "loadIForInc"),
+                new("loadIForInc", GraphVmControlPorts.Next, "loadOne"),
+                new("loadOne", GraphVmControlPorts.Next, "incI"),
+                new("incI", GraphVmControlPorts.Next, "storeNewI"),
+                new("storeNewI", GraphVmControlPorts.Next, "jumpCheck"),
+                new("jumpCheck", GraphVmControlPorts.Target, "loadIForCheck"),
+                new("loadSumForReturn", GraphVmControlPorts.Next, "done")
+            },
+            ValueEdges = new List<GraphVmValueEdge>
+            {
+                new("zeroI", GraphVmValuePorts.Value, "storeI", GraphVmValuePorts.Value),
+                new("zeroSum", GraphVmValuePorts.Value, "storeSum", GraphVmValuePorts.Value),
+                new("limit", GraphVmValuePorts.Value, "storeLimit", GraphVmValuePorts.Value),
+                new("one", GraphVmValuePorts.Value, "storeOne", GraphVmValuePorts.Value),
+                new("loadIForCheck", GraphVmValuePorts.Value, "iBelowLimit", GraphVmValuePorts.A),
+                new("loadLimit", GraphVmValuePorts.Value, "iBelowLimit", GraphVmValuePorts.B),
+                new("iBelowLimit", GraphVmValuePorts.Value, "branchLoop", GraphVmValuePorts.Condition),
+                new("loadSum", GraphVmValuePorts.Value, "addIToSum", GraphVmValuePorts.A),
+                new("loadIForAdd", GraphVmValuePorts.Value, "addIToSum", GraphVmValuePorts.B),
+                new("addIToSum", GraphVmValuePorts.Value, "storeNewSum", GraphVmValuePorts.Value),
+                new("loadIForInc", GraphVmValuePorts.Value, "incI", GraphVmValuePorts.A),
+                new("loadOne", GraphVmValuePorts.Value, "incI", GraphVmValuePorts.B),
+                new("incI", GraphVmValuePorts.Value, "storeNewI", GraphVmValuePorts.Value),
+                new("loadSumForReturn", GraphVmValuePorts.Value, "done", GraphVmValuePorts.Value)
+            }
+        };
+    }
+
+    public static GraphVmDocument CreateDrinkUntilFullGraph(int limit)
+    {
+        return new GraphVmDocument
+        {
+            Id = "bench.graphvm.drink-until-full",
+            Entry = "zeroWater",
+            Nodes = new List<GraphVmNode>
+            {
+                new() { Id = "drinkLoadWater", Op = nameof(GraphVmOpcode.LoadInt), Slot = 0 },
+                new() { Id = "drinkLoadOne", Op = nameof(GraphVmOpcode.LoadInt), Slot = 2 },
+                new() { Id = "drinkAdd", Op = nameof(GraphVmOpcode.AddInt) },
+                new() { Id = "drinkStoreWater", Op = nameof(GraphVmOpcode.StoreInt), Slot = 0 },
+                new() { Id = "drinkYield", Op = nameof(GraphVmOpcode.Yield) },
+                new() { Id = "drinkReturn", Op = nameof(GraphVmOpcode.Return) },
+                new() { Id = "zeroWater", Op = nameof(GraphVmOpcode.ConstInt), IntValue = 0 },
+                new() { Id = "storeWater", Op = nameof(GraphVmOpcode.StoreInt), Slot = 0 },
+                new() { Id = "limitValue", Op = nameof(GraphVmOpcode.ConstInt), IntValue = limit },
+                new() { Id = "storeLimit", Op = nameof(GraphVmOpcode.StoreInt), Slot = 1 },
+                new() { Id = "oneValue", Op = nameof(GraphVmOpcode.ConstInt), IntValue = 1 },
+                new() { Id = "storeOne", Op = nameof(GraphVmOpcode.StoreInt), Slot = 2 },
+                new() { Id = "loadWaterForCheck", Op = nameof(GraphVmOpcode.LoadInt), Slot = 0 },
+                new() { Id = "loadLimit", Op = nameof(GraphVmOpcode.LoadInt), Slot = 1 },
+                new() { Id = "waterBelowLimit", Op = nameof(GraphVmOpcode.LessThanInt) },
+                new() { Id = "branchNeedDrink", Op = nameof(GraphVmOpcode.BranchBool) },
+                new() { Id = "callDrink", Op = nameof(GraphVmOpcode.Call) },
+                new() { Id = "loadWaterForReturn", Op = nameof(GraphVmOpcode.LoadInt), Slot = 0 },
+                new() { Id = "done", Op = nameof(GraphVmOpcode.ReturnInt) }
+            },
+            ControlEdges = new List<GraphVmControlEdge>
+            {
+                new("zeroWater", GraphVmControlPorts.Next, "storeWater"),
+                new("storeWater", GraphVmControlPorts.Next, "limitValue"),
+                new("limitValue", GraphVmControlPorts.Next, "storeLimit"),
+                new("storeLimit", GraphVmControlPorts.Next, "oneValue"),
+                new("oneValue", GraphVmControlPorts.Next, "storeOne"),
+                new("storeOne", GraphVmControlPorts.Next, "loadWaterForCheck"),
+                new("loadWaterForCheck", GraphVmControlPorts.Next, "loadLimit"),
+                new("loadLimit", GraphVmControlPorts.Next, "waterBelowLimit"),
+                new("waterBelowLimit", GraphVmControlPorts.Next, "branchNeedDrink"),
+                new("branchNeedDrink", GraphVmControlPorts.True, "callDrink"),
+                new("branchNeedDrink", GraphVmControlPorts.False, "loadWaterForReturn"),
+                new("callDrink", GraphVmControlPorts.Call, "drinkLoadWater"),
+                new("callDrink", GraphVmControlPorts.Next, "loadWaterForCheck"),
+                new("loadWaterForReturn", GraphVmControlPorts.Next, "done"),
+                new("drinkLoadWater", GraphVmControlPorts.Next, "drinkLoadOne"),
+                new("drinkLoadOne", GraphVmControlPorts.Next, "drinkAdd"),
+                new("drinkAdd", GraphVmControlPorts.Next, "drinkStoreWater"),
+                new("drinkStoreWater", GraphVmControlPorts.Next, "drinkYield"),
+                new("drinkYield", GraphVmControlPorts.Next, "drinkReturn")
+            },
+            ValueEdges = new List<GraphVmValueEdge>
+            {
+                new("zeroWater", GraphVmValuePorts.Value, "storeWater", GraphVmValuePorts.Value),
+                new("limitValue", GraphVmValuePorts.Value, "storeLimit", GraphVmValuePorts.Value),
+                new("oneValue", GraphVmValuePorts.Value, "storeOne", GraphVmValuePorts.Value),
+                new("loadWaterForCheck", GraphVmValuePorts.Value, "waterBelowLimit", GraphVmValuePorts.A),
+                new("loadLimit", GraphVmValuePorts.Value, "waterBelowLimit", GraphVmValuePorts.B),
+                new("waterBelowLimit", GraphVmValuePorts.Value, "branchNeedDrink", GraphVmValuePorts.Condition),
+                new("loadWaterForReturn", GraphVmValuePorts.Value, "done", GraphVmValuePorts.Value),
+                new("drinkLoadWater", GraphVmValuePorts.Value, "drinkAdd", GraphVmValuePorts.A),
+                new("drinkLoadOne", GraphVmValuePorts.Value, "drinkAdd", GraphVmValuePorts.B),
+                new("drinkAdd", GraphVmValuePorts.Value, "drinkStoreWater", GraphVmValuePorts.Value)
+            }
+        };
+    }
+}

--- a/src/Benchmarks/GraphRuntimeBenchmarks/GraphVmBenchmarkSmoke.cs
+++ b/src/Benchmarks/GraphRuntimeBenchmarks/GraphVmBenchmarkSmoke.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics;
+using Ludots.Core.GraphRuntime;
+
+namespace Ludots.Benchmarks.GraphRuntime;
+
+internal static class GraphVmBenchmarkSmoke
+{
+    public static void Run()
+    {
+        GraphVmDocument graph = GraphVmBenchmarkGraphs.CreateDrinkUntilFullGraph(limit: 3);
+        GraphVmCompileResult compiled = GraphVmCompiler.Compile(graph);
+        if (!compiled.Succeeded)
+        {
+            throw new InvalidOperationException(string.Join(Environment.NewLine, compiled.Diagnostics.Select(d =>
+                $"{d.Code}:{d.NodeId}:{d.Message}")));
+        }
+
+        Span<int> ints = stackalloc int[GraphVmRuntimeLimits.MaxIntRegisters];
+        Span<byte> bools = stackalloc byte[GraphVmRuntimeLimits.MaxBoolRegisters];
+        Span<int> callStack = stackalloc int[GraphVmRuntimeLimits.MaxCallStackDepth];
+        var cursor = new GraphVmExecutionCursor();
+
+        long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        long elapsedTicks = Stopwatch.GetTimestamp();
+        GraphVmExecutionResult result;
+        do
+        {
+            result = GraphVmExecutor.ExecuteSlice(
+                compiled.Program,
+                ints,
+                bools,
+                callStack,
+                ref cursor,
+                GraphVmRuntimeLimits.MaxInstructionsPerExecution);
+        }
+        while (!result.Halted);
+
+        elapsedTicks = Stopwatch.GetTimestamp() - elapsedTicks;
+        long allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+        double elapsedUs = elapsedTicks * 1_000_000.0 / Stopwatch.Frequency;
+
+        Console.WriteLine($"GraphVM smoke: status={result.Status}, return={result.ReturnInt}, steps={result.Steps}, elapsedUs={elapsedUs:F3}, allocatedBytes={allocatedBytes}");
+    }
+}

--- a/src/Benchmarks/GraphRuntimeBenchmarks/GraphVmBenchmarks.cs
+++ b/src/Benchmarks/GraphRuntimeBenchmarks/GraphVmBenchmarks.cs
@@ -1,0 +1,249 @@
+using BenchmarkDotNet.Attributes;
+using Ludots.Core.GraphRuntime;
+
+namespace Ludots.Benchmarks.GraphRuntime;
+
+[MemoryDiagnoser]
+public class GraphVmBenchmarks
+{
+    private const int EntityCount = 50_000;
+    private const int RegistryLookupIterations = 10_000;
+    private const int IntStride = GraphVmRuntimeLimits.MaxIntRegisters;
+    private const int BoolStride = GraphVmRuntimeLimits.MaxBoolRegisters;
+    private const int CallStackStride = GraphVmRuntimeLimits.MaxCallStackDepth;
+
+    private GraphVmDocument _loopDocument = null!;
+    private GraphVmDocument _asyncDocument = null!;
+    private GraphInstruction[] _loopProgram = Array.Empty<GraphInstruction>();
+    private GraphInstruction[] _asyncProgram = Array.Empty<GraphInstruction>();
+    private GraphInstructionSourceMap _asyncSourceMap;
+    private GraphProgramRegistry _registry = null!;
+    private int[] _ints = Array.Empty<int>();
+    private byte[] _bools = Array.Empty<byte>();
+    private int[] _callStacks = Array.Empty<int>();
+    private GraphVmExecutionCursor[] _cursors = Array.Empty<GraphVmExecutionCursor>();
+    private FixedTraceSink _traceSink = null!;
+    private int _sink;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _loopDocument = GraphVmBenchmarkGraphs.CreateCountedLoopGraph(limit: 32);
+        _asyncDocument = GraphVmBenchmarkGraphs.CreateDrinkUntilFullGraph(limit: 3);
+
+        GraphVmCompileResult loopCompiled = GraphVmCompiler.Compile(_loopDocument);
+        RequireCompiled(loopCompiled);
+        _loopProgram = loopCompiled.Program;
+
+        GraphVmCompileResult asyncCompiled = GraphVmCompiler.Compile(_asyncDocument);
+        RequireCompiled(asyncCompiled);
+        _asyncProgram = asyncCompiled.Program;
+        _asyncSourceMap = asyncCompiled.SourceMap;
+
+        _registry = new GraphProgramRegistry();
+        _registry.Register(1, _asyncProgram, GraphKind.Effect, _asyncSourceMap);
+
+        _ints = new int[EntityCount * IntStride];
+        _bools = new byte[EntityCount * BoolStride];
+        _callStacks = new int[EntityCount * CallStackStride];
+        _cursors = new GraphVmExecutionCursor[EntityCount];
+        _traceSink = new FixedTraceSink(_asyncSourceMap, 512);
+    }
+
+    [Benchmark(Baseline = true)]
+    public int ExecuteLoop_OneEntity_NoTrace()
+    {
+        Span<int> ints = stackalloc int[IntStride];
+        Span<byte> bools = stackalloc byte[BoolStride];
+        Span<int> callStack = stackalloc int[CallStackStride];
+        var cursor = new GraphVmExecutionCursor();
+
+        GraphVmExecutionResult result = GraphVmExecutor.ExecuteSlice(
+            _loopProgram,
+            ints,
+            bools,
+            callStack,
+            ref cursor,
+            GraphVmRuntimeLimits.MaxInstructionsPerExecution);
+
+        _sink = result.ReturnInt;
+        return _sink;
+    }
+
+    [Benchmark]
+    public int ExecuteAsyncFunction_ResumeToHalt_NoTrace()
+    {
+        Span<int> ints = stackalloc int[IntStride];
+        Span<byte> bools = stackalloc byte[BoolStride];
+        Span<int> callStack = stackalloc int[CallStackStride];
+        var cursor = new GraphVmExecutionCursor();
+        GraphVmExecutionResult result;
+
+        do
+        {
+            result = GraphVmExecutor.ExecuteSlice(
+                _asyncProgram,
+                ints,
+                bools,
+                callStack,
+                ref cursor,
+                GraphVmRuntimeLimits.MaxInstructionsPerExecution);
+        }
+        while (!result.Halted);
+
+        _sink = result.ReturnInt;
+        return _sink;
+    }
+
+    [Benchmark]
+    public int ExecuteAsyncFunction_ResumeToHalt_WithSourceMapTrace()
+    {
+        Span<int> ints = stackalloc int[IntStride];
+        Span<byte> bools = stackalloc byte[BoolStride];
+        Span<int> callStack = stackalloc int[CallStackStride];
+        var cursor = new GraphVmExecutionCursor();
+        GraphVmExecutionResult result;
+
+        _traceSink.Reset();
+        do
+        {
+            result = GraphVmExecutor.ExecuteSlice(
+                _asyncProgram,
+                ints,
+                bools,
+                callStack,
+                ref cursor,
+                GraphVmRuntimeLimits.MaxInstructionsPerExecution,
+                _traceSink);
+        }
+        while (!result.Halted);
+
+        _sink = result.ReturnInt + _traceSink.Count;
+        return _sink;
+    }
+
+    [Benchmark]
+    public int ExecuteLoop_50000Entities_NoTrace()
+    {
+        int sum = 0;
+        for (int entity = 0; entity < EntityCount; entity++)
+        {
+            Span<int> ints = _ints.AsSpan(entity * IntStride, IntStride);
+            Span<byte> bools = _bools.AsSpan(entity * BoolStride, BoolStride);
+            Span<int> callStack = _callStacks.AsSpan(entity * CallStackStride, CallStackStride);
+
+            _cursors[entity].Reset();
+            GraphVmExecutionCursor cursor = _cursors[entity];
+            GraphVmExecutionResult result = GraphVmExecutor.ExecuteSlice(
+                _loopProgram,
+                ints,
+                bools,
+                callStack,
+                ref cursor,
+                GraphVmRuntimeLimits.MaxInstructionsPerExecution);
+            _cursors[entity] = cursor;
+            sum += result.ReturnInt;
+        }
+
+        _sink = sum;
+        return _sink;
+    }
+
+    [Benchmark]
+    public int ExecuteAsyncFunction_50000Entities_OneTick()
+    {
+        int yielded = 0;
+        for (int entity = 0; entity < EntityCount; entity++)
+        {
+            Span<int> ints = _ints.AsSpan(entity * IntStride, IntStride);
+            Span<byte> bools = _bools.AsSpan(entity * BoolStride, BoolStride);
+            Span<int> callStack = _callStacks.AsSpan(entity * CallStackStride, CallStackStride);
+
+            _cursors[entity].Reset();
+            GraphVmExecutionCursor cursor = _cursors[entity];
+            GraphVmExecutionResult result = GraphVmExecutor.ExecuteSlice(
+                _asyncProgram,
+                ints,
+                bools,
+                callStack,
+                ref cursor,
+                GraphVmRuntimeLimits.MaxInstructionsPerExecution);
+            _cursors[entity] = cursor;
+            yielded += result.Yielded ? 1 : 0;
+        }
+
+        _sink = yielded;
+        return _sink;
+    }
+
+    [Benchmark]
+    public int CompileAsyncControlFlowGraph()
+    {
+        GraphVmCompileResult result = GraphVmCompiler.Compile(_asyncDocument);
+        _sink = result.Program.Length + result.SourceMap.Sources.Length;
+        return _sink;
+    }
+
+    [Benchmark]
+    public int RegistryLookup_ProgramAndSourceMap()
+    {
+        int count = 0;
+        for (int i = 0; i < RegistryLookupIterations; i++)
+        {
+            if (_registry.TryGetProgram(1, out ReadOnlySpan<GraphInstruction> program))
+            {
+                count += program.Length;
+            }
+
+            if (_registry.TryGetSourceMap(1, out GraphInstructionSourceMap sourceMap))
+            {
+                count += sourceMap.Sources.Length;
+            }
+        }
+
+        _sink = count;
+        return _sink;
+    }
+
+    private static void RequireCompiled(GraphVmCompileResult result)
+    {
+        if (result.Succeeded)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(string.Join(Environment.NewLine, result.Diagnostics.Select(d =>
+            $"{d.Code}:{d.NodeId}:{d.Message}")));
+    }
+
+    private sealed class FixedTraceSink : IGraphVmTraceSink
+    {
+        private readonly GraphInstructionSourceMap _sourceMap;
+        private readonly GraphInstructionSource[] _buffer;
+
+        public FixedTraceSink(GraphInstructionSourceMap sourceMap, int capacity)
+        {
+            _sourceMap = sourceMap;
+            _buffer = new GraphInstructionSource[capacity];
+        }
+
+        public int Count { get; private set; }
+
+        public void Reset() => Count = 0;
+
+        public void OnInstruction(in GraphVmTraceEvent traceEvent)
+        {
+            if (Count >= _buffer.Length)
+            {
+                throw new InvalidOperationException("GraphVM trace benchmark buffer overflow.");
+            }
+
+            if (!_sourceMap.TryGetSource(traceEvent.InstructionIndex, out GraphInstructionSource source))
+            {
+                throw new InvalidOperationException($"GraphVM source map missed instruction {traceEvent.InstructionIndex}.");
+            }
+
+            _buffer[Count++] = source;
+        }
+    }
+}

--- a/src/Benchmarks/GraphRuntimeBenchmarks/Program.cs
+++ b/src/Benchmarks/GraphRuntimeBenchmarks/Program.cs
@@ -1,0 +1,17 @@
+using BenchmarkDotNet.Running;
+
+namespace Ludots.Benchmarks.GraphRuntime;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        if (args.Length == 1 && string.Equals(args[0], "--smoke", StringComparison.Ordinal))
+        {
+            GraphVmBenchmarkSmoke.Run();
+            return;
+        }
+
+        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+    }
+}

--- a/src/Core/GraphRuntime/GraphInstructionSourceMap.cs
+++ b/src/Core/GraphRuntime/GraphInstructionSourceMap.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Ludots.Core.GraphRuntime
+{
+    public readonly record struct GraphInstructionSource(string GraphId, string NodeId, string Op, string ControlPort = "");
+
+    public readonly struct GraphInstructionSourceMap
+    {
+        public GraphInstructionSourceMap(string graphId, GraphInstructionSource[] sources)
+        {
+            GraphId = graphId ?? string.Empty;
+            Sources = sources ?? Array.Empty<GraphInstructionSource>();
+        }
+
+        public static GraphInstructionSourceMap Empty => new(string.Empty, Array.Empty<GraphInstructionSource>());
+
+        public string GraphId { get; }
+        public GraphInstructionSource[] Sources { get; }
+        public bool HasSources => Sources.Length > 0;
+
+        public bool TryGetSource(int instructionIndex, out GraphInstructionSource source)
+        {
+            if ((uint)instructionIndex < (uint)Sources.Length)
+            {
+                source = Sources[instructionIndex];
+                return !string.IsNullOrWhiteSpace(source.NodeId);
+            }
+
+            source = default;
+            return false;
+        }
+    }
+}

--- a/src/Core/GraphRuntime/GraphProgramRegistry.cs
+++ b/src/Core/GraphRuntime/GraphProgramRegistry.cs
@@ -18,10 +18,18 @@ namespace Ludots.Core.GraphRuntime
     public sealed class GraphProgramRegistry
     {
         private readonly Dictionary<int, GraphProgramRegistration> _programs = new();
+        private readonly Dictionary<int, GraphInstructionSourceMap> _sourceMaps = new();
 
-        public void Clear() => _programs.Clear();
+        public void Clear()
+        {
+            _programs.Clear();
+            _sourceMaps.Clear();
+        }
 
         public void Register(int graphId, GraphInstruction[] program, GraphKind kind)
+            => Register(graphId, program, kind, GraphInstructionSourceMap.Empty);
+
+        public void Register(int graphId, GraphInstruction[] program, GraphKind kind, GraphInstructionSourceMap sourceMap)
         {
             if (graphId <= 0) throw new ArgumentOutOfRangeException(nameof(graphId));
             if (program == null) throw new ArgumentNullException(nameof(program));
@@ -29,10 +37,16 @@ namespace Ludots.Core.GraphRuntime
             {
                 throw new ArgumentOutOfRangeException(nameof(kind), kind, "Graph registration requires an explicit supported kind.");
             }
+
             if (!_programs.TryAdd(graphId, new GraphProgramRegistration(program, kind)))
             {
                 throw new InvalidOperationException(
                     $"Graph program id {graphId} is already registered; duplicate registration is not allowed.");
+            }
+
+            if (sourceMap.HasSources)
+            {
+                _sourceMaps[graphId] = sourceMap;
             }
         }
 
@@ -81,5 +95,8 @@ namespace Ludots.Core.GraphRuntime
 
             return entry.Kind;
         }
+
+        public bool TryGetSourceMap(int graphId, out GraphInstructionSourceMap sourceMap)
+            => _sourceMaps.TryGetValue(graphId, out sourceMap);
     }
 }

--- a/src/Core/GraphRuntime/GraphVmCompiler.cs
+++ b/src/Core/GraphRuntime/GraphVmCompiler.cs
@@ -1,0 +1,935 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ludots.Core.GraphRuntime
+{
+    public readonly struct GraphVmCompileResult
+    {
+        public GraphVmCompileResult(
+            GraphInstruction[] program,
+            GraphInstructionSourceMap sourceMap,
+            GraphVmDiagnostic[] diagnostics)
+        {
+            Program = program ?? Array.Empty<GraphInstruction>();
+            SourceMap = sourceMap;
+            Diagnostics = diagnostics ?? Array.Empty<GraphVmDiagnostic>();
+        }
+
+        public GraphInstruction[] Program { get; }
+        public GraphInstructionSourceMap SourceMap { get; }
+        public GraphVmDiagnostic[] Diagnostics { get; }
+        public bool Succeeded => Diagnostics.Length == 0;
+    }
+
+    public static class GraphVmCompiler
+    {
+        private readonly struct ControlKey : IEquatable<ControlKey>
+        {
+            public ControlKey(string nodeId, string port)
+            {
+                NodeId = nodeId;
+                Port = port;
+            }
+
+            public string NodeId { get; }
+            public string Port { get; }
+
+            public bool Equals(ControlKey other)
+                => string.Equals(NodeId, other.NodeId, StringComparison.Ordinal) &&
+                   string.Equals(Port, other.Port, StringComparison.Ordinal);
+
+            public override bool Equals(object? obj)
+                => obj is ControlKey other && Equals(other);
+
+            public override int GetHashCode()
+                => HashCode.Combine(
+                    StringComparer.Ordinal.GetHashCode(NodeId),
+                    StringComparer.Ordinal.GetHashCode(Port));
+        }
+
+        private readonly struct ValueInputKey : IEquatable<ValueInputKey>
+        {
+            public ValueInputKey(string nodeId, string port)
+            {
+                NodeId = nodeId;
+                Port = port;
+            }
+
+            public string NodeId { get; }
+            public string Port { get; }
+
+            public bool Equals(ValueInputKey other)
+                => string.Equals(NodeId, other.NodeId, StringComparison.Ordinal) &&
+                   string.Equals(Port, other.Port, StringComparison.Ordinal);
+
+            public override bool Equals(object? obj)
+                => obj is ValueInputKey other && Equals(other);
+
+            public override int GetHashCode()
+                => HashCode.Combine(
+                    StringComparer.Ordinal.GetHashCode(NodeId),
+                    StringComparer.Ordinal.GetHashCode(Port));
+        }
+
+        private readonly struct NodeLayout
+        {
+            public NodeLayout(int bodyIndex, int instructionCount)
+            {
+                BodyIndex = bodyIndex;
+                InstructionCount = instructionCount;
+            }
+
+            public int BodyIndex { get; }
+            public int InstructionCount { get; }
+        }
+
+        public static GraphVmCompileResult Compile(GraphVmDocument document)
+        {
+            if (document == null) throw new ArgumentNullException(nameof(document));
+
+            var diagnostics = new List<GraphVmDiagnostic>();
+            ValidateHeader(document, diagnostics);
+
+            List<GraphVmNode> nodes = document.Nodes ?? new List<GraphVmNode>();
+            Dictionary<string, int> nodeIndices = BuildNodeIndex(nodes, diagnostics);
+
+            var ops = new GraphVmOpcode[nodes.Count];
+            ParseOps(nodes, ops, diagnostics);
+
+            if (!string.IsNullOrWhiteSpace(document.Entry) &&
+                !nodeIndices.ContainsKey(document.Entry))
+            {
+                diagnostics.Add(new GraphVmDiagnostic(
+                    GraphVmDiagnosticSeverity.Error,
+                    GraphVmDiagnosticCodes.MissingTargetNode,
+                    $"GraphVM entry node '{document.Entry}' does not exist.",
+                    document.Entry));
+            }
+
+            Dictionary<ControlKey, string> controlEdges = BuildControlEdges(document, nodeIndices, ops, diagnostics);
+            Dictionary<ValueInputKey, GraphVmValueEdge> valueEdges = BuildValueEdges(document, nodeIndices, ops, diagnostics);
+
+            var outputTypes = new GraphVmValueType[nodes.Count];
+            var outputRegisters = new byte[nodes.Count];
+            AllocateOutputs(nodes, ops, outputTypes, outputRegisters, diagnostics);
+            ValidateRequiredEdges(nodes, ops, controlEdges, valueEdges, nodeIndices, outputTypes, diagnostics);
+
+            NodeLayout[] layouts = BuildLayouts(nodes, ops, diagnostics);
+
+            if (diagnostics.Count > 0)
+            {
+                return new GraphVmCompileResult(
+                    Array.Empty<GraphInstruction>(),
+                    GraphInstructionSourceMap.Empty,
+                    diagnostics.ToArray());
+            }
+
+            int instructionCount = 1;
+            for (int i = 0; i < layouts.Length; i++)
+            {
+                instructionCount += layouts[i].InstructionCount;
+            }
+
+            if (instructionCount > GraphVmRuntimeLimits.MaxInstructions)
+            {
+                diagnostics.Add(new GraphVmDiagnostic(
+                    GraphVmDiagnosticSeverity.Error,
+                    GraphVmDiagnosticCodes.BudgetExceeded,
+                    $"GraphVM compiled instruction count {instructionCount} exceeds max {GraphVmRuntimeLimits.MaxInstructions}."));
+
+                return new GraphVmCompileResult(
+                    Array.Empty<GraphInstruction>(),
+                    GraphInstructionSourceMap.Empty,
+                    diagnostics.ToArray());
+            }
+
+            var program = new GraphInstruction[instructionCount];
+            var sources = new GraphInstructionSource[instructionCount];
+
+            program[0] = new GraphInstruction
+            {
+                Op = (ushort)GraphVmOpcode.Jump,
+                Imm = layouts[nodeIndices[document.Entry]].BodyIndex
+            };
+            sources[0] = new GraphInstructionSource(
+                document.Id,
+                document.Entry,
+                "Entry",
+                GraphVmControlPorts.Enter);
+
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                CompileNode(
+                    document,
+                    nodes[i],
+                    ops[i],
+                    outputRegisters,
+                    outputTypes,
+                    controlEdges,
+                    valueEdges,
+                    nodeIndices,
+                    layouts,
+                    program,
+                    sources,
+                    diagnostics);
+            }
+
+            return diagnostics.Count == 0
+                ? new GraphVmCompileResult(program, new GraphInstructionSourceMap(document.Id, sources), Array.Empty<GraphVmDiagnostic>())
+                : new GraphVmCompileResult(Array.Empty<GraphInstruction>(), GraphInstructionSourceMap.Empty, diagnostics.ToArray());
+        }
+
+        private static void ValidateHeader(GraphVmDocument document, List<GraphVmDiagnostic> diagnostics)
+        {
+            if (string.IsNullOrWhiteSpace(document.Id))
+            {
+                diagnostics.Add(new GraphVmDiagnostic(
+                    GraphVmDiagnosticSeverity.Error,
+                    GraphVmDiagnosticCodes.MissingGraphId,
+                    "GraphVM document requires a non-empty id."));
+            }
+
+            if (string.IsNullOrWhiteSpace(document.Entry))
+            {
+                diagnostics.Add(new GraphVmDiagnostic(
+                    GraphVmDiagnosticSeverity.Error,
+                    GraphVmDiagnosticCodes.MissingEntry,
+                    "GraphVM document requires a non-empty entry node id."));
+            }
+
+            if (document.Nodes == null || document.Nodes.Count == 0)
+            {
+                diagnostics.Add(new GraphVmDiagnostic(
+                    GraphVmDiagnosticSeverity.Error,
+                    GraphVmDiagnosticCodes.EmptyGraph,
+                    "GraphVM document requires at least one node."));
+                return;
+            }
+
+            if (document.Nodes.Count > GraphVmRuntimeLimits.MaxInstructions)
+            {
+                diagnostics.Add(new GraphVmDiagnostic(
+                    GraphVmDiagnosticSeverity.Error,
+                    GraphVmDiagnosticCodes.BudgetExceeded,
+                    $"GraphVM document exceeds max node count ({GraphVmRuntimeLimits.MaxInstructions})."));
+            }
+        }
+
+        private static Dictionary<string, int> BuildNodeIndex(
+            List<GraphVmNode> nodes,
+            List<GraphVmDiagnostic> diagnostics)
+        {
+            var indices = new Dictionary<string, int>(StringComparer.Ordinal);
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                GraphVmNode node = nodes[i];
+                if (string.IsNullOrWhiteSpace(node.Id))
+                {
+                    diagnostics.Add(new GraphVmDiagnostic(
+                        GraphVmDiagnosticSeverity.Error,
+                        GraphVmDiagnosticCodes.MissingNodeId,
+                        "GraphVM node requires a non-empty id."));
+                    continue;
+                }
+
+                if (!indices.TryAdd(node.Id, i))
+                {
+                    diagnostics.Add(new GraphVmDiagnostic(
+                        GraphVmDiagnosticSeverity.Error,
+                        GraphVmDiagnosticCodes.DuplicateNodeId,
+                        $"Duplicate GraphVM node id '{node.Id}'.",
+                        node.Id));
+                }
+            }
+
+            return indices;
+        }
+
+        private static void ParseOps(
+            List<GraphVmNode> nodes,
+            GraphVmOpcode[] ops,
+            List<GraphVmDiagnostic> diagnostics)
+        {
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                GraphVmNode node = nodes[i];
+                if (!Enum.TryParse(node.Op, ignoreCase: true, out GraphVmOpcode op) ||
+                    !Enum.IsDefined(typeof(GraphVmOpcode), op))
+                {
+                    diagnostics.Add(new GraphVmDiagnostic(
+                        GraphVmDiagnosticSeverity.Error,
+                        GraphVmDiagnosticCodes.UnknownOp,
+                        $"Unknown GraphVM op '{node.Op}'.",
+                        node.Id));
+                    continue;
+                }
+
+                ops[i] = op;
+            }
+        }
+
+        private static Dictionary<ControlKey, string> BuildControlEdges(
+            GraphVmDocument document,
+            Dictionary<string, int> nodeIndices,
+            GraphVmOpcode[] ops,
+            List<GraphVmDiagnostic> diagnostics)
+        {
+            var result = new Dictionary<ControlKey, string>();
+            if (document.ControlEdges == null)
+            {
+                return result;
+            }
+
+            for (int i = 0; i < document.ControlEdges.Count; i++)
+            {
+                GraphVmControlEdge edge = document.ControlEdges[i];
+                if (edge == null)
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(edge.From) ||
+                    string.IsNullOrWhiteSpace(edge.FromPort) ||
+                    string.IsNullOrWhiteSpace(edge.To))
+                {
+                    diagnostics.Add(new GraphVmDiagnostic(
+                        GraphVmDiagnosticSeverity.Error,
+                        GraphVmDiagnosticCodes.MissingTarget,
+                        $"GraphVM control edge[{i}] requires from, fromPort, and to."));
+                    continue;
+                }
+
+                if (!nodeIndices.TryGetValue(edge.From, out int fromIndex))
+                {
+                    diagnostics.Add(new GraphVmDiagnostic(
+                        GraphVmDiagnosticSeverity.Error,
+                        GraphVmDiagnosticCodes.MissingTargetNode,
+                        $"GraphVM control edge[{i}] references missing source node '{edge.From}'.",
+                        edge.From));
+                    continue;
+                }
+
+                if (!nodeIndices.ContainsKey(edge.To))
+                {
+                    diagnostics.Add(new GraphVmDiagnostic(
+                        GraphVmDiagnosticSeverity.Error,
+                        GraphVmDiagnosticCodes.MissingTargetNode,
+                        $"GraphVM control edge[{i}] references missing target node '{edge.To}'.",
+                        edge.From));
+                    continue;
+                }
+
+                if (!IsValidControlPort(ops[fromIndex], edge.FromPort))
+                {
+                    diagnostics.Add(new GraphVmDiagnostic(
+                        GraphVmDiagnosticSeverity.Error,
+                        GraphVmDiagnosticCodes.UnexpectedControlEdge,
+                        $"GraphVM node '{edge.From}' op '{ops[fromIndex]}' does not support control port '{edge.FromPort}'.",
+                        edge.From));
+                    continue;
+                }
+
+                var key = new ControlKey(edge.From, edge.FromPort);
+                if (result.ContainsKey(key))
+                {
+                    diagnostics.Add(new GraphVmDiagnostic(
+                        GraphVmDiagnosticSeverity.Error,
+                        GraphVmDiagnosticCodes.DuplicateControlEdge,
+                        $"GraphVM node '{edge.From}' has duplicate control edge for port '{edge.FromPort}'.",
+                        edge.From));
+                    continue;
+                }
+
+                result[key] = edge.To;
+            }
+
+            return result;
+        }
+
+        private static Dictionary<ValueInputKey, GraphVmValueEdge> BuildValueEdges(
+            GraphVmDocument document,
+            Dictionary<string, int> nodeIndices,
+            GraphVmOpcode[] ops,
+            List<GraphVmDiagnostic> diagnostics)
+        {
+            var result = new Dictionary<ValueInputKey, GraphVmValueEdge>();
+            if (document.ValueEdges == null)
+            {
+                return result;
+            }
+
+            for (int i = 0; i < document.ValueEdges.Count; i++)
+            {
+                GraphVmValueEdge edge = document.ValueEdges[i];
+                if (edge == null)
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(edge.From) ||
+                    string.IsNullOrWhiteSpace(edge.FromPort) ||
+                    string.IsNullOrWhiteSpace(edge.To) ||
+                    string.IsNullOrWhiteSpace(edge.ToPort))
+                {
+                    diagnostics.Add(new GraphVmDiagnostic(
+                        GraphVmDiagnosticSeverity.Error,
+                        GraphVmDiagnosticCodes.MissingValueInput,
+                        $"GraphVM value edge[{i}] requires from, fromPort, to, and toPort."));
+                    continue;
+                }
+
+                if (!nodeIndices.TryGetValue(edge.From, out int fromIndex))
+                {
+                    diagnostics.Add(new GraphVmDiagnostic(
+                        GraphVmDiagnosticSeverity.Error,
+                        GraphVmDiagnosticCodes.MissingValueSource,
+                        $"GraphVM value edge[{i}] references missing source node '{edge.From}'.",
+                        edge.To));
+                    continue;
+                }
+
+                if (!nodeIndices.TryGetValue(edge.To, out int toIndex))
+                {
+                    diagnostics.Add(new GraphVmDiagnostic(
+                        GraphVmDiagnosticSeverity.Error,
+                        GraphVmDiagnosticCodes.MissingTargetNode,
+                        $"GraphVM value edge[{i}] references missing target node '{edge.To}'.",
+                        edge.To));
+                    continue;
+                }
+
+                if (!string.Equals(edge.FromPort, GraphVmValuePorts.Value, StringComparison.Ordinal))
+                {
+                    diagnostics.Add(new GraphVmDiagnostic(
+                        GraphVmDiagnosticSeverity.Error,
+                        GraphVmDiagnosticCodes.MissingValueSource,
+                        $"GraphVM node '{edge.From}' exposes only value output port '{GraphVmValuePorts.Value}'.",
+                        edge.From));
+                    continue;
+                }
+
+                if (GetOutputType(ops[fromIndex]) == GraphVmValueType.Void)
+                {
+                    diagnostics.Add(new GraphVmDiagnostic(
+                        GraphVmDiagnosticSeverity.Error,
+                        GraphVmDiagnosticCodes.MissingValueSource,
+                        $"GraphVM node '{edge.From}' op '{ops[fromIndex]}' does not produce a value.",
+                        edge.To));
+                    continue;
+                }
+
+                if (!IsValidValueInputPort(ops[toIndex], edge.ToPort))
+                {
+                    diagnostics.Add(new GraphVmDiagnostic(
+                        GraphVmDiagnosticSeverity.Error,
+                        GraphVmDiagnosticCodes.MissingValueInput,
+                        $"GraphVM node '{edge.To}' op '{ops[toIndex]}' does not support value input port '{edge.ToPort}'.",
+                        edge.To));
+                    continue;
+                }
+
+                var key = new ValueInputKey(edge.To, edge.ToPort);
+                if (result.ContainsKey(key))
+                {
+                    diagnostics.Add(new GraphVmDiagnostic(
+                        GraphVmDiagnosticSeverity.Error,
+                        GraphVmDiagnosticCodes.DuplicateValueEdge,
+                        $"GraphVM node '{edge.To}' has duplicate value edge for port '{edge.ToPort}'.",
+                        edge.To));
+                    continue;
+                }
+
+                result[key] = edge;
+            }
+
+            return result;
+        }
+
+        private static void AllocateOutputs(
+            List<GraphVmNode> nodes,
+            GraphVmOpcode[] ops,
+            GraphVmValueType[] outputTypes,
+            byte[] outputRegisters,
+            List<GraphVmDiagnostic> diagnostics)
+        {
+            int intNext = 0;
+            int boolNext = 0;
+
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                GraphVmNode node = nodes[i];
+                GraphVmOpcode op = ops[i];
+                if (op == GraphVmOpcode.StoreInt)
+                {
+                    ReserveIntSlot(node.Slot, ref intNext, node.Id, diagnostics);
+                }
+                else if (op == GraphVmOpcode.LoadInt)
+                {
+                    ReserveIntSlot(node.Slot, ref intNext, node.Id, diagnostics);
+                }
+            }
+
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                GraphVmValueType outputType = GetOutputType(ops[i]);
+                outputTypes[i] = outputType;
+                outputRegisters[i] = outputType switch
+                {
+                    GraphVmValueType.Int => AllocInt(ref intNext, nodes[i].Id, diagnostics),
+                    GraphVmValueType.Bool => AllocBool(ref boolNext, nodes[i].Id, diagnostics),
+                    _ => 0
+                };
+            }
+        }
+
+        private static void ValidateRequiredEdges(
+            List<GraphVmNode> nodes,
+            GraphVmOpcode[] ops,
+            Dictionary<ControlKey, string> controlEdges,
+            Dictionary<ValueInputKey, GraphVmValueEdge> valueEdges,
+            Dictionary<string, int> nodeIndices,
+            GraphVmValueType[] outputTypes,
+            List<GraphVmDiagnostic> diagnostics)
+        {
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                GraphVmNode node = nodes[i];
+                GraphVmOpcode op = ops[i];
+
+                switch (op)
+                {
+                    case GraphVmOpcode.ConstInt:
+                    case GraphVmOpcode.LoadInt:
+                    case GraphVmOpcode.StoreInt:
+                    case GraphVmOpcode.AddInt:
+                    case GraphVmOpcode.LessThanInt:
+                    case GraphVmOpcode.Nop:
+                    case GraphVmOpcode.Yield:
+                        RequireControlEdge(node, GraphVmControlPorts.Next, controlEdges, diagnostics);
+                        break;
+                    case GraphVmOpcode.BranchBool:
+                    case GraphVmOpcode.JumpIfFalse:
+                        RequireControlEdge(node, GraphVmControlPorts.True, controlEdges, diagnostics);
+                        RequireControlEdge(node, GraphVmControlPorts.False, controlEdges, diagnostics);
+                        break;
+                    case GraphVmOpcode.Call:
+                        RequireControlEdge(node, GraphVmControlPorts.Call, controlEdges, diagnostics);
+                        RequireControlEdge(node, GraphVmControlPorts.Next, controlEdges, diagnostics);
+                        break;
+                    case GraphVmOpcode.Jump:
+                        RequireControlEdge(node, GraphVmControlPorts.Target, controlEdges, diagnostics);
+                        break;
+                    case GraphVmOpcode.Return:
+                    case GraphVmOpcode.ReturnInt:
+                        break;
+                }
+
+                switch (op)
+                {
+                    case GraphVmOpcode.StoreInt:
+                    case GraphVmOpcode.ReturnInt:
+                        RequireValueInput(node, GraphVmValuePorts.Value, GraphVmValueType.Int, valueEdges, nodeIndices, outputTypes, diagnostics);
+                        break;
+                    case GraphVmOpcode.AddInt:
+                    case GraphVmOpcode.LessThanInt:
+                        RequireValueInput(node, GraphVmValuePorts.A, GraphVmValueType.Int, valueEdges, nodeIndices, outputTypes, diagnostics);
+                        RequireValueInput(node, GraphVmValuePorts.B, GraphVmValueType.Int, valueEdges, nodeIndices, outputTypes, diagnostics);
+                        break;
+                    case GraphVmOpcode.BranchBool:
+                    case GraphVmOpcode.JumpIfFalse:
+                        RequireValueInput(node, GraphVmValuePorts.Condition, GraphVmValueType.Bool, valueEdges, nodeIndices, outputTypes, diagnostics);
+                        break;
+                }
+            }
+        }
+
+        private static NodeLayout[] BuildLayouts(
+            List<GraphVmNode> nodes,
+            GraphVmOpcode[] ops,
+            List<GraphVmDiagnostic> diagnostics)
+        {
+            var layouts = new NodeLayout[nodes.Count];
+            int nextInstruction = 1;
+
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                int count = GetInstructionCount(ops[i]);
+                layouts[i] = new NodeLayout(nextInstruction, count);
+                nextInstruction += count;
+            }
+
+            if (nextInstruction > GraphVmRuntimeLimits.MaxInstructions)
+            {
+                diagnostics.Add(new GraphVmDiagnostic(
+                    GraphVmDiagnosticSeverity.Error,
+                    GraphVmDiagnosticCodes.BudgetExceeded,
+                    $"GraphVM compiled instruction count {nextInstruction} exceeds max {GraphVmRuntimeLimits.MaxInstructions}."));
+            }
+
+            return layouts;
+        }
+
+        private static void CompileNode(
+            GraphVmDocument document,
+            GraphVmNode node,
+            GraphVmOpcode op,
+            byte[] outputRegisters,
+            GraphVmValueType[] outputTypes,
+            Dictionary<ControlKey, string> controlEdges,
+            Dictionary<ValueInputKey, GraphVmValueEdge> valueEdges,
+            Dictionary<string, int> nodeIndices,
+            NodeLayout[] layouts,
+            GraphInstruction[] program,
+            GraphInstructionSource[] sources,
+            List<GraphVmDiagnostic> diagnostics)
+        {
+            int nodeIndex = nodeIndices[node.Id];
+            int bodyIndex = layouts[nodeIndex].BodyIndex;
+
+            switch (op)
+            {
+                case GraphVmOpcode.ConstInt:
+                    program[bodyIndex] = new GraphInstruction
+                    {
+                        Op = (ushort)GraphVmOpcode.ConstInt,
+                        Dst = outputRegisters[nodeIndex],
+                        Imm = node.IntValue
+                    };
+                    SetSource(document, sources, bodyIndex, node, op, GraphVmControlPorts.Enter);
+                    EmitJumpToControlTarget(document, node, GraphVmControlPorts.Next, bodyIndex + 1, controlEdges, nodeIndices, layouts, program, sources);
+                    break;
+                case GraphVmOpcode.LoadInt:
+                    program[bodyIndex] = new GraphInstruction
+                    {
+                        Op = (ushort)GraphVmOpcode.LoadInt,
+                        Dst = outputRegisters[nodeIndex],
+                        A = node.Slot
+                    };
+                    SetSource(document, sources, bodyIndex, node, op, GraphVmControlPorts.Enter);
+                    EmitJumpToControlTarget(document, node, GraphVmControlPorts.Next, bodyIndex + 1, controlEdges, nodeIndices, layouts, program, sources);
+                    break;
+                case GraphVmOpcode.StoreInt:
+                    program[bodyIndex] = new GraphInstruction
+                    {
+                        Op = (ushort)GraphVmOpcode.StoreInt,
+                        Dst = node.Slot,
+                        A = ResolveValueInput(node, GraphVmValuePorts.Value, GraphVmValueType.Int, valueEdges, nodeIndices, outputTypes, outputRegisters, diagnostics)
+                    };
+                    SetSource(document, sources, bodyIndex, node, op, GraphVmControlPorts.Enter);
+                    EmitJumpToControlTarget(document, node, GraphVmControlPorts.Next, bodyIndex + 1, controlEdges, nodeIndices, layouts, program, sources);
+                    break;
+                case GraphVmOpcode.AddInt:
+                    program[bodyIndex] = new GraphInstruction
+                    {
+                        Op = (ushort)GraphVmOpcode.AddInt,
+                        Dst = outputRegisters[nodeIndex],
+                        A = ResolveValueInput(node, GraphVmValuePorts.A, GraphVmValueType.Int, valueEdges, nodeIndices, outputTypes, outputRegisters, diagnostics),
+                        B = ResolveValueInput(node, GraphVmValuePorts.B, GraphVmValueType.Int, valueEdges, nodeIndices, outputTypes, outputRegisters, diagnostics)
+                    };
+                    SetSource(document, sources, bodyIndex, node, op, GraphVmControlPorts.Enter);
+                    EmitJumpToControlTarget(document, node, GraphVmControlPorts.Next, bodyIndex + 1, controlEdges, nodeIndices, layouts, program, sources);
+                    break;
+                case GraphVmOpcode.LessThanInt:
+                    program[bodyIndex] = new GraphInstruction
+                    {
+                        Op = (ushort)GraphVmOpcode.LessThanInt,
+                        Dst = outputRegisters[nodeIndex],
+                        A = ResolveValueInput(node, GraphVmValuePorts.A, GraphVmValueType.Int, valueEdges, nodeIndices, outputTypes, outputRegisters, diagnostics),
+                        B = ResolveValueInput(node, GraphVmValuePorts.B, GraphVmValueType.Int, valueEdges, nodeIndices, outputTypes, outputRegisters, diagnostics)
+                    };
+                    SetSource(document, sources, bodyIndex, node, op, GraphVmControlPorts.Enter);
+                    EmitJumpToControlTarget(document, node, GraphVmControlPorts.Next, bodyIndex + 1, controlEdges, nodeIndices, layouts, program, sources);
+                    break;
+                case GraphVmOpcode.BranchBool:
+                case GraphVmOpcode.JumpIfFalse:
+                    program[bodyIndex] = new GraphInstruction
+                    {
+                        Op = (ushort)GraphVmOpcode.JumpIfFalse,
+                        A = ResolveValueInput(node, GraphVmValuePorts.Condition, GraphVmValueType.Bool, valueEdges, nodeIndices, outputTypes, outputRegisters, diagnostics),
+                        Imm = ResolveControlTarget(node, GraphVmControlPorts.False, controlEdges, nodeIndices, layouts)
+                    };
+                    SetSource(document, sources, bodyIndex, node, op, GraphVmControlPorts.Enter);
+                    EmitJumpToControlTarget(document, node, GraphVmControlPorts.True, bodyIndex + 1, controlEdges, nodeIndices, layouts, program, sources);
+                    break;
+                case GraphVmOpcode.Jump:
+                    EmitJumpToControlTarget(document, node, GraphVmControlPorts.Target, bodyIndex, controlEdges, nodeIndices, layouts, program, sources);
+                    break;
+                case GraphVmOpcode.Call:
+                    program[bodyIndex] = new GraphInstruction
+                    {
+                        Op = (ushort)GraphVmOpcode.Call,
+                        Imm = ResolveControlTarget(node, GraphVmControlPorts.Call, controlEdges, nodeIndices, layouts)
+                    };
+                    SetSource(document, sources, bodyIndex, node, op, GraphVmControlPorts.Call);
+                    EmitJumpToControlTarget(document, node, GraphVmControlPorts.Next, bodyIndex + 1, controlEdges, nodeIndices, layouts, program, sources);
+                    break;
+                case GraphVmOpcode.Return:
+                    program[bodyIndex] = new GraphInstruction
+                    {
+                        Op = (ushort)GraphVmOpcode.Return
+                    };
+                    SetSource(document, sources, bodyIndex, node, op, GraphVmControlPorts.Enter);
+                    break;
+                case GraphVmOpcode.ReturnInt:
+                    program[bodyIndex] = new GraphInstruction
+                    {
+                        Op = (ushort)GraphVmOpcode.ReturnInt,
+                        A = ResolveValueInput(node, GraphVmValuePorts.Value, GraphVmValueType.Int, valueEdges, nodeIndices, outputTypes, outputRegisters, diagnostics)
+                    };
+                    SetSource(document, sources, bodyIndex, node, op, GraphVmControlPorts.Enter);
+                    break;
+                case GraphVmOpcode.Yield:
+                    program[bodyIndex] = new GraphInstruction
+                    {
+                        Op = (ushort)GraphVmOpcode.Yield
+                    };
+                    SetSource(document, sources, bodyIndex, node, op, GraphVmControlPorts.Enter);
+                    EmitJumpToControlTarget(document, node, GraphVmControlPorts.Next, bodyIndex + 1, controlEdges, nodeIndices, layouts, program, sources);
+                    break;
+                case GraphVmOpcode.Nop:
+                    program[bodyIndex] = new GraphInstruction
+                    {
+                        Op = (ushort)GraphVmOpcode.Nop
+                    };
+                    SetSource(document, sources, bodyIndex, node, op, GraphVmControlPorts.Enter);
+                    EmitJumpToControlTarget(document, node, GraphVmControlPorts.Next, bodyIndex + 1, controlEdges, nodeIndices, layouts, program, sources);
+                    break;
+                default:
+                    diagnostics.Add(new GraphVmDiagnostic(
+                        GraphVmDiagnosticSeverity.Error,
+                        GraphVmDiagnosticCodes.UnknownOp,
+                        $"GraphVM op '{op}' is not supported by the compiler.",
+                        node.Id));
+                    break;
+            }
+        }
+
+        private static void EmitJumpToControlTarget(
+            GraphVmDocument document,
+            GraphVmNode node,
+            string port,
+            int instructionIndex,
+            Dictionary<ControlKey, string> controlEdges,
+            Dictionary<string, int> nodeIndices,
+            NodeLayout[] layouts,
+            GraphInstruction[] program,
+            GraphInstructionSource[] sources)
+        {
+            program[instructionIndex] = new GraphInstruction
+            {
+                Op = (ushort)GraphVmOpcode.Jump,
+                Imm = ResolveControlTarget(node, port, controlEdges, nodeIndices, layouts)
+            };
+            SetSource(document, sources, instructionIndex, node, GraphVmOpcode.Jump, port);
+        }
+
+        private static int ResolveControlTarget(
+            GraphVmNode node,
+            string port,
+            Dictionary<ControlKey, string> controlEdges,
+            Dictionary<string, int> nodeIndices,
+            NodeLayout[] layouts)
+        {
+            string targetNode = controlEdges[new ControlKey(node.Id, port)];
+            return layouts[nodeIndices[targetNode]].BodyIndex;
+        }
+
+        private static byte ResolveValueInput(
+            GraphVmNode node,
+            string port,
+            GraphVmValueType expectedType,
+            Dictionary<ValueInputKey, GraphVmValueEdge> valueEdges,
+            Dictionary<string, int> nodeIndices,
+            GraphVmValueType[] outputTypes,
+            byte[] outputRegisters,
+            List<GraphVmDiagnostic> diagnostics)
+        {
+            if (!valueEdges.TryGetValue(new ValueInputKey(node.Id, port), out GraphVmValueEdge edge))
+            {
+                diagnostics.Add(new GraphVmDiagnostic(
+                    GraphVmDiagnosticSeverity.Error,
+                    GraphVmDiagnosticCodes.MissingValueInput,
+                    $"GraphVM node '{node.Id}' requires value input '{port}'.",
+                    node.Id));
+                return 0;
+            }
+
+            int sourceIndex = nodeIndices[edge.From];
+            GraphVmValueType actualType = outputTypes[sourceIndex];
+            if (actualType != expectedType)
+            {
+                diagnostics.Add(new GraphVmDiagnostic(
+                    GraphVmDiagnosticSeverity.Error,
+                    GraphVmDiagnosticCodes.TypeMismatch,
+                    $"GraphVM node '{node.Id}' input '{port}' expected {expectedType} but got {actualType} from '{edge.From}'.",
+                    node.Id));
+                return 0;
+            }
+
+            return outputRegisters[sourceIndex];
+        }
+
+        private static void RequireControlEdge(
+            GraphVmNode node,
+            string port,
+            Dictionary<ControlKey, string> controlEdges,
+            List<GraphVmDiagnostic> diagnostics)
+        {
+            if (!controlEdges.ContainsKey(new ControlKey(node.Id, port)))
+            {
+                diagnostics.Add(new GraphVmDiagnostic(
+                    GraphVmDiagnosticSeverity.Error,
+                    GraphVmDiagnosticCodes.MissingControlEdge,
+                    $"GraphVM node '{node.Id}' requires control edge '{port}'.",
+                    node.Id));
+            }
+        }
+
+        private static void RequireValueInput(
+            GraphVmNode node,
+            string port,
+            GraphVmValueType expectedType,
+            Dictionary<ValueInputKey, GraphVmValueEdge> valueEdges,
+            Dictionary<string, int> nodeIndices,
+            GraphVmValueType[] outputTypes,
+            List<GraphVmDiagnostic> diagnostics)
+        {
+            if (!valueEdges.TryGetValue(new ValueInputKey(node.Id, port), out GraphVmValueEdge edge))
+            {
+                diagnostics.Add(new GraphVmDiagnostic(
+                    GraphVmDiagnosticSeverity.Error,
+                    GraphVmDiagnosticCodes.MissingValueInput,
+                    $"GraphVM node '{node.Id}' requires value input '{port}'.",
+                    node.Id));
+                return;
+            }
+
+            int sourceIndex = nodeIndices[edge.From];
+            GraphVmValueType actualType = outputTypes[sourceIndex];
+            if (actualType != expectedType)
+            {
+                diagnostics.Add(new GraphVmDiagnostic(
+                    GraphVmDiagnosticSeverity.Error,
+                    GraphVmDiagnosticCodes.TypeMismatch,
+                    $"GraphVM node '{node.Id}' input '{port}' expected {expectedType} but got {actualType} from '{edge.From}'.",
+                    node.Id));
+            }
+        }
+
+        private static void SetSource(
+            GraphVmDocument document,
+            GraphInstructionSource[] sources,
+            int instructionIndex,
+            GraphVmNode node,
+            GraphVmOpcode op,
+            string controlPort)
+        {
+            sources[instructionIndex] = new GraphInstructionSource(document.Id, node.Id, op.ToString(), controlPort);
+        }
+
+        private static int GetInstructionCount(GraphVmOpcode op)
+        {
+            return op switch
+            {
+                GraphVmOpcode.Return => 1,
+                GraphVmOpcode.ReturnInt => 1,
+                GraphVmOpcode.Jump => 1,
+                GraphVmOpcode.BranchBool => 2,
+                GraphVmOpcode.JumpIfFalse => 2,
+                GraphVmOpcode.Call => 2,
+                _ => 2
+            };
+        }
+
+        private static GraphVmValueType GetOutputType(GraphVmOpcode op)
+        {
+            return op switch
+            {
+                GraphVmOpcode.ConstInt => GraphVmValueType.Int,
+                GraphVmOpcode.LoadInt => GraphVmValueType.Int,
+                GraphVmOpcode.AddInt => GraphVmValueType.Int,
+                GraphVmOpcode.LessThanInt => GraphVmValueType.Bool,
+                _ => GraphVmValueType.Void
+            };
+        }
+
+        private static bool IsValidControlPort(GraphVmOpcode op, string port)
+        {
+            return op switch
+            {
+                GraphVmOpcode.Return or GraphVmOpcode.ReturnInt => false,
+                GraphVmOpcode.Jump => string.Equals(port, GraphVmControlPorts.Target, StringComparison.Ordinal),
+                GraphVmOpcode.BranchBool or GraphVmOpcode.JumpIfFalse =>
+                    string.Equals(port, GraphVmControlPorts.True, StringComparison.Ordinal) ||
+                    string.Equals(port, GraphVmControlPorts.False, StringComparison.Ordinal),
+                GraphVmOpcode.Call =>
+                    string.Equals(port, GraphVmControlPorts.Call, StringComparison.Ordinal) ||
+                    string.Equals(port, GraphVmControlPorts.Next, StringComparison.Ordinal),
+                _ => string.Equals(port, GraphVmControlPorts.Next, StringComparison.Ordinal)
+            };
+        }
+
+        private static bool IsValidValueInputPort(GraphVmOpcode op, string port)
+        {
+            return op switch
+            {
+                GraphVmOpcode.StoreInt or GraphVmOpcode.ReturnInt =>
+                    string.Equals(port, GraphVmValuePorts.Value, StringComparison.Ordinal),
+                GraphVmOpcode.AddInt or GraphVmOpcode.LessThanInt =>
+                    string.Equals(port, GraphVmValuePorts.A, StringComparison.Ordinal) ||
+                    string.Equals(port, GraphVmValuePorts.B, StringComparison.Ordinal),
+                GraphVmOpcode.BranchBool or GraphVmOpcode.JumpIfFalse =>
+                    string.Equals(port, GraphVmValuePorts.Condition, StringComparison.Ordinal),
+                _ => false
+            };
+        }
+
+        private static byte AllocInt(ref int next, string nodeId, List<GraphVmDiagnostic> diagnostics)
+        {
+            if (next >= GraphVmRuntimeLimits.MaxIntRegisters)
+            {
+                diagnostics.Add(new GraphVmDiagnostic(
+                    GraphVmDiagnosticSeverity.Error,
+                    GraphVmDiagnosticCodes.RegisterOutOfRange,
+                    $"GraphVM int register budget exceeded ({GraphVmRuntimeLimits.MaxIntRegisters}).",
+                    nodeId));
+                return 0;
+            }
+
+            return (byte)next++;
+        }
+
+        private static byte AllocBool(ref int next, string nodeId, List<GraphVmDiagnostic> diagnostics)
+        {
+            if (next >= GraphVmRuntimeLimits.MaxBoolRegisters)
+            {
+                diagnostics.Add(new GraphVmDiagnostic(
+                    GraphVmDiagnosticSeverity.Error,
+                    GraphVmDiagnosticCodes.RegisterOutOfRange,
+                    $"GraphVM bool register budget exceeded ({GraphVmRuntimeLimits.MaxBoolRegisters}).",
+                    nodeId));
+                return 0;
+            }
+
+            return (byte)next++;
+        }
+
+        private static void ReserveIntSlot(byte slot, ref int next, string nodeId, List<GraphVmDiagnostic> diagnostics)
+        {
+            if (slot >= GraphVmRuntimeLimits.MaxIntRegisters)
+            {
+                diagnostics.Add(new GraphVmDiagnostic(
+                    GraphVmDiagnosticSeverity.Error,
+                    GraphVmDiagnosticCodes.RegisterOutOfRange,
+                    $"GraphVM int register slot {slot} is out of range.",
+                    nodeId));
+                return;
+            }
+
+            if (slot >= next)
+            {
+                next = slot + 1;
+            }
+        }
+    }
+}

--- a/src/Core/GraphRuntime/GraphVmDiagnostics.cs
+++ b/src/Core/GraphRuntime/GraphVmDiagnostics.cs
@@ -1,0 +1,35 @@
+namespace Ludots.Core.GraphRuntime
+{
+    public enum GraphVmDiagnosticSeverity : byte
+    {
+        Error = 1
+    }
+
+    public readonly record struct GraphVmDiagnostic(
+        GraphVmDiagnosticSeverity Severity,
+        string Code,
+        string Message,
+        string? NodeId = null);
+
+    public static class GraphVmDiagnosticCodes
+    {
+        public const string MissingGraphId = "GVM0001";
+        public const string MissingEntry = "GVM0002";
+        public const string EmptyGraph = "GVM0003";
+        public const string EntryMustBeFirstNode = "GVM0004";
+        public const string DuplicateNodeId = "GVM0005";
+        public const string UnknownOp = "GVM0006";
+        public const string MissingTarget = "GVM0007";
+        public const string MissingTargetNode = "GVM0008";
+        public const string BudgetExceeded = "GVM0009";
+        public const string MissingNodeId = "GVM0010";
+        public const string DuplicateControlEdge = "GVM0011";
+        public const string MissingControlEdge = "GVM0012";
+        public const string UnexpectedControlEdge = "GVM0013";
+        public const string DuplicateValueEdge = "GVM0014";
+        public const string MissingValueInput = "GVM0015";
+        public const string MissingValueSource = "GVM0016";
+        public const string TypeMismatch = "GVM0017";
+        public const string RegisterOutOfRange = "GVM0018";
+    }
+}

--- a/src/Core/GraphRuntime/GraphVmDocument.cs
+++ b/src/Core/GraphRuntime/GraphVmDocument.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+
+namespace Ludots.Core.GraphRuntime
+{
+    public sealed class GraphVmDocument
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Entry { get; set; } = string.Empty;
+        public List<GraphVmNode> Nodes { get; set; } = new();
+        public List<GraphVmControlEdge> ControlEdges { get; set; } = new();
+        public List<GraphVmValueEdge> ValueEdges { get; set; } = new();
+    }
+
+    public sealed class GraphVmNode
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Op { get; set; } = string.Empty;
+        public byte Slot { get; set; }
+        public int IntValue { get; set; }
+    }
+
+    public sealed class GraphVmControlEdge
+    {
+        public GraphVmControlEdge()
+        {
+        }
+
+        public GraphVmControlEdge(string from, string fromPort, string to)
+        {
+            From = from;
+            FromPort = fromPort;
+            To = to;
+        }
+
+        public string From { get; set; } = string.Empty;
+        public string FromPort { get; set; } = string.Empty;
+        public string To { get; set; } = string.Empty;
+    }
+
+    public sealed class GraphVmValueEdge
+    {
+        public GraphVmValueEdge()
+        {
+        }
+
+        public GraphVmValueEdge(string from, string fromPort, string to, string toPort)
+        {
+            From = from;
+            FromPort = fromPort;
+            To = to;
+            ToPort = toPort;
+        }
+
+        public string From { get; set; } = string.Empty;
+        public string FromPort { get; set; } = string.Empty;
+        public string To { get; set; } = string.Empty;
+        public string ToPort { get; set; } = string.Empty;
+    }
+}

--- a/src/Core/GraphRuntime/GraphVmExecutor.cs
+++ b/src/Core/GraphRuntime/GraphVmExecutor.cs
@@ -1,0 +1,283 @@
+using System;
+
+namespace Ludots.Core.GraphRuntime
+{
+    public readonly record struct GraphVmExecutionResult
+    {
+        public GraphVmExecutionResult(bool halted, int returnInt, int steps)
+            : this(halted ? GraphVmExecutionStatus.Halted : GraphVmExecutionStatus.Running, returnInt, steps)
+        {
+        }
+
+        public GraphVmExecutionResult(GraphVmExecutionStatus status, int returnInt, int steps)
+        {
+            Status = status;
+            ReturnInt = returnInt;
+            Steps = steps;
+        }
+
+        public GraphVmExecutionStatus Status { get; }
+        public bool Halted => Status == GraphVmExecutionStatus.Halted;
+        public bool Yielded => Status == GraphVmExecutionStatus.Yielded;
+        public int ReturnInt { get; }
+        public int Steps { get; }
+    }
+
+    public struct GraphVmExecutionCursor
+    {
+        public int Pc;
+        public int Steps;
+        public int CallStackCount;
+        public int ReturnInt;
+        public GraphVmExecutionStatus Status;
+
+        public void Reset()
+        {
+            Pc = 0;
+            Steps = 0;
+            CallStackCount = 0;
+            ReturnInt = 0;
+            Status = GraphVmExecutionStatus.Running;
+        }
+    }
+
+    public readonly record struct GraphVmTraceEvent
+    {
+        public GraphVmTraceEvent(int step, int instructionIndex, ushort op)
+            : this(step, instructionIndex, op, instructionIndex + 1)
+        {
+        }
+
+        public GraphVmTraceEvent(int step, int instructionIndex, ushort op, int nextInstructionIndex)
+        {
+            Step = step;
+            InstructionIndex = instructionIndex;
+            Op = op;
+            NextInstructionIndex = nextInstructionIndex;
+        }
+
+        public int Step { get; }
+        public int InstructionIndex { get; }
+        public ushort Op { get; }
+        public int NextInstructionIndex { get; }
+    }
+
+    public interface IGraphVmTraceSink
+    {
+        void OnInstruction(in GraphVmTraceEvent traceEvent);
+    }
+
+    public static class GraphVmExecutor
+    {
+        public static GraphVmExecutionResult Execute(
+            ReadOnlySpan<GraphInstruction> program,
+            IGraphVmTraceSink? traceSink = null)
+        {
+            Span<int> ints = stackalloc int[GraphVmRuntimeLimits.MaxIntRegisters];
+            Span<byte> bools = stackalloc byte[GraphVmRuntimeLimits.MaxBoolRegisters];
+            Span<int> callStack = stackalloc int[GraphVmRuntimeLimits.MaxCallStackDepth];
+            return Execute(program, ints, bools, callStack, traceSink);
+        }
+
+        public static GraphVmExecutionResult Execute(
+            ReadOnlySpan<GraphInstruction> program,
+            Span<int> ints,
+            Span<byte> bools,
+            IGraphVmTraceSink? traceSink = null)
+        {
+            Span<int> callStack = stackalloc int[GraphVmRuntimeLimits.MaxCallStackDepth];
+            return Execute(program, ints, bools, callStack, traceSink);
+        }
+
+        public static GraphVmExecutionResult Execute(
+            ReadOnlySpan<GraphInstruction> program,
+            Span<int> ints,
+            Span<byte> bools,
+            Span<int> callStack,
+            IGraphVmTraceSink? traceSink = null)
+        {
+            var cursor = new GraphVmExecutionCursor();
+            GraphVmExecutionResult result = ExecuteSlice(
+                program,
+                ints,
+                bools,
+                callStack,
+                ref cursor,
+                GraphVmRuntimeLimits.MaxInstructionsPerExecution,
+                traceSink);
+
+            if (result.Status == GraphVmExecutionStatus.Running)
+            {
+                throw new InvalidOperationException(
+                    $"GraphVM exceeded MaxInstructionsPerExecution ({GraphVmRuntimeLimits.MaxInstructionsPerExecution}).");
+            }
+
+            return result;
+        }
+
+        public static GraphVmExecutionResult ExecuteSlice(
+            ReadOnlySpan<GraphInstruction> program,
+            Span<int> ints,
+            Span<byte> bools,
+            Span<int> callStack,
+            ref GraphVmExecutionCursor cursor,
+            int maxInstructionSteps,
+            IGraphVmTraceSink? traceSink = null)
+        {
+            if (program.Length == 0)
+            {
+                throw new InvalidOperationException("GraphVM cannot execute an empty program.");
+            }
+
+            if (ints.Length < GraphVmRuntimeLimits.MaxIntRegisters)
+            {
+                throw new ArgumentException("GraphVM int register span is smaller than the runtime contract.", nameof(ints));
+            }
+
+            if (bools.Length < GraphVmRuntimeLimits.MaxBoolRegisters)
+            {
+                throw new ArgumentException("GraphVM bool register span is smaller than the runtime contract.", nameof(bools));
+            }
+
+            if (callStack.Length < GraphVmRuntimeLimits.MaxCallStackDepth)
+            {
+                throw new ArgumentException("GraphVM call stack span is smaller than the runtime contract.", nameof(callStack));
+            }
+
+            if (maxInstructionSteps <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxInstructionSteps));
+            }
+
+            if (cursor.Status == GraphVmExecutionStatus.Halted)
+            {
+                return new GraphVmExecutionResult(GraphVmExecutionStatus.Halted, cursor.ReturnInt, cursor.Steps);
+            }
+
+            if (cursor.CallStackCount < 0 || cursor.CallStackCount > callStack.Length)
+            {
+                throw new InvalidOperationException($"GraphVM call stack count out of range: {cursor.CallStackCount}.");
+            }
+
+            cursor.Status = GraphVmExecutionStatus.Running;
+
+            int pc = cursor.Pc;
+            int stepsThisSlice = 0;
+
+            while (stepsThisSlice < maxInstructionSteps)
+            {
+                if ((uint)pc >= (uint)program.Length)
+                {
+                    throw new InvalidOperationException($"GraphVM PC left program without ReturnInt: pc={pc}, len={program.Length}.");
+                }
+
+                int instructionIndex = pc;
+                ref readonly GraphInstruction instruction = ref program[instructionIndex];
+                pc++;
+                cursor.Steps++;
+                stepsThisSlice++;
+
+                switch ((GraphVmOpcode)instruction.Op)
+                {
+                    case GraphVmOpcode.Nop:
+                        break;
+                    case GraphVmOpcode.ConstInt:
+                        ints[RequireIntRegister(instruction.Dst)] = instruction.Imm;
+                        break;
+                    case GraphVmOpcode.LoadInt:
+                        ints[RequireIntRegister(instruction.Dst)] = ints[RequireIntRegister(instruction.A)];
+                        break;
+                    case GraphVmOpcode.StoreInt:
+                        ints[RequireIntRegister(instruction.Dst)] = ints[RequireIntRegister(instruction.A)];
+                        break;
+                    case GraphVmOpcode.AddInt:
+                        ints[RequireIntRegister(instruction.Dst)] =
+                            ints[RequireIntRegister(instruction.A)] + ints[RequireIntRegister(instruction.B)];
+                        break;
+                    case GraphVmOpcode.LessThanInt:
+                        bools[RequireBoolRegister(instruction.Dst)] =
+                            (byte)(ints[RequireIntRegister(instruction.A)] < ints[RequireIntRegister(instruction.B)] ? 1 : 0);
+                        break;
+                    case GraphVmOpcode.Jump:
+                        pc = RequireInstructionTarget(program, instruction.Imm);
+                        break;
+                    case GraphVmOpcode.JumpIfFalse:
+                        if (bools[RequireBoolRegister(instruction.A)] == 0)
+                        {
+                            pc = RequireInstructionTarget(program, instruction.Imm);
+                        }
+                        break;
+                    case GraphVmOpcode.BranchBool:
+                        throw new InvalidOperationException("GraphVM BranchBool must be lowered by GraphVmCompiler before execution.");
+                    case GraphVmOpcode.Call:
+                        if (cursor.CallStackCount >= GraphVmRuntimeLimits.MaxCallStackDepth)
+                        {
+                            throw new InvalidOperationException(
+                                $"GraphVM call stack exceeded MaxCallStackDepth ({GraphVmRuntimeLimits.MaxCallStackDepth}).");
+                        }
+
+                        callStack[cursor.CallStackCount++] = pc;
+                        pc = RequireInstructionTarget(program, instruction.Imm);
+                        break;
+                    case GraphVmOpcode.Return:
+                        if (cursor.CallStackCount == 0)
+                        {
+                            throw new InvalidOperationException("GraphVM Return executed with an empty call stack.");
+                        }
+
+                        pc = callStack[--cursor.CallStackCount];
+                        break;
+                    case GraphVmOpcode.Yield:
+                        cursor.Pc = pc;
+                        cursor.Status = GraphVmExecutionStatus.Yielded;
+                        traceSink?.OnInstruction(new GraphVmTraceEvent(cursor.Steps - 1, instructionIndex, instruction.Op, pc));
+                        return new GraphVmExecutionResult(GraphVmExecutionStatus.Yielded, cursor.ReturnInt, cursor.Steps);
+                    case GraphVmOpcode.ReturnInt:
+                        cursor.Pc = pc;
+                        cursor.ReturnInt = ints[RequireIntRegister(instruction.A)];
+                        cursor.Status = GraphVmExecutionStatus.Halted;
+                        traceSink?.OnInstruction(new GraphVmTraceEvent(cursor.Steps - 1, instructionIndex, instruction.Op, pc));
+                        return new GraphVmExecutionResult(GraphVmExecutionStatus.Halted, cursor.ReturnInt, cursor.Steps);
+                    default:
+                        throw new InvalidOperationException($"GraphVM op {instruction.Op} is not registered.");
+                }
+
+                traceSink?.OnInstruction(new GraphVmTraceEvent(cursor.Steps - 1, instructionIndex, instruction.Op, pc));
+            }
+
+            cursor.Pc = pc;
+            cursor.Status = GraphVmExecutionStatus.Running;
+            return new GraphVmExecutionResult(GraphVmExecutionStatus.Running, cursor.ReturnInt, cursor.Steps);
+        }
+
+        private static int RequireIntRegister(byte register)
+        {
+            if (register >= GraphVmRuntimeLimits.MaxIntRegisters)
+            {
+                throw new InvalidOperationException($"GraphVM int register out of range: {register}.");
+            }
+
+            return register;
+        }
+
+        private static int RequireBoolRegister(byte register)
+        {
+            if (register >= GraphVmRuntimeLimits.MaxBoolRegisters)
+            {
+                throw new InvalidOperationException($"GraphVM bool register out of range: {register}.");
+            }
+
+            return register;
+        }
+
+        private static int RequireInstructionTarget(ReadOnlySpan<GraphInstruction> program, int target)
+        {
+            if ((uint)target >= (uint)program.Length)
+            {
+                throw new InvalidOperationException($"GraphVM jump target out of range: {target}.");
+            }
+
+            return target;
+        }
+    }
+}

--- a/src/Core/GraphRuntime/GraphVmOpcode.cs
+++ b/src/Core/GraphRuntime/GraphVmOpcode.cs
@@ -1,0 +1,60 @@
+namespace Ludots.Core.GraphRuntime
+{
+    public enum GraphVmOpcode : ushort
+    {
+        Nop = 0,
+        ConstInt = 1,
+        AddInt = 2,
+        LessThanInt = 3,
+        Jump = 4,
+        JumpIfFalse = 5,
+        ReturnInt = 6,
+        BranchBool = 7,
+        LoadInt = 8,
+        StoreInt = 9,
+        Call = 10,
+        Return = 11,
+        Yield = 12
+    }
+
+    public enum GraphVmValueType : byte
+    {
+        Void = 0,
+        Bool = 1,
+        Int = 2
+    }
+
+    public enum GraphVmExecutionStatus : byte
+    {
+        Running = 0,
+        Yielded = 1,
+        Halted = 2
+    }
+
+    public static class GraphVmRuntimeLimits
+    {
+        public const int MaxIntRegisters = 32;
+        public const int MaxBoolRegisters = 32;
+        public const int MaxInstructions = 256;
+        public const int MaxInstructionsPerExecution = 1024;
+        public const int MaxCallStackDepth = 16;
+    }
+
+    public static class GraphVmControlPorts
+    {
+        public const string Enter = "enter";
+        public const string Next = "next";
+        public const string True = "true";
+        public const string False = "false";
+        public const string Call = "call";
+        public const string Target = "target";
+    }
+
+    public static class GraphVmValuePorts
+    {
+        public const string Value = "value";
+        public const string A = "a";
+        public const string B = "b";
+        public const string Condition = "condition";
+    }
+}

--- a/src/Tests/GraphRuntimeTests/GraphRuntimeTests.csproj
+++ b/src/Tests/GraphRuntimeTests/GraphRuntimeTests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\Ludots.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/GraphRuntimeTests/GraphVmAllocationTests.cs
+++ b/src/Tests/GraphRuntimeTests/GraphVmAllocationTests.cs
@@ -1,0 +1,113 @@
+using Ludots.Core.GraphRuntime;
+using NUnit.Framework;
+
+namespace Ludots.Tests.GraphRuntime
+{
+    [TestFixture]
+    public sealed class GraphVmAllocationTests
+    {
+        private const int EntityCount = 50_000;
+
+        [Test]
+        public void ExecuteSlice_AsyncFunctionResumeToHalt_DoesNotAllocate()
+        {
+            GraphVmCompileResult compiled = GraphVmCompiler.Compile(GraphVmTestGraphs.CreateDrinkUntilFullGraph());
+            Assert.That(compiled.Succeeded, Is.True, GraphVmTestGraphs.FormatDiagnostics(compiled.Diagnostics));
+
+            Span<int> ints = stackalloc int[GraphVmRuntimeLimits.MaxIntRegisters];
+            Span<byte> bools = stackalloc byte[GraphVmRuntimeLimits.MaxBoolRegisters];
+            Span<int> callStack = stackalloc int[GraphVmRuntimeLimits.MaxCallStackDepth];
+            var cursor = new GraphVmExecutionCursor();
+
+            RunToHalt(compiled.Program, ints, bools, callStack, ref cursor);
+            cursor.Reset();
+
+            long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+            GraphVmExecutionResult result = RunToHalt(compiled.Program, ints, bools, callStack, ref cursor);
+            long allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+            Assert.That(result.ReturnInt, Is.EqualTo(3));
+            Assert.That(allocatedBytes, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void ExecuteSlice_50000EntityOneTickBatch_DoesNotAllocate()
+        {
+            GraphVmCompileResult compiled = GraphVmCompiler.Compile(GraphVmTestGraphs.CreateDrinkUntilFullGraph());
+            Assert.That(compiled.Succeeded, Is.True, GraphVmTestGraphs.FormatDiagnostics(compiled.Diagnostics));
+
+            int[] ints = new int[EntityCount * GraphVmRuntimeLimits.MaxIntRegisters];
+            byte[] bools = new byte[EntityCount * GraphVmRuntimeLimits.MaxBoolRegisters];
+            int[] callStacks = new int[EntityCount * GraphVmRuntimeLimits.MaxCallStackDepth];
+            GraphVmExecutionCursor[] cursors = new GraphVmExecutionCursor[EntityCount];
+
+            RunOneTick(compiled.Program, ints, bools, callStacks, cursors, entity: 0);
+
+            long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+            int yielded = 0;
+            for (int entity = 0; entity < EntityCount; entity++)
+            {
+                GraphVmExecutionResult result = RunOneTick(compiled.Program, ints, bools, callStacks, cursors, entity);
+                yielded += result.Yielded ? 1 : 0;
+            }
+
+            long allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+            Assert.That(yielded, Is.EqualTo(EntityCount));
+            Assert.That(allocatedBytes, Is.EqualTo(0));
+        }
+
+        private static GraphVmExecutionResult RunToHalt(
+            GraphInstruction[] program,
+            Span<int> ints,
+            Span<byte> bools,
+            Span<int> callStack,
+            ref GraphVmExecutionCursor cursor)
+        {
+            GraphVmExecutionResult result;
+            do
+            {
+                result = GraphVmExecutor.ExecuteSlice(
+                    program,
+                    ints,
+                    bools,
+                    callStack,
+                    ref cursor,
+                    GraphVmRuntimeLimits.MaxInstructionsPerExecution);
+            }
+            while (!result.Halted);
+
+            return result;
+        }
+
+        private static GraphVmExecutionResult RunOneTick(
+            GraphInstruction[] program,
+            int[] ints,
+            byte[] bools,
+            int[] callStacks,
+            GraphVmExecutionCursor[] cursors,
+            int entity)
+        {
+            int intOffset = entity * GraphVmRuntimeLimits.MaxIntRegisters;
+            int boolOffset = entity * GraphVmRuntimeLimits.MaxBoolRegisters;
+            int stackOffset = entity * GraphVmRuntimeLimits.MaxCallStackDepth;
+
+            Span<int> entityInts = ints.AsSpan(intOffset, GraphVmRuntimeLimits.MaxIntRegisters);
+            Span<byte> entityBools = bools.AsSpan(boolOffset, GraphVmRuntimeLimits.MaxBoolRegisters);
+            Span<int> entityCallStack = callStacks.AsSpan(stackOffset, GraphVmRuntimeLimits.MaxCallStackDepth);
+
+            cursors[entity].Reset();
+            GraphVmExecutionCursor cursor = cursors[entity];
+            GraphVmExecutionResult result = GraphVmExecutor.ExecuteSlice(
+                program,
+                entityInts,
+                entityBools,
+                entityCallStack,
+                ref cursor,
+                GraphVmRuntimeLimits.MaxInstructionsPerExecution);
+            cursors[entity] = cursor;
+            return result;
+        }
+
+    }
+}

--- a/src/Tests/GraphRuntimeTests/GraphVmControlFlowTests.cs
+++ b/src/Tests/GraphRuntimeTests/GraphVmControlFlowTests.cs
@@ -1,0 +1,185 @@
+using System.Collections.Generic;
+using System.Linq;
+using Ludots.Core.GraphRuntime;
+using NUnit.Framework;
+
+namespace Ludots.Tests.GraphRuntime
+{
+    [TestFixture]
+    public sealed class GraphVmControlFlowTests
+    {
+        [Test]
+        public void CompileRegisterRun_GraphWithExplicitControlFlow_CallsFunctionYieldsAndHalts()
+        {
+            GraphVmDocument graph = GraphVmTestGraphs.CreateDrinkUntilFullGraph();
+
+            GraphVmCompileResult compiled = GraphVmCompiler.Compile(graph);
+
+            Assert.That(compiled.Succeeded, Is.True, GraphVmTestGraphs.FormatDiagnostics(compiled.Diagnostics));
+            Assert.That(compiled.Program.Select(i => (GraphVmOpcode)i.Op), Does.Contain(GraphVmOpcode.JumpIfFalse));
+            Assert.That(compiled.Program.Select(i => (GraphVmOpcode)i.Op), Does.Contain(GraphVmOpcode.Call));
+            Assert.That(compiled.Program.Select(i => (GraphVmOpcode)i.Op), Does.Contain(GraphVmOpcode.Return));
+            Assert.That(compiled.Program.Select(i => (GraphVmOpcode)i.Op), Does.Contain(GraphVmOpcode.Yield));
+
+            var registry = new GraphProgramRegistry();
+            registry.Register(7, compiled.Program, GraphKind.Effect, compiled.SourceMap);
+
+            Assert.That(registry.TryGetProgram(7, out var program), Is.True);
+            Assert.That(registry.TryGetKind(7, out GraphKind kind), Is.True);
+            Assert.That(kind, Is.EqualTo(GraphKind.Effect));
+            Assert.That(registry.RequireKind(7, GraphKind.Effect), Is.EqualTo(GraphKind.Effect));
+            Assert.That(registry.TryGetSourceMap(7, out GraphInstructionSourceMap sourceMap), Is.True);
+
+            Span<int> ints = stackalloc int[GraphVmRuntimeLimits.MaxIntRegisters];
+            Span<byte> bools = stackalloc byte[GraphVmRuntimeLimits.MaxBoolRegisters];
+            Span<int> callStack = stackalloc int[GraphVmRuntimeLimits.MaxCallStackDepth];
+            var cursor = new GraphVmExecutionCursor();
+            var trace = new RecordingTraceSink(sourceMap);
+
+            GraphVmExecutionResult first = GraphVmExecutor.ExecuteSlice(program, ints, bools, callStack, ref cursor, 64, trace);
+            Assert.That(first.Yielded, Is.True);
+            Assert.That(cursor.CallStackCount, Is.EqualTo(1));
+
+            GraphVmExecutionResult second = GraphVmExecutor.ExecuteSlice(program, ints, bools, callStack, ref cursor, 64, trace);
+            Assert.That(second.Yielded, Is.True);
+            Assert.That(cursor.CallStackCount, Is.EqualTo(1));
+
+            GraphVmExecutionResult third = GraphVmExecutor.ExecuteSlice(program, ints, bools, callStack, ref cursor, 64, trace);
+            Assert.That(third.Yielded, Is.True);
+            Assert.That(cursor.CallStackCount, Is.EqualTo(1));
+
+            GraphVmExecutionResult fourth = GraphVmExecutor.ExecuteSlice(program, ints, bools, callStack, ref cursor, 64, trace);
+
+            Assert.That(fourth.Halted, Is.True);
+            Assert.That(fourth.ReturnInt, Is.EqualTo(3));
+            Assert.That(cursor.CallStackCount, Is.EqualTo(0));
+
+            Assert.That(Count(trace.Sources, "callDrink", GraphVmControlPorts.Call), Is.EqualTo(3));
+            Assert.That(Count(trace.Sources, "drinkReturn", GraphVmControlPorts.Enter), Is.EqualTo(3));
+            Assert.That(Count(trace.Sources, "drinkYield", GraphVmControlPorts.Enter), Is.EqualTo(3));
+            Assert.That(Count(trace.Sources, "branchNeedDrink"), Is.EqualTo(7));
+            Assert.That(trace.Sources.Last().NodeId, Is.EqualTo("done"));
+        }
+
+        [Test]
+        public void Compile_BranchWithoutFalseEdge_FailsFast()
+        {
+            var graph = new GraphVmDocument
+            {
+                Id = "tests.graphvm.missing-false",
+                Entry = "one",
+                Nodes = new List<GraphVmNode>
+                {
+                    new() { Id = "one", Op = nameof(GraphVmOpcode.ConstInt), IntValue = 1 },
+                    new() { Id = "two", Op = nameof(GraphVmOpcode.ConstInt), IntValue = 2 },
+                    new() { Id = "predicate", Op = nameof(GraphVmOpcode.LessThanInt) },
+                    new() { Id = "branch", Op = nameof(GraphVmOpcode.BranchBool) },
+                    new() { Id = "done", Op = nameof(GraphVmOpcode.ReturnInt) }
+                },
+                ControlEdges = new List<GraphVmControlEdge>
+                {
+                    new("one", GraphVmControlPorts.Next, "two"),
+                    new("two", GraphVmControlPorts.Next, "predicate"),
+                    new("predicate", GraphVmControlPorts.Next, "branch"),
+                    new("branch", GraphVmControlPorts.True, "done")
+                },
+                ValueEdges = new List<GraphVmValueEdge>
+                {
+                    new("one", GraphVmValuePorts.Value, "predicate", GraphVmValuePorts.A),
+                    new("two", GraphVmValuePorts.Value, "predicate", GraphVmValuePorts.B),
+                    new("predicate", GraphVmValuePorts.Value, "branch", GraphVmValuePorts.Condition),
+                    new("one", GraphVmValuePorts.Value, "done", GraphVmValuePorts.Value)
+                }
+            };
+
+            GraphVmCompileResult compiled = GraphVmCompiler.Compile(graph);
+
+            Assert.That(compiled.Succeeded, Is.False);
+            Assert.That(compiled.Diagnostics, Has.Some.Matches<GraphVmDiagnostic>(d =>
+                d.Code == GraphVmDiagnosticCodes.MissingControlEdge &&
+                d.NodeId == "branch"));
+        }
+
+        [Test]
+        public void Compile_ValuePinTypeMismatch_FailsFast()
+        {
+            var graph = new GraphVmDocument
+            {
+                Id = "tests.graphvm.type-mismatch",
+                Entry = "one",
+                Nodes = new List<GraphVmNode>
+                {
+                    new() { Id = "one", Op = nameof(GraphVmOpcode.ConstInt), IntValue = 1 },
+                    new() { Id = "branch", Op = nameof(GraphVmOpcode.BranchBool) },
+                    new() { Id = "done", Op = nameof(GraphVmOpcode.ReturnInt) }
+                },
+                ControlEdges = new List<GraphVmControlEdge>
+                {
+                    new("one", GraphVmControlPorts.Next, "branch"),
+                    new("branch", GraphVmControlPorts.True, "done"),
+                    new("branch", GraphVmControlPorts.False, "done")
+                },
+                ValueEdges = new List<GraphVmValueEdge>
+                {
+                    new("one", GraphVmValuePorts.Value, "branch", GraphVmValuePorts.Condition),
+                    new("one", GraphVmValuePorts.Value, "done", GraphVmValuePorts.Value)
+                }
+            };
+
+            GraphVmCompileResult compiled = GraphVmCompiler.Compile(graph);
+
+            Assert.That(compiled.Succeeded, Is.False);
+            Assert.That(compiled.Diagnostics, Has.Some.Matches<GraphVmDiagnostic>(d =>
+                d.Code == GraphVmDiagnosticCodes.TypeMismatch &&
+                d.NodeId == "branch"));
+        }
+
+        private static int Count(IReadOnlyList<GraphInstructionSource> values, string nodeId)
+        {
+            int count = 0;
+            for (int i = 0; i < values.Count; i++)
+            {
+                if (values[i].NodeId == nodeId)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        private static int Count(IReadOnlyList<GraphInstructionSource> values, string nodeId, string controlPort)
+        {
+            int count = 0;
+            for (int i = 0; i < values.Count; i++)
+            {
+                if (values[i].NodeId == nodeId && values[i].ControlPort == controlPort)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        private sealed class RecordingTraceSink : IGraphVmTraceSink
+        {
+            private readonly GraphInstructionSourceMap _sourceMap;
+
+            public RecordingTraceSink(GraphInstructionSourceMap sourceMap)
+            {
+                _sourceMap = sourceMap;
+            }
+
+            public List<GraphInstructionSource> Sources { get; } = new();
+
+            public void OnInstruction(in GraphVmTraceEvent traceEvent)
+            {
+                if (_sourceMap.TryGetSource(traceEvent.InstructionIndex, out GraphInstructionSource source))
+                {
+                    Sources.Add(source);
+                }
+            }
+        }
+    }
+}

--- a/src/Tests/GraphRuntimeTests/GraphVmTestGraphs.cs
+++ b/src/Tests/GraphRuntimeTests/GraphVmTestGraphs.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using Ludots.Core.GraphRuntime;
+
+namespace Ludots.Tests.GraphRuntime
+{
+    internal static class GraphVmTestGraphs
+    {
+        public static GraphVmDocument CreateDrinkUntilFullGraph(int limit = 3)
+        {
+            return new GraphVmDocument
+            {
+                Id = "tests.graphvm.drink-until-full",
+                Entry = "zeroWater",
+                Nodes = new List<GraphVmNode>
+                {
+                    new() { Id = "drinkLoadWater", Op = nameof(GraphVmOpcode.LoadInt), Slot = 0 },
+                    new() { Id = "drinkLoadOne", Op = nameof(GraphVmOpcode.LoadInt), Slot = 2 },
+                    new() { Id = "drinkAdd", Op = nameof(GraphVmOpcode.AddInt) },
+                    new() { Id = "drinkStoreWater", Op = nameof(GraphVmOpcode.StoreInt), Slot = 0 },
+                    new() { Id = "drinkYield", Op = nameof(GraphVmOpcode.Yield) },
+                    new() { Id = "drinkReturn", Op = nameof(GraphVmOpcode.Return) },
+                    new() { Id = "zeroWater", Op = nameof(GraphVmOpcode.ConstInt), IntValue = 0 },
+                    new() { Id = "storeWater", Op = nameof(GraphVmOpcode.StoreInt), Slot = 0 },
+                    new() { Id = "limitValue", Op = nameof(GraphVmOpcode.ConstInt), IntValue = limit },
+                    new() { Id = "storeLimit", Op = nameof(GraphVmOpcode.StoreInt), Slot = 1 },
+                    new() { Id = "oneValue", Op = nameof(GraphVmOpcode.ConstInt), IntValue = 1 },
+                    new() { Id = "storeOne", Op = nameof(GraphVmOpcode.StoreInt), Slot = 2 },
+                    new() { Id = "loadWaterForCheck", Op = nameof(GraphVmOpcode.LoadInt), Slot = 0 },
+                    new() { Id = "loadLimit", Op = nameof(GraphVmOpcode.LoadInt), Slot = 1 },
+                    new() { Id = "waterBelowLimit", Op = nameof(GraphVmOpcode.LessThanInt) },
+                    new() { Id = "branchNeedDrink", Op = nameof(GraphVmOpcode.BranchBool) },
+                    new() { Id = "callDrink", Op = nameof(GraphVmOpcode.Call) },
+                    new() { Id = "loadWaterForReturn", Op = nameof(GraphVmOpcode.LoadInt), Slot = 0 },
+                    new() { Id = "done", Op = nameof(GraphVmOpcode.ReturnInt) }
+                },
+                ControlEdges = new List<GraphVmControlEdge>
+                {
+                    new("zeroWater", GraphVmControlPorts.Next, "storeWater"),
+                    new("storeWater", GraphVmControlPorts.Next, "limitValue"),
+                    new("limitValue", GraphVmControlPorts.Next, "storeLimit"),
+                    new("storeLimit", GraphVmControlPorts.Next, "oneValue"),
+                    new("oneValue", GraphVmControlPorts.Next, "storeOne"),
+                    new("storeOne", GraphVmControlPorts.Next, "loadWaterForCheck"),
+                    new("loadWaterForCheck", GraphVmControlPorts.Next, "loadLimit"),
+                    new("loadLimit", GraphVmControlPorts.Next, "waterBelowLimit"),
+                    new("waterBelowLimit", GraphVmControlPorts.Next, "branchNeedDrink"),
+                    new("branchNeedDrink", GraphVmControlPorts.True, "callDrink"),
+                    new("branchNeedDrink", GraphVmControlPorts.False, "loadWaterForReturn"),
+                    new("callDrink", GraphVmControlPorts.Call, "drinkLoadWater"),
+                    new("callDrink", GraphVmControlPorts.Next, "loadWaterForCheck"),
+                    new("loadWaterForReturn", GraphVmControlPorts.Next, "done"),
+                    new("drinkLoadWater", GraphVmControlPorts.Next, "drinkLoadOne"),
+                    new("drinkLoadOne", GraphVmControlPorts.Next, "drinkAdd"),
+                    new("drinkAdd", GraphVmControlPorts.Next, "drinkStoreWater"),
+                    new("drinkStoreWater", GraphVmControlPorts.Next, "drinkYield"),
+                    new("drinkYield", GraphVmControlPorts.Next, "drinkReturn")
+                },
+                ValueEdges = new List<GraphVmValueEdge>
+                {
+                    new("zeroWater", GraphVmValuePorts.Value, "storeWater", GraphVmValuePorts.Value),
+                    new("limitValue", GraphVmValuePorts.Value, "storeLimit", GraphVmValuePorts.Value),
+                    new("oneValue", GraphVmValuePorts.Value, "storeOne", GraphVmValuePorts.Value),
+                    new("loadWaterForCheck", GraphVmValuePorts.Value, "waterBelowLimit", GraphVmValuePorts.A),
+                    new("loadLimit", GraphVmValuePorts.Value, "waterBelowLimit", GraphVmValuePorts.B),
+                    new("waterBelowLimit", GraphVmValuePorts.Value, "branchNeedDrink", GraphVmValuePorts.Condition),
+                    new("loadWaterForReturn", GraphVmValuePorts.Value, "done", GraphVmValuePorts.Value),
+                    new("drinkLoadWater", GraphVmValuePorts.Value, "drinkAdd", GraphVmValuePorts.A),
+                    new("drinkLoadOne", GraphVmValuePorts.Value, "drinkAdd", GraphVmValuePorts.B),
+                    new("drinkAdd", GraphVmValuePorts.Value, "drinkStoreWater", GraphVmValuePorts.Value)
+                }
+            };
+        }
+
+        public static string FormatDiagnostics(GraphVmDiagnostic[] diagnostics)
+        {
+            if (diagnostics.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var parts = new string[diagnostics.Length];
+            for (int i = 0; i < diagnostics.Length; i++)
+            {
+                parts[i] = $"{diagnostics[i].Code}:{diagnostics[i].NodeId}:{diagnostics[i].Message}";
+            }
+
+            return string.Join("\n", parts);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds the minimal domain-neutral Core GraphVM loop only. It does not include showcase, FSM, BT, GAS wiring, or editor work.

- Adds authored graph documents, opcodes, diagnostics, source maps, compiler, and executor.
- Supports explicit control flow: branch, jump, call, yield/resume, return, and return-int.
- Keeps execution hot paths caller-owned through spans/cursors/call stacks so entity ticks avoid heap allocation.
- Extends GraphProgramRegistry with explicit GraphKind, duplicate registration rejection, and optional source-map lookup.
- Adds focused GraphRuntime tests and a separate BenchmarkDotNet project for the 50,000-entity ECS-shaped batch.

## Verification

- `dotnet test src\Tests\GraphRuntimeTests\GraphRuntimeTests.csproj -c Debug --nologo --disable-build-servers --logger console;verbosity=minimal` passed: 5/5.
- `dotnet test src\Tests\ArchitectureTests\ArchitectureTests.csproj -c Debug --filter FullyQualifiedName~GraphRuntimeArchitectureGuardTests --nologo --disable-build-servers --logger console;verbosity=minimal` passed: 1/1.
- `dotnet run -c Release --project src\Benchmarks\GraphRuntimeBenchmarks\GraphRuntimeBenchmarks.csproj -- --smoke` passed: `status=Halted`, `return=3`, `steps=86`, `allocatedBytes=0`.

## Benchmark Snapshot

Short local BDN run on 2026-08-06 JST, Windows 11, .NET SDK 9.0.312, runtime .NET 8.0.25:

| Benchmark | Mean | Allocation |
| --- | ---: | ---: |
| `ExecuteLoop_OneEntity_NoTrace` | `4.682 us` | `0 B` |
| `ExecuteAsyncFunction_ResumeToHalt_NoTrace` | `560.7 ns` | `0 B` |
| `ExecuteAsyncFunction_ResumeToHalt_WithSourceMapTrace` | `2.153 us` | `0 B` |
| `ExecuteLoop_50000Entities_NoTrace` | `274.069 ms` | BDN noise: `133 B/op` |
| `ExecuteAsyncFunction_50000Entities_OneTick` | `10.475 ms` | BDN noise: `3 B/op` |
| `CompileAsyncControlFlowGraph` | `27.078 us` | `9,393 B` |
| `RegistryLookup_ProgramAndSourceMap` | `323.711 us` | `0 B` |

The 50,000-entity one-tick async row is the ECS-shaped acceptance signal for this slice: one compiled graph, contiguous per-entity state, no runtime collection growth.