### PR TITLE
feat(showcase): Crowd Physics Arena——massnav×物理桥 + 人群物理竞技场（#734 / #643 增量2）

### DIFF
--- a/artifacts/gas-composition-gate.md
+++ b/artifacts/gas-composition-gate.md
@@ -2,6 +2,63 @@
 
 Current closeouts and prior issue reviews follow.
 
+## GAS Composition Gate - Issue #734 Crowd Physics Arena (massnav→kinematic bridge + showcase) - 2026-08-06
+
+- **Task / Issue**: Issue #734 — deliver the #643 increment-2 massnav→kinematic bridge, then the `CapabilityStandardCrowdPhysicsArenaMod` showcase (Q shockwave knockback via GAS displacement, E boulder spawn with initial velocity, pressure plate → door via contact events, HUD counters).
+- **Date**: 2026-08-06
+- **Agent / Author**: Cursor cloud agent
+
+### 1. Core judgment
+
+新变体主要交付物是（A/B/C/D）: A
+
+结论: PASS
+
+一句话理由: 冲击波击退复用既有 `presetType=Displacement` effect preset（`DisplacementDirectionMode.AwayFromSource` 是既有 enum 值，非新增）；巨石释放复用既有 `unitCreation`(templateId) effect preset + `RuntimeEntitySpawnQueue` 物化管线，初速度走 Physics2D 模板 authoring 的既有 `velocityCmPerSec` 声明；不新增 `BuiltinHandlerId`、`EffectPresetType`、graph op、profile enum 或平行 spawn/位移管线。
+
+### 2. Layer assignment
+
+| 步骤/能力 | Layer (0/1/2/3) | 实现载体 |
+|-----------|-----------------|----------|
+| massnav→kinematic 位姿喂送 | 0/1 | 新组合层系统（消费既有 `KinematicTargetPoseBuffer2D.SetKinematicTargetPose` 与 `WorldPositionCm`，不是 GAS 步骤） |
+| 碰撞事件路由（压力板层→消费者） | 1 | 新组合层 drain/dispatch 服务（消费既有 `ContactEventQueue2D.DrainEvents`） |
+| Q 冲击波击退 | 2/3 | 既有 `Displacement` effect preset authoring（showcase effects.json，AwayFromSource） |
+| E 巨石 spawn + 初速度 | 2/3 | 既有 `unitCreation` effect preset + 既有物理模板 authoring（dynamic body + velocityCmPerSec） |
+| 压力板计数与开门 | 2 | showcase 内事件消费者（挂接组合层路由入口），阈值数据驱动 |
+| HUD 三数字 | 3 | 复用既有 HUD 文本管线（10k showcase 模式） |
+
+### 3. Reuse list
+
+- Handlers: `BuiltinHandlers.HandleApplyDisplacement`（不改）；`unitCreation` 编译路径 `CompileUnitCreation`（不改）。
+- Queues / Systems: `DisplacementRuntimeSystem`、`PoseAuthorityArbiter`/`PoseAuthorityCommitSystem`、`RuntimeEntitySpawnQueue`、`KinematicDriveSystem2D`、`ContactEventSystem2D`（全部不改，只消费）。
+- Resolvers / Registries: `ComponentRegistry`（MovementParticipation 既有解析）、`Physics2DTemplateAuthoring`（bodyType kinematic/dynamic 既有声明）、`LayerRegistry`、`MassNavigationProfileRegistry`。
+- Existing presets / graphs: `presetType=Displacement`（AwayFromSource）、`presetType` unit-creation 路径；order/target 管线沿用 10k showcase 的本地 order source 模式。
+
+### 4. New Layer 0 ops (if any)
+
+N/A — 无新增 graph op / builtin handler。新增的是组合层系统（位姿喂送 + 事件路由），属于 #643/#733 合同的接线，不是 effect 步骤。
+
+### 5. Transaction boundary
+
+位姿喂送每固定步恰一次（`SetKinematicTargetPose` 重复提交/超容量即抛）；碰撞事件当帧 Drain 后同步分发，消费者异常直接上抛不吞；位移窗口写权切换仍由 `PoseAuthorityCommitSystem` 在固定步边界经 CommandBuffer 结算；巨石 spawn 走 `RuntimeEntitySpawnQueue` 既有事务。
+
+### 6. Config SSOT
+
+行为配置落在: showcase 根 mod 的 effects/abilities/templates JSON + `Physics2D/kinematic.json`（kinematicBodyCapacity、contactEventQueueCapacity、contactEventEmitterLayers）+ `MassNavigationConfig.json`（agentProfiles.radiusCm = 半径 SSOT，displacedAgentCapacity）。压力板阈值、队伍规模、巨石初速全部 showcase 配置显式声明。
+
+是否新增 JSON schema: NO（全部挂既有 authoring/config 管线；无平行 loader）。
+
+### 7. Red flag scan
+
+- [x] 未新增 profile inherit/placement enum
+- [x] 未新建与 spawn 平行的物化管线（巨石走 RuntimeEntitySpawnQueue）
+- [x] 未把 placement 校验塞进 lifecycle op
+- [x] 未添加「说不清的」默认 fallback（半径漂移/容量不足/未注册 layer 全部显式抛错或计数暴露）
+
+### 8. Next variant test
+
+「下一个 Mod 变体」将修改: showcase effects.json（位移距离/方向/时长）、templates.json（队伍规模、板阈值、巨石参数）与 kinematic.json 容量，不改 Core enum、不加新 preset 开关。
+
 ## GAS Composition Gate - Issue #643 Stage 0+1 Movement Participation Increment - 2026-08-06
 
 - **Task / Issue**: Issue #643 stage 0+1 — introduce the `MovementParticipation`/`PoseAuthority` two-axis vocabulary, converge the three `WorldPositionCm` writers under a pose-authority contract, and wire the GAS displacement window into MassNavigation's displaced state.

--- a/artifacts/showcases/capability-standard-physics2d-stress/acceptance.md
+++ b/artifacts/showcases/capability-standard-physics2d-stress/acceptance.md
@@ -4,14 +4,14 @@
 | --- | --- |
 | Pure Physics2D startup | `physics2D.enabled=true`, tick policy and shape storage services registered |
 | Spawn path | Config-driven RuntimeEntitySpawnQueue batch produced `256` dynamic bodies and `16` static columns |
-| Throughput budget | avg measured tick `0.664` ms, budget `12` ms |
+| Throughput budget | avg measured tick `0.444` ms, budget `12` ms |
 | Pipeline steady-state allocation | measured `49152` bytes over `48` frames, budget `65536` bytes |
 | #358 blind spot closure | This is a pipeline-level measurement; the existing 0Alloc unit tests remain static hot-path guards and are not treated as endpoint throughput proof. |
-| Physics stats | Hz `60`, potential pairs `68`, contact pairs `38`, last update `1.3163` ms |
+| Physics stats | Hz `60`, potential pairs `68`, contact pairs `38`, last update `1.1602` ms |
 
 ## Keyframes
 
 | Frame | Potential Pairs | Contact Pairs | Step Ms | Hash |
 | ---: | ---: | ---: | ---: | ---: |
-| 0 | 68 | 38 | 1.97 | 571515438270212163 |
-| 48 | 68 | 38 | 1.316 | 7191022207570260291 |
+| 0 | 68 | 38 | 1.168 | 9203984069077353355 |
+| 48 | 68 | 38 | 1.16 | -3508170479959963037 |

--- a/artifacts/showcases/capability-standard-physics2d-stress/acceptance.md
+++ b/artifacts/showcases/capability-standard-physics2d-stress/acceptance.md
@@ -4,14 +4,14 @@
 | --- | --- |
 | Pure Physics2D startup | `physics2D.enabled=true`, tick policy and shape storage services registered |
 | Spawn path | Config-driven RuntimeEntitySpawnQueue batch produced `256` dynamic bodies and `16` static columns |
-| Throughput budget | avg measured tick `0.664` ms, budget `12` ms |
+| Throughput budget | avg measured tick `0.469` ms, budget `12` ms |
 | Pipeline steady-state allocation | measured `49152` bytes over `48` frames, budget `65536` bytes |
 | #358 blind spot closure | This is a pipeline-level measurement; the existing 0Alloc unit tests remain static hot-path guards and are not treated as endpoint throughput proof. |
-| Physics stats | Hz `60`, potential pairs `68`, contact pairs `38`, last update `1.3163` ms |
+| Physics stats | Hz `60`, potential pairs `68`, contact pairs `38`, last update `1.2560` ms |
 
 ## Keyframes
 
 | Frame | Potential Pairs | Contact Pairs | Step Ms | Hash |
 | ---: | ---: | ---: | ---: | ---: |
-| 0 | 68 | 38 | 1.97 | 571515438270212163 |
-| 48 | 68 | 38 | 1.316 | 7191022207570260291 |
+| 0 | 68 | 38 | 1.277 | 9203984069077353355 |
+| 48 | 68 | 38 | 1.256 | -3508170479959963037 |

--- a/artifacts/showcases/capability-standard-physics2d-stress/acceptance.md
+++ b/artifacts/showcases/capability-standard-physics2d-stress/acceptance.md
@@ -4,14 +4,14 @@
 | --- | --- |
 | Pure Physics2D startup | `physics2D.enabled=true`, tick policy and shape storage services registered |
 | Spawn path | Config-driven RuntimeEntitySpawnQueue batch produced `256` dynamic bodies and `16` static columns |
-| Throughput budget | avg measured tick `0.444` ms, budget `12` ms |
+| Throughput budget | avg measured tick `0.664` ms, budget `12` ms |
 | Pipeline steady-state allocation | measured `49152` bytes over `48` frames, budget `65536` bytes |
 | #358 blind spot closure | This is a pipeline-level measurement; the existing 0Alloc unit tests remain static hot-path guards and are not treated as endpoint throughput proof. |
-| Physics stats | Hz `60`, potential pairs `68`, contact pairs `38`, last update `1.1602` ms |
+| Physics stats | Hz `60`, potential pairs `68`, contact pairs `38`, last update `1.3163` ms |
 
 ## Keyframes
 
 | Frame | Potential Pairs | Contact Pairs | Step Ms | Hash |
 | ---: | ---: | ---: | ---: | ---: |
-| 0 | 68 | 38 | 1.168 | 9203984069077353355 |
-| 48 | 68 | 38 | 1.16 | -3508170479959963037 |
+| 0 | 68 | 38 | 1.97 | 571515438270212163 |
+| 48 | 68 | 38 | 1.316 | 7191022207570260291 |

--- a/artifacts/showcases/capability-standard-physics2d-stress/keyframes.jsonl
+++ b/artifacts/showcases/capability-standard-physics2d-stress/keyframes.jsonl
@@ -1,2 +1,2 @@
-﻿{"Frame":0,"PotentialPairs":68,"ContactPairs":38,"PhysicsUpdateMs":1.9697,"DeterminismHash":571515438270212163}
-{"Frame":48,"PotentialPairs":68,"ContactPairs":38,"PhysicsUpdateMs":1.3163,"DeterminismHash":7191022207570260291}
+﻿{"Frame":0,"PotentialPairs":68,"ContactPairs":38,"PhysicsUpdateMs":1.1683,"DeterminismHash":9203984069077353355}
+{"Frame":48,"PotentialPairs":68,"ContactPairs":38,"PhysicsUpdateMs":1.1602,"DeterminismHash":-3508170479959963037}

--- a/artifacts/showcases/capability-standard-physics2d-stress/keyframes.jsonl
+++ b/artifacts/showcases/capability-standard-physics2d-stress/keyframes.jsonl
@@ -1,2 +1,2 @@
-﻿{"Frame":0,"PotentialPairs":68,"ContactPairs":38,"PhysicsUpdateMs":1.1683,"DeterminismHash":9203984069077353355}
-{"Frame":48,"PotentialPairs":68,"ContactPairs":38,"PhysicsUpdateMs":1.1602,"DeterminismHash":-3508170479959963037}
+﻿{"Frame":0,"PotentialPairs":68,"ContactPairs":38,"PhysicsUpdateMs":1.9697,"DeterminismHash":571515438270212163}
+{"Frame":48,"PotentialPairs":68,"ContactPairs":38,"PhysicsUpdateMs":1.3163,"DeterminismHash":7191022207570260291}

--- a/artifacts/showcases/capability-standard-physics2d-stress/keyframes.jsonl
+++ b/artifacts/showcases/capability-standard-physics2d-stress/keyframes.jsonl
@@ -1,2 +1,2 @@
-﻿{"Frame":0,"PotentialPairs":68,"ContactPairs":38,"PhysicsUpdateMs":1.9697,"DeterminismHash":571515438270212163}
-{"Frame":48,"PotentialPairs":68,"ContactPairs":38,"PhysicsUpdateMs":1.3163,"DeterminismHash":7191022207570260291}
+﻿{"Frame":0,"PotentialPairs":68,"ContactPairs":38,"PhysicsUpdateMs":1.2773,"DeterminismHash":9203984069077353355}
+{"Frame":48,"PotentialPairs":68,"ContactPairs":38,"PhysicsUpdateMs":1.256,"DeterminismHash":-3508170479959963037}

--- a/gitbook/architecture/capability-standard-showcases.md
+++ b/gitbook/architecture/capability-standard-showcases.md
@@ -15,6 +15,7 @@ This page is the SSOT for production-grade capability acceptance showcase roots 
 | Physics2D Stress | `capability_standard_physics2d_stress` | `mods/showcases/capability_standard/CapabilityStandardPhysics2DStressMod` | Large-N Physics2D throughput budget and pipeline-level steady-state allocation evidence |
 | Physics2D Tuning | `capability_standard_physics2d_showcase` | `mods/showcases/capability_standard/CapabilityStandardPhysics2DShowcaseMod` | 15Hz Physics2D, 30K dynamic entities, 100K static entities, broadphase strategy, static obstacle templates, polygon authoring |
 | TimeFlow | `capability_standard_time_flow_showcase` | `mods/showcases/capability_standard/CapabilityStandardTimeFlowShowcaseMod` | TimeFlow pause/scale token stacks: settings pause, menu pause, skill indicator pause, nested system guide pause, scale layering, with MassNavigation, Physics2D, and GAS clock probes and no Formation/action coupling |
+| Crowd Physics Arena | `capability_standard_crowd_physics_arena` | `mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod` | massnav→kinematic bridge acceptance: kinematic squads push dynamic crates, pressure plate contact events open a door, Q shockwave displacement windows with handback, E boulder spawn with initial velocity, HUD counters |
 
 Standard launch commands:
 
@@ -28,6 +29,7 @@ Standard launch commands:
 .\scripts\run-mod-launcher.cmd cli launch '$capability_standard_physics2d_stress' --adapter raylib
 .\scripts\run-mod-launcher.cmd cli launch '$capability_standard_physics2d_showcase' --adapter raylib
 .\scripts\run-mod-launcher.cmd cli launch '$capability_standard_time_flow_showcase' --adapter raylib
+.\scripts\run-mod-launcher.cmd cli launch '$capability_standard_crowd_physics_arena' --adapter raylib
 ```
 
 Preset launch commands:
@@ -42,6 +44,7 @@ Preset launch commands:
 .\scripts\run-mod-launcher.cmd cli launch 'preset:capability_standard_physics2d_stress_raylib'
 .\scripts\run-mod-launcher.cmd cli launch 'preset:capability_standard_physics2d_showcase_raylib'
 .\scripts\run-mod-launcher.cmd cli launch 'preset:capability_standard_time_flow_showcase_raylib'
+.\scripts\run-mod-launcher.cmd cli launch 'preset:capability_standard_crowd_physics_arena_raylib'
 ```
 
 ## Dependency Path

--- a/launcher.config.json
+++ b/launcher.config.json
@@ -114,6 +114,14 @@
       }
     },
     {
+      "name": "capability_standard_crowd_physics_arena",
+      "target": {
+        "type": "path",
+        "value": "mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod",
+        "projectPath": "CapabilityStandardCrowdPhysicsArenaMod.csproj"
+      }
+    },
+    {
       "name": "formation_capability_showcase",
       "target": {
         "type": "path",

--- a/launcher.presets.json
+++ b/launcher.presets.json
@@ -110,6 +110,15 @@
       "buildMode": "auto"
     },
     {
+      "id": "capability_standard_crowd_physics_arena_raylib",
+      "name": "Capability Standard Crowd Physics Arena Raylib",
+      "selectors": [
+        "$capability_standard_crowd_physics_arena"
+      ],
+      "adapterId": "raylib",
+      "buildMode": "auto"
+    },
+    {
       "id": "formation_capability_showcase_raylib",
       "name": "Formation Capability Showcase Raylib",
       "selectors": [

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/CapabilityStandardCrowdPhysicsArenaMapFocus.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/CapabilityStandardCrowdPhysicsArenaMapFocus.cs
@@ -1,0 +1,19 @@
+using System;
+using Ludots.Core.Engine;
+
+namespace CapabilityStandardCrowdPhysicsArenaMod;
+
+internal static class CapabilityStandardCrowdPhysicsArenaMapFocus
+{
+    public static bool IsStartupMapFocused(GameEngine engine)
+    {
+        ArgumentNullException.ThrowIfNull(engine);
+
+        string? startupMapId = engine.MergedConfig?.StartupMapId;
+        return !string.IsNullOrWhiteSpace(startupMapId) &&
+               string.Equals(
+                   engine.CurrentMapSession?.MapId.Value,
+                   startupMapId,
+                   StringComparison.Ordinal);
+    }
+}

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/CapabilityStandardCrowdPhysicsArenaMod.csproj
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/CapabilityStandardCrowdPhysicsArenaMod.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Core.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Physics2D\Ludots.Physics2D.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Core\Ludots.Movement.Physics2DBridge\Ludots.Movement.Physics2DBridge.csproj" />
+    <ProjectReference Include="..\..\..\CoreInputMod\CoreInputMod.csproj" />
+  </ItemGroup>
+</Project>

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/CapabilityStandardCrowdPhysicsArenaModEntry.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/CapabilityStandardCrowdPhysicsArenaModEntry.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Threading.Tasks;
+using CapabilityStandardCrowdPhysicsArenaMod.Runtime;
+using CapabilityStandardCrowdPhysicsArenaMod.Systems;
+using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.GAS.Orders;
+using Ludots.Core.Modding;
+using Ludots.Core.Presentation.Minimap;
+using Ludots.Core.Scripting;
+
+namespace CapabilityStandardCrowdPhysicsArenaMod;
+
+public sealed class CapabilityStandardCrowdPhysicsArenaModEntry : IMod
+{
+    private const string ObserverVisibilitySystemInstalledKey =
+        "CapabilityStandardCrowdPhysicsArena.ObserverVisibilitySystemInstalled";
+    private const string LocalOrderSourceSystemInstalledKey =
+        "CapabilityStandardCrowdPhysicsArena.LocalOrderSourceSystemInstalled";
+    private IModContext? _context;
+
+    public void OnLoad(IModContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        context.Log("[CapabilityStandardCrowdPhysicsArenaMod] Loaded");
+        CrowdPhysicsArenaComponentAuthoring.Register(context.ModId);
+        context.OnEvent(GameEvents.GameStart, ConfigureArenaShowcaseAsync);
+        context.OnEvent(GameEvents.MapLoaded, ConfigureArenaShowcaseAsync);
+        context.OnEvent(GameEvents.MapResumed, ConfigureArenaShowcaseAsync);
+    }
+
+    public void OnUnload()
+    {
+    }
+
+    private Task ConfigureArenaShowcaseAsync(ScriptContext context)
+    {
+        GameEngine? engine = context.GetEngine();
+        if (engine == null)
+        {
+            return Task.CompletedTask;
+        }
+
+        IModContext modContext = _context
+            ?? throw new InvalidOperationException("CapabilityStandardCrowdPhysicsArenaMod requires IModContext.");
+        EnsureObserverVisibilitySystem(engine);
+        EnsureLocalOrderSourceSystem(engine, modContext);
+        bool mapFocused = CapabilityStandardCrowdPhysicsArenaMapFocus.IsStartupMapFocused(engine);
+        engine.SetService(CoreServiceKeys.PresentationAudienceRevealHidden, mapFocused);
+        if (!mapFocused)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (engine.GetService(CoreServiceKeys.MinimapRuntime) is MinimapRuntime minimap)
+        {
+            minimap.Visible = true;
+            minimap.SetRotateWithCamera(false);
+            minimap.UseRtsFullMapPreset();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static void EnsureObserverVisibilitySystem(GameEngine engine)
+    {
+        if (engine.GlobalContext.ContainsKey(ObserverVisibilitySystemInstalledKey))
+        {
+            return;
+        }
+
+        engine.RegisterSystem(
+            new CrowdPhysicsArenaObserverVisibilityBindingSystem(engine),
+            SystemGroup.RuntimeEntityBinding);
+        engine.GlobalContext[ObserverVisibilitySystemInstalledKey] = true;
+    }
+
+    private static void EnsureLocalOrderSourceSystem(GameEngine engine, IModContext context)
+    {
+        if (engine.GlobalContext.ContainsKey(LocalOrderSourceSystemInstalledKey))
+        {
+            return;
+        }
+
+        OrderQueue orders = engine.GetService(CoreServiceKeys.OrderQueue)
+            ?? throw new InvalidOperationException("CapabilityStandardCrowdPhysicsArenaMod requires OrderQueue.");
+        engine.RegisterSystem(
+            new CrowdPhysicsArenaLocalOrderSourceSystem(engine.World, engine.GlobalContext, orders, context),
+            SystemGroup.InputCollection);
+        engine.GlobalContext[LocalOrderSourceSystemInstalledKey] = true;
+    }
+}

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/CapabilityStandardCrowdPhysicsArenaModEntry.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/CapabilityStandardCrowdPhysicsArenaModEntry.cs
@@ -5,6 +5,7 @@ using CapabilityStandardCrowdPhysicsArenaMod.Systems;
 using Ludots.Core.Engine;
 using Ludots.Core.Gameplay.GAS.Orders;
 using Ludots.Core.Modding;
+using Ludots.Core.Movement.Physics2DBridge;
 using Ludots.Core.Presentation.Minimap;
 using Ludots.Core.Scripting;
 
@@ -16,7 +17,13 @@ public sealed class CapabilityStandardCrowdPhysicsArenaModEntry : IMod
         "CapabilityStandardCrowdPhysicsArena.ObserverVisibilitySystemInstalled";
     private const string LocalOrderSourceSystemInstalledKey =
         "CapabilityStandardCrowdPhysicsArena.LocalOrderSourceSystemInstalled";
+    private const string PressurePlateDoorSystemInstalledKey =
+        "CapabilityStandardCrowdPhysicsArena.PressurePlateDoorSystemInstalled";
     private IModContext? _context;
+
+    /// <summary>Queryable plate/door state for tests and HUD (installed once per engine).</summary>
+    public static readonly ServiceKey<CrowdPhysicsArenaPressurePlateDoorSystem> PressurePlateDoorSystemKey =
+        new("CapabilityStandardCrowdPhysicsArena.PressurePlateDoorSystem");
 
     public void OnLoad(IModContext context)
     {
@@ -44,6 +51,7 @@ public sealed class CapabilityStandardCrowdPhysicsArenaModEntry : IMod
             ?? throw new InvalidOperationException("CapabilityStandardCrowdPhysicsArenaMod requires IModContext.");
         EnsureObserverVisibilitySystem(engine);
         EnsureLocalOrderSourceSystem(engine, modContext);
+        EnsurePressurePlateDoorAndHudSystems(engine);
         bool mapFocused = CapabilityStandardCrowdPhysicsArenaMapFocus.IsStartupMapFocused(engine);
         engine.SetService(CoreServiceKeys.PresentationAudienceRevealHidden, mapFocused);
         if (!mapFocused)
@@ -72,6 +80,27 @@ public sealed class CapabilityStandardCrowdPhysicsArenaModEntry : IMod
             new CrowdPhysicsArenaObserverVisibilityBindingSystem(engine),
             SystemGroup.RuntimeEntityBinding);
         engine.GlobalContext[ObserverVisibilitySystemInstalledKey] = true;
+    }
+
+    private static void EnsurePressurePlateDoorAndHudSystems(GameEngine engine)
+    {
+        if (engine.GlobalContext.ContainsKey(PressurePlateDoorSystemInstalledKey))
+        {
+            return;
+        }
+
+        ContactEventRouter2D router = engine.GetService(MovementPhysics2DBridgeKeys.ContactEventRouter)
+            ?? throw new InvalidOperationException(
+                "CapabilityStandardCrowdPhysicsArenaMod requires the massnav→kinematic bridge contact event router; " +
+                "Physics2D + Ludots.Movement.Physics2DBridge must be installed.");
+
+        var plateSystem = new CrowdPhysicsArenaPressurePlateDoorSystem(engine.World);
+        router.RegisterConsumer(CrowdPhysicsArenaLayerNames.Plate, plateSystem);
+        engine.RegisterSystem(plateSystem, SystemGroup.InputCollection);
+        engine.SetService(PressurePlateDoorSystemKey, plateSystem);
+
+        engine.RegisterSystem(new CrowdPhysicsArenaHudSystem(engine, plateSystem), SystemGroup.EventDispatch);
+        engine.GlobalContext[PressurePlateDoorSystemInstalledKey] = true;
     }
 
     private static void EnsureLocalOrderSourceSystem(GameEngine engine, IModContext context)

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/README.md
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/README.md
@@ -40,12 +40,18 @@ Q 冲击波击退单位、用 E 释放带初速度的巨石。
 - **木箱堆**：通路上的 dynamic 箱体，行军穿越时被推开。物理材质 `baseDamping` 是每固定步的
   速度保留系数（`IntegrationSystem2D` 中 `velocity *= baseDamping`），必须 < 1.0：
   箱 0.9 / 压力板 0.5 / 巨石 0.98。
-- **压力板 → 门**：压力板是薄 dynamic 体（卡在四面 static 插槽墙内），携带 `ContactEventEmitter2D`，
-  EntityLayer `arena.plate` 在 `assets/Configs/Physics2D/kinematic.json` 的 `contactEventEmitterLayers`
-  允许清单里。桥的 `ContactEventRouter2D` 把 Begin/End 事件路由给
-  `CrowdPhysicsArenaPressurePlateDoorSystem`，agent ContactBegin 达到门模板的
-  `CrowdPhysicsArena.Door.OpenThresholdContacts`（地图 override，默认 20）后开门——门体的
-  `ManifestationObstacleIntent2D` sink 位清零并标脏，物理碰撞体与导航障碍同时移除。
+- **压力板 → 门**：压力板必须是 dynamic 体才能与 kinematic 单位配对（broadphase 跳过
+  kinematic×static 对），但 kinematic 体逆质量为 0，穿透修正 100% 落在板上——整队踩板时
+  修正逐对叠加会把板从插槽中挤飞。因此板模板带 `CrowdPhysicsArena.PlateAnchor`：
+  每固定步把板重新钉回授权位置并清零速度（锚点在首步从授权 `Position2D` 捕获，地图
+  `RigidBody.positionCm` 是唯一事实源），并且板体做成行军方向上的薄条（80×840cm，
+  封顶单对穿透深度）。板携带 `ContactEventEmitter2D`，EntityLayer `arena.plate` 在
+  `assets/Configs/Physics2D/kinematic.json` 的 `contactEventEmitterLayers` 允许清单里。
+  桥的 `ContactEventRouter2D` 把 Begin/End 事件路由给
+  `CrowdPhysicsArenaPressurePlateDoorSystem`（按 agent 去重：N 单位过板恰好 N 次 Begin），
+  agent ContactBegin 达到门模板的 `CrowdPhysicsArena.Door.OpenThresholdContacts`
+  （地图 override，默认 20）后开门——门体的 `ManifestationObstacleIntent2D` sink 位清零并
+  标脏，物理碰撞体与导航障碍同时移除。
 - **Q 冲击波**：纯 effect 步骤组合（无新 BuiltinHandler/enum）：`CreateUnit` 在目标点生成震中
   （`linkSourceAsParent` + `DestroyWhenParentExecutionEnds`，随能力执行结束销毁）→ 震中
   `onSpawnEffect` 触发 `Search`（Circle，origin=Source）→ 对命中单位派发 `Displacement`

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/README.md
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/README.md
@@ -31,10 +31,15 @@ Q 冲击波击退单位、用 E 释放带初速度的巨石。
 
 ## 场景机制
 
+- **世界窗口**：`assets/MassNavigationConfig.json` 覆盖 `world.hotZones`，把活跃热区（=仿真窗口
+  中心）定在 (5000, 5000)，与地图上箱堆 (4250–4510)、压力板 (5600)、门 (6400) 的世界坐标对齐；
+  两队沿 `OrbitOpposedTargets` 轨道（半径 2600cm）在窗口中心两侧对置生成。
 - **小队**：2 队 × 48（`assets/MassNavigationConfig.json` 的 `scenario` 全配置化），单位模板组合
   `MovementParticipation`（kinematic + displacement.allowed）+ kinematic 刚体（半径与 agent profile
   `bodyRadiusCm` 同源，桥启动时校验）+ massnav agent。
-- **木箱堆**：通路上的 dynamic 箱体，行军穿越时被推开。
+- **木箱堆**：通路上的 dynamic 箱体，行军穿越时被推开。物理材质 `baseDamping` 是每固定步的
+  速度保留系数（`IntegrationSystem2D` 中 `velocity *= baseDamping`），必须 < 1.0：
+  箱 0.9 / 压力板 0.5 / 巨石 0.98。
 - **压力板 → 门**：压力板是薄 dynamic 体（卡在四面 static 插槽墙内），携带 `ContactEventEmitter2D`，
   EntityLayer `arena.plate` 在 `assets/Configs/Physics2D/kinematic.json` 的 `contactEventEmitterLayers`
   允许清单里。桥的 `ContactEventRouter2D` 把 Begin/End 事件路由给
@@ -45,6 +50,24 @@ Q 冲击波击退单位、用 E 释放带初速度的巨石。
   （`linkSourceAsParent` + `DestroyWhenParentExecutionEnds`，随能力执行结束销毁）→ 震中
   `onSpawnEffect` 触发 `Search`（Circle，origin=Source）→ 对命中单位派发 `Displacement`
   （`AwayFromSource`）。位移期间单位仍被桥喂进 kinematic 物理体（物理视角单位永远在场）。
+  场景道具（箱/板/墙/门）、本地玩家标记与震中自身模板都带 `SpatialPartitionExcluded`，
+  不进空间索引，Search 只会命中 massnav agent。
+
+## Q 冷却硬约束（issue #737）
+
+当前 GAS 位移对同一目标**无去重**：对仍处于位移窗口中的 agent 再次施加位移会触发
+`PoseAuthorityArbiter` 双窗口异常。因此本 mod 的授权值必须满足
+**Q 冷却时长 严格大于 单位模板 `displacement.maxDurationMs`（留余量）**：
+
+| 配置项 | 位置 | 值 |
+|--------|------|----|
+| Q 冷却 `TagClip.duration` | `assets/GAS/abilities.json` | 45 tick @20Hz = 2250ms |
+| 位移窗口上限 `displacement.maxDurationMs` | `assets/Entities/templates.json`（4 个 agent 模板） | 2000ms |
+| 实际位移时长 `totalDurationTicks` | `assets/GAS/effects.json` | 24 tick = 1200ms |
+
+不变量：`冷却 2250ms > maxDurationMs 2000ms > 实际位移 1200ms`。调整任一值时必须保持
+该不等式链，否则连续施放 Q 会命中仍在窗口中的单位并按合同 fail-fast 抛异常
+（见 <https://github.com/MightyBubble/Ludots/issues/737>）。
 - **E 巨石**：`CreateUnit` 生成 `crowd_arena_boulder` 模板（dynamic 刚体 + 模板授权初速度），
   走正常物理积分路径。
 

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/README.md
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/README.md
@@ -1,0 +1,63 @@
+# Capability Standard: Crowd Physics Arena
+
+massnav→kinematic 桥（issue #643 增量 2）的标准能力验收 showcase（issue #734）。
+两支 kinematic 小队在竞技场集结，穿越动态木箱堆、踩压压力板开门，玩家可用
+Q 冲击波击退单位、用 E 释放带初速度的巨石。
+
+## 启动
+
+```powershell
+.\scripts\run-mod-launcher.cmd cli launch '$capability_standard_crowd_physics_arena' --adapter raylib
+# 或
+.\scripts\run-mod-launcher.cmd cli launch 'preset:capability_standard_crowd_physics_arena_raylib'
+```
+
+## 玩家操作
+
+| 输入 | 行为 |
+|------|------|
+| 鼠标左键拖框 | 框选己方小队单位 |
+| 鼠标右键点地面 | 下达 massnav 移动命令（选中单位行军） |
+| `Q` + 光标位置 | 冲击波：以光标点为震中，480cm 半径内所有单位被向外击退 400cm |
+| `E` + 光标位置 | 巨石释放：在光标点生成 dynamic 巨石（初速度 -900cm/s X 轴，正常物理路径滚动/碰撞） |
+
+## HUD
+
+屏幕左上角三行计数：
+
+1. `Selected units` — 当前框选单位数（command source 集合）。
+2. `Displaced recovering` — 被击飞、位移窗口尚未交还的单位数（PoseAuthorityArbiter 活跃窗口）。
+3. `Plate steps` — 压力板累计 agent ContactBegin 人次；括号内为当前在板上的人数（Begin−End 对账）与已开门数。
+
+## 场景机制
+
+- **小队**：2 队 × 48（`assets/MassNavigationConfig.json` 的 `scenario` 全配置化），单位模板组合
+  `MovementParticipation`（kinematic + displacement.allowed）+ kinematic 刚体（半径与 agent profile
+  `bodyRadiusCm` 同源，桥启动时校验）+ massnav agent。
+- **木箱堆**：通路上的 dynamic 箱体，行军穿越时被推开。
+- **压力板 → 门**：压力板是薄 dynamic 体（卡在四面 static 插槽墙内），携带 `ContactEventEmitter2D`，
+  EntityLayer `arena.plate` 在 `assets/Configs/Physics2D/kinematic.json` 的 `contactEventEmitterLayers`
+  允许清单里。桥的 `ContactEventRouter2D` 把 Begin/End 事件路由给
+  `CrowdPhysicsArenaPressurePlateDoorSystem`，agent ContactBegin 达到门模板的
+  `CrowdPhysicsArena.Door.OpenThresholdContacts`（地图 override，默认 20）后开门——门体的
+  `ManifestationObstacleIntent2D` sink 位清零并标脏，物理碰撞体与导航障碍同时移除。
+- **Q 冲击波**：纯 effect 步骤组合（无新 BuiltinHandler/enum）：`CreateUnit` 在目标点生成震中
+  （`linkSourceAsParent` + `DestroyWhenParentExecutionEnds`，随能力执行结束销毁）→ 震中
+  `onSpawnEffect` 触发 `Search`（Circle，origin=Source）→ 对命中单位派发 `Displacement`
+  （`AwayFromSource`）。位移期间单位仍被桥喂进 kinematic 物理体（物理视角单位永远在场）。
+- **E 巨石**：`CreateUnit` 生成 `crowd_arena_boulder` 模板（dynamic 刚体 + 模板授权初速度），
+  走正常物理积分路径。
+
+## 容量说明
+
+- `scenarioRuntime.runtimeCapacity.displacedAgentCapacity = 128`：冲击波 `Search.maxTargets = 96`
+  （全场单位数），容量必须 ≥ 同时处于位移窗口的单位数；命中数超过容量时按合同 fail-fast 抛异常，
+  本 showcase 的配置保证容量够用。
+- `Physics2D/kinematic.json` 的 `kinematicBodyCapacity`（默认 4096）必须 ≥ 参与 kinematic 物理的
+  单位数（96），不足时桥在喂送时 fail-fast。
+
+## 验收测试
+
+```bash
+dotnet test src/Tests/PresentationTests/PresentationTests.csproj --filter CapabilityStandardCrowdPhysicsArenaProductionPathTests
+```

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Runtime/CrowdPhysicsArenaComponentAuthoring.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Runtime/CrowdPhysicsArenaComponentAuthoring.cs
@@ -1,0 +1,19 @@
+using Ludots.Core.Config;
+using Ludots.Core.Layers;
+using Ludots.Core.Physics2D.Authoring;
+
+namespace CapabilityStandardCrowdPhysicsArenaMod.Runtime;
+
+internal static class CrowdPhysicsArenaComponentAuthoring
+{
+    public static void Register(string modId)
+    {
+        LayerRegistry.Register(CrowdPhysicsArenaLayerNames.Plate);
+        LayerRegistry.Register(CrowdPhysicsArenaLayerNames.Prop);
+        LayerRegistry.Register(CrowdPhysicsArenaLayerNames.Wall);
+
+        Physics2DTemplateAuthoring.RegisterRigidBody("CrowdPhysicsArena.RigidBody", modId);
+        Physics2DTemplateAuthoring.RegisterContactEventEmitter("CrowdPhysicsArena.ContactEventEmitter", modId);
+        ComponentRegistry.Register<CrowdPhysicsArenaDoor>("CrowdPhysicsArena.Door", modId);
+    }
+}

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Runtime/CrowdPhysicsArenaComponentAuthoring.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Runtime/CrowdPhysicsArenaComponentAuthoring.cs
@@ -15,5 +15,6 @@ internal static class CrowdPhysicsArenaComponentAuthoring
         Physics2DTemplateAuthoring.RegisterRigidBody("CrowdPhysicsArena.RigidBody", modId);
         Physics2DTemplateAuthoring.RegisterContactEventEmitter("CrowdPhysicsArena.ContactEventEmitter", modId);
         ComponentRegistry.Register<CrowdPhysicsArenaDoor>("CrowdPhysicsArena.Door", modId);
+        ComponentRegistry.Register<CrowdPhysicsArenaPlateAnchor>("CrowdPhysicsArena.PlateAnchor", modId);
     }
 }

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Runtime/CrowdPhysicsArenaComponents.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Runtime/CrowdPhysicsArenaComponents.cs
@@ -1,0 +1,11 @@
+namespace CapabilityStandardCrowdPhysicsArenaMod.Runtime;
+
+/// <summary>
+/// Authored door marker: the pressure-plate consumer opens this door once the plate
+/// accumulated <see cref="OpenThresholdContacts"/> agent ContactBegin events.
+/// The threshold is template/map data, not code.
+/// </summary>
+public struct CrowdPhysicsArenaDoor
+{
+    public int OpenThresholdContacts;
+}

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Runtime/CrowdPhysicsArenaComponents.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Runtime/CrowdPhysicsArenaComponents.cs
@@ -1,3 +1,5 @@
+using Ludots.Core.Mathematics.FixedPoint;
+
 namespace CapabilityStandardCrowdPhysicsArenaMod.Runtime;
 
 /// <summary>
@@ -8,4 +10,20 @@ namespace CapabilityStandardCrowdPhysicsArenaMod.Runtime;
 public struct CrowdPhysicsArenaDoor
 {
     public int OpenThresholdContacts;
+}
+
+/// <summary>
+/// Bolts the pressure plate to the arena floor. The plate must stay a Dynamic contact-event
+/// emitter so the broadphase pairs it with kinematic squad agents (kinematic×static pairs are
+/// solver-meaningless and skipped), but a full squad wave shoves an unconstrained dynamic
+/// plate through its static socket in one correction burst and ejects it from the arena.
+/// The pressure-plate system therefore re-seats anchored plates on their authored rigid-body
+/// position with zero velocity every fixed step (the anchor is captured from the authored
+/// Position2D on the first step, keeping the map's RigidBody positionCm the single source
+/// of truth).
+/// </summary>
+public struct CrowdPhysicsArenaPlateAnchor
+{
+    public byte Captured;
+    public Fix64Vec2 AnchorCm;
 }

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Runtime/CrowdPhysicsArenaLayerNames.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Runtime/CrowdPhysicsArenaLayerNames.cs
@@ -1,0 +1,12 @@
+namespace CapabilityStandardCrowdPhysicsArenaMod.Runtime;
+
+/// <summary>
+/// Entity layer vocabulary of the arena. The plate layer is the only contact event
+/// emitter layer and must be listed in `Physics2D/kinematic.json` contactEventEmitterLayers.
+/// </summary>
+public static class CrowdPhysicsArenaLayerNames
+{
+    public const string Plate = "arena.plate";
+    public const string Prop = "arena.prop";
+    public const string Wall = "arena.wall";
+}

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Systems/CrowdPhysicsArenaHudSystem.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Systems/CrowdPhysicsArenaHudSystem.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Numerics;
+using Arch.Core;
+using Arch.System;
+using Ludots.Core.Engine;
+using Ludots.Core.EntityCollections;
+using Ludots.Core.Input.CommandSources;
+using Ludots.Core.Movement;
+using Ludots.Core.Presentation.Hud;
+using Ludots.Core.Scripting;
+
+namespace CapabilityStandardCrowdPhysicsArenaMod.Systems;
+
+/// <summary>
+/// Arena HUD (issue #734): three live numbers on the screen overlay —
+/// selected unit count (command source view), units currently displaced/recovering
+/// (pose authority windows), and total agent plate steps (ContactBegin count).
+/// Reuses the core screen overlay text pipeline.
+/// </summary>
+internal sealed class CrowdPhysicsArenaHudSystem : ISystem<float>
+{
+    private const int HudStableIdBase = 73400;
+
+    private readonly GameEngine _engine;
+    private readonly CrowdPhysicsArenaPressurePlateDoorSystem _plateSystem;
+
+    public CrowdPhysicsArenaHudSystem(GameEngine engine, CrowdPhysicsArenaPressurePlateDoorSystem plateSystem)
+    {
+        _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+        _plateSystem = plateSystem ?? throw new ArgumentNullException(nameof(plateSystem));
+    }
+
+    public void Initialize()
+    {
+    }
+
+    public void BeforeUpdate(in float dt)
+    {
+    }
+
+    public void AfterUpdate(in float dt)
+    {
+    }
+
+    public void Dispose()
+    {
+    }
+
+    public void Update(in float dt)
+    {
+        if (!CapabilityStandardCrowdPhysicsArenaMapFocus.IsStartupMapFocused(_engine) ||
+            _engine.GetService(CoreServiceKeys.ScreenOverlayBuffer) is not ScreenOverlayBuffer overlay)
+        {
+            return;
+        }
+
+        int selectedCount = ResolveSelectedCount();
+        int recoveringCount = _engine.GetService(CoreServiceKeys.PoseAuthorityArbiter) is PoseAuthorityArbiter arbiter
+            ? arbiter.ActiveWindowCount
+            : 0;
+        long plateSteps = _plateSystem.AgentContactBeginCount;
+        long plateActive = _plateSystem.ActiveAgentContacts;
+
+        string selectedLine = $"Selected units: {selectedCount}";
+        string recoveringLine = $"Displaced recovering: {recoveringCount}";
+        string plateLine = $"Plate steps: {plateSteps} (on plate: {plateActive}, doors opened: {_plateSystem.OpenedDoorCount})";
+
+        overlay.AddRect(12, 12, 480, 108, new Vector4(0.04f, 0.07f, 0.10f, 0.78f), new Vector4(0.35f, 0.51f, 0.60f, 0.92f), stableId: HudStableIdBase, dirtySerial: 1);
+        overlay.AddText(24, 22, "Crowd Physics Arena", 18, new Vector4(0.94f, 0.96f, 0.98f, 1f), stableId: HudStableIdBase + 1, dirtySerial: 1);
+        overlay.AddText(24, 48, selectedLine, 14, new Vector4(0.66f, 0.83f, 0.96f, 1f), stableId: HudStableIdBase + 2, dirtySerial: StringHash(selectedLine));
+        overlay.AddText(24, 70, recoveringLine, 14, new Vector4(0.94f, 0.83f, 0.57f, 1f), stableId: HudStableIdBase + 3, dirtySerial: StringHash(recoveringLine));
+        overlay.AddText(24, 92, plateLine, 14, new Vector4(0.72f, 0.94f, 0.70f, 1f), stableId: HudStableIdBase + 4, dirtySerial: StringHash(plateLine));
+    }
+
+    private int ResolveSelectedCount()
+    {
+        Entity owner = _engine.GetService(CoreServiceKeys.LocalPlayerEntity);
+        if (owner == Entity.Null ||
+            !_engine.TryGetService(CoreServiceKeys.EntityCollectionStore, out EntityCollectionStore collections))
+        {
+            return 0;
+        }
+
+        return EntityCollectionContextRuntime.TryDescribeView(collections, owner, EntityCollectionKeys.CommandSource, out EntityCollectionView view)
+            ? view.Count
+            : 0;
+    }
+
+    private static int StringHash(string value)
+    {
+        return StringComparer.Ordinal.GetHashCode(value);
+    }
+}

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Systems/CrowdPhysicsArenaHudSystem.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Systems/CrowdPhysicsArenaHudSystem.cs
@@ -12,7 +12,7 @@ using Ludots.Core.Scripting;
 namespace CapabilityStandardCrowdPhysicsArenaMod.Systems;
 
 /// <summary>
-/// Arena HUD (issue #734): three live numbers on the screen overlay —
+/// Arena HUD: three live numbers on the screen overlay —
 /// selected unit count (command source view), units currently displaced/recovering
 /// (pose authority windows), and total agent plate steps (ContactBegin count).
 /// Reuses the core screen overlay text pipeline.

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Systems/CrowdPhysicsArenaLocalOrderSourceSystem.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Systems/CrowdPhysicsArenaLocalOrderSourceSystem.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using Arch.Core;
+using Arch.System;
+using CoreInputMod.Systems;
+using Ludots.Core.Gameplay.GAS.Orders;
+using Ludots.Core.Input.Orders;
+using Ludots.Core.Modding;
+
+namespace CapabilityStandardCrowdPhysicsArenaMod.Systems;
+
+internal sealed class CrowdPhysicsArenaLocalOrderSourceSystem : ISystem<float>
+{
+    private readonly World _world;
+    private readonly IModContext _context;
+    private readonly LocalOrderSourceHelper _helper;
+    private InputOrderMappingSystem? _mapping;
+    private bool _initialized;
+
+    public CrowdPhysicsArenaLocalOrderSourceSystem(
+        World world,
+        Dictionary<string, object> globals,
+        OrderQueue orders,
+        IModContext context)
+    {
+        _world = world;
+        _context = context;
+        _helper = new LocalOrderSourceHelper(world, globals, orders);
+    }
+
+    public void Initialize() { }
+    public void BeforeUpdate(in float dt) { }
+    public void AfterUpdate(in float dt) { }
+    public void Dispose() { }
+
+    public void Update(in float dt)
+    {
+        EnsureInitialized();
+        if (_mapping == null)
+        {
+            return;
+        }
+
+        Entity actor = _helper.GetControlledActor();
+        if (_helper.TrySetLocalPlayer(_mapping, actor))
+        {
+            _mapping.Update(dt);
+        }
+    }
+
+    private void EnsureInitialized()
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        _initialized = true;
+        _mapping = _helper.TryCreateMapping(_context);
+    }
+}

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Systems/CrowdPhysicsArenaObserverVisibilityBindingSystem.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Systems/CrowdPhysicsArenaObserverVisibilityBindingSystem.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Runtime.CompilerServices;
+using Arch.Core;
+using Arch.System;
+using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.Components;
+using Ludots.Core.Knowledge;
+using Ludots.Core.MassNavigation;
+using Ludots.Core.MassNavigation.Runtime;
+using Ludots.Core.Presentation.Components;
+using Ludots.Core.Presentation.Performers;
+using Ludots.Core.Scripting;
+
+namespace CapabilityStandardCrowdPhysicsArenaMod.Systems;
+
+/// <summary>
+/// Publishes live knowledge for every auto-spawned arena squad agent to the local
+/// observer so performers, minimap markers, and command-source selection work
+/// (same contract as the 10k mass-navigation showcase).
+/// </summary>
+internal sealed class CrowdPhysicsArenaObserverVisibilityBindingSystem : BaseSystem<World, float>
+{
+    private const int LiveKnowledgeConfidencePermille = 1000;
+
+    private static readonly QueryDescription AgentQuery = new QueryDescription()
+        .WithAll<MassNavigationAgent, MassNavigationAgentIndex>()
+        .WithNone<PresentationDestroyPending>();
+
+    private readonly GameEngine _engine;
+    private Entity _publishedViewer = Entity.Null;
+    private int _publishedStructuralRevision = -1;
+    private int _publishedPerformerDefinitionVersion = -1;
+    private KnowledgeIdMask256 _publishedAttributeMask;
+
+    public CrowdPhysicsArenaObserverVisibilityBindingSystem(GameEngine engine)
+        : base(engine?.World ?? throw new ArgumentNullException(nameof(engine)))
+    {
+        _engine = engine;
+    }
+
+    public override void Update(in float dt)
+    {
+        if (!CapabilityStandardCrowdPhysicsArenaMapFocus.IsStartupMapFocused(_engine) ||
+            !MassNavigationIds.IsCurrentNavigationRuntimeReady(_engine) ||
+            _engine.GetService(MassNavigationKeys.RuntimeBinding) is not { IsReady: true, Current: { } simulation } ||
+            _engine.GetService(CoreServiceKeys.KnowledgeProjectionStore) is not KnowledgeProjectionStore knowledge ||
+            _engine.GetService(CoreServiceKeys.PerformerDefinitionRegistry) is not PerformerDefinitionRegistry performers ||
+            !TryResolveViewer(out Entity viewer))
+        {
+            return;
+        }
+
+        int expectedAgentCount = ResolveExpectedAgentCount(simulation);
+        if (expectedAgentCount <= 0 || simulation.NavigationAgentCount < expectedAgentCount)
+        {
+            return;
+        }
+
+        KnowledgeIdMask256 attributeMask = ResolveHudAttributeMask(simulation, performers);
+        if (_publishedViewer == viewer &&
+            _publishedStructuralRevision == simulation.StructuralChangeRevision &&
+            _publishedPerformerDefinitionVersion == performers.Version &&
+            _publishedAttributeMask == attributeMask)
+        {
+            return;
+        }
+
+        int observedTick = KnowledgeProjectionConsumer.ResolveCurrentTick(_engine.GlobalContext);
+        var emptyMask = KnowledgeIdMask256.Empty;
+        var record = new KnowledgeDisclosureRecord(
+            KnowledgePresence.LiveVisible,
+            KnowledgePositionAccess.Live,
+            attributeMask,
+            emptyMask,
+            emptyMask,
+            viewer,
+            observedTick,
+            expiryTick: 0,
+            confidencePermille: LiveKnowledgeConfidencePermille,
+            revision: 0);
+
+        int published = PublishAgentKnowledge(knowledge, viewer, in record);
+        if (published < expectedAgentCount)
+        {
+            return;
+        }
+
+        _publishedViewer = viewer;
+        _publishedStructuralRevision = simulation.StructuralChangeRevision;
+        _publishedPerformerDefinitionVersion = performers.Version;
+        _publishedAttributeMask = attributeMask;
+    }
+
+    private bool TryResolveViewer(out Entity viewer)
+    {
+        Entity candidate = _engine.GetService(CoreServiceKeys.LocalPlayerEntity);
+        viewer = candidate;
+        return candidate != Entity.Null && World.IsAlive(candidate);
+    }
+
+    private static int ResolveExpectedAgentCount(MassNavigationSimulationRuntime simulation)
+    {
+        return checked(simulation.Config.Scenario.Teams.Length * simulation.Config.Scenario.AgentsPerTeam);
+    }
+
+    private static KnowledgeIdMask256 ResolveHudAttributeMask(
+        MassNavigationSimulationRuntime simulation,
+        PerformerDefinitionRegistry performers)
+    {
+        KnowledgeIdMask256 mask = KnowledgeIdMask256.Empty;
+        ReadOnlySpan<int> teamIds = simulation.TeamIds;
+        for (int i = 0; i < teamIds.Length; i++)
+        {
+            int teamId = teamIds[i];
+            mask = mask.Union(ResolveHudAttributeMask(
+                performers,
+                simulation.Config.Presentation.ResolveAgentPerformerId(teamId, heavy: false)));
+            mask = mask.Union(ResolveHudAttributeMask(
+                performers,
+                simulation.Config.Presentation.ResolveAgentPerformerId(teamId, heavy: true)));
+        }
+
+        return mask;
+    }
+
+    private static KnowledgeIdMask256 ResolveHudAttributeMask(
+        PerformerDefinitionRegistry performers,
+        string performerKey)
+    {
+        int definitionId = performers.GetId(performerKey);
+        if (definitionId <= 0 || !performers.TryGet(definitionId, out PerformerDefinition definition))
+        {
+            throw new InvalidOperationException(
+                $"CrowdPhysicsArena observer visibility requires performer definition '{performerKey}'.");
+        }
+
+        return ResolveHudAttributeMask(performers, definition);
+    }
+
+    private static KnowledgeIdMask256 ResolveHudAttributeMask(
+        PerformerDefinitionRegistry performers,
+        PerformerDefinition definition)
+    {
+        KnowledgeIdMask256 mask = HasHudAssetBinding(definition)
+            ? BuildMask(definition.RequiredAttributeIds)
+            : KnowledgeIdMask256.Empty;
+
+        ChildPerformerRef[] children = definition.Children;
+        for (int i = 0; i < children.Length; i++)
+        {
+            int childDefinitionId = children[i].DefinitionId;
+            if (childDefinitionId <= 0 || !performers.TryGet(childDefinitionId, out PerformerDefinition child))
+            {
+                throw new InvalidOperationException(
+                    $"CrowdPhysicsArena observer visibility requires child performer definition id {childDefinitionId}.");
+            }
+
+            mask = mask.Union(ResolveHudAttributeMask(performers, child));
+        }
+
+        return mask;
+    }
+
+    private static bool HasHudAssetBinding(PerformerDefinition definition)
+    {
+        BehaviorSlot[] behaviors = definition.Behaviors;
+        for (int i = 0; i < behaviors.Length; i++)
+        {
+            if ((behaviors[i].Kind == BehaviorKind.AssetBinding ||
+                 behaviors[i].Kind == BehaviorKind.WorldText) &&
+                behaviors[i].AssetBinding.AssetKind is AssetKind.WorldHud or AssetKind.WorldText)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static KnowledgeIdMask256 BuildMask(ReadOnlySpan<int> attributeIds)
+    {
+        KnowledgeIdMask256 mask = KnowledgeIdMask256.Empty;
+        for (int i = 0; i < attributeIds.Length; i++)
+        {
+            mask = mask.WithId(attributeIds[i]);
+        }
+
+        return mask;
+    }
+
+    private int PublishAgentKnowledge(
+        KnowledgeProjectionStore knowledge,
+        Entity viewer,
+        in KnowledgeDisclosureRecord record)
+    {
+        int published = 0;
+        foreach (ref var chunk in World.Query(in AgentQuery))
+        {
+            ref Entity firstEntity = ref chunk.Entity(0);
+            foreach (int index in chunk)
+            {
+                Entity target = Unsafe.Add(ref firstEntity, index);
+                knowledge.Upsert(viewer, target, in record);
+                published++;
+            }
+        }
+
+        return published;
+    }
+}

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Systems/CrowdPhysicsArenaPressurePlateDoorSystem.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Systems/CrowdPhysicsArenaPressurePlateDoorSystem.cs
@@ -13,7 +13,7 @@ using Ludots.Core.Physics2D.Components;
 namespace CapabilityStandardCrowdPhysicsArenaMod.Systems;
 
 /// <summary>
-/// Pressure plate → door gameplay bridge (issue #734).
+/// Pressure plate → door gameplay bridge.
 ///
 /// Consumes ContactBegin/ContactEnd events routed for the <c>arena.plate</c> layer by the
 /// massnav→kinematic bridge's <see cref="ContactEventRouter2D"/> and counts distinct squad

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Systems/CrowdPhysicsArenaPressurePlateDoorSystem.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Systems/CrowdPhysicsArenaPressurePlateDoorSystem.cs
@@ -8,6 +8,7 @@ using Ludots.Core.Layers;
 using Ludots.Core.MassNavigation;
 using Ludots.Core.Movement.Physics2DBridge;
 using Ludots.Core.Physics2D;
+using Ludots.Core.Physics2D.Components;
 
 namespace CapabilityStandardCrowdPhysicsArenaMod.Systems;
 
@@ -15,9 +16,12 @@ namespace CapabilityStandardCrowdPhysicsArenaMod.Systems;
 /// Pressure plate → door gameplay bridge (issue #734).
 ///
 /// Consumes ContactBegin/ContactEnd events routed for the <c>arena.plate</c> layer by the
-/// massnav→kinematic bridge's <see cref="ContactEventRouter2D"/>, counts squad-agent contacts
-/// (Begin/End are both exposed so "everyone who stepped on also stepped off" is a queryable
-/// invariant), and opens every authored door once the configured ContactBegin threshold is
+/// massnav→kinematic bridge's <see cref="ContactEventRouter2D"/> and counts distinct squad
+/// agents. The plate is a dynamic body seated in a static socket, so a single crossing agent
+/// produces flickering raw Begin/End pairs while position correction pushes the plate out of
+/// penetration each step; counting unique agents keeps "N units cross → exactly N Begins"
+/// exact. Begin/End are both exposed so "everyone who stepped on also stepped off" stays a
+/// queryable invariant, and every authored door opens once the configured Begin threshold is
 /// reached. Opening a door means zeroing its ManifestationObstacleIntent2D sink flags and
 /// marking it dirty so <c>ManifestationObstacleBridge2DSystem</c> removes the physics collider
 /// and the navigation obstacle projection.
@@ -28,7 +32,15 @@ public sealed class CrowdPhysicsArenaPressurePlateDoorSystem : BaseSystem<World,
         .WithAll<CrowdPhysicsArenaDoor, ManifestationObstacleIntent2D>()
         .WithNone<ManifestationObstacleBridge2DDirty>();
 
+    private static readonly QueryDescription PlateAnchorQuery = new QueryDescription()
+        .WithAll<CrowdPhysicsArenaPlateAnchor, Position2D, Velocity2D>();
+
+    private const int AgentTrackingCapacity = 256;
+
     private readonly List<Entity> _doorsToOpen = new(4);
+    private readonly HashSet<Entity> _agentsEverOnPlate = new(AgentTrackingCapacity);
+    private readonly Dictionary<Entity, int> _activePlatePairsByAgent = new(AgentTrackingCapacity);
+    private readonly HashSet<Entity> _agentsOffPlate = new(AgentTrackingCapacity);
     private uint _plateCategoryBit;
     private uint _agentCategoryBit;
     private bool _layerBitsResolved;
@@ -37,10 +49,10 @@ public sealed class CrowdPhysicsArenaPressurePlateDoorSystem : BaseSystem<World,
     {
     }
 
-    /// <summary>Total agent ContactBegin events on the plate.</summary>
+    /// <summary>Distinct squad agents that have begun contact with the plate (one Begin per agent).</summary>
     public long AgentContactBeginCount { get; private set; }
 
-    /// <summary>Total agent ContactEnd events on the plate.</summary>
+    /// <summary>Distinct counted agents that have since fully separated from the plate.</summary>
     public long AgentContactEndCount { get; private set; }
 
     /// <summary>Agents currently standing on the plate (Begin − End reconciliation).</summary>
@@ -69,18 +81,47 @@ public sealed class CrowdPhysicsArenaPressurePlateDoorSystem : BaseSystem<World,
             return;
         }
 
+        Entity agent = aIsPlate ? contactEvent.EntityB : contactEvent.EntityA;
         if (contactEvent.Type == ContactEventType2D.Begin)
         {
-            AgentContactBeginCount++;
+            if (_agentsEverOnPlate.Add(agent))
+            {
+                AgentContactBeginCount++;
+            }
+
+            _activePlatePairsByAgent.TryGetValue(agent, out int activePairs);
+            _activePlatePairsByAgent[agent] = activePairs + 1;
+            if (_agentsOffPlate.Remove(agent))
+            {
+                AgentContactEndCount--;
+            }
+
+            return;
+        }
+
+        if (!_activePlatePairsByAgent.TryGetValue(agent, out int pairs) || pairs <= 0)
+        {
+            throw new InvalidOperationException(
+                $"CrowdPhysicsArenaPressurePlateDoorSystem received ContactEnd for agent {agent.Id} without a matching Begin; " +
+                "the bridge Begin/End edge contract is broken.");
+        }
+
+        if (pairs == 1)
+        {
+            _activePlatePairsByAgent.Remove(agent);
+            _agentsOffPlate.Add(agent);
+            AgentContactEndCount++;
         }
         else
         {
-            AgentContactEndCount++;
+            _activePlatePairsByAgent[agent] = pairs - 1;
         }
     }
 
     public override void Update(in float dt)
     {
+        ReseatAnchoredPlates();
+
         _doorsToOpen.Clear();
         long beginCount = AgentContactBeginCount;
         World.Query(in ClosedDoorQuery, (Entity entity, ref CrowdPhysicsArenaDoor door, ref ManifestationObstacleIntent2D intent) =>
@@ -111,6 +152,32 @@ public sealed class CrowdPhysicsArenaPressurePlateDoorSystem : BaseSystem<World,
             World.Add(entity, new ManifestationObstacleBridge2DDirty());
             OpenedDoorCount++;
         }
+    }
+
+    /// <summary>
+    /// Re-seats every anchored plate on its authored position with zero velocity (see
+    /// <see cref="CrowdPhysicsArenaPlateAnchor"/>): the plate stays a bolted-down sensor while
+    /// remaining a Dynamic emitter that pairs with kinematic agents in the broadphase.
+    /// Per-step solver corrections still move it transiently within a physics step, but they
+    /// can no longer accumulate into socket tunneling and ejection under full-squad pressure.
+    /// </summary>
+    private void ReseatAnchoredPlates()
+    {
+        World.Query(in PlateAnchorQuery, (
+            ref CrowdPhysicsArenaPlateAnchor anchor,
+            ref Position2D position,
+            ref Velocity2D velocity) =>
+        {
+            if (anchor.Captured == 0)
+            {
+                anchor.AnchorCm = position.Value;
+                anchor.Captured = 1;
+                return;
+            }
+
+            position.Value = anchor.AnchorCm;
+            velocity = Velocity2D.Zero;
+        });
     }
 
     private void ResolveLayerBitsOnce()

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Systems/CrowdPhysicsArenaPressurePlateDoorSystem.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/Systems/CrowdPhysicsArenaPressurePlateDoorSystem.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using Arch.Core;
+using Arch.System;
+using CapabilityStandardCrowdPhysicsArenaMod.Runtime;
+using Ludots.Core.Gameplay.Spawning;
+using Ludots.Core.Layers;
+using Ludots.Core.MassNavigation;
+using Ludots.Core.Movement.Physics2DBridge;
+using Ludots.Core.Physics2D;
+
+namespace CapabilityStandardCrowdPhysicsArenaMod.Systems;
+
+/// <summary>
+/// Pressure plate → door gameplay bridge (issue #734).
+///
+/// Consumes ContactBegin/ContactEnd events routed for the <c>arena.plate</c> layer by the
+/// massnav→kinematic bridge's <see cref="ContactEventRouter2D"/>, counts squad-agent contacts
+/// (Begin/End are both exposed so "everyone who stepped on also stepped off" is a queryable
+/// invariant), and opens every authored door once the configured ContactBegin threshold is
+/// reached. Opening a door means zeroing its ManifestationObstacleIntent2D sink flags and
+/// marking it dirty so <c>ManifestationObstacleBridge2DSystem</c> removes the physics collider
+/// and the navigation obstacle projection.
+/// </summary>
+public sealed class CrowdPhysicsArenaPressurePlateDoorSystem : BaseSystem<World, float>, IContactEventConsumer2D
+{
+    private static readonly QueryDescription ClosedDoorQuery = new QueryDescription()
+        .WithAll<CrowdPhysicsArenaDoor, ManifestationObstacleIntent2D>()
+        .WithNone<ManifestationObstacleBridge2DDirty>();
+
+    private readonly List<Entity> _doorsToOpen = new(4);
+    private uint _plateCategoryBit;
+    private uint _agentCategoryBit;
+    private bool _layerBitsResolved;
+
+    public CrowdPhysicsArenaPressurePlateDoorSystem(World world) : base(world)
+    {
+    }
+
+    /// <summary>Total agent ContactBegin events on the plate.</summary>
+    public long AgentContactBeginCount { get; private set; }
+
+    /// <summary>Total agent ContactEnd events on the plate.</summary>
+    public long AgentContactEndCount { get; private set; }
+
+    /// <summary>Agents currently standing on the plate (Begin − End reconciliation).</summary>
+    public long ActiveAgentContacts => AgentContactBeginCount - AgentContactEndCount;
+
+    /// <summary>Number of doors this system has opened.</summary>
+    public int OpenedDoorCount { get; private set; }
+
+    public void OnContactEvent(in ContactEvent2D contactEvent)
+    {
+        ResolveLayerBitsOnce();
+
+        // Identify the plate's contact partner; only squad agents count toward the door.
+        bool aIsPlate = (contactEvent.LayerA.Category & _plateCategoryBit) != 0u;
+        bool bIsPlate = (contactEvent.LayerB.Category & _plateCategoryBit) != 0u;
+        if (!aIsPlate && !bIsPlate)
+        {
+            throw new InvalidOperationException(
+                "CrowdPhysicsArenaPressurePlateDoorSystem received a contact event without the arena.plate layer; " +
+                "router layer dispatch is broken.");
+        }
+
+        uint partnerCategory = aIsPlate ? contactEvent.LayerB.Category : contactEvent.LayerA.Category;
+        if ((partnerCategory & _agentCategoryBit) == 0u)
+        {
+            return;
+        }
+
+        if (contactEvent.Type == ContactEventType2D.Begin)
+        {
+            AgentContactBeginCount++;
+        }
+        else
+        {
+            AgentContactEndCount++;
+        }
+    }
+
+    public override void Update(in float dt)
+    {
+        _doorsToOpen.Clear();
+        long beginCount = AgentContactBeginCount;
+        World.Query(in ClosedDoorQuery, (Entity entity, ref CrowdPhysicsArenaDoor door, ref ManifestationObstacleIntent2D intent) =>
+        {
+            if (intent.SinkPhysicsCollider == 0 && intent.SinkNavigationObstacle == 0)
+            {
+                return;
+            }
+
+            if (door.OpenThresholdContacts <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"CrowdPhysicsArena.Door on entity {entity.Id} requires openThresholdContacts > 0 (data-driven, no default).");
+            }
+
+            if (beginCount >= door.OpenThresholdContacts)
+            {
+                _doorsToOpen.Add(entity);
+            }
+        });
+
+        for (int i = 0; i < _doorsToOpen.Count; i++)
+        {
+            Entity entity = _doorsToOpen[i];
+            ref ManifestationObstacleIntent2D intent = ref World.Get<ManifestationObstacleIntent2D>(entity);
+            intent.SinkPhysicsCollider = 0;
+            intent.SinkNavigationObstacle = 0;
+            World.Add(entity, new ManifestationObstacleBridge2DDirty());
+            OpenedDoorCount++;
+        }
+    }
+
+    private void ResolveLayerBitsOnce()
+    {
+        if (_layerBitsResolved)
+        {
+            return;
+        }
+
+        _plateCategoryBit = 1u << LayerRegistry.GetIndex(CrowdPhysicsArenaLayerNames.Plate);
+        _agentCategoryBit = 1u << LayerRegistry.GetIndex(MassNavigationLayerNames.Agent);
+        _layerBitsResolved = true;
+    }
+}

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Configs/Physics2D/kinematic.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Configs/Physics2D/kinematic.json
@@ -1,0 +1,3 @@
+{
+  "contactEventEmitterLayers": [ "arena.plate" ]
+}

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Entities/templates.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Entities/templates.json
@@ -29,6 +29,7 @@
       "OrderBuffer": {},
       "GameplayTagContainer": {},
       "TagCountContainer": {},
+      "SpatialPartitionExcluded": {},
       "AbilityStateBuffer": {
         "abilityIds": [
           "Ability.CrowdArena.Shockwave",
@@ -54,6 +55,7 @@
         "AngleRad": 0
       },
       "GameplayTagContainer": {},
+      "SpatialPartitionExcluded": {},
       "DestroyWhenParentExecutionEnds": {}
     }
   },
@@ -98,7 +100,7 @@
         "displacement": {
           "allowed": true,
           "handbackSpeedThresholdCmPerSec": 40,
-          "maxDurationMs": 5000
+          "maxDurationMs": 2000
         }
       },
       "CrowdPhysicsArena.RigidBody": {
@@ -152,7 +154,7 @@
         "displacement": {
           "allowed": true,
           "handbackSpeedThresholdCmPerSec": 40,
-          "maxDurationMs": 5000
+          "maxDurationMs": 2000
         }
       },
       "CrowdPhysicsArena.RigidBody": {
@@ -206,7 +208,7 @@
         "displacement": {
           "allowed": true,
           "handbackSpeedThresholdCmPerSec": 40,
-          "maxDurationMs": 5000
+          "maxDurationMs": 2000
         }
       },
       "CrowdPhysicsArena.RigidBody": {
@@ -260,7 +262,7 @@
         "displacement": {
           "allowed": true,
           "handbackSpeedThresholdCmPerSec": 40,
-          "maxDurationMs": 5000
+          "maxDurationMs": 2000
         }
       },
       "CrowdPhysicsArena.RigidBody": {
@@ -279,6 +281,7 @@
       "Name": {
         "Value": "CrowdPhysicsArena.Crate"
       },
+      "SpatialPartitionExcluded": {},
       "EntityLayer": {
         "category": [
           "arena.prop"
@@ -299,7 +302,7 @@
         "material": {
           "friction": 0.6,
           "restitution": 0.05,
-          "baseDamping": 1.2
+          "baseDamping": 0.9
         }
       }
     }
@@ -310,6 +313,7 @@
       "Name": {
         "Value": "CrowdPhysicsArena.Boulder"
       },
+      "SpatialPartitionExcluded": {},
       "EntityLayer": {
         "category": [
           "arena.prop"
@@ -330,7 +334,7 @@
         "material": {
           "friction": 0.3,
           "restitution": 0.45,
-          "baseDamping": 0.35
+          "baseDamping": 0.98
         }
       }
     }
@@ -341,6 +345,7 @@
       "Name": {
         "Value": "CrowdPhysicsArena.PressurePlate"
       },
+      "SpatialPartitionExcluded": {},
       "EntityLayer": {
         "category": [
           "arena.plate"
@@ -361,7 +366,7 @@
         "material": {
           "friction": 0.8,
           "restitution": 0.0,
-          "baseDamping": 4.0
+          "baseDamping": 0.5
         }
       },
       "CrowdPhysicsArena.ContactEventEmitter": {}
@@ -373,6 +378,7 @@
       "Name": {
         "Value": "CrowdPhysicsArena.PlateSocketWall"
       },
+      "SpatialPartitionExcluded": {},
       "EntityLayer": {
         "category": [
           "arena.wall"
@@ -398,6 +404,7 @@
       "Name": {
         "Value": "CrowdPhysicsArena.Door"
       },
+      "SpatialPartitionExcluded": {},
       "WorldPositionCm": {
         "Value": {
           "X": 0,

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Entities/templates.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Entities/templates.json
@@ -369,7 +369,8 @@
           "baseDamping": 0.5
         }
       },
-      "CrowdPhysicsArena.ContactEventEmitter": {}
+      "CrowdPhysicsArena.ContactEventEmitter": {},
+      "CrowdPhysicsArena.PlateAnchor": {}
     }
   },
   {
@@ -405,6 +406,14 @@
         "Value": "CrowdPhysicsArena.Door"
       },
       "SpatialPartitionExcluded": {},
+      "EntityLayer": {
+        "category": [
+          "arena.wall"
+        ],
+        "mask": [
+          "arena.wall"
+        ]
+      },
       "WorldPositionCm": {
         "Value": {
           "X": 0,

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Entities/templates.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Entities/templates.json
@@ -28,7 +28,33 @@
       },
       "OrderBuffer": {},
       "GameplayTagContainer": {},
-      "TagCountContainer": {}
+      "TagCountContainer": {},
+      "AbilityStateBuffer": {
+        "abilityIds": [
+          "Ability.CrowdArena.Shockwave",
+          "Ability.CrowdArena.BoulderRelease"
+        ]
+      }
+    }
+  },
+  {
+    "id": "crowd_arena_shockwave_epicenter",
+    "onSpawnEffect": "Effect.CrowdArena.Shockwave.Search",
+    "components": {
+      "Name": {
+        "Value": "CrowdPhysicsArena.ShockwaveEpicenter"
+      },
+      "WorldPositionCm": {
+        "Value": {
+          "X": 0,
+          "Y": 0
+        }
+      },
+      "FacingDirection": {
+        "AngleRad": 0
+      },
+      "GameplayTagContainer": {},
+      "DestroyWhenParentExecutionEnds": {}
     }
   },
   {

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Entities/templates.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Entities/templates.json
@@ -1,0 +1,401 @@
+[
+  {
+    "id": "crowd_arena_player_team",
+    "components": {
+      "Name": {
+        "Value": "CrowdPhysicsArena.PlayerTeam"
+      }
+    }
+  },
+  {
+    "id": "crowd_arena_local_player",
+    "components": {
+      "Name": {
+        "Value": "CrowdPhysicsArena.LocalPlayer"
+      },
+      "PlayerOwner": {
+        "PlayerId": 1
+      },
+      "CommandSourceDragState": {},
+      "WorldPositionCm": {
+        "Value": {
+          "X": 5000,
+          "Y": 5000
+        }
+      },
+      "FacingDirection": {
+        "AngleRad": 0
+      },
+      "OrderBuffer": {},
+      "GameplayTagContainer": {},
+      "TagCountContainer": {}
+    }
+  },
+  {
+    "id": "crowd_arena_agent_azure_light",
+    "components": {
+      "Name": {
+        "Value": "CrowdPhysicsArena.Agent.Azure.Light"
+      },
+      "VisualHeightmapSampleState": {},
+      "FacingDirection": {
+        "AngleRad": 0
+      },
+      "OrderBuffer": {},
+      "CommandSourceSelectableTag": {},
+      "CommandSourceSelectableState": {
+        "IsEnabled": true
+      },
+      "AttributeBuffer": {
+        "base": {
+          "Health": 100
+        },
+        "current": {
+          "Health": 100
+        }
+      },
+      "GameplayTagContainer": {},
+      "TagCountContainer": {},
+      "EntityLayer": {
+        "category": [
+          "massNavigation.agent"
+        ],
+        "mask": [
+          "massNavigation.agent"
+        ]
+      },
+      "MassNavigationAgent": {
+        "profileId": "light"
+      },
+      "MovementParticipation": {
+        "physicsPresence": "kinematic",
+        "displacement": {
+          "allowed": true,
+          "handbackSpeedThresholdCmPerSec": 40,
+          "maxDurationMs": 5000
+        }
+      },
+      "CrowdPhysicsArena.RigidBody": {
+        "positionCm": { "x": 0, "y": 0 },
+        "bodyType": "Kinematic",
+        "shape": {
+          "type": "Circle",
+          "radiusCm": 20
+        }
+      }
+    }
+  },
+  {
+    "id": "crowd_arena_agent_azure_heavy",
+    "components": {
+      "Name": {
+        "Value": "CrowdPhysicsArena.Agent.Azure.Heavy"
+      },
+      "VisualHeightmapSampleState": {},
+      "FacingDirection": {
+        "AngleRad": 0
+      },
+      "OrderBuffer": {},
+      "CommandSourceSelectableTag": {},
+      "CommandSourceSelectableState": {
+        "IsEnabled": true
+      },
+      "AttributeBuffer": {
+        "base": {
+          "Health": 260
+        },
+        "current": {
+          "Health": 260
+        }
+      },
+      "GameplayTagContainer": {},
+      "TagCountContainer": {},
+      "EntityLayer": {
+        "category": [
+          "massNavigation.agent"
+        ],
+        "mask": [
+          "massNavigation.agent"
+        ]
+      },
+      "MassNavigationAgent": {
+        "profileId": "heavy"
+      },
+      "MovementParticipation": {
+        "physicsPresence": "kinematic",
+        "displacement": {
+          "allowed": true,
+          "handbackSpeedThresholdCmPerSec": 40,
+          "maxDurationMs": 5000
+        }
+      },
+      "CrowdPhysicsArena.RigidBody": {
+        "positionCm": { "x": 0, "y": 0 },
+        "bodyType": "Kinematic",
+        "shape": {
+          "type": "Circle",
+          "radiusCm": 28
+        }
+      }
+    }
+  },
+  {
+    "id": "crowd_arena_agent_crimson_light",
+    "components": {
+      "Name": {
+        "Value": "CrowdPhysicsArena.Agent.Crimson.Light"
+      },
+      "VisualHeightmapSampleState": {},
+      "FacingDirection": {
+        "AngleRad": 0
+      },
+      "OrderBuffer": {},
+      "CommandSourceSelectableTag": {},
+      "CommandSourceSelectableState": {
+        "IsEnabled": true
+      },
+      "AttributeBuffer": {
+        "base": {
+          "Health": 100
+        },
+        "current": {
+          "Health": 100
+        }
+      },
+      "GameplayTagContainer": {},
+      "TagCountContainer": {},
+      "EntityLayer": {
+        "category": [
+          "massNavigation.agent"
+        ],
+        "mask": [
+          "massNavigation.agent"
+        ]
+      },
+      "MassNavigationAgent": {
+        "profileId": "light"
+      },
+      "MovementParticipation": {
+        "physicsPresence": "kinematic",
+        "displacement": {
+          "allowed": true,
+          "handbackSpeedThresholdCmPerSec": 40,
+          "maxDurationMs": 5000
+        }
+      },
+      "CrowdPhysicsArena.RigidBody": {
+        "positionCm": { "x": 0, "y": 0 },
+        "bodyType": "Kinematic",
+        "shape": {
+          "type": "Circle",
+          "radiusCm": 20
+        }
+      }
+    }
+  },
+  {
+    "id": "crowd_arena_agent_crimson_heavy",
+    "components": {
+      "Name": {
+        "Value": "CrowdPhysicsArena.Agent.Crimson.Heavy"
+      },
+      "VisualHeightmapSampleState": {},
+      "FacingDirection": {
+        "AngleRad": 0
+      },
+      "OrderBuffer": {},
+      "CommandSourceSelectableTag": {},
+      "CommandSourceSelectableState": {
+        "IsEnabled": true
+      },
+      "AttributeBuffer": {
+        "base": {
+          "Health": 260
+        },
+        "current": {
+          "Health": 260
+        }
+      },
+      "GameplayTagContainer": {},
+      "TagCountContainer": {},
+      "EntityLayer": {
+        "category": [
+          "massNavigation.agent"
+        ],
+        "mask": [
+          "massNavigation.agent"
+        ]
+      },
+      "MassNavigationAgent": {
+        "profileId": "heavy"
+      },
+      "MovementParticipation": {
+        "physicsPresence": "kinematic",
+        "displacement": {
+          "allowed": true,
+          "handbackSpeedThresholdCmPerSec": 40,
+          "maxDurationMs": 5000
+        }
+      },
+      "CrowdPhysicsArena.RigidBody": {
+        "positionCm": { "x": 0, "y": 0 },
+        "bodyType": "Kinematic",
+        "shape": {
+          "type": "Circle",
+          "radiusCm": 28
+        }
+      }
+    }
+  },
+  {
+    "id": "crowd_arena_crate",
+    "components": {
+      "Name": {
+        "Value": "CrowdPhysicsArena.Crate"
+      },
+      "EntityLayer": {
+        "category": [
+          "arena.prop"
+        ],
+        "mask": [
+          "arena.prop"
+        ]
+      },
+      "CrowdPhysicsArena.RigidBody": {
+        "positionCm": { "x": 0, "y": 0 },
+        "bodyType": "Dynamic",
+        "inverseMass": 0.01,
+        "shape": {
+          "type": "Box",
+          "halfWidthCm": 60,
+          "halfHeightCm": 60
+        },
+        "material": {
+          "friction": 0.6,
+          "restitution": 0.05,
+          "baseDamping": 1.2
+        }
+      }
+    }
+  },
+  {
+    "id": "crowd_arena_boulder",
+    "components": {
+      "Name": {
+        "Value": "CrowdPhysicsArena.Boulder"
+      },
+      "EntityLayer": {
+        "category": [
+          "arena.prop"
+        ],
+        "mask": [
+          "arena.prop"
+        ]
+      },
+      "CrowdPhysicsArena.RigidBody": {
+        "positionCm": { "x": 0, "y": 0 },
+        "bodyType": "Dynamic",
+        "inverseMass": 0.002,
+        "velocityCmPerSec": { "x": -900, "y": 0 },
+        "shape": {
+          "type": "Circle",
+          "radiusCm": 120
+        },
+        "material": {
+          "friction": 0.3,
+          "restitution": 0.45,
+          "baseDamping": 0.35
+        }
+      }
+    }
+  },
+  {
+    "id": "crowd_arena_pressure_plate",
+    "components": {
+      "Name": {
+        "Value": "CrowdPhysicsArena.PressurePlate"
+      },
+      "EntityLayer": {
+        "category": [
+          "arena.plate"
+        ],
+        "mask": [
+          "arena.plate"
+        ]
+      },
+      "CrowdPhysicsArena.RigidBody": {
+        "positionCm": { "x": 0, "y": 0 },
+        "bodyType": "Dynamic",
+        "inverseMass": 0.001,
+        "shape": {
+          "type": "Box",
+          "halfWidthCm": 150,
+          "halfHeightCm": 150
+        },
+        "material": {
+          "friction": 0.8,
+          "restitution": 0.0,
+          "baseDamping": 4.0
+        }
+      },
+      "CrowdPhysicsArena.ContactEventEmitter": {}
+    }
+  },
+  {
+    "id": "crowd_arena_plate_socket_wall",
+    "components": {
+      "Name": {
+        "Value": "CrowdPhysicsArena.PlateSocketWall"
+      },
+      "EntityLayer": {
+        "category": [
+          "arena.wall"
+        ],
+        "mask": [
+          "arena.wall"
+        ]
+      },
+      "CrowdPhysicsArena.RigidBody": {
+        "positionCm": { "x": 0, "y": 0 },
+        "bodyType": "Static",
+        "shape": {
+          "type": "Box",
+          "halfWidthCm": 40,
+          "halfHeightCm": 40
+        }
+      }
+    }
+  },
+  {
+    "id": "crowd_arena_door",
+    "components": {
+      "Name": {
+        "Value": "CrowdPhysicsArena.Door"
+      },
+      "WorldPositionCm": {
+        "Value": {
+          "X": 0,
+          "Y": 0
+        }
+      },
+      "VisualHeightmapSampleState": {},
+      "FacingDirection": {
+        "AngleRad": 0
+      },
+      "GameplayTagContainer": {},
+      "TagCountContainer": {},
+      "ManifestationObstacleIntent2D": {
+        "shape": "Circle",
+        "sinkPhysicsCollider": true,
+        "sinkNavigationObstacle": true,
+        "navRadiusCm": 260,
+        "radiusCm": 260,
+        "localOffsetXCm": 0,
+        "localOffsetYCm": 0
+      },
+      "CrowdPhysicsArena.Door": {
+        "OpenThresholdContacts": 20
+      }
+    }
+  }
+]

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/GAS/abilities.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/GAS/abilities.json
@@ -7,7 +7,7 @@
         {
           "kind": "TagClip",
           "tick": 0,
-          "duration": 30,
+          "duration": 45,
           "tag": "Cooldown.CrowdArena.Q"
         },
         {

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/GAS/abilities.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/GAS/abilities.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "Ability.CrowdArena.Shockwave",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        {
+          "kind": "TagClip",
+          "tick": 0,
+          "duration": 30,
+          "tag": "Cooldown.CrowdArena.Q"
+        },
+        {
+          "kind": "EffectSignal",
+          "tick": 0,
+          "template": "Effect.CrowdArena.Shockwave.SpawnEpicenter"
+        },
+        {
+          "kind": "End",
+          "tick": 45
+        }
+      ]
+    },
+    "blockTags": {
+      "blockedAny": [ "Cooldown.CrowdArena.Q" ]
+    },
+    "presentation": {
+      "displayName": "Shockwave",
+      "iconGlyph": "Q",
+      "accentColor": "#7FD4FF",
+      "hintText": "Knock nearby squads away from the impact point"
+    },
+    "targeting": {
+      "castRangeCm": 0,
+      "impactEffect": "Effect.CrowdArena.Shockwave.SpawnEpicenter"
+    }
+  },
+  {
+    "id": "Ability.CrowdArena.BoulderRelease",
+    "exec": {
+      "clockId": "FixedFrame",
+      "items": [
+        {
+          "kind": "TagClip",
+          "tick": 0,
+          "duration": 30,
+          "tag": "Cooldown.CrowdArena.E"
+        },
+        {
+          "kind": "EffectSignal",
+          "tick": 0,
+          "template": "Effect.CrowdArena.Boulder.Spawn"
+        },
+        {
+          "kind": "End",
+          "tick": 0
+        }
+      ]
+    },
+    "blockTags": {
+      "blockedAny": [ "Cooldown.CrowdArena.E" ]
+    },
+    "presentation": {
+      "displayName": "Boulder Release",
+      "iconGlyph": "E",
+      "accentColor": "#E0A96B",
+      "hintText": "Release a rolling boulder with authored initial velocity"
+    },
+    "targeting": {
+      "castRangeCm": 0,
+      "impactEffect": "Effect.CrowdArena.Boulder.Spawn"
+    }
+  }
+]

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/GAS/effects.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/GAS/effects.json
@@ -1,0 +1,63 @@
+[
+  {
+    "id": "Effect.CrowdArena.Shockwave.SpawnEpicenter",
+    "tags": [ "Effect.CrowdArena.Shockwave" ],
+    "presetType": "CreateUnit",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "unitCreation": {
+      "templateId": "crowd_arena_shockwave_epicenter",
+      "count": 1,
+      "offsetRadius": 0,
+      "placementPattern": "Scatter",
+      "linkSourceAsParent": true
+    }
+  },
+  {
+    "id": "Effect.CrowdArena.Shockwave.Search",
+    "tags": [ "Effect.CrowdArena.Shockwave" ],
+    "presetType": "Search",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "targetQuery": {
+      "kind": "BuiltinSpatial",
+      "shape": "Circle",
+      "origin": "Source",
+      "radius": 480
+    },
+    "targetFilter": {
+      "relationFilter": "All",
+      "excludeSource": true,
+      "maxTargets": 96
+    },
+    "targetDispatch": {
+      "payloadEffect": "Effect.CrowdArena.Shockwave.Knockback"
+    }
+  },
+  {
+    "id": "Effect.CrowdArena.Shockwave.Knockback",
+    "tags": [ "Effect.CrowdArena.Shockwave" ],
+    "presetType": "Displacement",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "displacement": {
+      "directionMode": "AwayFromSource",
+      "totalDistanceCm": 400,
+      "totalDurationTicks": 24,
+      "overrideNavigation": true
+    }
+  },
+  {
+    "id": "Effect.CrowdArena.Boulder.Spawn",
+    "tags": [ "Effect.CrowdArena.Boulder" ],
+    "presetType": "CreateUnit",
+    "lifetime": "Instant",
+    "participatesInResponse": false,
+    "unitCreation": {
+      "templateId": "crowd_arena_boulder",
+      "count": 1,
+      "offsetRadius": 0,
+      "placementPattern": "Scatter"
+    }
+  }
+]

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Input/command_intent_profiles.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Input/command_intent_profiles.json
@@ -4,7 +4,8 @@
       "id": "intent.command.default",
       "groupPolicy": { "kind": "independent" },
       "rules": [
-        { "priority": 10, "target": { "hasEntity": false }, "route": { "orderTypeKey": "massNavigationMove" } }
+        { "priority": 10, "target": { "hasEntity": false }, "route": { "orderTypeKey": "massNavigationMove" } },
+        { "priority": 9, "target": { "hasEntity": true }, "route": { "orderTypeKey": "massNavigationMove" } }
       ]
     }
   ]

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Input/command_intent_profiles.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Input/command_intent_profiles.json
@@ -1,0 +1,11 @@
+{
+  "profiles": [
+    {
+      "id": "intent.command.default",
+      "groupPolicy": { "kind": "independent" },
+      "rules": [
+        { "priority": 10, "target": { "hasEntity": false }, "route": { "orderTypeKey": "massNavigationMove" } }
+      ]
+    }
+  ]
+}

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Input/default_input.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Input/default_input.json
@@ -1,0 +1,17 @@
+{
+  "actions": [
+    { "id": "SkillQ", "name": "CrowdPhysicsArena_SkillQ", "type": "Button" },
+    { "id": "SkillE", "name": "CrowdPhysicsArena_SkillE", "type": "Button" }
+  ],
+  "contexts": [
+    {
+      "id": "CrowdPhysicsArena.Controls",
+      "name": "Crowd Physics Arena Controls",
+      "priority": 80,
+      "bindings": [
+        { "actionId": "SkillQ", "path": "<Keyboard>/q" },
+        { "actionId": "SkillE", "path": "<Keyboard>/e" }
+      ]
+    }
+  ]
+}

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Input/input_order_mappings.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Input/input_order_mappings.json
@@ -2,6 +2,26 @@
   "interactionMode": "SmartCast",
   "mappings": [
     {
+      "actionId": "SkillQ",
+      "trigger": "PressedThisFrame",
+      "orderTypeKey": "castAbility",
+      "argsTemplate": { "i0": 0 },
+      "requireTarget": false,
+      "targetType": "Position",
+      "isSkillMapping": true,
+      "modifierBehavior": "QueueOnModifier"
+    },
+    {
+      "actionId": "SkillE",
+      "trigger": "PressedThisFrame",
+      "orderTypeKey": "castAbility",
+      "argsTemplate": { "i0": 1 },
+      "requireTarget": false,
+      "targetType": "Position",
+      "isSkillMapping": true,
+      "modifierBehavior": "QueueOnModifier"
+    },
+    {
       "actionId": "Command",
       "actorCollectionKey": "collection.command.source",
       "trigger": "PressedThisFrame",

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Input/input_order_mappings.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Input/input_order_mappings.json
@@ -1,0 +1,20 @@
+{
+  "interactionMode": "SmartCast",
+  "mappings": [
+    {
+      "actionId": "Command",
+      "actorCollectionKey": "collection.command.source",
+      "trigger": "PressedThisFrame",
+      "orderTypeKey": "massNavigationMove",
+      "argsTemplate": {},
+      "requireTarget": true,
+      "targetType": "Position",
+      "isSkillMapping": false,
+      "modifierBehavior": "QueueOnModifier"
+    }
+  ],
+  "userOverrides": {
+    "enabled": false,
+    "persistPath": ""
+  }
+}

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Maps/crowd_physics_arena.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Maps/crowd_physics_arena.json
@@ -1,0 +1,200 @@
+{
+  "Id": "crowd_physics_arena",
+  "VisualHeightmapAsset": "assets/terrain/mass_navigation_large_world_relief.vhtm",
+  "Tags": [
+    "crowd_physics_arena"
+  ],
+  "DefaultCamera": {
+    "VirtualCameraId": "MassNavigation.Camera.LargeWorldHeightmap",
+    "TargetXCm": 5000,
+    "TargetYCm": 5000,
+    "Yaw": 45,
+    "Pitch": 42,
+    "DistanceCm": 9000,
+    "FovYDeg": 55
+  },
+  "Boards": [
+    {
+      "Name": "default",
+      "SpatialType": "Grid",
+      "WidthInMacroTiles": 250,
+      "HeightInMacroTiles": 250,
+      "GridCellSizeCm": 100,
+      "ChunkSizeCells": 64,
+      "LoadedChunkCapacity": 256
+    }
+  ],
+  "Entities": [
+    {
+      "InstanceId": "player_team",
+      "Template": "crowd_arena_player_team"
+    },
+    {
+      "InstanceId": "local_player",
+      "Template": "crowd_arena_local_player"
+    },
+    {
+      "InstanceId": "crate_1",
+      "Template": "crowd_arena_crate",
+      "Overrides": {
+        "CrowdPhysicsArena.RigidBody": {
+          "positionCm": { "x": 4250, "y": 4800 },
+          "bodyType": "Dynamic",
+          "inverseMass": 0.01,
+          "shape": { "type": "Box", "halfWidthCm": 60, "halfHeightCm": 60 },
+          "material": { "friction": 0.6, "restitution": 0.05, "baseDamping": 1.2 }
+        }
+      }
+    },
+    {
+      "InstanceId": "crate_2",
+      "Template": "crowd_arena_crate",
+      "Overrides": {
+        "CrowdPhysicsArena.RigidBody": {
+          "positionCm": { "x": 4250, "y": 5000 },
+          "bodyType": "Dynamic",
+          "inverseMass": 0.01,
+          "shape": { "type": "Box", "halfWidthCm": 60, "halfHeightCm": 60 },
+          "material": { "friction": 0.6, "restitution": 0.05, "baseDamping": 1.2 }
+        }
+      }
+    },
+    {
+      "InstanceId": "crate_3",
+      "Template": "crowd_arena_crate",
+      "Overrides": {
+        "CrowdPhysicsArena.RigidBody": {
+          "positionCm": { "x": 4250, "y": 5200 },
+          "bodyType": "Dynamic",
+          "inverseMass": 0.01,
+          "shape": { "type": "Box", "halfWidthCm": 60, "halfHeightCm": 60 },
+          "material": { "friction": 0.6, "restitution": 0.05, "baseDamping": 1.2 }
+        }
+      }
+    },
+    {
+      "InstanceId": "crate_4",
+      "Template": "crowd_arena_crate",
+      "Overrides": {
+        "CrowdPhysicsArena.RigidBody": {
+          "positionCm": { "x": 4380, "y": 4900 },
+          "bodyType": "Dynamic",
+          "inverseMass": 0.01,
+          "shape": { "type": "Box", "halfWidthCm": 60, "halfHeightCm": 60 },
+          "material": { "friction": 0.6, "restitution": 0.05, "baseDamping": 1.2 }
+        }
+      }
+    },
+    {
+      "InstanceId": "crate_5",
+      "Template": "crowd_arena_crate",
+      "Overrides": {
+        "CrowdPhysicsArena.RigidBody": {
+          "positionCm": { "x": 4380, "y": 5100 },
+          "bodyType": "Dynamic",
+          "inverseMass": 0.01,
+          "shape": { "type": "Box", "halfWidthCm": 60, "halfHeightCm": 60 },
+          "material": { "friction": 0.6, "restitution": 0.05, "baseDamping": 1.2 }
+        }
+      }
+    },
+    {
+      "InstanceId": "crate_6",
+      "Template": "crowd_arena_crate",
+      "Overrides": {
+        "CrowdPhysicsArena.RigidBody": {
+          "positionCm": { "x": 4510, "y": 5000 },
+          "bodyType": "Dynamic",
+          "inverseMass": 0.01,
+          "shape": { "type": "Box", "halfWidthCm": 60, "halfHeightCm": 60 },
+          "material": { "friction": 0.6, "restitution": 0.05, "baseDamping": 1.2 }
+        }
+      }
+    },
+    {
+      "InstanceId": "pressure_plate",
+      "Template": "crowd_arena_pressure_plate",
+      "Overrides": {
+        "CrowdPhysicsArena.RigidBody": {
+          "positionCm": { "x": 5600, "y": 5000 },
+          "bodyType": "Dynamic",
+          "inverseMass": 0.001,
+          "shape": { "type": "Box", "halfWidthCm": 150, "halfHeightCm": 150 },
+          "material": { "friction": 0.8, "restitution": 0.0, "baseDamping": 4.0 }
+        }
+      }
+    },
+    {
+      "InstanceId": "plate_socket_wall_north",
+      "Template": "crowd_arena_plate_socket_wall",
+      "Overrides": {
+        "CrowdPhysicsArena.RigidBody": {
+          "positionCm": { "x": 5600, "y": 5210 },
+          "bodyType": "Static",
+          "shape": { "type": "Box", "halfWidthCm": 220, "halfHeightCm": 40 }
+        }
+      }
+    },
+    {
+      "InstanceId": "plate_socket_wall_south",
+      "Template": "crowd_arena_plate_socket_wall",
+      "Overrides": {
+        "CrowdPhysicsArena.RigidBody": {
+          "positionCm": { "x": 5600, "y": 4790 },
+          "bodyType": "Static",
+          "shape": { "type": "Box", "halfWidthCm": 220, "halfHeightCm": 40 }
+        }
+      }
+    },
+    {
+      "InstanceId": "plate_socket_wall_east",
+      "Template": "crowd_arena_plate_socket_wall",
+      "Overrides": {
+        "CrowdPhysicsArena.RigidBody": {
+          "positionCm": { "x": 5810, "y": 5000 },
+          "bodyType": "Static",
+          "shape": { "type": "Box", "halfWidthCm": 40, "halfHeightCm": 220 }
+        }
+      }
+    },
+    {
+      "InstanceId": "plate_socket_wall_west",
+      "Template": "crowd_arena_plate_socket_wall",
+      "Overrides": {
+        "CrowdPhysicsArena.RigidBody": {
+          "positionCm": { "x": 5390, "y": 5000 },
+          "bodyType": "Static",
+          "shape": { "type": "Box", "halfWidthCm": 40, "halfHeightCm": 220 }
+        }
+      }
+    },
+    {
+      "InstanceId": "arena_door",
+      "Template": "crowd_arena_door",
+      "Overrides": {
+        "WorldPositionCm": {
+          "Value": {
+            "X": 6400,
+            "Y": 5000
+          }
+        },
+        "CrowdPhysicsArena.Door": {
+          "OpenThresholdContacts": 20
+        }
+      }
+    }
+  ],
+  "Teams": [
+    {
+      "TeamId": 1,
+      "RepresentativeInstanceId": "player_team"
+    }
+  ],
+  "Players": [
+    {
+      "PlayerId": 1,
+      "TeamId": 1,
+      "RepresentativeInstanceId": "local_player"
+    }
+  ]
+}

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Maps/crowd_physics_arena.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Maps/crowd_physics_arena.json
@@ -42,7 +42,7 @@
           "bodyType": "Dynamic",
           "inverseMass": 0.01,
           "shape": { "type": "Box", "halfWidthCm": 60, "halfHeightCm": 60 },
-          "material": { "friction": 0.6, "restitution": 0.05, "baseDamping": 1.2 }
+          "material": { "friction": 0.6, "restitution": 0.05, "baseDamping": 0.9 }
         }
       }
     },
@@ -55,7 +55,7 @@
           "bodyType": "Dynamic",
           "inverseMass": 0.01,
           "shape": { "type": "Box", "halfWidthCm": 60, "halfHeightCm": 60 },
-          "material": { "friction": 0.6, "restitution": 0.05, "baseDamping": 1.2 }
+          "material": { "friction": 0.6, "restitution": 0.05, "baseDamping": 0.9 }
         }
       }
     },
@@ -68,7 +68,7 @@
           "bodyType": "Dynamic",
           "inverseMass": 0.01,
           "shape": { "type": "Box", "halfWidthCm": 60, "halfHeightCm": 60 },
-          "material": { "friction": 0.6, "restitution": 0.05, "baseDamping": 1.2 }
+          "material": { "friction": 0.6, "restitution": 0.05, "baseDamping": 0.9 }
         }
       }
     },
@@ -81,7 +81,7 @@
           "bodyType": "Dynamic",
           "inverseMass": 0.01,
           "shape": { "type": "Box", "halfWidthCm": 60, "halfHeightCm": 60 },
-          "material": { "friction": 0.6, "restitution": 0.05, "baseDamping": 1.2 }
+          "material": { "friction": 0.6, "restitution": 0.05, "baseDamping": 0.9 }
         }
       }
     },
@@ -94,7 +94,7 @@
           "bodyType": "Dynamic",
           "inverseMass": 0.01,
           "shape": { "type": "Box", "halfWidthCm": 60, "halfHeightCm": 60 },
-          "material": { "friction": 0.6, "restitution": 0.05, "baseDamping": 1.2 }
+          "material": { "friction": 0.6, "restitution": 0.05, "baseDamping": 0.9 }
         }
       }
     },
@@ -107,7 +107,7 @@
           "bodyType": "Dynamic",
           "inverseMass": 0.01,
           "shape": { "type": "Box", "halfWidthCm": 60, "halfHeightCm": 60 },
-          "material": { "friction": 0.6, "restitution": 0.05, "baseDamping": 1.2 }
+          "material": { "friction": 0.6, "restitution": 0.05, "baseDamping": 0.9 }
         }
       }
     },
@@ -120,7 +120,7 @@
           "bodyType": "Dynamic",
           "inverseMass": 0.001,
           "shape": { "type": "Box", "halfWidthCm": 150, "halfHeightCm": 150 },
-          "material": { "friction": 0.8, "restitution": 0.0, "baseDamping": 4.0 }
+          "material": { "friction": 0.8, "restitution": 0.0, "baseDamping": 0.5 }
         }
       }
     },

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Maps/crowd_physics_arena.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Maps/crowd_physics_arena.json
@@ -119,7 +119,7 @@
           "positionCm": { "x": 5600, "y": 5000 },
           "bodyType": "Dynamic",
           "inverseMass": 0.001,
-          "shape": { "type": "Box", "halfWidthCm": 150, "halfHeightCm": 150 },
+          "shape": { "type": "Box", "halfWidthCm": 40, "halfHeightCm": 420 },
           "material": { "friction": 0.8, "restitution": 0.0, "baseDamping": 0.5 }
         }
       }
@@ -129,9 +129,9 @@
       "Template": "crowd_arena_plate_socket_wall",
       "Overrides": {
         "CrowdPhysicsArena.RigidBody": {
-          "positionCm": { "x": 5600, "y": 5210 },
+          "positionCm": { "x": 5600, "y": 5640 },
           "bodyType": "Static",
-          "shape": { "type": "Box", "halfWidthCm": 220, "halfHeightCm": 40 }
+          "shape": { "type": "Box", "halfWidthCm": 400, "halfHeightCm": 200 }
         }
       }
     },
@@ -140,9 +140,9 @@
       "Template": "crowd_arena_plate_socket_wall",
       "Overrides": {
         "CrowdPhysicsArena.RigidBody": {
-          "positionCm": { "x": 5600, "y": 4790 },
+          "positionCm": { "x": 5600, "y": 4360 },
           "bodyType": "Static",
-          "shape": { "type": "Box", "halfWidthCm": 220, "halfHeightCm": 40 }
+          "shape": { "type": "Box", "halfWidthCm": 400, "halfHeightCm": 200 }
         }
       }
     },
@@ -151,9 +151,9 @@
       "Template": "crowd_arena_plate_socket_wall",
       "Overrides": {
         "CrowdPhysicsArena.RigidBody": {
-          "positionCm": { "x": 5810, "y": 5000 },
+          "positionCm": { "x": 5860, "y": 5000 },
           "bodyType": "Static",
-          "shape": { "type": "Box", "halfWidthCm": 40, "halfHeightCm": 220 }
+          "shape": { "type": "Box", "halfWidthCm": 200, "halfHeightCm": 640 }
         }
       }
     },
@@ -162,9 +162,9 @@
       "Template": "crowd_arena_plate_socket_wall",
       "Overrides": {
         "CrowdPhysicsArena.RigidBody": {
-          "positionCm": { "x": 5390, "y": 5000 },
+          "positionCm": { "x": 5340, "y": 5000 },
           "bodyType": "Static",
-          "shape": { "type": "Box", "halfWidthCm": 40, "halfHeightCm": 220 }
+          "shape": { "type": "Box", "halfWidthCm": 200, "halfHeightCm": 640 }
         }
       }
     },

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/MassNavigationConfig.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/MassNavigationConfig.json
@@ -1,5 +1,17 @@
 {
   "mapId": "crowd_physics_arena",
+  "world": {
+    "hotZones": [
+      {
+        "id": "central",
+        "label": "Arena",
+        "centerXCm": 5000,
+        "centerYCm": 5000,
+        "widthCm": 10000,
+        "heightCm": 10000
+      }
+    ]
+  },
   "scenario": {
     "agentsPerTeam": 48,
     "teams": [

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/MassNavigationConfig.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/MassNavigationConfig.json
@@ -1,0 +1,50 @@
+{
+  "mapId": "crowd_physics_arena",
+  "scenario": {
+    "agentsPerTeam": 48,
+    "teams": [
+      {
+        "id": 1,
+        "name": "Azure Vanguard"
+      },
+      {
+        "id": 2,
+        "name": "Crimson Column"
+      }
+    ],
+    "spawnLayout": {
+      "kind": "OrbitOpposedTargets",
+      "orbitRadiusCm": 2600,
+      "randomSeed": 12648430
+    }
+  },
+  "presentation": {
+    "teams": [
+      {
+        "teamId": 1,
+        "styleId": "blue",
+        "lightTemplateId": "crowd_arena_agent_azure_light",
+        "heavyTemplateId": "crowd_arena_agent_azure_heavy",
+        "lightPerformerId": "mass_navigation_agent_azure_light",
+        "heavyPerformerId": "mass_navigation_agent_azure_heavy"
+      },
+      {
+        "teamId": 2,
+        "styleId": "red",
+        "lightTemplateId": "crowd_arena_agent_crimson_light",
+        "heavyTemplateId": "crowd_arena_agent_crimson_heavy",
+        "lightPerformerId": "mass_navigation_agent_crimson_light",
+        "heavyPerformerId": "mass_navigation_agent_crimson_heavy"
+      }
+    ]
+  },
+  "teamRelationships": {
+    "defaultRelationship": "Hostile",
+    "relationships": []
+  },
+  "scenarioRuntime": {
+    "runtimeCapacity": {
+      "displacedAgentCapacity": 128
+    }
+  }
+}

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/game.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/game.json
@@ -1,0 +1,55 @@
+{
+  "startupMapId": "crowd_physics_arena",
+  "startupLocalPlayerId": 1,
+  "windowTitle": "Ludots Engine - Capability Standard Crowd Physics Arena",
+  "targetFps": 0,
+  "worldWidthInMacroTiles": 250,
+  "worldHeightInMacroTiles": 250,
+  "gasRuntimeCapacity": {
+    "orderQueueCapacity": 16384,
+    "orderAdmissionResultCapacity": 32768,
+    "orderAdmissionRejectionCapacity": 16384,
+    "orderTerminalResultCapacity": 16384
+  },
+  "commandSource": {
+    "targetFilter": { "relationFilter": "Friendly" },
+    "movePathPreviewOrderTypeKeys": [ "massNavigationMove" ]
+  },
+  "presentation": {
+    "performerInstanceCapacity": 16384,
+    "gasPresentationEventCapacity": 16384,
+    "presentationEventStreamCapacity": 16384,
+    "presentationOwnerChangeCapacity": 16384,
+    "performerCommandCapacity": 32768,
+    "primitiveDrawBufferCapacity": 16384,
+    "visualSnapshotBufferCapacity": 16384,
+    "visualProxyBufferCapacity": 16384,
+    "presentationRequestCapacity": 32768,
+    "groundOverlayCapacity": 8192,
+    "roadSplineCapacity": 8192,
+    "worldHudCapacity": 16384,
+    "screenHudCapacity": 16384,
+    "skinnedVisualBatchCapacity": 16384,
+    "minimapMarkerCapacity": 16384,
+    "runtimeEntitySpawnQueueCapacity": 16384,
+    "runtimeEntitySpawnReceiptQueueCapacity": 16384,
+    "cameraCulling": {
+      "highLodDistanceCm": 4000.0,
+      "mediumLodDistanceCm": 10000.0,
+      "lowLodDistanceCm": 20000.0
+    },
+    "minimap": {
+      "initialZoomNormalized": 0.12,
+      "wheelZoomNormalizedStep": 0.08,
+      "buttonZoomNormalizedStep": 0.18,
+      "zoomSliderEnabled": true,
+      "modeToggleEnabled": true,
+      "rotateToggleEnabled": true,
+      "debugMarkerSampleCapacity": 128,
+      "minZoomExtentMode": "OneChunk",
+      "maxZoomExtentMode": "FullMap",
+      "minZoomExplicitHalfExtentCm": 750.0,
+      "maxZoomExplicitHalfExtentCm": 0.0
+    }
+  }
+}

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/game.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/game.json
@@ -1,6 +1,7 @@
 {
   "startupMapId": "crowd_physics_arena",
   "startupLocalPlayerId": 1,
+  "startupInputContexts": [ "Default_Gameplay", "CrowdPhysicsArena.Controls" ],
   "windowTitle": "Ludots Engine - Capability Standard Crowd Physics Arena",
   "targetFps": 0,
   "worldWidthInMacroTiles": 250,

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/mod.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/mod.json
@@ -1,0 +1,14 @@
+{
+  "name": "CapabilityStandardCrowdPhysicsArenaMod",
+  "version": "1.0.0",
+  "description": "Standard capability acceptance entry for the Crowd Physics Arena showcase: massnav kinematic squads, dynamic crates, pressure plate + door, shockwave knockback, and boulder release.",
+  "main": "bin/net8.0/CapabilityStandardCrowdPhysicsArenaMod.dll",
+  "priority": -2000,
+  "dependencies": {
+    "LudotsCoreMod": "^1.0.0",
+    "CoreInputMod": "^1.0.0",
+    "MassNavigationMod": "^1.0.0"
+  },
+  "author": "Ludots Team",
+  "tags": ["showcase", "capability-standard", "mass-navigation", "physics2d", "kinematic", "crowd", "pressure-plate"]
+}

--- a/showcase.registry.json
+++ b/showcase.registry.json
@@ -227,6 +227,30 @@
       "notes": "截图证据待 CI 验收产物补录"
     },
     {
+      "id": "capability_standard_crowd_physics_arena",
+      "path": "mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod",
+      "projectPath": "CapabilityStandardCrowdPhysicsArenaMod.csproj",
+      "title": "标准能力·人群物理竞技场",
+      "summary": "massnav→kinematic 桥标准验收：kinematic 小队推箱、压力板碰撞事件开门、Q 冲击波位移窗口与交还、E 巨石初速度释放、HUD 三计数。",
+      "tier": "T1",
+      "category": "capability",
+      "tags": [
+        "navigation",
+        "physics2d",
+        "kinematic",
+        "movement-participation"
+      ],
+      "binding": "capability_standard_crowd_physics_arena",
+      "preset": "capability_standard_crowd_physics_arena_raylib",
+      "docsPath": "gitbook/architecture/capability-standard-showcases.md",
+      "readmePath": "mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/README.md",
+      "acceptanceTest": "CapabilityStandardCrowdPhysicsArenaProductionPathTests",
+      "artifactDir": null,
+      "screenshot": null,
+      "status": "active",
+      "notes": "截图证据待 CI 验收产物补录"
+    },
+    {
       "id": "capability_standard_virtual_camera_showcase",
       "path": "mods/showcases/capability_standard/CapabilityStandardVirtualCameraShowcaseMod",
       "projectPath": "CapabilityStandardVirtualCameraShowcaseMod.csproj",

--- a/src/Apps/Raylib/Ludots.App.Raylib/Ludots.App.Raylib.csproj
+++ b/src/Apps/Raylib/Ludots.App.Raylib/Ludots.App.Raylib.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\..\Adapters\Raylib\Ludots.Adapter.Raylib\Ludots.Adapter.Raylib.csproj" />
     <ProjectReference Include="..\..\..\Core\Ludots.Physics.Broadphase\Ludots.Physics.Broadphase.csproj" />
     <ProjectReference Include="..\..\..\Core\Ludots.Physics2D\Ludots.Physics2D.csproj" />
+    <ProjectReference Include="..\..\..\Core\Ludots.Movement.Physics2DBridge\Ludots.Movement.Physics2DBridge.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">

--- a/src/Apps/Web/Ludots.App.Web/Ludots.App.Web.csproj
+++ b/src/Apps/Web/Ludots.App.Web/Ludots.App.Web.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\..\..\Adapters\Web\Ludots.Adapter.Web\Ludots.Adapter.Web.csproj" />
     <ProjectReference Include="..\..\..\Core\Ludots.Physics.Broadphase\Ludots.Physics.Broadphase.csproj" />
     <ProjectReference Include="..\..\..\Core\Ludots.Physics2D\Ludots.Physics2D.csproj" />
+    <ProjectReference Include="..\..\..\Core\Ludots.Movement.Physics2DBridge\Ludots.Movement.Physics2DBridge.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core/Engine/GameEngine.cs
+++ b/src/Core/Engine/GameEngine.cs
@@ -1964,6 +1964,32 @@ namespace Ludots.Core.Engine
             RegisterSystem(worldSyncSystem, SystemGroup.PostMovement);
             GlobalContext["Ludots.Core.Physics2D.Ticking.Physics2DSimulationSystem"] = physics2dSystem;
             GlobalContext["Ludots.Core.Physics2D.Systems.Physics2DToWorldPositionSyncSystem"] = worldSyncSystem;
+
+            InstallMovementPhysics2DBridge();
+        }
+
+        /// <summary>
+        /// massnav→kinematic 桥（issue #643 增量 2）：Physics2D 在场时为必装项。
+        /// 桥装配组合层的位姿喂送与碰撞事件路由；缺装即启动失败，不允许 kinematic
+        /// 参与单位静默失去物理体喂送。
+        /// </summary>
+        private void InstallMovementPhysics2DBridge()
+        {
+            const string bridgeAssemblyName = "Ludots.Movement.Physics2DBridge";
+            const string bridgeInstallerTypeName = "Ludots.Core.Movement.Physics2DBridge.MovementPhysics2DBridgeInstaller";
+
+            Type? installerType = TryResolveOptionalAssemblyType(bridgeAssemblyName, bridgeInstallerTypeName);
+            if (installerType == null)
+            {
+                throw new InvalidOperationException(
+                    $"Physics2D startup requires '{bridgeInstallerTypeName}' from '{bridgeAssemblyName}' (massnav→kinematic bridge, issue #643 increment 2) when 'Ludots.Physics2D' is present.");
+            }
+
+            MethodInfo installMethod = installerType.GetMethod("Install", BindingFlags.Public | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    $"'{bridgeInstallerTypeName}' must expose a public static Install(GameEngine) method.");
+            var install = (Action<GameEngine>)Delegate.CreateDelegate(typeof(Action<GameEngine>), installMethod);
+            install(this);
         }
 
         private static Type? TryResolveOptionalAssemblyType(string assemblyName, string typeName)

--- a/src/Core/Engine/GameEngine.cs
+++ b/src/Core/Engine/GameEngine.cs
@@ -1774,7 +1774,7 @@ namespace Ludots.Core.Engine
                     throw new InvalidOperationException($"Failed to create runtime navmesh obstacle dirty system '{runtimeNavMeshObstacleSystemTypeName}'.");
                 }
             }
-            // Pose-authority arbitration (issue #643): transitions queue during the tick and are
+            // Pose-authority arbitration: transitions queue during the tick and are
             // committed at the next fixed-step boundary by PoseAuthorityCommitSystem (SchemaUpdate).
             var poseAuthorityArbiter = new PoseAuthorityArbiter();
             SetService(CoreServiceKeys.PoseAuthorityArbiter, poseAuthorityArbiter);
@@ -1969,7 +1969,7 @@ namespace Ludots.Core.Engine
         }
 
         /// <summary>
-        /// massnav→kinematic 桥（issue #643 增量 2）：Physics2D 在场时为必装项。
+        /// massnav→kinematic 桥：Physics2D 在场时为必装项。
         /// 桥装配组合层的位姿喂送与碰撞事件路由；缺装即启动失败，不允许 kinematic
         /// 参与单位静默失去物理体喂送。
         /// </summary>
@@ -1982,7 +1982,7 @@ namespace Ludots.Core.Engine
             if (installerType == null)
             {
                 throw new InvalidOperationException(
-                    $"Physics2D startup requires '{bridgeInstallerTypeName}' from '{bridgeAssemblyName}' (massnav→kinematic bridge, issue #643 increment 2) when 'Ludots.Physics2D' is present.");
+                    $"Physics2D startup requires '{bridgeInstallerTypeName}' from '{bridgeAssemblyName}' (massnav→kinematic bridge) when 'Ludots.Physics2D' is present.");
             }
 
             MethodInfo installMethod = installerType.GetMethod("Install", BindingFlags.Public | BindingFlags.Static)

--- a/src/Core/Gameplay/GAS/Systems/DisplacementRuntimeSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/DisplacementRuntimeSystem.cs
@@ -208,7 +208,15 @@ namespace Ludots.Core.Gameplay.GAS.Systems
 
         private void ApplyPositionStep(Entity target, Fix64Vec2 step)
         {
-            if (World.Has<Position2D>(target))
+            // physicsPresence=Kinematic 的参与单位（issue #643 增量 2）：Position2D 由
+            // KinematicTargetPoseBuffer2D → KinematicDriveSystem2D 唯一驱动（massnav→kinematic
+            // 桥喂送已提交 WorldPositionCm，物理步内应用并推导 Velocity2D）。位移窗口只写
+            // WorldPositionCm；直写 Position2D 会绕过速度推导、在物理步之外瞬移刚体（双写违规）。
+            bool kinematicPoseDriven =
+                World.TryGet(target, out MovementParticipation participation) &&
+                participation.PhysicsPresence == PhysicsPresenceKind.Kinematic;
+
+            if (!kinematicPoseDriven && World.Has<Position2D>(target))
             {
                 ref var physicsPosition = ref World.Get<Position2D>(target);
                 physicsPosition.Value = physicsPosition.Value + step;

--- a/src/Core/Gameplay/GAS/Systems/DisplacementRuntimeSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/DisplacementRuntimeSystem.cs
@@ -17,7 +17,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
     /// Runs in <see cref="Engine.GameEngine.SystemGroup.EffectProcessing"/> alongside projectile/spawn systems.
     /// Uses deferred destruction to avoid structural changes inside query lambdas.
     /// All math uses Fix64/Fix64Vec2 for determinism.
-    /// Targets bound as MassNavigation agents (issue #643) go through the pose-authority
+    /// Targets bound as MassNavigation agents go through the pose-authority
     /// displacement window: the window is requested at effect start, committed at the next
     /// fixed-step boundary, and handed back to Nav when the effect ends or its speed drops
     /// below the authored handback threshold. Agents without an explicit
@@ -81,7 +81,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                         if (!World.Has<MovementParticipation>(disp.TargetEntity))
                         {
                             throw new System.InvalidOperationException(
-                                $"Displacement targets MassNavigation agent entity {disp.TargetEntity.Id} without a MovementParticipation declaration; silent double-writes of WorldPositionCm are forbidden (issue #643).");
+                                $"Displacement targets MassNavigation agent entity {disp.TargetEntity.Id} without a MovementParticipation declaration; silent double-writes of WorldPositionCm are forbidden.");
                         }
 
                         participation = World.Get<MovementParticipation>(disp.TargetEntity);
@@ -208,7 +208,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
 
         private void ApplyPositionStep(Entity target, Fix64Vec2 step)
         {
-            // physicsPresence=Kinematic 的参与单位（issue #643 增量 2）：Position2D 由
+            // physicsPresence=Kinematic 的参与单位：Position2D 由
             // KinematicTargetPoseBuffer2D → KinematicDriveSystem2D 唯一驱动（massnav→kinematic
             // 桥喂送已提交 WorldPositionCm，物理步内应用并推导 Velocity2D）。位移窗口只写
             // WorldPositionCm；直写 Position2D 会绕过速度推导、在物理步之外瞬移刚体（双写违规）。

--- a/src/Core/Ludots.Core.csproj
+++ b/src/Core/Ludots.Core.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <Compile Remove="Ludots.Physics2D\**\*.cs" />
     <Compile Remove="Ludots.Physics.Broadphase\**\*.cs" />
+    <Compile Remove="Ludots.Movement.Physics2DBridge\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core/Ludots.Movement.Physics2DBridge/ContactEventRouter2D.cs
+++ b/src/Core/Ludots.Movement.Physics2DBridge/ContactEventRouter2D.cs
@@ -16,7 +16,7 @@ namespace Ludots.Core.Movement.Physics2DBridge
     }
 
     /// <summary>
-    /// massnav→kinematic 桥的事件路由半边（issue #643 增量 2 / #734）。
+    /// massnav→kinematic 桥的事件路由半边。
     ///
     /// 物理步后由 <see cref="ContactEventRoutingSystem2D"/> Drain <see cref="ContactEventQueue2D"/>，
     /// 按事件双方的 EntityLayer category 位分发给注册的消费者（每个命中 layer 的消费者各收到一次；

--- a/src/Core/Ludots.Movement.Physics2DBridge/ContactEventRouter2D.cs
+++ b/src/Core/Ludots.Movement.Physics2DBridge/ContactEventRouter2D.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Ludots.Core.Layers;
+using Ludots.Core.Physics2D;
+
+namespace Ludots.Core.Movement.Physics2DBridge
+{
+    /// <summary>
+    /// 碰撞事件消费入口：按 <see cref="IContactEventConsumer2D"/> 注册的 EntityLayer 接收
+    /// 该 layer 参与的 Begin/End 事件。消费者异常直接上抛（不静默吞）。
+    /// </summary>
+    public interface IContactEventConsumer2D
+    {
+        void OnContactEvent(in ContactEvent2D contactEvent);
+    }
+
+    /// <summary>
+    /// massnav→kinematic 桥的事件路由半边（issue #643 增量 2 / #734）。
+    ///
+    /// 物理步后由 <see cref="ContactEventRoutingSystem2D"/> Drain <see cref="ContactEventQueue2D"/>，
+    /// 按事件双方的 EntityLayer category 位分发给注册的消费者（每个命中 layer 的消费者各收到一次；
+    /// 同一消费者注册在事件双方各自命中的两个 layer 上时会收到两次，按 layer 视角消费）。
+    ///
+    /// 无消费者命中的事件不静默丢弃：先校验其 layer 与 'Physics2D/kinematic.json'
+    /// contactEventEmitterLayers 允许清单相交（不相交视为管线缺陷抛异常），然后按 layer 计数暴露
+    /// （<see cref="GetDroppedEventCount"/> / <see cref="TotalDroppedEventCount"/>）。
+    /// </summary>
+    public sealed class ContactEventRouter2D
+    {
+        private readonly IContactEventConsumer2D?[] _consumersByLayerIndex =
+            new IContactEventConsumer2D?[LayerRegistry.MaxLayers];
+        private readonly long[] _droppedEventCountByLayerIndex = new long[LayerRegistry.MaxLayers];
+        private readonly IReadOnlyList<string> _allowedEmitterLayerNames;
+
+        private uint _consumerCategoryMask;
+        private uint _allowedCategoryMask;
+        private bool _allowedMaskResolved;
+
+        public ContactEventRouter2D(IReadOnlyList<string> allowedEmitterLayerNames)
+        {
+            _allowedEmitterLayerNames = allowedEmitterLayerNames
+                ?? throw new ArgumentNullException(nameof(allowedEmitterLayerNames));
+        }
+
+        /// <summary>路由不到消费者而被丢弃计数的事件总数（可观测，不静默）。</summary>
+        public long TotalDroppedEventCount { get; private set; }
+
+        public void RegisterConsumer(string layerName, IContactEventConsumer2D consumer)
+        {
+            ArgumentNullException.ThrowIfNull(consumer);
+            int layerIndex = LayerRegistry.GetIndex(layerName);
+            if (_consumersByLayerIndex[layerIndex] != null)
+            {
+                throw new InvalidOperationException(
+                    $"ContactEventRouter2D already has a consumer registered for layer '{layerName}'; " +
+                    "one consumer per layer — compose fan-out inside the consumer instead of double-registering.");
+            }
+
+            _consumersByLayerIndex[layerIndex] = consumer;
+            _consumerCategoryMask |= 1u << layerIndex;
+        }
+
+        public long GetDroppedEventCount(string layerName)
+        {
+            return _droppedEventCountByLayerIndex[LayerRegistry.GetIndex(layerName)];
+        }
+
+        public void Dispatch(ReadOnlySpan<ContactEvent2D> events)
+        {
+            if (events.Length == 0)
+            {
+                return;
+            }
+
+            ResolveAllowedMaskOnce();
+
+            for (int i = 0; i < events.Length; i++)
+            {
+                ref readonly ContactEvent2D contactEvent = ref events[i];
+                uint categories = contactEvent.LayerA.Category | contactEvent.LayerB.Category;
+
+                uint routedBits = categories & _consumerCategoryMask;
+                if (routedBits != 0u)
+                {
+                    while (routedBits != 0u)
+                    {
+                        int layerIndex = BitOperations.TrailingZeroCount(routedBits);
+                        routedBits &= routedBits - 1u;
+                        _consumersByLayerIndex[layerIndex]!.OnContactEvent(in contactEvent);
+                    }
+
+                    continue;
+                }
+
+                uint allowedBits = categories & _allowedCategoryMask;
+                if (allowedBits == 0u)
+                {
+                    throw new InvalidOperationException(
+                        $"ContactEventRouter2D received a {contactEvent.Type} event between entities {contactEvent.EntityA.Id} and {contactEvent.EntityB.Id} " +
+                        $"whose layers (0x{categories:X8}) intersect neither a registered consumer nor the 'Physics2D/kinematic.json' contactEventEmitterLayers allowlist " +
+                        $"(0x{_allowedCategoryMask:X8}); this indicates a contact event pipeline defect.");
+                }
+
+                while (allowedBits != 0u)
+                {
+                    int layerIndex = BitOperations.TrailingZeroCount(allowedBits);
+                    allowedBits &= allowedBits - 1u;
+                    _droppedEventCountByLayerIndex[layerIndex]++;
+                }
+
+                TotalDroppedEventCount++;
+            }
+        }
+
+        private void ResolveAllowedMaskOnce()
+        {
+            if (_allowedMaskResolved)
+            {
+                return;
+            }
+
+            uint mask = 0u;
+            for (int i = 0; i < _allowedEmitterLayerNames.Count; i++)
+            {
+                mask |= 1u << LayerRegistry.GetIndex(_allowedEmitterLayerNames[i]);
+            }
+
+            _allowedCategoryMask = mask;
+            _allowedMaskResolved = true;
+        }
+    }
+}

--- a/src/Core/Ludots.Movement.Physics2DBridge/ContactEventRoutingSystem2D.cs
+++ b/src/Core/Ludots.Movement.Physics2DBridge/ContactEventRoutingSystem2D.cs
@@ -1,0 +1,43 @@
+using System;
+using Ludots.Core.Physics2D;
+
+namespace Ludots.Core.Movement.Physics2DBridge
+{
+    /// <summary>
+    /// 物理步后（同一帧、同一 SystemGroup 内紧随 Physics2DSimulationSystem）Drain
+    /// <see cref="ContactEventQueue2D"/> 并交给 <see cref="ContactEventRouter2D"/> 分发。
+    /// 这是碰撞事件的唯一生产路径消费点：queue 合同要求每帧清空，未消费会溢出抛异常。
+    /// </summary>
+    public sealed class ContactEventRoutingSystem2D : ISystem<float>
+    {
+        private readonly ContactEventQueue2D _queue;
+        private readonly ContactEventRouter2D _router;
+
+        public ContactEventRoutingSystem2D(ContactEventQueue2D queue, ContactEventRouter2D router)
+        {
+            _queue = queue ?? throw new ArgumentNullException(nameof(queue));
+            _router = router ?? throw new ArgumentNullException(nameof(router));
+        }
+
+        public void Initialize()
+        {
+        }
+
+        public void BeforeUpdate(in float deltaTime)
+        {
+        }
+
+        public void Update(in float deltaTime)
+        {
+            _router.Dispatch(_queue.DrainEvents());
+        }
+
+        public void AfterUpdate(in float deltaTime)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Core/Ludots.Movement.Physics2DBridge/Ludots.Movement.Physics2DBridge.csproj
+++ b/src/Core/Ludots.Movement.Physics2DBridge/Ludots.Movement.Physics2DBridge.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Ludots.Core.csproj" />
+    <ProjectReference Include="..\Ludots.Physics2D\Ludots.Physics2D.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Arch.System" />
+  </ItemGroup>
+</Project>

--- a/src/Core/Ludots.Movement.Physics2DBridge/MassNavKinematicPoseFeedSystem2D.cs
+++ b/src/Core/Ludots.Movement.Physics2DBridge/MassNavKinematicPoseFeedSystem2D.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Arch.Core;
+using Ludots.Core.Components;
+using Ludots.Core.MassNavigation.Runtime;
+using Ludots.Core.Mathematics.FixedPoint;
+using Ludots.Core.Physics2D;
+using Ludots.Core.Physics2D.Components;
+
+namespace Ludots.Core.Movement.Physics2DBridge
+{
+    /// <summary>
+    /// massnav→kinematic 桥的位姿喂送半边（issue #643 增量 2 / #734）。
+    ///
+    /// 每个引擎固定步、在 Physics2D 步进之前，把 physicsPresence=Kinematic 且已绑定
+    /// massnav agent 的实体的已提交 <see cref="WorldPositionCm"/>（Nav 写权由 entity-sync
+    /// 提交、Displacement 写权由位移窗口提交——物理视角单位永远在场，仅驱动源不同）
+    /// 通过 <see cref="KinematicTargetPoseBuffer2D.SetKinematicTargetPose"/> 喂给 kinematic body。
+    ///
+    /// 合同（全部 fail-fast，无静默降级）：
+    /// - 模板配对：participation=Kinematic 的 massnav 实体必须同时具备
+    ///   Mass2D.Kinematic + Position2D + Collider2D + PoseAuthority，缺任何一半抛异常；
+    ///   反之，绑定了 massnav agent 的 kinematic 物理体必须声明 MovementParticipation。
+    /// - 半径 SSOT：kinematic 圆形 collider 半径必须等于 agent profile 的 bodyRadiusCm
+    ///   （首次绑定校验，agent index 变化时重校验），漂移即抛异常。
+    /// - 容量：参与单位数超过 kinematicBodyCapacity 抛异常。
+    /// - 节拍：位姿在上一固定步各写权系统提交之后、本固定步物理消费之前喂送；
+    ///   若上一步的位姿未被物理消费（physicsHz &lt; 固定步 Hz 或物理被禁用）抛异常。
+    /// - 热路径零分配：chunk 遍历 + 预分配校验缓存，无每帧 LINQ/装箱/字典扩容。
+    /// </summary>
+    public sealed class MassNavKinematicPoseFeedSystem2D : BaseSystem<World, float>
+    {
+        private static readonly QueryDescription _participantsQuery = new QueryDescription()
+            .WithAll<MovementParticipation, MassNavigationAgentIndex, WorldPositionCm>();
+
+        private static readonly QueryDescription _unparticipatedBodiesQuery = new QueryDescription()
+            .WithAll<MassNavigationAgentIndex, Mass2D>()
+            .WithNone<MovementParticipation>();
+
+        private readonly Func<MassNavigationSimulationRuntime?> _runtimeProvider;
+        private readonly KinematicTargetPoseBuffer2D _poseBuffer;
+        private readonly ShapeDataStorage2D _shapeStorage;
+        private readonly Dictionary<Entity, int> _validatedAgentIndexByEntity;
+        private readonly List<Entity> _staleValidationEntries;
+
+        public MassNavKinematicPoseFeedSystem2D(
+            World world,
+            Func<MassNavigationSimulationRuntime?> runtimeProvider,
+            KinematicTargetPoseBuffer2D poseBuffer,
+            ShapeDataStorage2D shapeStorage) : base(world)
+        {
+            _runtimeProvider = runtimeProvider ?? throw new ArgumentNullException(nameof(runtimeProvider));
+            _poseBuffer = poseBuffer ?? throw new ArgumentNullException(nameof(poseBuffer));
+            _shapeStorage = shapeStorage ?? throw new ArgumentNullException(nameof(shapeStorage));
+            _validatedAgentIndexByEntity = new Dictionary<Entity, int>(poseBuffer.Capacity);
+            _staleValidationEntries = new List<Entity>(poseBuffer.Capacity);
+        }
+
+        /// <summary>上一固定步实际喂送的参与单位数（可观测状态，供测试与 HUD 查询）。</summary>
+        public int LastFedParticipantCount { get; private set; }
+
+        public override void Update(in float deltaTime)
+        {
+            MassNavigationSimulationRuntime? runtime = _runtimeProvider();
+            if (runtime == null)
+            {
+                LastFedParticipantCount = 0;
+                return;
+            }
+
+            RejectKinematicBodiesWithoutParticipation();
+
+            int fedCount = 0;
+            foreach (ref var chunk in World.Query(in _participantsQuery))
+            {
+                if (chunk.Count <= 0)
+                {
+                    continue;
+                }
+
+                chunk.GetSpan<MovementParticipation, MassNavigationAgentIndex, WorldPositionCm>(
+                    out var participations, out var agentIndices, out var worldPositions);
+                bool hasMass = chunk.Has<Mass2D>();
+                Span<Mass2D> masses = hasMass ? chunk.GetSpan<Mass2D>() : default;
+                bool hasPosition = chunk.Has<Position2D>();
+                bool hasPoseAuthority = chunk.Has<PoseAuthority>();
+                bool hasRotation = chunk.Has<Rotation2D>();
+                Span<Rotation2D> rotations = hasRotation ? chunk.GetSpan<Rotation2D>() : default;
+                ref Entity entityFirst = ref chunk.Entity(0);
+
+                foreach (int index in chunk)
+                {
+                    ref MovementParticipation participation = ref participations[index];
+                    Entity entity = Unsafe.Add(ref entityFirst, index);
+
+                    if (participation.PhysicsPresence != PhysicsPresenceKind.Kinematic)
+                    {
+                        if (hasMass && masses[index].IsKinematic)
+                        {
+                            throw new InvalidOperationException(
+                                $"massnav→kinematic bridge: entity {entity.Id} authored movementParticipation.physicsPresence={participation.PhysicsPresence} " +
+                                "but carries a kinematic Mass2D body. Template authoring gap: declare physicsPresence=Kinematic or remove the kinematic rigid body.");
+                        }
+
+                        continue;
+                    }
+
+                    if (!hasMass || !masses[index].IsKinematic || !hasPosition)
+                    {
+                        throw new InvalidOperationException(
+                            $"massnav→kinematic bridge: entity {entity.Id} authored movementParticipation.physicsPresence=Kinematic " +
+                            "but is missing its kinematic physics half (requires Mass2D.Kinematic + Position2D via rigidBody2D template authoring). " +
+                            "Template authoring gap: participation and physics body must be declared together.");
+                    }
+
+                    if (!hasPoseAuthority)
+                    {
+                        throw new InvalidOperationException(
+                            $"massnav→kinematic bridge: entity {entity.Id} has MovementParticipation but no PoseAuthority runtime state; " +
+                            "MovementParticipation authoring must always attach the derived PoseAuthority component.");
+                    }
+
+                    ValidateRadiusSsot(entity, agentIndices[index].Value, runtime);
+
+                    if (_poseBuffer.TryGetPending(entity, out _))
+                    {
+                        throw new InvalidOperationException(
+                            $"massnav→kinematic bridge: entity {entity.Id} still has an unconsumed kinematic target pose from the previous fixed step. " +
+                            "Physics2D did not step between two feeds; the bridge cadence contract requires physicsHz >= the engine fixed-step Hz and an enabled Physics2D simulation.");
+                    }
+
+                    if (_poseBuffer.PendingCount >= _poseBuffer.Capacity)
+                    {
+                        throw new InvalidOperationException(
+                            $"massnav→kinematic bridge: kinematicBodyCapacity={_poseBuffer.Capacity} cannot admit massnav participant entity {entity.Id} " +
+                            $"(pending poses this step: {_poseBuffer.PendingCount}). Raise 'Physics2D/kinematic.json' kinematicBodyCapacity to at least the participating unit count.");
+                    }
+
+                    Fix64 rotationRad = hasRotation ? rotations[index].Value : Fix64.Zero;
+                    _poseBuffer.SetKinematicTargetPose(entity, worldPositions[index].Value, rotationRad);
+                    fedCount++;
+                }
+            }
+
+            LastFedParticipantCount = fedCount;
+        }
+
+        private void RejectKinematicBodiesWithoutParticipation()
+        {
+            foreach (ref var chunk in World.Query(in _unparticipatedBodiesQuery))
+            {
+                if (chunk.Count <= 0)
+                {
+                    continue;
+                }
+
+                Span<Mass2D> masses = chunk.GetSpan<Mass2D>();
+                ref Entity entityFirst = ref chunk.Entity(0);
+                foreach (int index in chunk)
+                {
+                    if (masses[index].IsKinematic)
+                    {
+                        Entity entity = Unsafe.Add(ref entityFirst, index);
+                        throw new InvalidOperationException(
+                            $"massnav→kinematic bridge: massnav agent entity {entity.Id} carries a kinematic Mass2D body but no MovementParticipation. " +
+                            "Template authoring gap: declare movementParticipation with physicsPresence=Kinematic alongside the kinematic rigid body.");
+                    }
+                }
+            }
+        }
+
+        private void ValidateRadiusSsot(Entity entity, int agentIndex, MassNavigationSimulationRuntime runtime)
+        {
+            if (_validatedAgentIndexByEntity.TryGetValue(entity, out int validatedAgentIndex) &&
+                validatedAgentIndex == agentIndex)
+            {
+                return;
+            }
+
+            if (!World.TryGet(entity, out Collider2D collider))
+            {
+                throw new InvalidOperationException(
+                    $"massnav→kinematic bridge: kinematic massnav participant entity {entity.Id} has no Collider2D; " +
+                    "the kinematic physics half requires a circle collider matching the agent profile bodyRadiusCm.");
+            }
+
+            if (collider.Type != ColliderType2D.Circle)
+            {
+                throw new InvalidOperationException(
+                    $"massnav→kinematic bridge: kinematic massnav participant entity {entity.Id} declares a {collider.Type} collider; " +
+                    "the agent body contract is a circle whose radius is single-sourced from the agent profile bodyRadiusCm.");
+            }
+
+            if (!_shapeStorage.TryGetCircle(collider.ShapeDataIndex, out CircleShapeData circle))
+            {
+                throw new InvalidOperationException(
+                    $"massnav→kinematic bridge: entity {entity.Id} circle collider shape index {collider.ShapeDataIndex} does not resolve in ShapeDataStorage2D.");
+            }
+
+            float profileRadiusCm = runtime.GetAgentBodyRadiusCm(agentIndex);
+            Fix64 expectedRadius = Fix64.FromFloat(profileRadiusCm);
+            if (circle.Radius != expectedRadius)
+            {
+                throw new InvalidOperationException(
+                    $"massnav→kinematic bridge: radius drift on entity {entity.Id} (agent {agentIndex}): " +
+                    $"kinematic collider radius {circle.Radius.ToFloat()}cm != agent profile bodyRadiusCm {profileRadiusCm}cm. " +
+                    "The agent profile is the single source of truth for body radius; fix the physics template to match the profile.");
+            }
+
+            if (circle.LocalCenter.X != Fix64.Zero || circle.LocalCenter.Y != Fix64.Zero)
+            {
+                throw new InvalidOperationException(
+                    $"massnav→kinematic bridge: entity {entity.Id} kinematic circle collider has non-zero localCenterCm " +
+                    $"({circle.LocalCenter.X.ToFloat()}, {circle.LocalCenter.Y.ToFloat()}); the agent body disc must be centered on the entity pose.");
+            }
+
+            if (_validatedAgentIndexByEntity.Count >= _poseBuffer.Capacity &&
+                !_validatedAgentIndexByEntity.ContainsKey(entity))
+            {
+                PruneDeadValidationEntries();
+                if (_validatedAgentIndexByEntity.Count >= _poseBuffer.Capacity)
+                {
+                    throw new InvalidOperationException(
+                        $"massnav→kinematic bridge: live massnav kinematic participants exceed kinematicBodyCapacity={_poseBuffer.Capacity}; " +
+                        "raise 'Physics2D/kinematic.json' kinematicBodyCapacity to at least the participating unit count.");
+                }
+            }
+
+            _validatedAgentIndexByEntity[entity] = agentIndex;
+        }
+
+        private void PruneDeadValidationEntries()
+        {
+            _staleValidationEntries.Clear();
+            foreach (KeyValuePair<Entity, int> entry in _validatedAgentIndexByEntity)
+            {
+                if (!World.IsAlive(entry.Key))
+                {
+                    _staleValidationEntries.Add(entry.Key);
+                }
+            }
+
+            for (int i = 0; i < _staleValidationEntries.Count; i++)
+            {
+                _validatedAgentIndexByEntity.Remove(_staleValidationEntries[i]);
+            }
+        }
+    }
+}

--- a/src/Core/Ludots.Movement.Physics2DBridge/MassNavKinematicPoseFeedSystem2D.cs
+++ b/src/Core/Ludots.Movement.Physics2DBridge/MassNavKinematicPoseFeedSystem2D.cs
@@ -11,7 +11,7 @@ using Ludots.Core.Physics2D.Components;
 namespace Ludots.Core.Movement.Physics2DBridge
 {
     /// <summary>
-    /// massnav→kinematic 桥的位姿喂送半边（issue #643 增量 2 / #734）。
+    /// massnav→kinematic 桥的位姿喂送半边。
     ///
     /// 每个引擎固定步、在 Physics2D 步进之前，把 physicsPresence=Kinematic 且已绑定
     /// massnav agent 的实体的已提交 <see cref="WorldPositionCm"/>（Nav 写权由 entity-sync

--- a/src/Core/Ludots.Movement.Physics2DBridge/MovementPhysics2DBridgeInstaller.cs
+++ b/src/Core/Ludots.Movement.Physics2DBridge/MovementPhysics2DBridgeInstaller.cs
@@ -1,0 +1,55 @@
+using System;
+using Ludots.Core.Engine;
+using Ludots.Core.MassNavigation;
+using Ludots.Core.MassNavigation.Runtime;
+using Ludots.Core.Physics2D;
+using Ludots.Core.Physics2D.Ticking;
+using Ludots.Core.Scripting;
+
+namespace Ludots.Core.Movement.Physics2DBridge
+{
+    /// <summary>
+    /// massnav→kinematic 桥安装入口。GameEngine 在注册 Physics2D 系统后反射调用
+    /// （Physics2D 在场时桥为必装项，缺装即启动失败——不允许静默缺喂送）。
+    ///
+    /// 系统落位：
+    /// - <see cref="MassNavKinematicPoseFeedSystem2D"/> 插到 InputCollection 组
+    ///   Physics2DSimulationSystem 之前：喂送发生在上一固定步全部写权系统
+    ///   （PostMovement 的 massnav entity-sync、EffectProcessing 的位移窗口）提交之后、
+    ///   本固定步物理消费之前，同帧即被 KinematicDriveSystem2D 消费。
+    /// - <see cref="ContactEventRoutingSystem2D"/> 追加在 InputCollection 组
+    ///   Physics2DSimulationSystem 之后：满足「物理写、同帧 gameplay Drain」的 queue 合同。
+    /// </summary>
+    public static class MovementPhysics2DBridgeInstaller
+    {
+        public static void Install(GameEngine engine)
+        {
+            ArgumentNullException.ThrowIfNull(engine);
+
+            KinematicTargetPoseBuffer2D poseBuffer = engine.GetService(CoreServiceKeys.Physics2DKinematicPoseBuffer)
+                ?? throw new InvalidOperationException("massnav→kinematic bridge requires the Physics2D kinematic pose buffer service.");
+            ContactEventQueue2D contactEvents = engine.GetService(CoreServiceKeys.Physics2DContactEvents)
+                ?? throw new InvalidOperationException("massnav→kinematic bridge requires the Physics2D contact event queue service.");
+            var kinematicConfig = engine.GetService(CoreServiceKeys.Physics2DKinematicConfig)
+                ?? throw new InvalidOperationException("massnav→kinematic bridge requires the Physics2D kinematic config service.");
+            if (engine.GetService(CoreServiceKeys.Physics2DShapeStorage) is not ShapeDataStorage2D shapeStorage)
+            {
+                throw new InvalidOperationException("massnav→kinematic bridge requires the Physics2D shape storage service.");
+            }
+
+            var feedSystem = new MassNavKinematicPoseFeedSystem2D(
+                engine.World,
+                () => MassNavigationIds.TryGetCurrentNavigationRuntime(engine, out MassNavigationSimulationRuntime simulation)
+                    ? simulation
+                    : null,
+                poseBuffer,
+                shapeStorage);
+            engine.InsertSystemBeforeRequired<Physics2DSimulationSystem>(feedSystem, SystemGroup.InputCollection);
+            engine.SetService(MovementPhysics2DBridgeKeys.KinematicPoseFeedSystem, feedSystem);
+
+            var router = new ContactEventRouter2D(kinematicConfig.ContactEventEmitterLayers);
+            engine.RegisterSystem(new ContactEventRoutingSystem2D(contactEvents, router), SystemGroup.InputCollection);
+            engine.SetService(MovementPhysics2DBridgeKeys.ContactEventRouter, router);
+        }
+    }
+}

--- a/src/Core/Ludots.Movement.Physics2DBridge/MovementPhysics2DBridgeKeys.cs
+++ b/src/Core/Ludots.Movement.Physics2DBridge/MovementPhysics2DBridgeKeys.cs
@@ -1,0 +1,14 @@
+using Ludots.Core.Scripting;
+
+namespace Ludots.Core.Movement.Physics2DBridge
+{
+    /// <summary>massnav→kinematic 桥的服务键（消费者注册与可观测状态查询入口）。</summary>
+    public static class MovementPhysics2DBridgeKeys
+    {
+        public static readonly ServiceKey<ContactEventRouter2D> ContactEventRouter =
+            new("MovementPhysics2DBridge.ContactEventRouter");
+
+        public static readonly ServiceKey<MassNavKinematicPoseFeedSystem2D> KinematicPoseFeedSystem =
+            new("MovementPhysics2DBridge.KinematicPoseFeedSystem");
+    }
+}

--- a/src/Tests/GasTests/GasTests.csproj
+++ b/src/Tests/GasTests/GasTests.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\..\Core\Ludots.Core.csproj" />
     <ProjectReference Include="..\..\Core\Ludots.Physics.Broadphase\Ludots.Physics.Broadphase.csproj" />
     <ProjectReference Include="..\..\Core\Ludots.Physics2D\Ludots.Physics2D.csproj" />
+    <ProjectReference Include="..\..\Core\Ludots.Movement.Physics2DBridge\Ludots.Movement.Physics2DBridge.csproj" />
     <ProjectReference Include="..\..\Tools\Ludots.Launcher.Backend\Ludots.Launcher.Backend.csproj" />
     <ProjectReference Include="..\..\..\mods\LudotsCoreMod\LudotsCoreMod.csproj" />
     <ProjectReference Include="..\..\..\mods\CoreInputMod\CoreInputMod.csproj" />

--- a/src/Tests/PresentationTests/CrowdPhysicsArena/CapabilityStandardCrowdPhysicsArenaProductionPathTests.cs
+++ b/src/Tests/PresentationTests/CrowdPhysicsArena/CapabilityStandardCrowdPhysicsArenaProductionPathTests.cs
@@ -1,0 +1,248 @@
+using System;
+using System.IO;
+using System.Numerics;
+using Arch.Core;
+using CapabilityStandardCrowdPhysicsArenaMod;
+using Ludots.Core.Components;
+using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.Input.Config;
+using Ludots.Core.Input.Runtime;
+using Ludots.Core.MassNavigation;
+using Ludots.Core.MassNavigation.Runtime;
+using Ludots.Core.Movement.Physics2DBridge;
+using Ludots.Core.Physics2D;
+using Ludots.Core.Physics2D.Components;
+using Ludots.Core.Presentation.Config;
+using Ludots.Core.Presentation.Performers;
+using Ludots.Core.Scripting;
+using Ludots.Platform.Abstractions;
+using NUnit.Framework;
+
+namespace Ludots.Tests.Presentation
+{
+    [TestFixture]
+    public sealed class CapabilityStandardCrowdPhysicsArenaProductionPathTests
+    {
+        private const float FixedDeltaSeconds = 1f / 60f;
+        private const int MaxWarmupFrames = 240;
+
+        private static readonly string[] ShowcaseMods =
+        {
+            "LudotsCoreMod",
+            "CoreInputMod",
+            "MassNavigationMod",
+            "CapabilityStandardCrowdPhysicsArenaMod"
+        };
+
+        [SetUp]
+        public void SetUp()
+        {
+            AttributeRegistry.Clear();
+            TagRegistry.Clear();
+            PerformerScopeTagRegistry.Clear();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            AttributeRegistry.Clear();
+            TagRegistry.Clear();
+            PerformerScopeTagRegistry.Clear();
+        }
+
+        [Test]
+        public void Showcase_BootsArenaWithKinematicSquadsDrivenByBridge()
+        {
+            GC.KeepAlive(typeof(CapabilityStandardCrowdPhysicsArenaModEntry).Assembly);
+
+            using var engine = CreateEngine();
+            StartStartupMap(engine);
+
+            MassNavigationSimulationRuntime simulation = RequireMassNavigationSimulation(engine);
+            int expectedAgents = checked(simulation.Config.Scenario.Teams.Length * simulation.Config.Scenario.AgentsPerTeam);
+            Assert.That(expectedAgents, Is.EqualTo(96));
+
+            WaitForScenarioAgents(engine, simulation, expectedAgents);
+
+            // Every squad agent must be a kinematic physics participant driven by the massnav bridge.
+            var feedSystem = RequireService(engine, MovementPhysics2DBridgeKeys.KinematicPoseFeedSystem);
+            TickFrames(engine, 2);
+            Assert.That(feedSystem.LastFedParticipantCount, Is.EqualTo(expectedAgents),
+                "All arena squad agents must be fed into the kinematic pose buffer every fixed step.");
+
+            int kinematicAgents = 0;
+            var agentQuery = new QueryDescription()
+                .WithAll<MassNavigationAgentIndex, MovementParticipation, Mass2D, Position2D, WorldPositionCm>();
+            engine.World.Query(in agentQuery, (
+                Entity entity,
+                ref MassNavigationAgentIndex agentIndex,
+                ref MovementParticipation participation,
+                ref Mass2D mass,
+                ref Position2D position,
+                ref WorldPositionCm worldPosition) =>
+            {
+                Assert.That(participation.PhysicsPresence, Is.EqualTo(PhysicsPresenceKind.Kinematic));
+                Assert.That(mass.IsKinematic, Is.True);
+                Vector2 bodyCm = new((float)position.Value.X, (float)position.Value.Y);
+                Vector2 committedCm = worldPosition.Value.ToVector2();
+                Assert.That(Vector2.Distance(bodyCm, committedCm), Is.LessThanOrEqualTo(1f),
+                    $"Agent {agentIndex.Value}: kinematic body must mirror the committed WorldPositionCm.");
+                kinematicAgents++;
+            });
+            Assert.That(kinematicAgents, Is.EqualTo(expectedAgents));
+        }
+
+        private static void WaitForScenarioAgents(
+            GameEngine engine,
+            MassNavigationSimulationRuntime simulation,
+            int expectedAgents)
+        {
+            for (int frame = 0; frame < MaxWarmupFrames; frame++)
+            {
+                if (simulation.NavigationAgentCount >= expectedAgents)
+                {
+                    return;
+                }
+
+                TickFrames(engine, 1);
+            }
+
+            Assert.Fail(
+                $"Arena scenario did not spawn {expectedAgents} agents within {MaxWarmupFrames} frames " +
+                $"(current: {simulation.NavigationAgentCount}).");
+        }
+
+        private static void TickFrames(GameEngine engine, int frames)
+        {
+            for (int i = 0; i < frames; i++)
+            {
+                engine.SetService(CoreServiceKeys.UiCaptured, false);
+                engine.Tick(FixedDeltaSeconds);
+                HeadlessPresentationTestHost.UpdateCamera(engine);
+            }
+        }
+
+        private static void StartStartupMap(GameEngine engine)
+        {
+            Assert.That(engine.MergedConfig.StartupMapId, Is.EqualTo("crowd_physics_arena"));
+            Assert.That(engine.MergedConfig.StartupLocalPlayerId, Is.GreaterThan(0));
+
+            engine.Start();
+            engine.LoadStartupMap();
+            WaitForMassNavigationRuntimeReady(engine);
+        }
+
+        private static void WaitForMassNavigationRuntimeReady(GameEngine engine)
+        {
+            for (int frame = 0; frame < MaxWarmupFrames; frame++)
+            {
+                if (MassNavigationIds.IsCurrentNavigationRuntimeReady(engine))
+                {
+                    return;
+                }
+
+                TickFrames(engine, 1);
+            }
+
+            MassNavigationRuntimeBinding binding = RequireService(engine, MassNavigationKeys.RuntimeBinding);
+            Assert.Fail(
+                $"MassNavigation runtime did not become prepared within {MaxWarmupFrames} frames. " +
+                $"currentMap={engine.CurrentMapSession?.MapId.Value ?? "<none>"}, bindingMap={binding.CurrentMapId.Value ?? "<none>"}, revision={binding.Revision}, preparedRevision={binding.PreparedRevision}.");
+        }
+
+        private static MassNavigationSimulationRuntime RequireMassNavigationSimulation(GameEngine engine)
+        {
+            return RequireService(engine, MassNavigationKeys.RuntimeBinding).RequireCurrent();
+        }
+
+        private static GameEngine CreateEngine()
+        {
+            string repoRoot = FindRepoRoot();
+            var engine = new GameEngine();
+            engine.InitializeWithConfigPipeline(
+                RepoModPaths.ResolveExplicit(repoRoot, ShowcaseMods),
+                Path.Combine(repoRoot, "assets"));
+            ApplyHostAssets(engine);
+            InstallInput(engine);
+            HeadlessPresentationTestHost.Install(engine);
+            return engine;
+        }
+
+        private static void ApplyHostAssets(GameEngine engine)
+        {
+            var meshAssets = RequireService(engine, CoreServiceKeys.PresentationMeshAssetRegistry);
+            var materialAssets = RequireService(engine, CoreServiceKeys.PresentationMaterialRegistry);
+            new PresentationHostAssetConfigLoader(engine.ConfigPipeline, meshAssets, materialAssets)
+                .Apply("raylib", engine.ConfigCatalog, engine.ConfigConflictReport);
+        }
+
+        private static void InstallInput(GameEngine engine)
+        {
+            var inputConfig = new InputConfigPipelineLoader(engine.ConfigPipeline).Load();
+            var backend = new HeadlessInputBackend();
+            var inputHandler = new PlayerInputHandler(backend, inputConfig);
+            for (int i = 0; i < engine.MergedConfig.StartupInputContexts.Count; i++)
+            {
+                inputHandler.PushContext(engine.MergedConfig.StartupInputContexts[i]);
+            }
+
+            engine.SetService(CoreServiceKeys.InputHandler, inputHandler);
+            engine.SetService(CoreServiceKeys.InputBackend, (IInputBackend)backend);
+            engine.SetService(CoreServiceKeys.UiCaptured, false);
+        }
+
+        private static T RequireService<T>(GameEngine engine, ServiceKey<T> key)
+        {
+            T value = engine.GetService(key);
+            return value ?? throw new InvalidOperationException($"{key.Name} service is missing.");
+        }
+
+        private static string FindRepoRoot()
+        {
+            string current = TestContext.CurrentContext.WorkDirectory;
+            while (!string.IsNullOrEmpty(current))
+            {
+                if (Directory.Exists(Path.Combine(current, "mods")) &&
+                    File.Exists(Path.Combine(current, "AGENTS.md")))
+                {
+                    return current;
+                }
+
+                current = Path.GetDirectoryName(current)!;
+            }
+
+            throw new DirectoryNotFoundException("Repository root not found from test work directory.");
+        }
+
+        private sealed class HeadlessInputBackend : IInputBackend
+        {
+            private readonly HashSet<string> _pressedButtons = new(StringComparer.Ordinal);
+            private Vector2 _mousePosition;
+
+            public float GetAxis(string devicePath) => 0f;
+            public bool GetButton(string devicePath) => _pressedButtons.Contains(devicePath);
+            public Vector2 GetMousePosition() => _mousePosition;
+            public float GetMouseWheel() => 0f;
+            public void EnableIME(bool enable) { }
+            public void SetIMECandidatePosition(int x, int y) { }
+            public string GetCharBuffer() => string.Empty;
+
+            public void SetMousePosition(Vector2 mousePosition)
+            {
+                _mousePosition = mousePosition;
+            }
+
+            public void SetButton(string devicePath, bool pressed)
+            {
+                if (pressed)
+                {
+                    _pressedButtons.Add(devicePath);
+                    return;
+                }
+
+                _pressedButtons.Remove(devicePath);
+            }
+        }
+    }
+}

--- a/src/Tests/PresentationTests/CrowdPhysicsArena/CapabilityStandardCrowdPhysicsArenaProductionPathTests.cs
+++ b/src/Tests/PresentationTests/CrowdPhysicsArena/CapabilityStandardCrowdPhysicsArenaProductionPathTests.cs
@@ -1,19 +1,30 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
 using Arch.Core;
 using CapabilityStandardCrowdPhysicsArenaMod;
+using CapabilityStandardCrowdPhysicsArenaMod.Runtime;
+using CapabilityStandardCrowdPhysicsArenaMod.Systems;
 using Ludots.Core.Components;
 using Ludots.Core.Engine;
+using Ludots.Core.EntityCollections;
+using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.Gameplay.Relationships;
+using Ludots.Core.Gameplay.Spawning;
 using Ludots.Core.Input.Config;
+using Ludots.Core.Input.Orders;
 using Ludots.Core.Input.Runtime;
 using Ludots.Core.MassNavigation;
 using Ludots.Core.MassNavigation.Runtime;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Movement;
 using Ludots.Core.Movement.Physics2DBridge;
 using Ludots.Core.Physics2D;
 using Ludots.Core.Physics2D.Components;
 using Ludots.Core.Presentation.Config;
+using Ludots.Core.Presentation.Minimap;
 using Ludots.Core.Presentation.Performers;
 using Ludots.Core.Scripting;
 using Ludots.Platform.Abstractions;
@@ -26,6 +37,17 @@ namespace Ludots.Tests.Presentation
     {
         private const float FixedDeltaSeconds = 1f / 60f;
         private const int MaxWarmupFrames = 240;
+        private const int SettleFrames = 90;
+        private const int MarchBudgetFrames = 3600;
+        private const float ArrivalToleranceCm = 800f;
+        private const int ExpectedSquadSize = 48;
+        private const string MouseRightButtonPath = "<Mouse>/RightButton";
+        private const string SkillQKeyPath = "<Keyboard>/q";
+        private const string SkillEKeyPath = "<Keyboard>/e";
+        private const string CrateName = "CrowdPhysicsArena.Crate";
+        private const string BoulderName = "CrowdPhysicsArena.Boulder";
+
+        private static readonly QueryDescription DisplacementQuery = new QueryDescription().WithAll<DisplacementState>();
 
         private static readonly string[] ShowcaseMods =
         {
@@ -93,6 +115,341 @@ namespace Ludots.Tests.Presentation
             Assert.That(kinematicAgents, Is.EqualTo(expectedAgents));
         }
 
+        [Test]
+        public void Showcase_MarchThroughCrates_CratesDisplaceAndSquadArrives()
+        {
+            GC.KeepAlive(typeof(CapabilityStandardCrowdPhysicsArenaModEntry).Assembly);
+
+            using var engine = CreateEngine();
+            StartStartupMap(engine);
+            MassNavigationSimulationRuntime simulation = RequireMassNavigationSimulation(engine);
+            WaitForScenarioAgents(engine, simulation, 96);
+            ParkAllScenarioAgents(engine);
+
+            List<Entity> squad = CollectAgents(engine, controllable: true);
+            Assert.That(squad, Has.Count.EqualTo(ExpectedSquadSize));
+
+            List<(Entity Entity, Vector2 PositionCm)> cratesBefore = CaptureNamedBodies(engine, CrateName);
+            Assert.That(cratesBefore, Has.Count.EqualTo(6), "The arena map authors six crates in the corridor.");
+
+            var backend = RequireBackend(engine);
+            Entity localPlayer = RequireService(engine, CoreServiceKeys.LocalPlayerEntity);
+            ReplaceCommandSource(engine, localPlayer, squad.ToArray());
+
+            // The crate corridor sits at x 4250..4510; marching from the west spawn (~2400) to just
+            // past it forces the squad through the dynamic crate stack.
+            Vector2 target = DriveRightClickCommand(engine, backend, new Vector2(4900f, 5000f));
+
+            WaitUntil(
+                engine,
+                MarchBudgetFrames,
+                () => CountAgentsWithin(engine, squad, target, ArrivalToleranceCm) == squad.Count,
+                () => $"Only {CountAgentsWithin(engine, squad, target, ArrivalToleranceCm)} of {squad.Count} agents " +
+                    $"arrived within {ArrivalToleranceCm}cm of {target}. " +
+                    $"lastOrderMemberCount={simulation.LastOrderMemberCount}, firstAgent={ReadAgentPositionCm(engine, squad[0])}, " +
+                    $"centroid={ComputeCentroid(engine, squad)}, " +
+                    $"lastOrder={ReadDebugGlobal(engine, "CoreInputMod.Debug.LastOrder")}, " +
+                    $"lastGround={ReadDebugGlobal(engine, "CoreInputMod.Debug.LastGroundWorldCm")}, " +
+                    $"lastActivation={DescribeLastActivation(engine)}");
+
+            float maxCrateDisplacementCm = 0f;
+            foreach ((Entity crate, Vector2 before) in cratesBefore)
+            {
+                Vector2 after = ReadBodyPositionCm(engine, crate);
+                maxCrateDisplacementCm = MathF.Max(maxCrateDisplacementCm, Vector2.Distance(before, after));
+            }
+
+            Assert.That(maxCrateDisplacementCm, Is.GreaterThan(5f),
+                "Marching through the corridor must physically displace at least one dynamic crate.");
+        }
+
+        [Test]
+        public void Showcase_PressurePlate_CountsAgentBeginsAndOpensDoorAtThreshold()
+        {
+            GC.KeepAlive(typeof(CapabilityStandardCrowdPhysicsArenaModEntry).Assembly);
+
+            using var engine = CreateEngine();
+            StartStartupMap(engine);
+            MassNavigationSimulationRuntime simulation = RequireMassNavigationSimulation(engine);
+            WaitForScenarioAgents(engine, simulation, 96);
+            ParkAllScenarioAgents(engine);
+
+            CrowdPhysicsArenaPressurePlateDoorSystem plate =
+                RequireService(engine, CapabilityStandardCrowdPhysicsArenaModEntry.PressurePlateDoorSystemKey);
+            Assert.That(plate.AgentContactBeginCount, Is.Zero, "No agent may touch the plate before any orders.");
+            Assert.That(plate.OpenedDoorCount, Is.Zero);
+
+            List<Entity> squad = CollectAgents(engine, controllable: true);
+            Assert.That(squad, Has.Count.EqualTo(ExpectedSquadSize));
+            var backend = RequireBackend(engine);
+            Entity localPlayer = RequireService(engine, CoreServiceKeys.LocalPlayerEntity);
+
+            // Phase 1: send exactly four units straight across the plate (plate box: x 5560..5640,
+            // y 4580..5420), each on its own lane with its own arrival point so the runners never
+            // jostle each other back onto the plate. Expect exactly four Begin events and, once
+            // everyone left the plate, Begin == End with the door still closed (4 < threshold 20).
+            List<Entity> fourAcross = PickAgentsNearestToY(engine, squad, 5000f, 4);
+            fourAcross.Sort((a, b) => ReadAgentPositionCm(engine, a).Y.CompareTo(ReadAgentPositionCm(engine, b).Y));
+            float[] laneYs = { 4900f, 4970f, 5030f, 5100f };
+            var laneTargets = new Vector2[fourAcross.Count];
+            for (int i = 0; i < fourAcross.Count; i++)
+            {
+                ReplaceCommandSource(engine, localPlayer, new[] { fourAcross[i] });
+                laneTargets[i] = DriveRightClickCommand(engine, backend, new Vector2(6000f, laneYs[i]));
+            }
+
+            WaitUntil(
+                engine,
+                MarchBudgetFrames,
+                () => CountArrivedLaneRunners(engine, fourAcross, laneTargets, 300f) == fourAcross.Count,
+                () => $"Only {CountArrivedLaneRunners(engine, fourAcross, laneTargets, 300f)} of {fourAcross.Count} plate " +
+                    $"runners arrived at their lanes. plateBegin={plate.AgentContactBeginCount}, plateEnd={plate.AgentContactEndCount}");
+
+            // Runners keep creeping toward their exact lane targets after entering the arrival
+            // tolerance; wait until the last one has fully stepped off the plate.
+            WaitUntil(
+                engine,
+                600,
+                () => plate.AgentContactEndCount == plate.AgentContactBeginCount,
+                () => $"Plate contacts did not reconcile after the runners left. " +
+                    $"plateBegin={plate.AgentContactBeginCount}, plateEnd={plate.AgentContactEndCount}");
+
+            Assert.That(plate.AgentContactBeginCount, Is.EqualTo(fourAcross.Count),
+                "Each crossing agent must produce exactly one ContactBegin.");
+            Assert.That(plate.AgentContactEndCount, Is.EqualTo(plate.AgentContactBeginCount),
+                "After all runners left the plate, Begin and End counts must reconcile.");
+            Assert.That(plate.OpenedDoorCount, Is.Zero, "Four crossings are below the authored threshold of 20.");
+            Assert.That(ReadDoorOpenThreshold(engine), Is.EqualTo(20));
+
+            // Phase 2: march the whole squad across the plate. Begins are deduplicated per
+            // agent ("N units cross -> exactly N Begins"), so one full-squad crossing counts
+            // 48 distinct agents and clears the authored threshold of 20.
+            ReplaceCommandSource(engine, localPlayer, squad.ToArray());
+            DriveRightClickCommand(engine, backend, new Vector2(6000f, 5000f));
+            WaitUntil(
+                engine,
+                MarchBudgetFrames,
+                () => plate.OpenedDoorCount >= 1,
+                () => $"Door did not open after a full-squad crossing. plateBegin={plate.AgentContactBeginCount}, " +
+                    $"plateEnd={plate.AgentContactEndCount}, centroid={ComputeCentroid(engine, squad)}, " +
+                    $"lastActivation={DescribeLastActivation(engine)}");
+            Assert.That(plate.AgentContactBeginCount, Is.GreaterThanOrEqualTo(20));
+            AssertDoorObstacleSinksCleared(engine);
+        }
+
+        [Test]
+        public void Showcase_ShockwaveKnockback_WindowsRecoverAndSecondCastIsSafe()
+        {
+            GC.KeepAlive(typeof(CapabilityStandardCrowdPhysicsArenaModEntry).Assembly);
+
+            using var engine = CreateEngine();
+            StartStartupMap(engine);
+            MassNavigationSimulationRuntime simulation = RequireMassNavigationSimulation(engine);
+            WaitForScenarioAgents(engine, simulation, 96);
+            ParkAllScenarioAgents(engine);
+
+            List<Entity> squad = CollectAgents(engine, controllable: true);
+            Assert.That(squad, Has.Count.EqualTo(ExpectedSquadSize));
+            var backend = RequireBackend(engine);
+            Entity localPlayer = RequireService(engine, CoreServiceKeys.LocalPlayerEntity);
+            PoseAuthorityArbiter arbiter = RequireService(engine, CoreServiceKeys.PoseAuthorityArbiter);
+
+            // March into the open south-western field: the knockback scenario asserts full-squad
+            // recovery + arrival, so the route must not entangle the squad with the crate stack.
+            ReplaceCommandSource(engine, localPlayer, squad.ToArray());
+            Vector2 target = DriveRightClickCommand(engine, backend, new Vector2(3600f, 6600f));
+
+            // Let the squad march for ~2 simulated seconds, then detonate Q on its centroid.
+            TickFrames(engine, 120);
+            Vector2 centroid = ComputeCentroid(engine, squad);
+            DriveAbilityCast(engine, backend, SkillQKeyPath, centroid);
+
+            WaitUntil(
+                engine,
+                60,
+                () => CountDisplacements(engine) > 0,
+                () => "Q shockwave did not create any displacement effects.");
+
+            int hitCount = CountDisplacements(engine);
+            int peakWindows = arbiter.ActiveWindowCount;
+            for (int frame = 0; frame < 300 && (CountDisplacements(engine) > 0 || arbiter.ActiveWindowCount > 0); frame++)
+            {
+                hitCount = Math.Max(hitCount, CountDisplacements(engine));
+                peakWindows = Math.Max(peakWindows, arbiter.ActiveWindowCount);
+                TickFrames(engine, 1);
+            }
+
+            Assert.That(hitCount, Is.GreaterThan(0).And.LessThanOrEqualTo(squad.Count));
+            Assert.That(peakWindows, Is.EqualTo(hitCount),
+                "Every displaced agent must hold exactly one pose-authority window (M hits -> M windows).");
+            Assert.That(arbiter.ActiveWindowCount, Is.Zero, "All displacement windows must be handed back.");
+            Assert.That(CountDisplacements(engine), Is.Zero, "All displacement effects must complete.");
+
+            // Recovered agents must resume their original move order and reach the target. The
+            // full 48-agent formation plus post-knockback congestion settle spreads the tail of
+            // the crowd slightly wider than a clean march, hence the wider knockback tolerance.
+            const float knockbackArrivalToleranceCm = 1200f;
+            WaitUntil(
+                engine,
+                MarchBudgetFrames,
+                () => CountAgentsWithin(engine, squad, target, knockbackArrivalToleranceCm) == squad.Count,
+                () => $"After knockback recovery only {CountAgentsWithin(engine, squad, target, knockbackArrivalToleranceCm)} of " +
+                    $"{squad.Count} agents resumed and arrived near {target}. Stragglers: {DescribeStragglers(engine, squad, target, knockbackArrivalToleranceCm)}");
+
+            // Second cast: the arrival march far exceeds the 45-tick Q cooldown (issue #737 requires
+            // cooldown 2250ms > displacement.maxDurationMs 2000ms), so no unit is still inside a window.
+            Assert.That(arbiter.ActiveWindowCount, Is.Zero,
+                "No agent may still hold a displacement window before the second Q cast (issue #737 guard).");
+            Vector2 secondCentroid = ComputeCentroid(engine, squad);
+            DriveAbilityCast(engine, backend, SkillQKeyPath, secondCentroid);
+
+            WaitUntil(
+                engine,
+                60,
+                () => CountDisplacements(engine) > 0,
+                () => "Second Q cast did not create any displacement effects (cooldown should have expired).");
+
+            for (int frame = 0; frame < 300 && (CountDisplacements(engine) > 0 || arbiter.ActiveWindowCount > 0); frame++)
+            {
+                TickFrames(engine, 1);
+            }
+
+            Assert.That(arbiter.ActiveWindowCount, Is.Zero,
+                "Second shockwave must also hand every window back without exceptions.");
+            Assert.That(CountDisplacements(engine), Is.Zero);
+        }
+
+        [Test]
+        public void Showcase_BoulderWall_BoulderRepelledWhileUnitsStayBitwiseStill()
+        {
+            GC.KeepAlive(typeof(CapabilityStandardCrowdPhysicsArenaModEntry).Assembly);
+
+            using var engine = CreateEngine();
+            StartStartupMap(engine);
+            MassNavigationSimulationRuntime simulation = RequireMassNavigationSimulation(engine);
+            WaitForScenarioAgents(engine, simulation, 96);
+            ParkAllScenarioAgents(engine);
+
+            // The parked eastern squad forms the human wall around its spawn slots (~7600, 5000).
+            List<Entity> wall = CollectAgents(engine, controllable: false);
+            Assert.That(wall, Has.Count.EqualTo(ExpectedSquadSize));
+
+            Dictionary<int, (long X, long Y)> baseline = SnapshotAgentPositionsRaw(engine, wall);
+            TickFrames(engine, 90);
+            AssertAgentPositionsBitwiseEqual(engine, wall, baseline,
+                "Idle wall agents drifted before the boulder was released; the scenario baseline must be settled.");
+
+            var backend = RequireBackend(engine);
+            float wallMinX = float.MaxValue;
+            foreach (Entity agent in wall)
+            {
+                wallMinX = MathF.Min(wallMinX, ReadAgentPositionCm(engine, agent).X);
+            }
+
+            // E spawns the boulder at the cursor with an authored initial velocity of (-900, 0),
+            // rolling it westward into the wall.
+            DriveAbilityCast(engine, backend, SkillEKeyPath, new Vector2(8400f, 5000f));
+
+            Entity boulder = default;
+            WaitUntil(
+                engine,
+                60,
+                () => TryFindNamedBody(engine, BoulderName, out boulder),
+                () => "E cast did not spawn the boulder.");
+
+            float initialSpeed = ReadBodySpeedCmPerSec(engine, boulder);
+            Assert.That(initialSpeed, Is.GreaterThan(500f), "The boulder template authors a 900cm/s initial velocity.");
+
+            bool decayedOrRepelled = false;
+            float minBoulderX = float.MaxValue;
+            for (int frame = 0; frame < 900; frame++)
+            {
+                TickFrames(engine, 1);
+                float speed = ReadBodySpeedCmPerSec(engine, boulder);
+                float velocityX = (float)engine.World.Get<Velocity2D>(boulder).Linear.X;
+                minBoulderX = MathF.Min(minBoulderX, ReadBodyPositionCm(engine, boulder).X);
+                if (speed < initialSpeed * 0.5f || velocityX > 0f)
+                {
+                    decayedOrRepelled = true;
+                    break;
+                }
+            }
+
+            Assert.That(decayedOrRepelled, Is.True,
+                $"Boulder must decay or bounce against the kinematic wall (initial={initialSpeed}cm/s, " +
+                $"final={ReadBodySpeedCmPerSec(engine, boulder)}cm/s).");
+            Assert.That(minBoulderX, Is.GreaterThan(wallMinX),
+                "The boulder must not plow through the entire human wall.");
+
+            TickFrames(engine, 60);
+            AssertAgentPositionsBitwiseEqual(engine, wall, baseline,
+                "Kinematic wall agents must remain bitwise unmoved by the dynamic boulder impact.");
+        }
+
+        [Test]
+        public void Showcase_KinematicBudgetBelowUnitCount_FailsFastOnStartup()
+        {
+            GC.KeepAlive(typeof(CapabilityStandardCrowdPhysicsArenaModEntry).Assembly);
+
+            string tempModDir = Path.Combine(
+                Path.GetTempPath(),
+                "crowd_arena_kinematic_budget_" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                WriteKinematicBudgetOverrideMod(tempModDir, kinematicBodyCapacity: 32);
+
+                string repoRoot = FindRepoRoot();
+                List<string> modPaths = RepoModPaths.ResolveExplicit(repoRoot, ShowcaseMods);
+                modPaths.Add(tempModDir);
+
+                using var engine = new GameEngine();
+                engine.InitializeWithConfigPipeline(modPaths, Path.Combine(repoRoot, "assets"));
+                ApplyHostAssets(engine);
+                InstallInput(engine);
+                HeadlessPresentationTestHost.Install(engine);
+
+                var exception = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    engine.Start();
+                    engine.LoadStartupMap();
+                    for (int frame = 0; frame < MaxWarmupFrames * 3; frame++)
+                    {
+                        TickFrames(engine, 1);
+                    }
+                });
+
+                Assert.That(exception!.Message, Does.Contain("kinematicBodyCapacity"),
+                    "The massnav->kinematic bridge must fail fast when the kinematic budget is below the unit count.");
+            }
+            finally
+            {
+                if (Directory.Exists(tempModDir))
+                {
+                    Directory.Delete(tempModDir, recursive: true);
+                }
+            }
+        }
+
+        private static void WriteKinematicBudgetOverrideMod(string modDir, int kinematicBodyCapacity)
+        {
+            Directory.CreateDirectory(Path.Combine(modDir, "assets", "Configs", "Physics2D"));
+            File.WriteAllText(
+                Path.Combine(modDir, "mod.json"),
+                "{\n" +
+                "  \"name\": \"CrowdArenaKinematicBudgetOverrideTestMod\",\n" +
+                "  \"version\": \"1.0.0\",\n" +
+                "  \"description\": \"Test-only asset mod lowering kinematicBodyCapacity below the arena unit count to verify startup fail-fast.\",\n" +
+                "  \"priority\": -3000,\n" +
+                "  \"dependencies\": {\n" +
+                "    \"CapabilityStandardCrowdPhysicsArenaMod\": \"^1.0.0\"\n" +
+                "  },\n" +
+                "  \"author\": \"ProductionPathTests\"\n" +
+                "}\n");
+            File.WriteAllText(
+                Path.Combine(modDir, "assets", "Configs", "Physics2D", "kinematic.json"),
+                $"{{\n  \"kinematicBodyCapacity\": {kinematicBodyCapacity}\n}}\n");
+        }
+
         private static void WaitForScenarioAgents(
             GameEngine engine,
             MassNavigationSimulationRuntime simulation,
@@ -113,6 +470,78 @@ namespace Ludots.Tests.Presentation
                 $"(current: {simulation.NavigationAgentCount}).");
         }
 
+        private static string DescribeLastActivation(GameEngine engine)
+        {
+            InputOrderMappingSystem? mapping = engine.GetService(CoreServiceKeys.ActiveInputOrderMapping);
+            if (mapping == null)
+            {
+                return "<no mapping installed>";
+            }
+
+            var result = mapping.LastActivationResult;
+            return $"state={result.State}, rejection={result.Rejection}, actor={result.Actor.Id}, orderId={result.OrderId}";
+        }
+
+        private static string ReadDebugGlobal(GameEngine engine, string key)
+        {
+            return engine.GlobalContext.TryGetValue(key, out object? value) ? value?.ToString() ?? "<null>" : "<unset>";
+        }
+
+        private static void ParkAllScenarioAgents(GameEngine engine)
+        {
+            // Freshly spawned squads spread out from the spawn ring for a few simulated seconds.
+            // Wait until every agent's committed position is bitwise stable across consecutive
+            // frames so scenario phases start from a fully parked baseline.
+            const int parkBudgetFrames = 1800;
+            const int requiredStableFrames = 30;
+            List<Entity> agents = CollectAllAgents(engine);
+            Dictionary<int, (long X, long Y)> previous = SnapshotAgentPositionsRaw(engine, agents);
+            int stableFrames = 0;
+            for (int frame = 0; frame < parkBudgetFrames; frame++)
+            {
+                TickFrames(engine, 1);
+                Dictionary<int, (long X, long Y)> current = SnapshotAgentPositionsRaw(engine, agents);
+                stableFrames = PositionsBitwiseEqual(current, previous) ? stableFrames + 1 : 0;
+                previous = current;
+                if (stableFrames >= requiredStableFrames)
+                {
+                    return;
+                }
+            }
+
+            Assert.Fail(
+                $"Scenario agents did not park (bitwise-stable positions for {requiredStableFrames} consecutive frames) " +
+                $"within {parkBudgetFrames} frames.");
+        }
+
+        private static bool PositionsBitwiseEqual(
+            IReadOnlyDictionary<int, (long X, long Y)> a,
+            IReadOnlyDictionary<int, (long X, long Y)> b)
+        {
+            foreach (KeyValuePair<int, (long X, long Y)> pair in a)
+            {
+                if (!b.TryGetValue(pair.Key, out (long X, long Y) other) ||
+                    pair.Value.X != other.X ||
+                    pair.Value.Y != other.Y)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static List<Entity> CollectAllAgents(GameEngine engine)
+        {
+            var result = new List<Entity>();
+            var query = new QueryDescription().WithAll<MassNavigationAgent, MassNavigationAgentIndex, WorldPositionCm>();
+            engine.World.Query(in query, (Entity entity, ref MassNavigationAgent _, ref MassNavigationAgentIndex _, ref WorldPositionCm _) =>
+            {
+                result.Add(entity);
+            });
+            return result;
+        }
+
         private static void TickFrames(GameEngine engine, int frames)
         {
             for (int i = 0; i < frames; i++)
@@ -123,6 +552,272 @@ namespace Ludots.Tests.Presentation
             }
         }
 
+        private static void WaitUntil(GameEngine engine, int maxFrames, Func<bool> condition, Func<string> failMessage)
+        {
+            for (int frame = 0; frame < maxFrames; frame++)
+            {
+                if (condition())
+                {
+                    return;
+                }
+
+                TickFrames(engine, 1);
+            }
+
+            if (!condition())
+            {
+                Assert.Fail(failMessage());
+            }
+        }
+
+        private static List<Entity> CollectAgents(GameEngine engine, bool controllable)
+        {
+            Entity localPlayer = RequireService(engine, CoreServiceKeys.LocalPlayerEntity);
+            ControlDomainQuery domains = RequireService(engine, CoreServiceKeys.ControlDomainQuery);
+            var result = new List<Entity>();
+            var query = new QueryDescription().WithAll<MassNavigationAgent, MassNavigationAgentIndex, WorldPositionCm>();
+            engine.World.Query(in query, (Entity entity, ref MassNavigationAgent _, ref MassNavigationAgentIndex _, ref WorldPositionCm _) =>
+            {
+                if (domains.IsControllableBy(localPlayer, entity) == controllable)
+                {
+                    result.Add(entity);
+                }
+            });
+            return result;
+        }
+
+        private static int CountArrivedLaneRunners(
+            GameEngine engine,
+            List<Entity> runners,
+            Vector2[] laneTargets,
+            float toleranceCm)
+        {
+            int count = 0;
+            for (int i = 0; i < runners.Count; i++)
+            {
+                if (Vector2.Distance(ReadAgentPositionCm(engine, runners[i]), laneTargets[i]) <= toleranceCm)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        private static List<Entity> PickAgentsNearestToY(GameEngine engine, List<Entity> agents, float targetY, int count)
+        {
+            var sorted = new List<Entity>(agents);
+            sorted.Sort((a, b) =>
+                MathF.Abs(ReadAgentPositionCm(engine, a).Y - targetY)
+                    .CompareTo(MathF.Abs(ReadAgentPositionCm(engine, b).Y - targetY)));
+            return sorted.GetRange(0, count);
+        }
+
+        private static Vector2 ReadAgentPositionCm(GameEngine engine, Entity agent)
+        {
+            return engine.World.Get<WorldPositionCm>(agent).Value.ToVector2();
+        }
+
+        private static int CountAgentsWithin(GameEngine engine, List<Entity> agents, Vector2 target, float toleranceCm)
+        {
+            int count = 0;
+            foreach (Entity agent in agents)
+            {
+                if (Vector2.Distance(ReadAgentPositionCm(engine, agent), target) <= toleranceCm)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        private static string DescribeStragglers(GameEngine engine, List<Entity> agents, Vector2 target, float toleranceCm)
+        {
+            var parts = new List<string>();
+            foreach (Entity agent in agents)
+            {
+                Vector2 position = ReadAgentPositionCm(engine, agent);
+                if (Vector2.Distance(position, target) > toleranceCm)
+                {
+                    parts.Add($"agent {agent.Id} at {position} (dist {Vector2.Distance(position, target):0})");
+                }
+            }
+
+            return string.Join("; ", parts);
+        }
+
+        private static Vector2 ComputeCentroid(GameEngine engine, List<Entity> agents)
+        {
+            Vector2 sum = Vector2.Zero;
+            foreach (Entity agent in agents)
+            {
+                sum += ReadAgentPositionCm(engine, agent);
+            }
+
+            return sum / agents.Count;
+        }
+
+        private static Dictionary<int, (long X, long Y)> SnapshotAgentPositionsRaw(GameEngine engine, List<Entity> agents)
+        {
+            var snapshot = new Dictionary<int, (long X, long Y)>(agents.Count);
+            foreach (Entity agent in agents)
+            {
+                var position = engine.World.Get<WorldPositionCm>(agent).Value;
+                snapshot[agent.Id] = (position.X.RawValue, position.Y.RawValue);
+            }
+
+            return snapshot;
+        }
+
+        private static void AssertAgentPositionsBitwiseEqual(
+            GameEngine engine,
+            List<Entity> agents,
+            IReadOnlyDictionary<int, (long X, long Y)> baseline,
+            string message)
+        {
+            foreach (Entity agent in agents)
+            {
+                var position = engine.World.Get<WorldPositionCm>(agent).Value;
+                (long X, long Y) expected = baseline[agent.Id];
+                Assert.That(position.X.RawValue, Is.EqualTo(expected.X), $"{message} (agent {agent.Id} X)");
+                Assert.That(position.Y.RawValue, Is.EqualTo(expected.Y), $"{message} (agent {agent.Id} Y)");
+            }
+        }
+
+        private static List<(Entity Entity, Vector2 PositionCm)> CaptureNamedBodies(GameEngine engine, string name)
+        {
+            var result = new List<(Entity, Vector2)>();
+            var query = new QueryDescription().WithAll<Name, Position2D>();
+            engine.World.Query(in query, (Entity entity, ref Name entityName, ref Position2D position) =>
+            {
+                if (string.Equals(entityName.Value, name, StringComparison.Ordinal))
+                {
+                    result.Add((entity, new Vector2((float)position.Value.X, (float)position.Value.Y)));
+                }
+            });
+            return result;
+        }
+
+        private static bool TryFindNamedBody(GameEngine engine, string name, out Entity found)
+        {
+            List<(Entity Entity, Vector2 PositionCm)> bodies = CaptureNamedBodies(engine, name);
+            if (bodies.Count > 0)
+            {
+                found = bodies[0].Entity;
+                return true;
+            }
+
+            found = default;
+            return false;
+        }
+
+        private static Vector2 ReadBodyPositionCm(GameEngine engine, Entity body)
+        {
+            var position = engine.World.Get<Position2D>(body).Value;
+            return new Vector2((float)position.X, (float)position.Y);
+        }
+
+        private static float ReadBodySpeedCmPerSec(GameEngine engine, Entity body)
+        {
+            var velocity = engine.World.Get<Velocity2D>(body).Linear;
+            return new Vector2((float)velocity.X, (float)velocity.Y).Length();
+        }
+
+        private static int CountDisplacements(GameEngine engine)
+        {
+            return engine.World.CountEntities(in DisplacementQuery);
+        }
+
+        private static int ReadDoorOpenThreshold(GameEngine engine)
+        {
+            int threshold = 0;
+            var query = new QueryDescription().WithAll<CrowdPhysicsArenaDoor>();
+            engine.World.Query(in query, (ref CrowdPhysicsArenaDoor door) =>
+            {
+                threshold = door.OpenThresholdContacts;
+            });
+            Assert.That(threshold, Is.GreaterThan(0), "The arena map must author one door with a positive threshold.");
+            return threshold;
+        }
+
+        private static void AssertDoorObstacleSinksCleared(GameEngine engine)
+        {
+            int doors = 0;
+            var query = new QueryDescription().WithAll<CrowdPhysicsArenaDoor, ManifestationObstacleIntent2D>();
+            engine.World.Query(in query, (ref CrowdPhysicsArenaDoor _, ref ManifestationObstacleIntent2D intent) =>
+            {
+                doors++;
+                Assert.That(intent.SinkPhysicsCollider, Is.Zero, "Opened door must sink no physics collider.");
+                Assert.That(intent.SinkNavigationObstacle, Is.Zero, "Opened door must sink no navigation obstacle.");
+            });
+            Assert.That(doors, Is.EqualTo(1), "The arena map authors exactly one door.");
+        }
+
+        private static void ReplaceCommandSource(GameEngine engine, Entity owner, ReadOnlySpan<Entity> members)
+        {
+            EntityCollectionStore collections = RequireService(engine, CoreServiceKeys.EntityCollectionStore);
+            var descriptor = EntityCollectionDescriptor.Create(
+                EntityCollectionKeys.CommandSource,
+                EntityCollectionSourceKind.Explicit,
+                EntityCollectionRoleKind.CommandSource,
+                owner,
+                members.Length > 0 ? members[0] : Entity.Null,
+                "Command source",
+                $"{members.Length} entity(s)");
+            collections.Replace(owner, descriptor, members, owner);
+        }
+
+        private static Vector2 DriveRightClickCommand(GameEngine engine, HeadlessInputBackend backend, Vector2 worldCm)
+        {
+            Vector2 resolved = PointMouseAtGround(engine, backend, worldCm);
+            backend.SetButton(MouseRightButtonPath, false);
+            TickFrames(engine, 1);
+            backend.SetButton(MouseRightButtonPath, true);
+            TickFrames(engine, 1);
+            backend.SetButton(MouseRightButtonPath, false);
+            TickFrames(engine, 2);
+            return resolved;
+        }
+
+        private static Vector2 DriveAbilityCast(GameEngine engine, HeadlessInputBackend backend, string keyPath, Vector2 worldCm)
+        {
+            Vector2 resolved = PointMouseAtGround(engine, backend, worldCm);
+            backend.SetButton(keyPath, false);
+            TickFrames(engine, 1);
+            backend.SetButton(keyPath, true);
+            TickFrames(engine, 1);
+            backend.SetButton(keyPath, false);
+            TickFrames(engine, 2);
+            return resolved;
+        }
+
+        private static Vector2 PointMouseAtGround(GameEngine engine, HeadlessInputBackend backend, Vector2 worldCm)
+        {
+            // The relief heightmap sits hundreds of meters above y=0; projecting the ground point at
+            // its sampled terrain height keeps it in front of the camera (finite screen coordinates).
+            var heightmap = RequireService(engine, CoreServiceKeys.VisualHeightmap);
+            Assert.That(heightmap.TrySampleHeightCm(worldCm.X, worldCm.Y, out float groundHeightCm), Is.True,
+                $"Visual heightmap does not cover ground point {worldCm}.");
+            var projector = RequireService(engine, CoreServiceKeys.ScreenProjector);
+            Vector2 screen = projector.WorldToScreen(new Vector3(worldCm.X / 100f, groundHeightCm / 100f, worldCm.Y / 100f));
+            Assert.That(
+                AuthoritativeGroundPointerHelper.TryResolveFromScreen(engine.GlobalContext, screen, out WorldCmInt2 resolved),
+                Is.True,
+                $"Ground point {worldCm} did not resolve from screen point {screen}.");
+            MassNavigationSimulationRuntime simulation = RequireMassNavigationSimulation(engine);
+            Assert.That(simulation.ContainsWorldPoint(resolved.X, resolved.Y), Is.True,
+                $"Resolved ground point ({resolved.X}, {resolved.Y}) is outside the massnav solver window.");
+            backend.SetMousePosition(screen);
+            return new Vector2(resolved.X, resolved.Y);
+        }
+
+        private static HeadlessInputBackend RequireBackend(GameEngine engine)
+        {
+            return RequireService(engine, CoreServiceKeys.InputBackend) as HeadlessInputBackend
+                ?? throw new InvalidOperationException("Arena production path test requires the headless input backend.");
+        }
+
         private static void StartStartupMap(GameEngine engine)
         {
             Assert.That(engine.MergedConfig.StartupMapId, Is.EqualTo("crowd_physics_arena"));
@@ -131,6 +826,14 @@ namespace Ludots.Tests.Presentation
             engine.Start();
             engine.LoadStartupMap();
             WaitForMassNavigationRuntimeReady(engine);
+
+            // The showcase enables a large RTS full-map minimap panel whose input-capturing rect
+            // overlaps the screen projection of the arena landmarks (crate corridor, plate, ramp).
+            // These tests drive world-ground clicks, not minimap interactions, so hide the panel.
+            if (engine.GetService(CoreServiceKeys.MinimapRuntime) is MinimapRuntime minimap)
+            {
+                minimap.Visible = false;
+            }
         }
 
         private static void WaitForMassNavigationRuntimeReady(GameEngine engine)

--- a/src/Tests/PresentationTests/CrowdPhysicsArena/CapabilityStandardCrowdPhysicsArenaProductionPathTests.cs
+++ b/src/Tests/PresentationTests/CrowdPhysicsArena/CapabilityStandardCrowdPhysicsArenaProductionPathTests.cs
@@ -296,10 +296,10 @@ namespace Ludots.Tests.Presentation
                 () => $"After knockback recovery only {CountAgentsWithin(engine, squad, target, knockbackArrivalToleranceCm)} of " +
                     $"{squad.Count} agents resumed and arrived near {target}. Stragglers: {DescribeStragglers(engine, squad, target, knockbackArrivalToleranceCm)}");
 
-            // Second cast: the arrival march far exceeds the 45-tick Q cooldown (issue #737 requires
+            // Second cast: the arrival march far exceeds the 45-tick Q cooldown (the stacking guard requires
             // cooldown 2250ms > displacement.maxDurationMs 2000ms), so no unit is still inside a window.
             Assert.That(arbiter.ActiveWindowCount, Is.Zero,
-                "No agent may still hold a displacement window before the second Q cast (issue #737 guard).");
+                "No agent may still hold a displacement window before the second Q cast (stacking guard).");
             Vector2 secondCentroid = ComputeCentroid(engine, squad);
             DriveAbilityCast(engine, backend, SkillQKeyPath, secondCentroid);
 

--- a/src/Tests/PresentationTests/Movement/MassNavKinematicBridgeTests.cs
+++ b/src/Tests/PresentationTests/Movement/MassNavKinematicBridgeTests.cs
@@ -1,0 +1,449 @@
+using System;
+using Arch.Core;
+using Ludots.Core.Components;
+using Ludots.Core.Gameplay.Components;
+using Ludots.Core.Gameplay.GAS;
+using Ludots.Core.Gameplay.GAS.Systems;
+using Ludots.Core.Layers;
+using Ludots.Core.MassNavigation;
+using Ludots.Core.MassNavigation.Runtime;
+using Ludots.Core.MassNavigation.Systems;
+using Ludots.Core.Mathematics.FixedPoint;
+using Ludots.Core.Movement;
+using Ludots.Core.Movement.Physics2DBridge;
+using Ludots.Core.Physics2D;
+using Ludots.Core.Physics2D.Components;
+using Ludots.Core.Physics2D.Systems;
+using Ludots.Tests.Presentation;
+using NUnit.Framework;
+
+namespace Ludots.Tests.Presentation.Movement
+{
+    /// <summary>
+    /// Issue #643 增量 2 / #734：massnav→kinematic 桥的合同测试。
+    /// 覆盖：位姿喂送正确性（已提交 WorldPositionCm = kinematic body Position2D）、
+    /// 位移写权窗口中的单位仍被喂送、半径 SSOT 漂移 fail-fast、kinematicBodyCapacity
+    /// 不足 fail-fast、模板配对缺一半 fail-fast、稳态喂送零分配，
+    /// 以及碰撞事件路由（注册消费者分发、允许清单校验、丢弃计数、消费异常上抛）。
+    /// </summary>
+    [TestFixture]
+    public sealed class MassNavKinematicBridgeTests
+    {
+        private const int TeamId = 1;
+        private const float TickDt = 0.05f;
+        private const float ProfileBodyRadiusCm = 20f;
+
+        [Test]
+        public void NavAuthorityMarch_FeedsCommittedWorldPositionIntoKinematicBody()
+        {
+            using var harness = new KinematicBridgeHarness(
+                poseBufferCapacity: 8,
+                new BridgeAgentSpec(1000f, 1000f, KinematicParticipation(), PhysicsBody.KinematicCircle(ProfileBodyRadiusCm)));
+            Entity agent = harness.Agents[0];
+            harness.Simulation.SetAgentNavigationTargetWorldCm(0, 3000f, 1000f, resetRecovery: true);
+
+            harness.RunFixedTick(TickDt);
+            Fix64Vec2 committedAfterFirstTick = harness.World.Get<WorldPositionCm>(agent).Value;
+
+            harness.RunFixedTick(TickDt);
+            Fix64Vec2 bodyPosition = harness.World.Get<Position2D>(agent).Value;
+
+            Assert.That(harness.FeedSystem.LastFedParticipantCount, Is.EqualTo(1),
+                "the kinematic massnav participant must be fed every fixed step");
+            Assert.That(bodyPosition.X.RawValue, Is.EqualTo(committedAfterFirstTick.X.RawValue),
+                "kinematic body must mirror the committed WorldPositionCm of the previous fixed step verbatim (X)");
+            Assert.That(bodyPosition.Y.RawValue, Is.EqualTo(committedAfterFirstTick.Y.RawValue),
+                "kinematic body must mirror the committed WorldPositionCm of the previous fixed step verbatim (Y)");
+
+            Fix64Vec2 committedNow = harness.World.Get<WorldPositionCm>(agent).Value;
+            Assert.That(committedNow.X.RawValue, Is.Not.EqualTo(committedAfterFirstTick.X.RawValue),
+                "sanity: the agent must actually be marching so the mirrored pose is a moving target");
+        }
+
+        [Test]
+        public void DisplacedAgent_IsStillFedIntoKinematicBody()
+        {
+            using var harness = new KinematicBridgeHarness(
+                poseBufferCapacity: 8,
+                new BridgeAgentSpec(1000f, 1000f, KinematicParticipation(), PhysicsBody.KinematicCircle(ProfileBodyRadiusCm)));
+            Entity agent = harness.Agents[0];
+
+            // +Y 400cm / 8 tick 位移窗口：申请 tick + 提交 tick 后写权归 Displacement。
+            CreateFixedDirectionDisplacement(harness.World, agent, totalDistanceCm: 400, totalTicks: 8, directionDeg: 90f);
+            harness.RunFixedTick(TickDt);
+            harness.RunFixedTick(TickDt);
+            Assert.That(harness.World.Get<PoseAuthority>(agent).Value, Is.EqualTo(PoseAuthorityKind.Displacement),
+                "sanity: the displacement window must hold pose authority for this scenario");
+
+            Fix64Vec2 committedDuringWindow = harness.World.Get<WorldPositionCm>(agent).Value;
+            harness.RunFixedTick(TickDt);
+
+            Assert.That(harness.FeedSystem.LastFedParticipantCount, Is.EqualTo(1),
+                "a unit inside a displacement window must still be fed — the physics view never loses the unit");
+            Fix64Vec2 bodyPosition = harness.World.Get<Position2D>(agent).Value;
+            Assert.That(bodyPosition.X.RawValue, Is.EqualTo(committedDuringWindow.X.RawValue),
+                "kinematic body must mirror the displacement-committed WorldPositionCm (X)");
+            Assert.That(bodyPosition.Y.RawValue, Is.EqualTo(committedDuringWindow.Y.RawValue),
+                "kinematic body must mirror the displacement-committed WorldPositionCm (Y)");
+        }
+
+        [Test]
+        public void ColliderRadiusDriftingFromAgentProfile_Throws()
+        {
+            using var harness = new KinematicBridgeHarness(
+                poseBufferCapacity: 8,
+                new BridgeAgentSpec(1000f, 1000f, KinematicParticipation(), PhysicsBody.KinematicCircle(ProfileBodyRadiusCm + 5f)));
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                () => harness.RunFixedTick(TickDt))!;
+            Assert.That(ex.Message, Does.Contain("radius drift"));
+            Assert.That(ex.Message, Does.Contain("bodyRadiusCm"));
+        }
+
+        [Test]
+        public void ParticipantsExceedingKinematicBodyCapacity_Throw()
+        {
+            using var harness = new KinematicBridgeHarness(
+                poseBufferCapacity: 1,
+                new BridgeAgentSpec(1000f, 1000f, KinematicParticipation(), PhysicsBody.KinematicCircle(ProfileBodyRadiusCm)),
+                new BridgeAgentSpec(1200f, 1200f, KinematicParticipation(), PhysicsBody.KinematicCircle(ProfileBodyRadiusCm)));
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                () => harness.RunFixedTick(TickDt))!;
+            Assert.That(ex.Message, Does.Contain("kinematicBodyCapacity=1"));
+        }
+
+        [Test]
+        public void KinematicParticipationWithoutPhysicsBody_Throws()
+        {
+            using var harness = new KinematicBridgeHarness(
+                poseBufferCapacity: 8,
+                new BridgeAgentSpec(1000f, 1000f, KinematicParticipation(), PhysicsBody.None()));
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                () => harness.RunFixedTick(TickDt))!;
+            Assert.That(ex.Message, Does.Contain("missing its kinematic physics half"));
+        }
+
+        [Test]
+        public void KinematicBodyWithoutMovementParticipation_Throws()
+        {
+            using var harness = new KinematicBridgeHarness(
+                poseBufferCapacity: 8,
+                new BridgeAgentSpec(1000f, 1000f, participation: null, PhysicsBody.KinematicCircle(ProfileBodyRadiusCm)));
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                () => harness.RunFixedTick(TickDt))!;
+            Assert.That(ex.Message, Does.Contain("no MovementParticipation"));
+        }
+
+        [Test]
+        public void SteadyStatePoseFeed_AllocatesZeroBytes()
+        {
+            using var harness = new KinematicBridgeHarness(
+                poseBufferCapacity: 8,
+                new BridgeAgentSpec(1000f, 1000f, KinematicParticipation(), PhysicsBody.KinematicCircle(ProfileBodyRadiusCm)),
+                new BridgeAgentSpec(1200f, 1200f, KinematicParticipation(), PhysicsBody.KinematicCircle(ProfileBodyRadiusCm)));
+            harness.Simulation.SetAgentNavigationTargetWorldCm(0, 3000f, 1000f, resetRecovery: true);
+
+            for (int i = 0; i < 5; i++)
+            {
+                harness.RunFixedTick(TickDt);
+            }
+
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            for (int i = 0; i < 200; i++)
+            {
+                harness.FeedSystem.Update(TickDt);
+                harness.DriveSystem.Update(TickDt);
+            }
+
+            long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+            Assert.That(allocated, Is.Zero,
+                $"steady-state pose feed must be allocation free, but allocated {allocated} bytes over 200 fixed steps");
+        }
+
+        [Test]
+        public void ContactEventRouter_DispatchesRegisteredLayerAndCountsUnroutedAllowedLayers()
+        {
+            int plateIndex = LayerRegistry.Register("BridgeTest.Plate");
+            int crateIndex = LayerRegistry.Register("BridgeTest.Crate");
+            int agentIndex = LayerRegistry.Register("BridgeTest.Agent");
+            var router = new ContactEventRouter2D(new[] { "BridgeTest.Plate", "BridgeTest.Crate" });
+            var consumer = new RecordingConsumer();
+            router.RegisterConsumer("BridgeTest.Plate", consumer);
+
+            var routed = new ContactEvent2D
+            {
+                Type = ContactEventType2D.Begin,
+                LayerA = new LayerMask(1u << plateIndex, uint.MaxValue),
+                LayerB = new LayerMask(1u << agentIndex, uint.MaxValue),
+            };
+            var unroutedAllowed = new ContactEvent2D
+            {
+                Type = ContactEventType2D.End,
+                LayerA = new LayerMask(1u << crateIndex, uint.MaxValue),
+                LayerB = new LayerMask(1u << agentIndex, uint.MaxValue),
+            };
+            router.Dispatch(new[] { routed, unroutedAllowed });
+
+            Assert.That(consumer.BeginCount, Is.EqualTo(1), "the plate consumer must receive the Begin event exactly once");
+            Assert.That(consumer.EndCount, Is.Zero);
+            Assert.That(router.GetDroppedEventCount("BridgeTest.Crate"), Is.EqualTo(1),
+                "an unrouted event on an allow-listed layer must be counted, not silently discarded");
+            Assert.That(router.TotalDroppedEventCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ContactEventRouter_UnroutedEventOutsideAllowList_Throws()
+        {
+            int rogueIndex = LayerRegistry.Register("BridgeTest.Rogue");
+            var router = new ContactEventRouter2D(Array.Empty<string>());
+            var rogueEvent = new ContactEvent2D
+            {
+                Type = ContactEventType2D.Begin,
+                LayerA = new LayerMask(1u << rogueIndex, uint.MaxValue),
+                LayerB = new LayerMask(1u << rogueIndex, uint.MaxValue),
+            };
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+                () => router.Dispatch(new[] { rogueEvent }))!;
+            Assert.That(ex.Message, Does.Contain("pipeline defect"));
+        }
+
+        [Test]
+        public void ContactEventRouter_DuplicateConsumerRegistration_Throws()
+        {
+            LayerRegistry.Register("BridgeTest.Duplicate");
+            var router = new ContactEventRouter2D(new[] { "BridgeTest.Duplicate" });
+            router.RegisterConsumer("BridgeTest.Duplicate", new RecordingConsumer());
+
+            Assert.Throws<InvalidOperationException>(
+                () => router.RegisterConsumer("BridgeTest.Duplicate", new RecordingConsumer()));
+        }
+
+        [Test]
+        public void ContactEventRouter_ConsumerExceptionPropagates()
+        {
+            LayerRegistry.Register("BridgeTest.Faulty");
+            var router = new ContactEventRouter2D(new[] { "BridgeTest.Faulty" });
+            router.RegisterConsumer("BridgeTest.Faulty", new ThrowingConsumer());
+            int faultyIndex = LayerRegistry.GetIndex("BridgeTest.Faulty");
+            var contactEvent = new ContactEvent2D
+            {
+                Type = ContactEventType2D.Begin,
+                LayerA = new LayerMask(1u << faultyIndex, uint.MaxValue),
+                LayerB = new LayerMask(1u << faultyIndex, uint.MaxValue),
+            };
+
+            Assert.Throws<InvalidOperationException>(
+                () => router.Dispatch(new[] { contactEvent }),
+                "consumer failures must propagate — contact events are never silently swallowed");
+        }
+
+        private static MovementParticipation KinematicParticipation()
+        {
+            return new MovementParticipation
+            {
+                PhysicsPresence = PhysicsPresenceKind.Kinematic,
+                DisplacementAllowed = true,
+                DisplacementHandbackSpeedThresholdCmPerSec = 1f,
+                DisplacementMaxDurationMs = 10_000,
+            };
+        }
+
+        private static void CreateFixedDirectionDisplacement(
+            World world,
+            Entity target,
+            int totalDistanceCm,
+            int totalTicks,
+            float directionDeg)
+        {
+            world.Create(new DisplacementState
+            {
+                TargetEntity = target,
+                SourceEntity = target,
+                DirectionMode = DisplacementDirectionMode.Fixed,
+                FixedDirectionRad = Fix64.FromFloat(directionDeg) * Fix64.Deg2Rad,
+                TotalDistanceCm = totalDistanceCm,
+                RemainingDistanceCm = Fix64.FromInt(totalDistanceCm),
+                TotalDurationTicks = totalTicks,
+                RemainingTicks = totalTicks,
+                OverrideNavigation = false,
+            });
+        }
+
+        private sealed class RecordingConsumer : IContactEventConsumer2D
+        {
+            public int BeginCount { get; private set; }
+            public int EndCount { get; private set; }
+
+            public void OnContactEvent(in ContactEvent2D contactEvent)
+            {
+                if (contactEvent.Type == ContactEventType2D.Begin)
+                {
+                    BeginCount++;
+                }
+                else
+                {
+                    EndCount++;
+                }
+            }
+        }
+
+        private sealed class ThrowingConsumer : IContactEventConsumer2D
+        {
+            public void OnContactEvent(in ContactEvent2D contactEvent)
+            {
+                throw new InvalidOperationException("consumer failure for propagation test");
+            }
+        }
+
+        private readonly struct PhysicsBody
+        {
+            private PhysicsBody(bool hasBody, float colliderRadiusCm)
+            {
+                HasBody = hasBody;
+                ColliderRadiusCm = colliderRadiusCm;
+            }
+
+            public bool HasBody { get; }
+            public float ColliderRadiusCm { get; }
+
+            public static PhysicsBody KinematicCircle(float colliderRadiusCm) => new(true, colliderRadiusCm);
+            public static PhysicsBody None() => new(false, 0f);
+        }
+
+        private readonly struct BridgeAgentSpec
+        {
+            public BridgeAgentSpec(float worldXCm, float worldYCm, MovementParticipation? participation, PhysicsBody body)
+            {
+                WorldXCm = worldXCm;
+                WorldYCm = worldYCm;
+                Participation = participation;
+                Body = body;
+            }
+
+            public float WorldXCm { get; }
+            public float WorldYCm { get; }
+            public MovementParticipation? Participation { get; }
+            public PhysicsBody Body { get; }
+        }
+
+        /// <summary>
+        /// 无引擎固定步 harness，按 GameEngine SystemGroup 顺序驱动：
+        /// SchemaUpdate（写权结算）→ InputCollection（桥喂送 → 物理 kinematic drive）
+        /// → PostMovement（求解器步进 + displaced 回灌 + entity sync）→ EffectProcessing（GAS 位移）。
+        /// </summary>
+        private sealed class KinematicBridgeHarness : IDisposable
+        {
+            public KinematicBridgeHarness(int poseBufferCapacity, params BridgeAgentSpec[] specs)
+            {
+                World = World.Create();
+                MassNavigationConfig config = MassNavigationOrderChainTests.CreateConfigForTests();
+                config.ScenarioRuntime.RuntimeCapacity.DisplacedAgentCapacity = 8;
+                Simulation = new MassNavigationSimulationRuntime(config);
+                Simulation.BindBoardWorld(
+                    new Ludots.Core.Spatial.WorldSizeSpec(new Ludots.Core.Mathematics.WorldAabbCm(0, 0, 10_000, 10_000), 100),
+                    MassNavigationOrderChainTests.CreateLoadedChunksForTests(Simulation));
+
+                int layerIndex = LayerRegistry.Register(MassNavigationLayerNames.Agent);
+                uint mask = 1u << layerIndex;
+                var layer = new MassNavigationAgentLayer(mask, mask);
+                int profileId = MassNavigationProfileRegistry.Register("light");
+
+                ShapeStorage = new ShapeDataStorage2D();
+                PoseBuffer = new KinematicTargetPoseBuffer2D(poseBufferCapacity);
+
+                Agents = new Entity[specs.Length];
+                var seeds = new MassNavigationAgentSeed[specs.Length];
+                var controllable = new bool[specs.Length];
+                for (int i = 0; i < specs.Length; i++)
+                {
+                    BridgeAgentSpec spec = specs[i];
+                    Entity entity = World.Create(
+                        new MassNavigationAgent { ProfileId = profileId },
+                        WorldPositionCm.FromCmFloat(spec.WorldXCm, spec.WorldYCm),
+                        new EntityLayer(layer.CategoryMask, layer.InteractionMask),
+                        new FacingDirection { AngleRad = 0f });
+                    if (spec.Participation.HasValue)
+                    {
+                        World.Add(entity, spec.Participation.Value);
+                        World.Add(entity, new PoseAuthority
+                        {
+                            Value = MovementParticipationRules.DeriveInitialPoseAuthority(spec.Participation.Value.PhysicsPresence),
+                        });
+                    }
+
+                    if (spec.Body.HasBody)
+                    {
+                        World.Add(entity, Mass2D.Kinematic);
+                        World.Add(entity, new Position2D
+                        {
+                            Value = new Fix64Vec2(Fix64.FromFloat(spec.WorldXCm), Fix64.FromFloat(spec.WorldYCm)),
+                        });
+                        World.Add(entity, new Velocity2D());
+                        World.Add(entity, new Collider2D
+                        {
+                            Type = ColliderType2D.Circle,
+                            ShapeDataIndex = ShapeStorage.RegisterCircle(Fix64.FromFloat(spec.Body.ColliderRadiusCm)),
+                        });
+                    }
+
+                    Agents[i] = entity;
+                    seeds[i] = new MassNavigationAgentSeed(
+                        teamId: TeamId,
+                        localPositionXCm: spec.WorldXCm,
+                        localPositionYCm: spec.WorldYCm,
+                        heavy: false,
+                        navMass: 1f,
+                        visualScale: 1f,
+                        bodyRadiusCm: ProfileBodyRadiusCm,
+                        speedCmPerSecond: 800f,
+                        layer);
+                    controllable[i] = true;
+                }
+
+                Simulation.RebuildFromAuthoredAgents(World, Agents, seeds, controllable);
+
+                Arbiter = new PoseAuthorityArbiter();
+                Arbiter.AddListener(new MassNavigationPoseAuthorityBridge(() => Simulation));
+                CommitSystem = new PoseAuthorityCommitSystem(World, Arbiter);
+                DisplacementSystem = new DisplacementRuntimeSystem(World, Arbiter);
+                FeedSystem = new MassNavKinematicPoseFeedSystem2D(World, () => Simulation, PoseBuffer, ShapeStorage);
+                DriveSystem = new KinematicDriveSystem2D(World, PoseBuffer);
+            }
+
+            public World World { get; }
+            public MassNavigationSimulationRuntime Simulation { get; }
+            public PoseAuthorityArbiter Arbiter { get; }
+            public PoseAuthorityCommitSystem CommitSystem { get; }
+            public DisplacementRuntimeSystem DisplacementSystem { get; }
+            public MassNavKinematicPoseFeedSystem2D FeedSystem { get; }
+            public KinematicDriveSystem2D DriveSystem { get; }
+            public KinematicTargetPoseBuffer2D PoseBuffer { get; }
+            public ShapeDataStorage2D ShapeStorage { get; }
+            public Entity[] Agents { get; }
+
+            public void RunFixedTick(float dt)
+            {
+                CommitSystem.Update(dt);
+                FeedSystem.Update(dt);
+                DriveSystem.Update(dt);
+                Simulation.StepNavigationForTests(World, dt, runHardResolve: true);
+                Simulation.MassNavigationFlow.SyncDisplacedAgentPoses(World, Simulation.AgentState);
+                Simulation.MassNavigationFlow.SyncEntities(World, Simulation.AgentState);
+                DisplacementSystem.Update(dt);
+            }
+
+            public void Dispose()
+            {
+                CommitSystem.Dispose();
+                DisplacementSystem.Dispose();
+                FeedSystem.Dispose();
+                DriveSystem.Dispose();
+                World.Dispose();
+            }
+        }
+    }
+}

--- a/src/Tests/PresentationTests/PresentationTests.csproj
+++ b/src/Tests/PresentationTests/PresentationTests.csproj
@@ -45,6 +45,7 @@
     <ProjectReference Include="..\..\..\mods\showcases\performer_blacksmith\PerformerBlacksmithShowcaseMod\PerformerBlacksmithShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\capabilities\navigation\MassNavigationMod\MassNavigationMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\capability_standard\CapabilityStandardMassNavigationLargeWorld10kMod\CapabilityStandardMassNavigationLargeWorld10kMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\capability_standard\CapabilityStandardCrowdPhysicsArenaMod\CapabilityStandardCrowdPhysicsArenaMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\formation_capability\FormationCapabilityShowcaseMod\FormationCapabilityShowcaseMod.csproj" />
     <ProjectReference Include="..\..\..\mods\showcases\raylib_ism_benchmark\RaylibIsmBenchmarkShowcaseMod\RaylibIsmBenchmarkShowcaseMod.csproj" />
   </ItemGroup>

--- a/src/Tests/PresentationTests/PresentationTests.csproj
+++ b/src/Tests/PresentationTests/PresentationTests.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Core\Ludots.Core.csproj" />
     <ProjectReference Include="..\..\Core\Ludots.Physics2D\Ludots.Physics2D.csproj" />
+    <ProjectReference Include="..\..\Core\Ludots.Movement.Physics2DBridge\Ludots.Movement.Physics2DBridge.csproj" />
     <ProjectReference Include="..\..\Libraries\Ludots.UI.Skia\Ludots.UI.Skia.csproj" />
     <ProjectReference Include="..\..\Libraries\Ludots.Presentation.Skia\Ludots.Presentation.Skia.csproj" />
     <ProjectReference Include="..\..\Client\Ludots.Client.Raylib\Ludots.Client.Raylib.csproj" />

--- a/src/Tests/ThreeCTests/ThreeCTests.csproj
+++ b/src/Tests/ThreeCTests/ThreeCTests.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\Core\Ludots.Core.csproj" />
     <ProjectReference Include="..\..\Core\Ludots.Physics.Broadphase\Ludots.Physics.Broadphase.csproj" />
     <ProjectReference Include="..\..\Core\Ludots.Physics2D\Ludots.Physics2D.csproj" />
+    <ProjectReference Include="..\..\Core\Ludots.Movement.Physics2DBridge\Ludots.Movement.Physics2DBridge.csproj" />
     <ProjectReference Include="..\..\Adapters\Web\Ludots.Adapter.Web\Ludots.Adapter.Web.csproj" />
     <ProjectReference Include="..\..\Libraries\Ludots.Presentation.Skia\Ludots.Presentation.Skia.csproj" />
     <ProjectReference Include="..\..\Tools\Ludots.Launcher.Backend\Ludots.Launcher.Backend.csproj" />

--- a/src/Tools/Ludots.Editor.Bridge/Ludots.Editor.Bridge.csproj
+++ b/src/Tools/Ludots.Editor.Bridge/Ludots.Editor.Bridge.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Core\Ludots.Core.csproj" />
     <ProjectReference Include="..\..\Core\Ludots.Physics2D\Ludots.Physics2D.csproj" />
+    <ProjectReference Include="..\..\Core\Ludots.Movement.Physics2DBridge\Ludots.Movement.Physics2DBridge.csproj" />
     <ProjectReference Include="..\Ludots.Launcher.Backend\Ludots.Launcher.Backend.csproj" />
     <ProjectReference Include="..\Ludots.Tool\Ludots.Tool.csproj" />
     <ProjectReference Include="..\Ludots.NavBake.Recast\Ludots.NavBake.Recast.csproj" />

--- a/src/Tools/Ludots.Tool/Ludots.Tool.csproj
+++ b/src/Tools/Ludots.Tool/Ludots.Tool.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Core\Ludots.Core.csproj" />
     <ProjectReference Include="..\..\Core\Ludots.Physics2D\Ludots.Physics2D.csproj" />
+    <ProjectReference Include="..\..\Core\Ludots.Movement.Physics2DBridge\Ludots.Movement.Physics2DBridge.csproj" />
     <ProjectReference Include="..\Ludots.NavBake.Recast\Ludots.NavBake.Recast.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# 概要

落地 issue #734 全部内容：#643 增量 2 的 massnav→kinematic 组合层桥，加 capability-standard showcase「Crowd Physics Arena」。玩家 60 秒上手：框选小队右键行军推开木箱、踩压力板逐人计数开门、Q 冲击波击飞后队友绕行倒地者并恢复行军、E 巨石撞不动人墙。

# 交付内容

**桥（组合层新程序集 `Ludots.Movement.Physics2DBridge`，两侧内核零改动）**：
- `MassNavKinematicPoseFeedSystem2D`：每固定步把 `physicsPresence=Kinematic` 参与单位的已提交 `WorldPositionCm` 喂入 `SetKinematicTargetPose`（位移中单位照喂——物理视角单位永远在场）；kinematic collider 半径与 agent profile `bodyRadiusCm` 同源校验，漂移抛异常；缺半边（有 participation 无物理体或反之）抛异常；容量预检；热路径预分配零分配（有 GC 断言测试）。
- `ContactEventRouter2D` + `ContactEventRoutingSystem2D`：物理步后 Drain 事件队列，按 `EntityLayer` 路由注册消费者。
- 顺手修复一个双写违规：位移窗口对 kinematic 参与单位不再直写 `Position2D`（物理位姿由 pose buffer → `KinematicDriveSystem2D` 唯一驱动，保证速度推导正确）。

**Showcase（`CapabilityStandardCrowdPhysicsArenaMod`，binding `capability_standard_crowd_physics_arena`）**：
- 2 队 × 48 单位（配置化）、木箱堆、压力板+门（阈值 20）、斜坡巨石，全数据驱动；
- Q 冲击波 = 纯既有 effect 步骤组合（`CreateUnit` epicenter + `Search` + `Displacement`，零新 enum/handler，composition gate 自审在 `artifacts/gas-composition-gate.md`）；**冷却 45tick@20Hz=2250ms > 位移窗口上限 2000ms > 实际位移 1200ms**，README 记录该不变量——在 #739（叠加=替换合同）合入前从数据上杜绝叠加崩溃；
- 压力板按**去重 agent** 计数（N 单位过板恰好 N 次），Begin/End 对账可查询；板体经组合层锚定组件固定在授权位置 + 薄条形状压制穿透修正叠加（详见下方缺口备案 1）；
- HUD 三数字（已选/恢复中/踩板人次）；registry、gitbook 表格、launcher preset 三处注册；README 玩家视角操作说明。

**测试**：`MassNavKinematicBridgeTests`（11）+ `CapabilityStandardCrowdPhysicsArenaProductionPathTests`（6 个全引擎用例：行军推箱、踩板计数与开门、击退恢复+按冷却二次施放无窗口冲突、巨石人墙 agent 逐位不动、kinematic 预算 fail-fast）。

# 验证证据（验收者独立复跑）

```text
CrowdPhysicsArena|MassNavKinematicBridge:  Passed! 17/17
MassNavigation:                            Passed! 98/98（基线保持）
GasTests Physics2D|Displacement:           Passed! 82/82（基线保持）
ArchitectureTests:                         Passed! 191（1 skip 存量 Explicit）
```

# 实现中发现的引擎缺口备案（本 PR 已用 mod 层方案绕开，不阻塞合并，供后续排期）

1. **宽相排除 kinematic×static 使"静态传感器"不可表达**：PRD 设想压力板 = static 传感器 + 事件发射，但宽相按设计排除 kinematic×static 配对，kinematic 人群踩静态板永远不产生接触事件。本 PR 的替代：板保持 dynamic + `PlateAnchor` 每固定步钉回授权位置；副作用是几十个零逆质量 kinematic 体挤压单个 dynamic 体时，子步内穿透修正逐对叠加会把板推飞（实测单子步 +1800cm），靠锚定 + 薄条形状压制。若触发区玩法增多，值得给宽相加"emitter-aware 的 kinematic×static 配对"（只发事件、不进求解），届时锚定方案可退役。
2. **`EffectTemplateLoader.ParseLayerMask` 抛 `NotImplementedException`**：GAS `Search` 的 layer 过滤 authoring 入口存在但未实现，属运行时才炸的暗坑。本 PR 用 `SpatialPartitionExcluded` 绕开。建议实现之，或改为加载期显式"未支持"校验错误。

# 合并顺序与 #739 的关系

- 与 PR #739（位移窗口终止路径/叠加替换合同）在 `DisplacementRuntimeSystem` 有共同文件但不同 hunk（本 PR 只加 `ApplyPositionStep` 的 kinematic 守卫），预计可自动合并；建议 **先合 #739，本 PR rebase 后合**。
- #739 合入后，Q 技能的冷却>窗口约束从"防崩溃的硬性要求"降级为普通平衡参数（叠加击退届时是合法替换语义）；README 的不变量说明可在后续增量放宽。

# 验收备注

- 验收清理提交 `7e782e3f`：按仓库注释纪律清除代码注释与合同错误消息中的 issue/PR 编号（12 处）。
- 实现过程有两个 agent 先后接力（中途误判一次假死），双方交错提交但最终状态经双方与验收者三方核对一致；探针调试测试未进提交，测试运行副产物已还原。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca6bcf12-8b5f-4aa9-8df0-86526f4de03b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca6bcf12-8b5f-4aa9-8df0-86526f4de03b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

