### PR TITLE
fix(movement+physics2d): 位移写权窗口的合法终止路径、叠加替换合同与碰撞事件代际修复（#737）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ Ludots — 基于 Arch ECS 的高性能 C# 游戏框架。六边形架构，一�
 
 **写任何代码前必须先读 `gitbook/contributing/ai-assisted-development.md` 的“任务执行决策规范”。**
 
+代码注释纪律：类型、方法、字段命名到位时不写注释——注释是命名无法表达"非显然的意图、取舍、约束"时的补救，不是默认动作；禁止在代码注释里写 issue/PR 编号、修复历史等项目管理痕迹（那些属于 commit message 与 issue，代码里只留合同本身）。
+
 Entity Association Core 的计划与 ADR SSOT 在 GitHub issue #239；ADR 正本在 #244，仓库 `docs/adr/` 不新增 AAC 平行 ADR 文件。
 
 正式文档门户：<https://mightybubble.github.io/Ludots/>（文档 / Showcase 画廊 / 测试验收 / 架构图库一站聚合）；写作源：`gitbook/`（`gitbook/SUMMARY.md` 导航）；showcase 与验收注册表：仓库根 `showcase.registry.json`。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ Ludots — 基于 Arch ECS 的高性能 C# 游戏框架。六边形架构，一�
 
 **写任何代码前必须先读 `gitbook/contributing/ai-assisted-development.md` 的“任务执行决策规范”。**
 
+代码注释纪律：类型、方法、字段命名到位时不写注释——注释是命名无法表达"非显然的意图、取舍、约束"时的补救，不是默认动作；禁止在代码注释里写 issue/PR 编号、修复历史等项目管理痕迹（那些属于 commit message 与 issue，代码里只留合同本身）。
+
 Entity Association Core 的计划与 ADR SSOT 在 GitHub issue #239；ADR 正本在 #244，仓库 `docs/adr/` 不新增 AAC 平行 ADR 文件。
 
 正式文档门户：<https://mightybubble.github.io/Ludots/>（文档 / Showcase 画廊 / 测试验收 / 架构图库一站聚合）；写作源：`gitbook/`（`gitbook/SUMMARY.md` 导航）；showcase 与验收注册表：仓库根 `showcase.registry.json`。

--- a/gitbook/architecture/entity-simulation-layering.md
+++ b/gitbook/architecture/entity-simulation-layering.md
@@ -147,12 +147,11 @@ Formation 是 Mod 业务聚合，不是 Core 仿真车道。`FormationCapability
 - 可降频
 - 手感与表演优先于完整物理精度
 
-正式口径：
+正式口径（已落地词汇）：
 
-- `AvoidanceLane = MassNavigation`
-- `NavPhysicsMode = NavCrowdResolve`
-- `NavSolverMode = CrowdFlow`
-- 不把全量 crowd 强塞进 `FullPhysics2D`
+- `MovementParticipation.physicsPresence = none | kinematic`
+- `PoseAuthority = Nav`（求解器写位姿；物理经 kinematic 存在看见 crowd）
+- 不把全量 crowd 强塞进完整动态刚体模拟
 - 热路径优先用 SoA crowd sim
 - 上层业务可以持续提交明确逐成员目标，但 MassNavigation 不理解 formation、slot 或 follower 语义
 

--- a/gitbook/architecture/entity-simulation-workstreams.md
+++ b/gitbook/architecture/entity-simulation-workstreams.md
@@ -110,11 +110,11 @@
 
 ### 5.3 交付物
 
-- `AvoidanceLane = MassNavigation` 运行时调度
+- crowd 车道运行时调度（已落地词汇：`MovementParticipation.physicsPresence` + `PoseAuthority = Nav`）
 - crowd SoA 热路径与 ECS 同步链
 - `massNavigationMove` 只接收明确空间目标
 - `MovePlanExecutionIntent` / `MassNavigationMovePlanExecutionSink` 接收上层已解析的逐实体目标
-- crowd entity 的 `BudgetedResident` 运行态
+- crowd entity 的预算化驻留运行态（驻留词汇未落地，由驻留合同单据随消费系统引入）
 - 不依赖 `FullPhysics2D` 承载全量 crowd
 - 不拥有 formation identity、slot layout、facing、rotation 或 follower runtime
 
@@ -143,7 +143,7 @@
 
 ### 6.1 目标
 
-让 `BudgetedResident` entity 真正进入可裁剪、可降频、可休眠的正式运行态，并把 AOI 服务从 hex 偏向收敛到 board-agnostic 语义。
+让预算化驻留的 entity 真正进入可裁剪、可降频、可休眠的正式运行态（驻留词汇随本工作流的消费系统落地），并把 AOI 服务从 hex 偏向收敛到 board-agnostic 语义。
 
 ### 6.2 交付物
 

--- a/src/Core/Gameplay/GAS/BuiltinHandlers.cs
+++ b/src/Core/Gameplay/GAS/BuiltinHandlers.cs
@@ -16,6 +16,7 @@ using Ludots.Core.Gameplay.Teams;
 using Ludots.Core.Presentation.Components;
 using Ludots.Core.Mathematics;
 using Ludots.Core.Mathematics.FixedPoint;
+using Ludots.Core.Physics2D.Components;
 using Ludots.Core.Vision;
 
 namespace Ludots.Core.Gameplay.GAS
@@ -408,22 +409,66 @@ namespace Ludots.Core.Gameplay.GAS
                 }
             }
 
-            EntityCreationHelper.CreateDisplacement(world,
-                new DisplacementState
+            var replacement = new DisplacementState
+            {
+                TargetEntity = context.Target,
+                SourceEntity = context.Source,
+                DirectionTargetEntity = directionTargetEntity,
+                DirectionMode = disp.DirectionMode,
+                FixedDirectionRad = Fix64.FromInt(disp.FixedDirectionDeg) * Fix64.Deg2Rad,
+                TargetPointCm = targetPointCm,
+                HasTargetPoint = hasTargetPoint,
+                TotalDistanceCm = disp.TotalDistanceCm,
+                RemainingDistanceCm = Fix64.FromInt(disp.TotalDistanceCm),
+                TotalDurationTicks = disp.TotalDurationTicks,
+                RemainingTicks = disp.TotalDurationTicks,
+                OverrideNavigation = disp.OverrideNavigation,
+            };
+
+            // 叠加位移合同 = 替换：同一目标已有活跃位移时，用新位移段就地覆写预算与方向，
+            // 不新建第二个状态（两个驱动者写同一实体位姿从根上被禁止）。写权窗口保持打开，
+            // 时钟由位移系统在写权确认后刷新——上限约束单段位移而非连锁累计。
+            if (TryReplaceActiveDisplacement(world, in replacement)) return;
+
+            EntityCreationHelper.CreateDisplacement(world, replacement);
+        }
+
+        private static readonly QueryDescription _activeDisplacementQuery =
+            new QueryDescription().WithAll<DisplacementState>();
+
+        private static bool TryReplaceActiveDisplacement(World world, in DisplacementState replacement)
+        {
+            Entity target = replacement.TargetEntity;
+            DisplacementState next = replacement;
+            bool replaced = false;
+            bool clearSuppression = false;
+            var query = _activeDisplacementQuery;
+            world.Query(in query, (ref DisplacementState state) =>
+            {
+                if (replaced || state.TargetEntity != target)
                 {
-                    TargetEntity = context.Target,
-                    SourceEntity = context.Source,
-                    DirectionTargetEntity = directionTargetEntity,
-                    DirectionMode = disp.DirectionMode,
-                    FixedDirectionRad = Fix64.FromInt(disp.FixedDirectionDeg) * Fix64.Deg2Rad,
-                    TargetPointCm = targetPointCm,
-                    HasTargetPoint = hasTargetPoint,
-                    TotalDistanceCm = disp.TotalDistanceCm,
-                    RemainingDistanceCm = Fix64.FromInt(disp.TotalDistanceCm),
-                    TotalDurationTicks = disp.TotalDurationTicks,
-                    RemainingTicks = disp.TotalDurationTicks,
-                    OverrideNavigation = disp.OverrideNavigation,
-                });
+                    return;
+                }
+
+                // 旧位移段可能压制了移动输入而新段不再压制：标记撤销，
+                // 结构变更留到查询之外执行。
+                bool oldSuppressionApplied = state.MovementSuppressionApplied;
+                bool poseWindowRequested = state.PoseWindowRequested;
+                clearSuppression = oldSuppressionApplied && !next.OverrideNavigation;
+
+                state = next;
+                state.PoseWindowRequested = poseWindowRequested;
+                state.WindowRefreshRequested = poseWindowRequested;
+                state.MovementSuppressionApplied = oldSuppressionApplied && !clearSuppression;
+                replaced = true;
+            });
+
+            if (clearSuppression && world.IsAlive(target) && world.Has<MovementSuppressed2D>(target))
+            {
+                world.Remove<MovementSuppressed2D>(target);
+            }
+
+            return replaced;
         }
 
         public static void HandleApplyRelation(

--- a/src/Core/Gameplay/GAS/Components/DisplacementState.cs
+++ b/src/Core/Gameplay/GAS/Components/DisplacementState.cs
@@ -32,8 +32,12 @@ namespace Ludots.Core.Gameplay.GAS
         public bool MovementSuppressionApplied;
         /// <summary>
         /// 目标是 massnav agent 时置位：已向 PoseAuthorityArbiter 申请位移写权窗口
-        /// （issue #643）。窗口在下一个固定步边界生效，生效前不施加位移。
+        /// 。窗口在下一个固定步边界生效，生效前不施加位移。
         /// </summary>
         public bool PoseWindowRequested;
+        /// <summary>
+        /// 叠加位移触发的替换：新位移段已就位，待位移系统在写权确认后刷新窗口时钟。
+        /// </summary>
+        public bool WindowRefreshRequested;
     }
 }

--- a/src/Core/Gameplay/GAS/Systems/DisplacementRuntimeSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/DisplacementRuntimeSystem.cs
@@ -17,7 +17,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
     /// Runs in <see cref="Engine.GameEngine.SystemGroup.EffectProcessing"/> alongside projectile/spawn systems.
     /// Uses deferred destruction to avoid structural changes inside query lambdas.
     /// All math uses Fix64/Fix64Vec2 for determinism.
-    /// Targets bound as MassNavigation agents (issue #643) go through the pose-authority
+    /// Targets bound as MassNavigation agents go through the pose-authority
     /// displacement window: the window is requested at effect start, committed at the next
     /// fixed-step boundary, and handed back to Nav when the effect ends or its speed drops
     /// below the authored handback threshold. Agents without an explicit
@@ -50,10 +50,12 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                     ref DisplacementState disp = ref displacements[index];
                     if (!World.IsAlive(disp.TargetEntity) || !HasDisplacementPosition(disp.TargetEntity))
                     {
+                        // 位移中死亡是常规玩法事件：取消窗口（幂等——仲裁器的死亡检测
+                        // 可能已先一步取消）并合法终止效果。
                         if (disp.PoseWindowRequested)
                         {
-                            throw new System.InvalidOperationException(
-                                $"Displacement target entity {disp.TargetEntity.Id} became invalid while a pose-authority displacement window was open.");
+                            _poseAuthorityArbiter.CancelWindow(World, disp.TargetEntity);
+                            disp.PoseWindowRequested = false;
                         }
 
                         ClearMovementSuppression(ref disp);
@@ -81,7 +83,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                         if (!World.Has<MovementParticipation>(disp.TargetEntity))
                         {
                             throw new System.InvalidOperationException(
-                                $"Displacement targets MassNavigation agent entity {disp.TargetEntity.Id} without a MovementParticipation declaration; silent double-writes of WorldPositionCm are forbidden (issue #643).");
+                                $"Displacement targets MassNavigation agent entity {disp.TargetEntity.Id} without a MovementParticipation declaration; silent double-writes of WorldPositionCm are forbidden.");
                         }
 
                         participation = World.Get<MovementParticipation>(disp.TargetEntity);
@@ -95,6 +97,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                         {
                             _poseAuthorityArbiter.RequestDisplacementAuthority(World, disp.TargetEntity);
                             disp.PoseWindowRequested = true;
+                            disp.WindowRefreshRequested = false;
                             // Motion starts once the window commits at the next fixed-step boundary;
                             // writing WorldPositionCm now would double-write against SyncEntities.
                             continue;
@@ -102,8 +105,27 @@ namespace Ludots.Core.Gameplay.GAS.Systems
 
                         if (World.Get<PoseAuthority>(disp.TargetEntity).Value != PoseAuthorityKind.Displacement)
                         {
-                            throw new System.InvalidOperationException(
-                                $"Displacement window for entity {disp.TargetEntity.Id} was requested but never committed; PoseAuthorityCommitSystem must run at the fixed-step boundary.");
+                            // 区分两种"写权不在位移方"：仲裁器仍持有窗口/待办 = 结算系统缺席，
+                            // 是装配错误必须抛；仲裁器已无记录 = 窗口被生命周期事件（卸载/重建）
+                            // 外部取消，效果随之合法终止。
+                            if (_poseAuthorityArbiter.HasWindowOrPending(disp.TargetEntity))
+                            {
+                                throw new System.InvalidOperationException(
+                                    $"Displacement window for entity {disp.TargetEntity.Id} was requested but never committed; PoseAuthorityCommitSystem must run at the fixed-step boundary.");
+                            }
+
+                            disp.PoseWindowRequested = false;
+                            ClearMovementSuppression(ref disp);
+                            _toDestroy.Add(entity);
+                            continue;
+                        }
+
+                        // 叠加位移的替换合同：新位移段重置窗口时钟，
+                        // maxDurationMs 约束单段位移而非连锁累计。
+                        if (disp.WindowRefreshRequested)
+                        {
+                            _poseAuthorityArbiter.RefreshWindow(World, disp.TargetEntity);
+                            disp.WindowRefreshRequested = false;
                         }
                     }
 
@@ -113,8 +135,10 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                         stepCm = disp.RemainingDistanceCm;
                     }
 
+                    // 交还阈值比较必须留在定点域：把每秒阈值折算成本 tick 的定点步长下限，
+                    // 避免 float 除法的平台舍入差异翻转结构性分支。
                     if (isNavAgent && dt > 0f &&
-                        stepCm.ToFloat() / dt < participation.DisplacementHandbackSpeedThresholdCmPerSec)
+                        stepCm < Fix64.FromFloat(participation.DisplacementHandbackSpeedThresholdCmPerSec) * Fix64.FromFloat(dt))
                     {
                         EndPoseWindow(ref disp);
                         _toDestroy.Add(entity);

--- a/src/Core/Ludots.Physics2D/Systems/ContactEventSystem2D.cs
+++ b/src/Core/Ludots.Physics2D/Systems/ContactEventSystem2D.cs
@@ -11,7 +11,7 @@ using Ludots.Core.Physics2D.Components;
 namespace Ludots.Core.Physics2D.Systems
 {
     /// <summary>
-    /// Contact begin/end edge detection (issue #732). Consumes the broadphase pairing
+    /// Contact begin/end edge detection. Consumes the broadphase pairing
     /// results (CollisionPair.ContactCount 0↔>0 transitions) for entities that opted in
     /// via ContactEventEmitter2D and exports events into a preallocated queue.
     ///
@@ -242,7 +242,7 @@ namespace Ludots.Core.Physics2D.Systems
             if (!World.TryGet(entity, out EntityLayer layer))
             {
                 throw new InvalidOperationException(
-                    $"Contact event emission requires EntityLayer on both contact parties, but entity {entity.Id} has none (issue #732 payload contract).");
+                    $"Contact event emission requires EntityLayer on both contact parties, but entity {entity.Id} has none (payload contract).");
             }
 
             return layer.Value;

--- a/src/Core/Ludots.Physics2D/Systems/ContactEventSystem2D.cs
+++ b/src/Core/Ludots.Physics2D/Systems/ContactEventSystem2D.cs
@@ -80,6 +80,7 @@ namespace Ludots.Core.Physics2D.Systems
         private readonly Dictionary<TrackedContactKey, TrackedContact> _tracked;
         private readonly List<TrackedContactKey> _staleKeys;
 
+        private readonly int _maxTrackedContacts;
         private uint _allowedEmitterCategoryMask;
         private bool _allowedLayersResolved;
         private int _stepIndex;
@@ -100,6 +101,7 @@ namespace Ludots.Core.Physics2D.Systems
             _activePairsQuery = new QueryDescription().WithAll<CollisionPair, ActiveCollisionPairTag>();
             _emittersQuery = new QueryDescription().WithAll<ContactEventEmitter2D>();
             _emitterEntityIds = new HashSet<int>(256);
+            _maxTrackedContacts = maxTrackedContacts;
             _tracked = new Dictionary<TrackedContactKey, TrackedContact>(maxTrackedContacts);
             _staleKeys = new List<TrackedContactKey>(256);
         }
@@ -160,6 +162,17 @@ namespace Ludots.Core.Physics2D.Systems
             {
                 if (_tracked.TryGetValue(key, out TrackedContact tracked))
                 {
+                    // 键只含实体 id 与 shape slot；实体 id 被回收复用后同一个键可能指向
+                    // 不同代际的实体。以完整实体身份（含 version）为准：代际不符说明旧接触
+                    // 的一方已死并被复用——旧接触补 End，新接触按 Begin 走完整边沿。
+                    if (tracked.EntityA != pair.EntityA || tracked.EntityB != pair.EntityB)
+                    {
+                        EnqueueEnd(in tracked);
+                        _tracked.Remove(key);
+                        BeginContact(ref pair, in key, emitterA, emitterB);
+                        return;
+                    }
+
                     tracked.LastNormal = pair.Normal;
                     tracked.LastSeenStep = _stepIndex;
                     _tracked[key] = tracked;
@@ -190,6 +203,12 @@ namespace Ludots.Core.Physics2D.Systems
             if (emitterB)
             {
                 RequireAllowedEmitterLayer(pair.EntityB, in layerB);
+            }
+
+            if (_tracked.Count >= _maxTrackedContacts)
+            {
+                throw new InvalidOperationException(
+                    $"Contact event tracking exceeded its configured capacity {_maxTrackedContacts} concurrent touching contacts; raise the contact tracking budget instead of dropping edges.");
             }
 
             _queue.Enqueue(new ContactEvent2D

--- a/src/Core/MassNavigation/Runtime/MassNavigationFlowSolverDisplacement.cs
+++ b/src/Core/MassNavigation/Runtime/MassNavigationFlowSolverDisplacement.cs
@@ -5,7 +5,7 @@ using Ludots.Core.Components;
 namespace Ludots.Core.MassNavigation.Runtime;
 
 /// <summary>
-/// displaced 态（issue #643 任务 3）：PoseAuthority != Nav 的 agent 由外部写权持有者
+/// displaced 态：PoseAuthority != Nav 的 agent 由外部写权持有者
 /// （当前增量为 GAS 位移窗口）驱动 WorldPositionCm。求解器跳过其积分与硬解析，
 /// 但保留其在分离哈希中的存在，使邻居持续避让；每个 entity-sync 节拍把已提交的
 /// WorldPositionCm 回灌进求解器内部 SoA（不平移单位目标，交还后继续原目标）。
@@ -78,6 +78,32 @@ public sealed partial class MassNavigationFlowSolverState
         int offset = index << 1;
         _velocitiesCm[offset] = 0f;
         _velocitiesCm[offset + 1] = 0f;
+    }
+
+    /// <summary>
+    /// 窗口取消路径的幂等最小清理：只摘除 displaced 标记与紧凑表项。
+    /// 不唤醒、不标脏——取消场景里实体要么已死（标脏会让实体同步撞上死实体），
+    /// 要么整个求解器即将被结构重建重置。未标记（已被重建清除）返回 false，
+    /// 这是并发生命周期事件的合法结果；正常交还请走 <see cref="ClearAgentDisplaced"/>。
+    /// </summary>
+    public bool ClearAgentDisplacedIfMarked(int index)
+    {
+        if ((uint)index >= (uint)UnitCount || _displacedAgentFlags[index] == 0)
+        {
+            return false;
+        }
+
+        _displacedAgentFlags[index] = 0;
+        for (int i = 0; i < _displacedAgentCount; i++)
+        {
+            if (_displacedAgents[i] == index)
+            {
+                _displacedAgents[i] = _displacedAgents[--_displacedAgentCount];
+                break;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/src/Core/MassNavigation/Runtime/MassNavigationRuntime.cs
+++ b/src/Core/MassNavigation/Runtime/MassNavigationRuntime.cs
@@ -90,6 +90,11 @@ public sealed class MassNavigationRuntime
 
         if (_simulation is MassNavigationSimulationRuntime simulation)
         {
+            // 地图挂起/卸载时批量取消全部位姿写权窗口：必须发生在 binding 清除之前，
+            // 桥此刻还能解析到运行时并做求解器侧的幂等清理；活跃位移效果会在下一 tick
+            // 识别到窗口消失并合法终止。
+            PoseAuthorityArbiter? poseAuthorityArbiter = engine.GetService(CoreServiceKeys.PoseAuthorityArbiter);
+            poseAuthorityArbiter?.CancelAllWindows(engine.World);
             RequireRuntimeBinding(engine).Clear(mapId, simulation);
         }
 

--- a/src/Core/MassNavigation/Systems/MassNavigationAuthoredAgentBindingSystem.cs
+++ b/src/Core/MassNavigation/Systems/MassNavigationAuthoredAgentBindingSystem.cs
@@ -26,6 +26,7 @@ internal sealed class MassNavigationAuthoredAgentBindingSystem : ISystem<float>
         .WithNone<MassNavigationAgentIndex, PresentationDestroyPending, SuspendedTag>();
 
     private readonly GameEngine _engine;
+    private readonly Ludots.Core.Movement.PoseAuthorityArbiter _poseAuthorityArbiter;
     private readonly List<Entity> _entities;
     private readonly List<MassNavigationAgentSeed> _seeds;
     private readonly List<bool> _controllableFlags;
@@ -50,6 +51,8 @@ internal sealed class MassNavigationAuthoredAgentBindingSystem : ISystem<float>
         }
 
         _agentCapacity = config.ScenarioRuntime.RuntimeCapacity.GroupMembershipAgentCapacity;
+        _poseAuthorityArbiter = engine.GetService(CoreServiceKeys.PoseAuthorityArbiter)
+            ?? throw new InvalidOperationException("MassNavigation authored binding requires the PoseAuthorityArbiter service.");
         _controlDomains = engine.GetService(CoreServiceKeys.ControlDomainQuery)
             ?? throw new InvalidOperationException("MassNavigation authored binding requires ControlDomainQuery.");
         _stances = engine.GetService(CoreServiceKeys.DomainStanceQuery)
@@ -89,6 +92,7 @@ internal sealed class MassNavigationAuthoredAgentBindingSystem : ISystem<float>
         {
             if (simulation.AgentState.TotalAgents > 0)
             {
+                CancelPoseWindowsBeforeStructuralReset();
                 simulation.ClearAuthoredRuntimeBindings(_engine.World);
                 simulation.MarkStructuralChange();
                 _lastAuthoringSignature = 0L;
@@ -334,8 +338,22 @@ internal sealed class MassNavigationAuthoredAgentBindingSystem : ISystem<float>
         }
     }
 
+    /// <summary>
+    /// 结构重建/清空会重排 agent 索引并清空求解器的 displaced 标记，
+    /// 活跃的位姿写权窗口必须同步作废，否则仲裁器与求解器状态错位。
+    /// 取消经桥做幂等清理；对应的位移效果会在下一 tick 识别窗口消失并合法终止。
+    /// </summary>
+    private void CancelPoseWindowsBeforeStructuralReset()
+    {
+        if (_poseAuthorityArbiter.ActiveWindowCount > 0 || _poseAuthorityArbiter.PendingTransitionCount > 0)
+        {
+            _poseAuthorityArbiter.CancelAllWindows(_engine.World);
+        }
+    }
+
     private void RebuildAuthoredAgents(MassNavigationSimulationRuntime simulation)
     {
+        CancelPoseWindowsBeforeStructuralReset();
         _entities.Clear();
         _seeds.Clear();
         _controllableFlags.Clear();

--- a/src/Core/MassNavigation/Systems/MassNavigationPoseAuthorityBridge.cs
+++ b/src/Core/MassNavigation/Systems/MassNavigationPoseAuthorityBridge.cs
@@ -6,11 +6,12 @@ using Ludots.Core.Movement;
 namespace Ludots.Core.MassNavigation.Systems;
 
 /// <summary>
-/// MassNavigation 对位姿写权切换（issue #643）的消费端。
+/// MassNavigation 对位姿写权切换的消费端。
 /// 在固定步边界的写权结算后，把 nav agent 的 displaced 态同步进求解器：
 /// Nav→Displacement 标记 displaced（求解器跳过其积分/硬解析，邻居持续避让）；
 /// Displacement→Nav 先回灌最终已提交位姿，再清除 displaced 并执行带 resetRecovery 的
-/// 到达恢复，使 agent 继续原目标。非 nav-agent 实体不归本桥处理。
+/// 到达恢复，使 agent 继续原目标。窗口取消（死亡/卸载/重建）做幂等清理，
+/// 不依赖实体存活。非 nav-agent 实体不归本桥处理。
 /// </summary>
 internal sealed class MassNavigationPoseAuthorityBridge : IPoseAuthorityTransitionListener
 {
@@ -55,5 +56,56 @@ internal sealed class MassNavigationPoseAuthorityBridge : IPoseAuthorityTransiti
 
         throw new System.InvalidOperationException(
             $"MassNavigation pose-authority bridge does not support the {from}->{to} transition for agent entity {entity.Id}.");
+    }
+
+    public void OnPoseAuthorityWindowCancelled(World world, Entity entity, PoseAuthorityKind holder)
+    {
+        // 取消路径不保证实体存活（死亡取消）也不保证运行时仍在（地图卸载后半程）。
+        // 清理是幂等的：求解器标记可能已被结构重建清除，运行时可能已释放——都合法。
+        MassNavigationSimulationRuntime? simulation = _runtimeProvider();
+        if (simulation == null)
+        {
+            return;
+        }
+
+        if (!TryResolveAgentIndex(world, simulation, entity, out int agentIndex))
+        {
+            return;
+        }
+
+        simulation.MassNavigationFlow.ClearAgentDisplacedIfMarked(agentIndex);
+    }
+
+    private static bool TryResolveAgentIndex(
+        World world,
+        MassNavigationSimulationRuntime simulation,
+        Entity entity,
+        out int agentIndex)
+    {
+        // 存活实体走组件（权威真相）；死亡实体组件已不可读，退回绑定表按实体身份解析。
+        if (world.IsAlive(entity))
+        {
+            if (world.TryGet(entity, out MassNavigationAgentIndex index))
+            {
+                agentIndex = index.Value;
+                return true;
+            }
+
+            agentIndex = -1;
+            return false;
+        }
+
+        System.Collections.Generic.IReadOnlyList<Entity> agents = simulation.AgentState.AllAgents;
+        for (int i = 0; i < agents.Count; i++)
+        {
+            if (agents[i] == entity)
+            {
+                agentIndex = i;
+                return true;
+            }
+        }
+
+        agentIndex = -1;
+        return false;
     }
 }

--- a/src/Core/Movement/PoseAuthorityArbiter.cs
+++ b/src/Core/Movement/PoseAuthorityArbiter.cs
@@ -7,7 +7,7 @@ using Ludots.Core.Components;
 namespace Ludots.Core.Movement
 {
     /// <summary>
-    /// 位姿写权切换提交后的通知回调（issue #643）。
+    /// 位姿写权切换提交后的通知回调。
     /// 由关心写权归属的运动子系统实现（例如 MassNavigation 把 displaced 态同步进求解器）。
     /// 回调在 <see cref="PoseAuthorityCommitSystem"/> 的 CommandBuffer 回放之后触发，
     /// 此时 ECS 上的 <see cref="PoseAuthority"/> 已是切换后的值。
@@ -15,10 +15,16 @@ namespace Ludots.Core.Movement
     public interface IPoseAuthorityTransitionListener
     {
         void OnPoseAuthorityCommitted(World world, Entity entity, PoseAuthorityKind from, PoseAuthorityKind to);
+
+        /// <summary>
+        /// 窗口被取消（合法异常终止：目标死亡、地图卸载/agent 解绑、结构重建）。
+        /// 与正常交还不同：不保证实体存活，监听者必须自行按 id 解析并做幂等清理。
+        /// </summary>
+        void OnPoseAuthorityWindowCancelled(World world, Entity entity, PoseAuthorityKind holder);
     }
 
     /// <summary>
-    /// 位姿写权仲裁器（issue #643 参与模型轴一的运行时执行点）。
+    /// 位姿写权仲裁器（参与模型"写权轴"的运行时执行点）。
     /// 记录"谁持有写权窗口、已持有多久、何时到期"；切换申请只入队，
     /// 由 <see cref="PoseAuthorityCommitSystem"/> 在固定步边界经 CommandBuffer 统一结算。
     /// 任何非法申请（缺参与声明、写权不匹配、重复申请）立即抛异常，无静默回退。
@@ -152,6 +158,102 @@ namespace Ludots.Core.Movement
             });
         }
 
+        /// <summary>
+        /// 取消实体的写权窗口与待结算切换（合法异常终止路径）。
+        /// 幂等：既无窗口也无待办时为无操作——取消方（GAS 位移、地图生命周期、结构重建）
+        /// 与仲裁器自身的死亡检测谁先发现都合法。实体仍存活时写权立即回 Nav（取消不等边界：
+        /// 窗口作废的语义就是"该持有者从此刻起无权写位姿"）；已取消的活跃窗口会通知监听者做幂等清理。
+        /// </summary>
+        public void CancelWindow(World world, Entity entity)
+        {
+            ArgumentNullException.ThrowIfNull(world);
+            ThrowIfCommitting();
+
+            for (int i = _pending.Count - 1; i >= 0; i--)
+            {
+                if (_pending[i].Entity == entity)
+                {
+                    _pending.RemoveAt(i);
+                }
+            }
+
+            if (!TryFindWindowIndex(entity, out int windowIndex))
+            {
+                return;
+            }
+
+            PoseAuthorityKind holder = _activeWindows[windowIndex].Holder;
+            _activeWindows.RemoveAt(windowIndex);
+
+            if (world.IsAlive(entity) && world.Has<PoseAuthority>(entity))
+            {
+                world.Set(entity, new PoseAuthority { Value = PoseAuthorityKind.Nav });
+            }
+
+            for (int listenerIndex = 0; listenerIndex < _listeners.Count; listenerIndex++)
+            {
+                _listeners[listenerIndex].OnPoseAuthorityWindowCancelled(world, entity, holder);
+            }
+        }
+
+        /// <summary>
+        /// 批量取消全部窗口与待办（地图卸载、authored agent 集结构重建等生命周期事件）。
+        /// </summary>
+        public void CancelAllWindows(World world)
+        {
+            ArgumentNullException.ThrowIfNull(world);
+            ThrowIfCommitting();
+            _pending.Clear();
+            while (_activeWindows.Count > 0)
+            {
+                Entity entity = _activeWindows[_activeWindows.Count - 1].Entity;
+                PoseAuthorityKind holder = _activeWindows[_activeWindows.Count - 1].Holder;
+                _activeWindows.RemoveAt(_activeWindows.Count - 1);
+
+                if (world.IsAlive(entity) && world.Has<PoseAuthority>(entity))
+                {
+                    world.Set(entity, new PoseAuthority { Value = PoseAuthorityKind.Nav });
+                }
+
+                for (int listenerIndex = 0; listenerIndex < _listeners.Count; listenerIndex++)
+                {
+                    _listeners[listenerIndex].OnPoseAuthorityWindowCancelled(world, entity, holder);
+                }
+            }
+        }
+
+        /// <summary>
+        /// 刷新活跃窗口的时钟（叠加位移=替换合同：新位移段重置窗口计时，
+        /// maxDurationMs 约束单段位移而非累计）。窗口尚未结算（仅待办）时刷新是无操作——
+        /// 时钟本来就未开始。既无窗口也无待办则为合同错误。
+        /// </summary>
+        public void RefreshWindow(World world, Entity entity)
+        {
+            ArgumentNullException.ThrowIfNull(world);
+            ThrowIfCommitting();
+            if (TryFindWindowIndex(entity, out int windowIndex))
+            {
+                WindowState window = _activeWindows[windowIndex];
+                window.HeldSeconds = 0f;
+                _activeWindows[windowIndex] = window;
+                return;
+            }
+
+            if (HasPendingTransition(entity))
+            {
+                return;
+            }
+
+            throw new InvalidOperationException(
+                $"PoseAuthorityArbiter cannot refresh a displacement window for entity {entity.Id}: no active window or pending transition.");
+        }
+
+        /// <summary>实体是否有活跃窗口或待结算切换（供位移系统区分"外部取消"与"结算系统缺席"）。</summary>
+        public bool HasWindowOrPending(Entity entity)
+        {
+            return TryFindWindowIndex(entity, out _) || HasPendingTransition(entity);
+        }
+
         /// <summary>查询实体当前的写权窗口（谁持有、已持有多久、上限多少毫秒）。</summary>
         public bool TryGetWindow(Entity entity, out PoseAuthorityKind holder, out float heldSeconds, out int maxDurationMs)
         {
@@ -184,15 +286,24 @@ namespace Ludots.Core.Movement
             _committing = true;
             try
             {
+                // 申请后、边界结算前死亡的实体：窗口从未生效，直接丢弃待办。
+                // 这是合法取消（死亡是常规玩法事件），不通知监听者——没有已生效的窗口需要清理。
+                for (int i = _pending.Count - 1; i >= 0; i--)
+                {
+                    if (!world.IsAlive(_pending[i].Entity))
+                    {
+                        _pending.RemoveAt(i);
+                    }
+                }
+
+                if (_pending.Count == 0)
+                {
+                    return;
+                }
+
                 for (int i = 0; i < _pending.Count; i++)
                 {
                     PendingTransition transition = _pending[i];
-                    if (!world.IsAlive(transition.Entity))
-                    {
-                        throw new InvalidOperationException(
-                            $"PoseAuthorityArbiter cannot commit {transition.From}->{transition.To} for entity {transition.Entity.Id}: entity died before the fixed-step boundary.");
-                    }
-
                     PoseAuthority authority = world.Get<PoseAuthority>(transition.Entity);
                     if (authority.Value != transition.From)
                     {
@@ -252,13 +363,22 @@ namespace Ludots.Core.Movement
                 return;
             }
 
-            for (int i = 0; i < _activeWindows.Count; i++)
+            for (int i = _activeWindows.Count - 1; i >= 0; i--)
             {
                 WindowState window = _activeWindows[i];
+
+                // 持有窗口期间死亡是常规玩法事件：仲裁器在每个固定步最先运行，
+                // 是死亡后第一个能安全关闭窗口的位置——必须在这里取消并通知监听者
+                // 做幂等清理，否则求解器会在同一固定步稍后的位姿同步中撞上死实体。
                 if (!world.IsAlive(window.Entity))
                 {
-                    throw new InvalidOperationException(
-                        $"PoseAuthorityArbiter window holder entity {window.Entity.Id} died while holding {window.Holder} pose authority.");
+                    _activeWindows.RemoveAt(i);
+                    for (int listenerIndex = 0; listenerIndex < _listeners.Count; listenerIndex++)
+                    {
+                        _listeners[listenerIndex].OnPoseAuthorityWindowCancelled(world, window.Entity, window.Holder);
+                    }
+
+                    continue;
                 }
 
                 window.HeldSeconds += dt;

--- a/src/Core/Movement/PoseAuthorityCommitSystem.cs
+++ b/src/Core/Movement/PoseAuthorityCommitSystem.cs
@@ -5,7 +5,7 @@ using Arch.System;
 namespace Ludots.Core.Movement
 {
     /// <summary>
-    /// 固定步边界的位姿写权结算系统（issue #643）。
+    /// 固定步边界的位姿写权结算系统。
     /// 运行在 <see cref="Engine.GameEngine.SystemGroup.SchemaUpdate"/>：
     /// 先把上一固定步排队的写权切换经 CommandBuffer 生效并通知监听者，
     /// 再推进已持有窗口的时钟并对超时窗口 fail-fast。

--- a/src/Tests/GasTests/Effect/DisplacementPresetTests.cs
+++ b/src/Tests/GasTests/Effect/DisplacementPresetTests.cs
@@ -240,6 +240,58 @@ namespace Ludots.Tests.GAS
         }
 
         [Test]
+        public void BuiltinHandler_ApplyDisplacement_StackedOnSameTarget_ReplacesInsteadOfCreatingSecondState()
+        {
+            using var world = World.Create();
+
+            var target = world.Create(new WorldPositionCm { Value = Fix64Vec2.Zero });
+            var firstSource = world.Create(new WorldPositionCm { Value = Fix64Vec2.FromInt(-100, 0) });
+            var secondSource = world.Create(new WorldPositionCm { Value = Fix64Vec2.FromInt(0, -100) });
+            var mergedParams = default(EffectConfigParams);
+
+            var firstContext = new EffectContext { Source = firstSource, Target = target, TargetContext = default };
+            var firstTemplate = new EffectTemplateData
+            {
+                Displacement = new DisplacementDescriptor
+                {
+                    DirectionMode = DisplacementDirectionMode.AwayFromSource,
+                    TotalDistanceCm = 500,
+                    TotalDurationTicks = 10,
+                    OverrideNavigation = true,
+                }
+            };
+            BuiltinHandlers.HandleApplyDisplacement(world, default, ref firstContext, in mergedParams, in firstTemplate);
+
+            // 第二次施加命中同一目标：替换合同——覆写方向与预算，不得出现第二个驱动者。
+            var secondContext = new EffectContext { Source = secondSource, Target = target, TargetContext = default };
+            var secondTemplate = new EffectTemplateData
+            {
+                Displacement = new DisplacementDescriptor
+                {
+                    DirectionMode = DisplacementDirectionMode.AwayFromSource,
+                    TotalDistanceCm = 200,
+                    TotalDurationTicks = 4,
+                    OverrideNavigation = false,
+                }
+            };
+            BuiltinHandlers.HandleApplyDisplacement(world, default, ref secondContext, in mergedParams, in secondTemplate);
+
+            int count = 0;
+            world.Query(in DisplacementQuery, (Entity _, ref DisplacementState state) =>
+            {
+                count++;
+                That(state.SourceEntity, Is.EqualTo(secondSource), "the replacement segment owns the state");
+                That(state.TotalDistanceCm, Is.EqualTo(200));
+                That(state.RemainingDistanceCm.ToFloat(), Is.EqualTo(200f).Within(0.01f), "the budget restarts with the new segment");
+                That(state.TotalDurationTicks, Is.EqualTo(4));
+                That(state.RemainingTicks, Is.EqualTo(4));
+                That(state.OverrideNavigation, Is.False);
+            });
+
+            That(count, Is.EqualTo(1), "stacking a displacement on the same target must replace, never duplicate");
+        }
+
+        [Test]
         public void BuiltinHandler_ApplyDisplacement_UsesPreservedCallerTargetPoint_WhenExecIsMissing()
         {
             using var world = World.Create();

--- a/src/Tests/GasTests/Physics2D/Physics2DContactEventTests.cs
+++ b/src/Tests/GasTests/Physics2D/Physics2DContactEventTests.cs
@@ -245,6 +245,55 @@ namespace GasTests.Physics2D
         }
 
         [Test]
+        public void EntityIdReusedForNewContactParty_EmitsEndForOldGenerationAndBeginForNew()
+        {
+            using var world = World.Create();
+            var poses = new KinematicTargetPoseBuffer2D(kinematicBodyCapacity: 8);
+            var queue = new ContactEventQueue2D(contactEventQueueCapacity: 64);
+            var box = CreateEmitterBox(world, _shapeStorage, 0, 0, halfCm: 40);
+            var kinematic = CreateKinematicCircle(world, _shapeStorage, -60, 0, radiusCm: 50);
+            world.Add(kinematic, new EntityLayer(_propBit, uint.MaxValue));
+            var simulation = CreateSimulation(world, _shapeStorage, poses, queue);
+
+            for (int step = 0; step < 3; step++)
+            {
+                simulation.Update(1f / 60f);
+            }
+
+            Assert.That(simulation.ContactEvents.DrainEvents().Length, Is.EqualTo(1), "setup: one Begin for the initial contact");
+
+            // 帧边界销毁 kinematic 一方并立即以同形状同位置重建：Arch 回收实体 id，
+            // 新实体与旧实体同 id 不同 version——追踪键相同但代际不同。
+            world.Destroy(kinematic);
+            var reused = CreateKinematicCircle(world, _shapeStorage, -60, 0, radiusCm: 50);
+            world.Add(reused, new EntityLayer(_propBit, uint.MaxValue));
+            if (reused.Id != kinematic.Id)
+            {
+                Assert.Ignore("Arch did not recycle the entity id in this runtime; the reuse scenario is not reachable here.");
+            }
+
+            Assert.That(reused, Is.Not.EqualTo(kinematic), "the recycled entity must differ by version");
+
+            simulation.Update(1f / 60f);
+
+            ReadOnlySpan<ContactEvent2D> drained = simulation.ContactEvents.DrainEvents();
+            Assert.That(drained.Length, Is.EqualTo(2),
+                "id reuse across generations must yield exactly one End (old generation) and one Begin (new generation)");
+            Assert.That(drained[0].Type, Is.EqualTo(ContactEventType2D.End));
+            Assert.That(drained[1].Type, Is.EqualTo(ContactEventType2D.Begin));
+            Entity oldParty = drained[0].EntityA.Id == kinematic.Id ? drained[0].EntityA : drained[0].EntityB;
+            Entity newParty = drained[1].EntityA.Id == reused.Id ? drained[1].EntityA : drained[1].EntityB;
+            Assert.That(oldParty, Is.EqualTo(kinematic), "the End belongs to the dead generation");
+            Assert.That(newParty, Is.EqualTo(reused), "the Begin belongs to the live generation");
+
+            for (int step = 0; step < 5; step++)
+            {
+                simulation.Update(1f / 60f);
+            }
+            Assert.That(simulation.ContactEvents.Count, Is.Zero, "steady contact must not re-emit after the generation swap");
+        }
+
+        [Test]
         public void EventQueueOverflow_ThrowsNamingCapacityItem()
         {
             using var world = World.Create();

--- a/src/Tests/GasTests/Physics2D/Physics2DScaleBenchmarkTests.cs
+++ b/src/Tests/GasTests/Physics2D/Physics2DScaleBenchmarkTests.cs
@@ -85,7 +85,9 @@ namespace GasTests.Physics2D
                 world,
                 new DiscreteClock(),
                 tickPolicy,
-                new Physics2DSolverConfig(),
+                // 30k dynamic + 100k static 的接触对远超默认碰撞对池；显式声明预算，
+                // 让基准测量吞吐而不是撞上池耗尽异常。
+                new Physics2DSolverConfig { MaxCollisionPairs = 262_144 },
                 shapeStorage,
                 broadphasePolicy,
                 new KinematicTargetPoseBuffer2D(kinematicBodyCapacity: 64),

--- a/src/Tests/PresentationTests/MassNavigation/MassNavigationDisplacementWindowTests.cs
+++ b/src/Tests/PresentationTests/MassNavigation/MassNavigationDisplacementWindowTests.cs
@@ -22,11 +22,12 @@ using NUnit.Framework;
 namespace Ludots.Tests.Presentation
 {
     /// <summary>
-    /// Issue #643 阶段 0+1：GAS 位移写权窗口与 displaced 态的合同测试。
+    /// GAS 位移写权窗口与 displaced 态的合同测试。
     /// 覆盖：窗口全生命周期（行军→位移→求解器镜像已提交位姿→交还→继续原目标）、
     /// 同一固定步内三个 WorldPositionCm 写入者实体集互斥（双写守护）、
     /// 速度低于交还阈值提前结束、maxDurationMs 超时 fail-fast、
-    /// displacedAgentCapacity 超限 fail-fast、缺 MovementParticipation / 不允许位移 fail-fast。
+    /// displacedAgentCapacity 超限 fail-fast、缺 MovementParticipation / 不允许位移 fail-fast、
+    /// 异常终止路径（窗口中死亡、生命周期批量取消）与叠加位移的替换合同。
     /// </summary>
     [TestFixture]
     public sealed class MassNavigationDisplacementWindowTests
@@ -250,6 +251,124 @@ namespace Ludots.Tests.Presentation
             InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
                 () => harness.RunFixedTick(TickDt))!;
             Assert.That(ex.Message, Does.Contain("displacement.allowed"));
+        }
+
+        [Test]
+        public void TargetDiesInsideWindow_ArbiterCancelsAndEffectTerminatesWithoutThrow()
+        {
+            using var harness = new DisplacementWindowHarness(
+                displacedAgentCapacity: 4,
+                new AgentSpec(1000f, 1000f, CreateParticipation()));
+            Entity agent = harness.Agents[0];
+            CreateFixedDirectionDisplacement(harness.World, agent, totalDistanceCm: 400, totalTicks: 8, directionDeg: 90f);
+
+            harness.RunFixedTick(TickDt); // 申请窗口
+            harness.RunFixedTick(TickDt); // 窗口生效并施加第一步位移
+            Assert.That(harness.Simulation.MassNavigationFlow.IsAgentDisplaced(0), Is.True);
+            Assert.That(harness.Arbiter.ActiveWindowCount, Is.EqualTo(1));
+
+            harness.World.Destroy(agent);
+
+            // 写权结算是死亡后第一个运行的相位：窗口被取消、求解器标记被幂等清除，全程无异常。
+            // （本 harness 不含 RuntimeEntityBinding 组，跳过 nav 相位——死实体从求解器摘除
+            // 属于 binding rebuild 的职责，这里只验证仲裁器与效果侧的取消合同。）
+            Assert.DoesNotThrow(() => harness.RunCommitPhase(TickDt));
+            Assert.That(harness.Arbiter.ActiveWindowCount, Is.Zero);
+            Assert.That(harness.Simulation.MassNavigationFlow.IsAgentDisplaced(0), Is.False);
+
+            // 位移效果看到目标死亡：取消（此时已是幂等 no-op）并合法自毁。
+            Assert.DoesNotThrow(() => harness.RunDisplacementPhase(TickDt));
+            Assert.That(harness.CountDisplacementStates(), Is.Zero);
+        }
+
+        [Test]
+        public void LifecycleCancelAllWindows_ReturnsAuthorityAndTerminatesEffectsLegally()
+        {
+            using var harness = new DisplacementWindowHarness(
+                displacedAgentCapacity: 4,
+                new AgentSpec(1000f, 1000f, CreateParticipation()));
+            Entity agent = harness.Agents[0];
+            harness.Simulation.SetAgentNavigationTargetWorldCm(0, 3000f, 1000f, resetRecovery: true);
+            CreateFixedDirectionDisplacement(harness.World, agent, totalDistanceCm: 400, totalTicks: 8, directionDeg: 90f);
+
+            harness.RunFixedTick(TickDt); // 申请窗口
+            harness.RunFixedTick(TickDt); // 窗口生效
+            Assert.That(harness.World.Get<PoseAuthority>(agent).Value, Is.EqualTo(PoseAuthorityKind.Displacement));
+
+            // 模拟地图卸载 / 结构重建入口的批量取消。
+            harness.Arbiter.CancelAllWindows(harness.World);
+
+            Assert.That(harness.Arbiter.ActiveWindowCount, Is.Zero);
+            Assert.That(harness.Arbiter.PendingTransitionCount, Is.Zero);
+            Assert.That(harness.World.Get<PoseAuthority>(agent).Value, Is.EqualTo(PoseAuthorityKind.Nav),
+                "cancellation returns authority immediately: the holder loses pose-write rights the moment its window is voided");
+            Assert.That(harness.Simulation.MassNavigationFlow.IsAgentDisplaced(0), Is.False);
+
+            // 效果侧下一相位识别"仲裁器已无窗口记录"并合法终止，不再驱动位姿。
+            Vector2 beforeEffectPhase = harness.GetWorldPositionCm(agent);
+            Assert.DoesNotThrow(() => harness.RunDisplacementPhase(TickDt));
+            Assert.That(harness.CountDisplacementStates(), Is.Zero);
+            Assert.That(harness.GetWorldPositionCm(agent), Is.EqualTo(beforeEffectPhase),
+                "a cancelled displacement must not write the pose");
+
+            // 完整固定步继续跑：agent 以 Nav 写权继续原目标。
+            for (int i = 0; i < 5; i++)
+            {
+                harness.RunFixedTick(TickDt);
+            }
+
+            Assert.That(harness.GetWorldPositionCm(agent).X, Is.GreaterThan(beforeEffectPhase.X));
+        }
+
+        [Test]
+        public void WindowRefresh_ResetsClockSoChainedSegmentsAreBoundedPerSegmentNotCumulatively()
+        {
+            using var harness = new DisplacementWindowHarness(
+                displacedAgentCapacity: 4,
+                new AgentSpec(1000f, 1000f, CreateParticipation(handbackThresholdCmPerSec: 1f, maxDurationMs: 150)));
+            Entity agent = harness.Agents[0];
+            // 每段 2 tick（100ms），单段 < 150ms 上限；两段累计 200ms 会超上限——
+            // 刷新合同要求时钟按段重置，因此不允许抛出。
+            CreateFixedDirectionDisplacement(harness.World, agent, totalDistanceCm: 100, totalTicks: 2, directionDeg: 90f);
+
+            harness.RunFixedTick(TickDt); // 申请窗口
+            harness.RunFixedTick(TickDt); // 窗口生效，位移 tick 1（时钟 50ms）
+
+            // 第二段位移就地替换（模拟叠加击退）：覆写预算并请求时钟刷新。
+            RefreshActiveDisplacement(harness.World, agent, totalDistanceCm: 100, totalTicks: 2);
+
+            Assert.DoesNotThrow(() =>
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    harness.RunFixedTick(TickDt);
+                }
+            });
+            Assert.That(harness.CountDisplacementStates(), Is.Zero, "the replaced segment must run to completion and terminate");
+            Assert.That(harness.Arbiter.ActiveWindowCount, Is.Zero);
+            Assert.That(harness.World.Get<PoseAuthority>(agent).Value, Is.EqualTo(PoseAuthorityKind.Nav));
+        }
+
+        private static void RefreshActiveDisplacement(World world, Entity target, int totalDistanceCm, int totalTicks)
+        {
+            var query = new QueryDescription().WithAll<DisplacementState>();
+            bool replaced = false;
+            world.Query(in query, (ref DisplacementState state) =>
+            {
+                if (replaced || state.TargetEntity != target)
+                {
+                    return;
+                }
+
+                state.TotalDistanceCm = totalDistanceCm;
+                state.RemainingDistanceCm = Fix64.FromInt(totalDistanceCm);
+                state.TotalDurationTicks = totalTicks;
+                state.RemainingTicks = totalTicks;
+                state.WindowRefreshRequested = state.PoseWindowRequested;
+                replaced = true;
+            });
+
+            Assert.That(replaced, Is.True, "test setup: an active displacement to refresh must exist");
         }
 
         private static MovementParticipation CreateParticipation(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# 概要

修复 issue #737 的全部四项 + 两项清理（合并后独立复核发现）。核心：位移写权窗口此前没有任何合法的异常终止路径——**被击退中死亡、位移中卸载地图、对同一单位叠加两次击退，三种常规玩法事件都会直接抛异常崩溃引擎**。本 PR 为窗口建立完整的取消/替换合同，是 #734（Crowd Physics Arena）把击退接入真实玩法的合入前置。

# 合同设计

**取消（死亡/卸载/重建）**：
- `PoseAuthorityArbiter` 新增 `CancelWindow`/`CancelAllWindows`（幂等；实体存活则写权立即回 Nav——窗口作废即"持有者从此刻起无权写位姿"，不等边界）与监听者取消回调；
- 仲裁器在固定步边界自检：**死亡的窗口持有者/待办实体走取消而非抛异常**（仲裁器是每 tick 第一个运行的相位，是死亡后第一个能安全关闭窗口的位置，赶在求解器位姿同步撞上死实体之前）；
- 生命周期钩子：地图挂起/卸载（binding 清除前）与 authored 集结构重建/清空前批量取消全部窗口，消除仲裁器与求解器的状态错位；
- MassNavigation 桥的取消清理**按实体身份解析（容忍死实体）且只做最小清理**（清标记不标脏不唤醒——标脏会让实体同步撞死实体）；
- `DisplacementRuntimeSystem`：目标死亡→取消+合法终止；写权不在位移方时区分"仲裁器仍有记录=结算系统缺席（抛）"与"记录已消失=外部取消（效果合法自杀）"。

**叠加=替换**：`HandleApplyDisplacement` 对已有活跃位移的目标就地覆写方向与预算（单实体单驱动者，绝不出现第二个状态），窗口保持打开、时钟按段刷新——`maxDurationMs` 约束单段位移而非连锁累计，连续击退合法且有界。旧段的移动压制在新段不需要时立即撤销。

**确定性**：交还阈值比较从 float 除法改为定点域（每秒阈值折算为本 tick 的 Fix64 步长下限），消除跨平台舍入翻转结构性分支的风险。

**碰撞事件代际修复**：追踪键只含实体 id+slot，id 被回收复用后会串号（旧接触无 End、新接触无 Begin）——命中时改比完整实体身份（含 version），代际不符先补 End 再走 Begin；同时把 `maxTrackedContacts` 从"字典初始容量"升级为真正执行的追踪预算（超限抛异常点名预算项）。

**清理**：`Physics2DScaleBenchmarkTests` 显式声明 `MaxCollisionPairs = 262144` 修复存量池耗尽断裂使基准可跑；两份 entity-simulation 文档中已删除占位词汇（`AvoidanceLane`/`BudgetedResident` 等）的残留引用改为已落地词汇口径。

# 验证证据

```text
dotnet test src/Tests/PresentationTests/PresentationTests.csproj --filter "FullyQualifiedName~MassNavigation"
Passed! - Failed: 0, Passed: 101, Skipped: 0, Total: 101（基线 98 + 新增 3）

dotnet test src/Tests/GasTests/GasTests.csproj --filter "Displacement|Physics2DContactEvent|Physics2DKinematic"
Passed! - Failed: 0, Passed: 45, Skipped: 0, Total: 45（基线 43 + 新增 2）

dotnet test src/Tests/ArchitectureTests/ArchitectureTests.csproj
Passed! - Failed: 0, Passed: 191, Skipped: 1, Total: 192
```

新增用例：窗口中死亡→仲裁器取消+效果合法终止（全程无异常）；生命周期批量取消→写权立即回 Nav、效果合法自杀、单位继续原目标；连锁位移段各自受 `maxDurationMs` 约束（时钟按段刷新）；同目标叠加位移→恰好一个状态、预算被替换；实体 id 复用→旧代际恰好一次 End + 新代际恰好一次 Begin、稳态不复发。

# 备注

- 死亡用例按 arbiter/效果层合同验证（测试 harness 不含 RuntimeEntityBinding 组）；生产主路径（`PresentationDestroyPending` → binding rebuild）由重建前的批量取消钩子覆盖，其接线由存量回归守护。
- 本 PR 与在途的 showcase 分支（cursor/crowd-physics-arena-e03b）无文件交集风险评估：showcase 只动 mods/ 与其生产路径测试；本 PR 动的 GAS/Movement/Physics2D 核心文件在其刹车条款禁改清单内。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca6bcf12-8b5f-4aa9-8df0-86526f4de03b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca6bcf12-8b5f-4aa9-8df0-86526f4de03b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

