### PR TITLE
fix(docs): 理清玩家动作图鉴排版

### DIFF
--- a/gitbook/reference/player-action-ux/catalog-app.js
+++ b/gitbook/reference/player-action-ux/catalog-app.js
@@ -271,7 +271,7 @@
    * Standard Mermaid sequenceDiagram:
    * 玩家 → 输入 → 画面 → 手感, one rect block per storyboard beat.
    */
-  function sequenceMermaid(beats) {
+  function sequenceMermaid(beats, onlyIndex = null) {
     const lines = [
       "sequenceDiagram",
       "  actor P as 玩家",
@@ -279,7 +279,9 @@
       "  participant S as 画面",
       "  participant F as 手感",
     ];
-    (beats || []).forEach((b, i) => {
+    const list = beats || [];
+    list.forEach((b, i) => {
+      if (onlyIndex != null && i !== onlyIndex) return;
       const title = mmdText(b.title || `步骤 ${i + 1}`);
       lines.push("  rect rgba(240, 163, 94, 0.08)");
       lines.push(`    Note over P,F: T${i + 1} ${title}`);
@@ -375,11 +377,10 @@
       return;
     }
     listEl.innerHTML = cases.map((c) => `
-      <button type="button" class="case-row ${selectedId === c.id ? "active" : ""}" data-id="${esc(c.id)}">
+      <button type="button" class="case-row ${selectedId === c.id ? "active" : ""}" data-id="${esc(c.id)}" title="${esc(c.id)}">
         <span class="title">${esc(c.title)}</span>
         <span class="beats">${c.beats.length} 镜</span>
         <p class="sub">${esc(c.summary)}</p>
-        <span class="meta">${esc(c.id)}</span>
       </button>`).join("");
     listEl.querySelectorAll(".case-row").forEach((btn) => {
       btn.addEventListener("click", () => {
@@ -393,19 +394,28 @@
     });
   }
 
-  function bindBeatSync(beatCount) {
-    const setBeat = (i) => {
-      activeBeat = Math.max(0, Math.min(beatCount - 1, i));
-      detailEl.querySelectorAll("[data-beat]").forEach((el) => {
-        el.classList.toggle("active", Number(el.dataset.beat) === activeBeat);
-      });
-      const panel = detailEl.querySelector(`.panel[data-beat="${activeBeat}"]`);
-      if (panel) panel.scrollIntoView({ block: "nearest", inline: "nearest", behavior: "smooth" });
-    };
-    detailEl.querySelectorAll("[data-beat]").forEach((el) => {
-      el.addEventListener("click", () => setBeat(Number(el.dataset.beat)));
+  function renderBeatStage(c) {
+    const beat = c.beats[activeBeat];
+    if (!beat) return;
+    const mmd = sequenceMermaid(c.beats, activeBeat);
+    const shot = `
+      <article class="panel">
+        ${storyboardSvg(beat, activeBeat)}
+        <div class="panel-cap">
+          <div class="cap-row"><span class="k">输入</span><span class="v">${esc(beat.input)}</span></div>
+          <div class="cap-row"><span class="k">画面</span><span class="v">${esc(beat.screen)}</span></div>
+          <div class="cap-row"><span class="k">手感</span><span class="v">${esc(beat.feel)}</span></div>
+        </div>
+      </article>`;
+    const mmdHost = detailEl.querySelector("#mmd-host");
+    const shotHost = detailEl.querySelector("#shot-host");
+    if (!mmdHost || !shotHost) return;
+    mmdHost.innerHTML = `<pre class="mermaid" data-pending="1">${esc(mmd)}</pre>`;
+    shotHost.innerHTML = shot;
+    detailEl.querySelectorAll(".beat-chip").forEach((el) => {
+      el.classList.toggle("active", Number(el.dataset.beat) === activeBeat);
     });
-    setBeat(activeBeat);
+    paintDetailMermaid().catch((err) => console.error(err));
   }
 
   function renderDetail() {
@@ -418,58 +428,50 @@
     const tags = (c.genres || []).map((g) => `<span class="tag">${esc(g)}</span>`).join("");
     const todos = (c.todos || []).map((t) => `<li>${esc(t)}</li>`).join("");
     const chips = c.beats.map((b, i) =>
-      `<button type="button" class="beat-chip" data-beat="${i}">T${i + 1} ${esc(b.title || "")}</button>`
+      `<button type="button" class="beat-chip ${i === activeBeat ? "active" : ""}" data-beat="${i}">T${i + 1} ${esc(b.title || "")}</button>`
     ).join("");
-    const panels = c.beats.map((b, i) => `
-      <article class="panel" data-beat="${i}">
-        ${storyboardSvg(b, i)}
-        <div class="panel-cap">
-          <div class="cap-row"><span class="k">输入</span><span class="v">${esc(b.input)}</span></div>
-          <div class="cap-row"><span class="k">画面</span><span class="v">${esc(b.screen)}</span></div>
-          <div class="cap-row"><span class="k">手感</span><span class="v">${esc(b.feel)}</span></div>
-        </div>
-      </article>`).join("");
-    const mmd = sequenceMermaid(c.beats);
-    const cp = data.checkpoint || {};
     detailEl.innerHTML = `
       <div class="detail-inner">
-        <div class="detail-head">
-          <h2>${esc(c.title)}</h2>
-          <span class="case-id">${esc(c.id)}</span>
-        </div>
-        <p class="summary">${esc(c.summary)}</p>
-        <div class="tags">${tags}</div>
-
-        <div class="impl-grid">
-          <div class="impl-card">
-            <div class="section-label">Ludots 现状</div>
-            <p>${esc(c.ludots || "未标注")}</p>
+        <div class="detail-top">
+          <div class="detail-head">
+            <h2>${esc(c.title)}</h2>
+            <span class="case-id">${esc(c.id)}</span>
           </div>
-          <div class="impl-card impl-todo">
-            <div class="section-label">缺口 TODO</div>
-            ${todos ? `<ul>${todos}</ul>` : `<p class="ok">本条暂无额外 TODO</p>`}
-          </div>
+          <p class="summary">${esc(c.summary)}</p>
+          <div class="tags">${tags}</div>
+          <div class="beat-rail" aria-label="分镜拍号">${chips}</div>
+          <details class="impl-details">
+            <summary>Ludots 现状 / 缺口 TODO</summary>
+            <div class="impl-line">
+              <div class="impl-card">
+                <div class="section-label">Ludots 现状</div>
+                <p>${esc(c.ludots || "未标注")}</p>
+              </div>
+              <div class="impl-card impl-todo">
+                <div class="section-label">缺口 TODO</div>
+                ${todos ? `<ul>${todos}</ul>` : `<p class="ok">本条暂无额外 TODO</p>`}
+              </div>
+            </div>
+          </details>
         </div>
-
-        <div class="beat-rail" aria-label="分镜拍号">${chips}</div>
-        <p class="sync-hint">左时序 · 右分镜 — 点拍号两侧同步高亮（checkpoint ${esc(cp.head || "?")}）</p>
-
         <div class="sync-split">
           <div class="sync-col">
-            <p class="section-label">Mermaid 时序</p>
-            <div class="mmd-box">
-              <pre class="mermaid" data-pending="1">${esc(mmd)}</pre>
-            </div>
+            <div class="section-label">时序 · 当前拍</div>
+            <div class="mmd-box" id="mmd-host"></div>
           </div>
           <div class="sync-col">
-            <p class="section-label">分镜（与左拍同步）</p>
-            <div class="storyboard storyboard-stack" aria-label="分镜条">${panels}</div>
+            <div class="section-label">分镜 · 当前拍</div>
+            <div class="storyboard storyboard-stack" id="shot-host" aria-label="当前分镜"></div>
           </div>
         </div>
       </div>`;
-    detailEl.scrollTop = 0;
-    bindBeatSync(c.beats.length);
-    paintDetailMermaid().catch((err) => console.error(err));
+    detailEl.querySelectorAll(".beat-chip").forEach((el) => {
+      el.addEventListener("click", () => {
+        activeBeat = Number(el.dataset.beat);
+        renderBeatStage(c);
+      });
+    });
+    renderBeatStage(c);
   }
 
   function render() {

--- a/gitbook/reference/player-action-ux/catalog.css
+++ b/gitbook/reference/player-action-ux/catalog.css
@@ -8,12 +8,10 @@
   --line: #2c3645;
   --accent: #f0a35e;
   --accent2: #6ec8ff;
-  --panel: #161b22;
+  --ok: #5dce8f;
   --serif: "Fraunces", "Songti SC", "Noto Serif SC", Georgia, serif;
   --sans: "DM Sans", "PingFang SC", "Noto Sans SC", "Segoe UI", sans-serif;
   --mono: "IBM Plex Mono", "SFMono-Regular", Menlo, monospace;
-  --topbar-h: 88px;
-  --foot-h: 36px;
 }
 
 * { box-sizing: border-box; }
@@ -29,333 +27,367 @@ html, body {
 
 a { color: var(--accent2); text-decoration: none; }
 a:hover { text-decoration: underline; }
-code { font-family: var(--mono); font-size: 0.92em; }
+code { font-family: var(--mono); font-size: 0.9em; }
 
 .app {
   height: 100dvh;
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
-  background:
-    radial-gradient(900px 420px at 8% -20%, #243044 0%, transparent 55%),
-    radial-gradient(700px 360px at 92% 0%, #3a2a1c 0%, transparent 50%),
-    var(--bg0);
+  grid-template-rows: 56px minmax(0, 1fr) 32px;
 }
 
+/* ===== top ===== */
 .topbar {
-  display: grid;
-  grid-template-columns: minmax(220px, 1.1fr) minmax(0, 1.4fr) auto;
-  gap: 16px 24px;
+  display: flex;
   align-items: center;
-  padding: 14px 18px;
+  gap: 16px;
+  padding: 0 16px;
   border-bottom: 1px solid var(--line);
-  background: rgba(14, 17, 22, 0.92);
-  backdrop-filter: blur(8px);
-  min-height: var(--topbar-h);
+  background: #12161d;
+  min-width: 0;
 }
 
+.brand { min-width: 0; flex: 0 1 auto; }
 .kicker {
-  font-size: 11px;
-  letter-spacing: 0.2em;
+  font-size: 10px;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--accent);
   font-weight: 700;
-  margin-bottom: 4px;
+  line-height: 1.2;
 }
-
 .topbar h1 {
-  font-family: var(--serif);
-  font-size: clamp(22px, 2.4vw, 30px);
-  line-height: 1.15;
   margin: 0;
+  font-family: var(--serif);
+  font-size: 18px;
   font-weight: 650;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-
 .topbar .lead {
   margin: 0;
-  color: var(--muted);
-  font-size: 13.5px;
-  line-height: 1.55;
-  max-width: 52ch;
+  flex: 1 1 auto;
+  min-width: 0;
+  color: var(--faint);
+  font-size: 12.5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-
 .hero-meta {
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  justify-content: flex-end;
+  gap: 6px;
+  flex: 0 0 auto;
 }
-
 .chip {
   border: 1px solid var(--line);
   background: var(--bg1);
   color: var(--muted);
   border-radius: 999px;
-  padding: 6px 10px;
-  font-size: 12px;
+  padding: 4px 9px;
+  font-size: 11.5px;
   white-space: nowrap;
 }
-
 .chip strong { color: var(--ink); }
 
+/* ===== workspace ===== */
 .workspace {
   min-height: 0;
   display: grid;
-  grid-template-columns: 240px minmax(260px, 340px) minmax(0, 1fr);
-  gap: 0;
-  border-bottom: 1px solid var(--line);
+  grid-template-columns: 190px 250px minmax(0, 1fr);
+  overflow: hidden;
 }
 
 .pane {
+  min-width: 0;
   min-height: 0;
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+  display: flex;
+  flex-direction: column;
   border-right: 1px solid var(--line);
-  background: rgba(22, 27, 34, 0.55);
+  background: var(--bg1);
+  overflow: hidden;
 }
-
 .pane:last-child { border-right: 0; }
 
 .pane-head {
-  padding: 10px 12px;
+  flex: 0 0 auto;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  border-bottom: 1px solid var(--line);
+  background: #12161d;
   font-size: 11px;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--faint);
   font-weight: 700;
-  border-bottom: 1px solid var(--line);
-  background: rgba(0, 0, 0, 0.18);
-}
-
-.pane-head-tools {
-  display: flex;
-  align-items: center;
-  gap: 10px;
 }
 
 .pane-head-tools input {
   flex: 1;
   min-width: 0;
+  height: 28px;
   border: 1px solid var(--line);
   background: var(--bg0);
   color: var(--ink);
-  border-radius: 8px;
-  padding: 7px 10px;
+  border-radius: 6px;
+  padding: 0 8px;
   font: inherit;
-  font-size: 13px;
+  font-size: 12.5px;
   text-transform: none;
   letter-spacing: 0;
   font-weight: 400;
 }
-
 .pane-head-tools input:focus {
-  outline: 2px solid rgba(240, 163, 94, 0.35);
+  outline: 2px solid rgba(240, 163, 94, 0.3);
   border-color: var(--accent);
 }
 
 .pane-body {
+  flex: 1 1 auto;
   min-height: 0;
   overflow: auto;
   overscroll-behavior: contain;
-  scrollbar-gutter: stable;
 }
 
-.pane-body::-webkit-scrollbar { width: 10px; height: 10px; }
-.pane-body::-webkit-scrollbar-thumb {
-  background: #3a4658;
-  border-radius: 999px;
-  border: 2px solid transparent;
-  background-clip: padding-box;
-}
-
-/* ---- nav ---- */
+/* ===== nav ===== */
 .nav-btn {
   display: block;
   width: 100%;
   text-align: left;
   border: 0;
-  border-bottom: 1px solid rgba(44, 54, 69, 0.55);
+  border-bottom: 1px solid rgba(44, 54, 69, 0.45);
   background: transparent;
   color: var(--muted);
-  padding: 10px 12px;
+  padding: 9px 10px;
   cursor: pointer;
   font: inherit;
-  font-size: 13px;
+  font-size: 12.5px;
   line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-
 .nav-btn:hover { background: var(--bg2); color: var(--ink); }
 .nav-btn.active {
   background: #243041;
   color: var(--ink);
   box-shadow: inset 3px 0 0 var(--accent);
 }
-.nav-btn .count { color: var(--faint); font-size: 12px; }
+.nav-btn .count { color: var(--faint); }
 
-/* ---- case list rows ---- */
+/* ===== list ===== */
 .case-row {
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: 6px 10px;
+  grid-template-rows: auto auto;
+  column-gap: 8px;
+  row-gap: 4px;
   width: 100%;
   text-align: left;
   border: 0;
-  border-bottom: 1px solid rgba(44, 54, 69, 0.55);
+  border-bottom: 1px solid rgba(44, 54, 69, 0.45);
   background: transparent;
   color: inherit;
-  padding: 12px 12px 11px;
+  padding: 10px 12px;
   cursor: pointer;
   font: inherit;
 }
-
-.case-row:hover { background: rgba(36, 48, 65, 0.75); }
+.case-row:hover { background: rgba(36, 48, 65, 0.7); }
 .case-row.active {
   background: #243041;
   box-shadow: inset 3px 0 0 var(--accent2);
 }
-
 .case-row .title {
-  font-size: 14.5px;
+  font-size: 13.5px;
   font-weight: 650;
   color: var(--ink);
-  line-height: 1.35;
+  line-height: 1.3;
+  min-width: 0;
 }
-
-.case-row .sub {
-  grid-column: 1 / -1;
-  margin: 0;
-  color: var(--muted);
-  font-size: 12.5px;
-  line-height: 1.45;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-.case-row .meta {
-  font-family: var(--mono);
-  font-size: 10.5px;
-  color: var(--faint);
-  align-self: start;
-}
-
 .case-row .beats {
   font-size: 11px;
   color: var(--accent);
   font-weight: 700;
   white-space: nowrap;
 }
-
-/* ---- detail ---- */
+.case-row .sub {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+/* ===== detail: single scroll-free stage ===== */
 .pane-detail {
-  background: rgba(14, 17, 22, 0.35);
+  background: #12161d;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .detail-inner {
-  padding: 16px 18px 28px;
+  flex: 1 1 auto;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 8px;
+  padding: 10px 12px 10px;
+  overflow: hidden;
+}
+
+.detail-top {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.impl-details {
+  border: 0;
+  background: transparent;
+  padding: 0;
+}
+.impl-details > summary {
+  cursor: pointer;
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 0;
+  color: var(--accent2);
+  font-size: 12px;
+  font-weight: 650;
+  user-select: none;
+}
+.impl-details > summary::before {
+  content: "▸";
+  color: var(--faint);
+  font-size: 11px;
+}
+.impl-details[open] > summary::before { content: "▾"; }
+.impl-details > summary::-webkit-details-marker { display: none; }
+.impl-details[open] {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.22);
+  padding: 8px 10px;
+}
+.impl-details[open] > summary { margin-bottom: 8px; color: var(--muted); }
+.impl-details .impl-line { margin-top: 2px; }
+.impl-card p, .impl-card ul {
+  -webkit-line-clamp: unset;
+  display: block;
+  overflow: visible;
 }
 
 .detail-head {
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px 14px;
-  justify-content: space-between;
   align-items: baseline;
-  margin-bottom: 8px;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
 }
-
 .detail-head h2 {
   margin: 0;
   font-family: var(--serif);
-  font-size: 26px;
+  font-size: 22px;
   font-weight: 650;
   line-height: 1.2;
+  min-width: 0;
 }
-
 .case-id {
   font-family: var(--mono);
-  font-size: 11.5px;
+  font-size: 11px;
   color: var(--faint);
+  flex: 0 0 auto;
 }
 
+.detail-meta {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
 .summary {
-  margin: 0 0 12px;
+  margin: 0;
   color: var(--muted);
-  line-height: 1.65;
-  font-size: 14.5px;
+  font-size: 13px;
+  line-height: 1.5;
 }
-
-.tags { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 16px; }
+.tags { display: flex; flex-wrap: wrap; gap: 5px; }
 .tag {
-  font-size: 11.5px;
+  font-size: 11px;
   color: var(--accent2);
   border: 1px solid rgba(110, 200, 255, 0.28);
   background: rgba(110, 200, 255, 0.08);
   border-radius: 999px;
-  padding: 3px 9px;
+  padding: 2px 8px;
 }
 
-.section-label {
-  font-size: 11px;
-  letter-spacing: 0.18em;
+.impl-line {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  min-width: 0;
+}
+.impl-card {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.25);
+  padding: 8px 10px;
+}
+.impl-card .section-label {
+  margin: 0 0 4px;
+  font-size: 10px;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--faint);
-  margin: 0 0 8px;
   font-weight: 700;
 }
-
-.impl-grid {
-  display: grid;
-  grid-template-columns: 1.3fr 1fr;
-  gap: 10px;
-  margin-bottom: 14px;
-}
-
-.impl-card {
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  background: rgba(0, 0, 0, 0.22);
-  padding: 10px 12px;
-}
-
 .impl-card p, .impl-card li {
   margin: 0;
   color: var(--muted);
-  font-size: 13px;
-  line-height: 1.55;
+  font-size: 12px;
+  line-height: 1.45;
 }
-
 .impl-card ul {
   margin: 0;
   padding-left: 1.1em;
 }
-
-.impl-todo {
-  border-color: rgba(240, 163, 94, 0.35);
-  background: rgba(240, 163, 94, 0.06);
+.impl-card p, .impl-card ul {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
-
+.impl-todo { border-color: rgba(240, 163, 94, 0.35); }
 .impl-todo li { color: #e7c39a; }
-.impl-card .ok { color: var(--ally, #5dce8f); }
+.impl-card .ok { color: var(--ok); }
 
 .beat-rail {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  margin-bottom: 6px;
+  align-items: center;
+  min-width: 0;
 }
-
 .beat-chip {
   border: 1px solid var(--line);
   background: var(--bg1);
   color: var(--muted);
   border-radius: 999px;
-  padding: 5px 10px;
+  padding: 4px 10px;
   font: inherit;
   font-size: 12px;
   cursor: pointer;
 }
-
 .beat-chip:hover { color: var(--ink); border-color: var(--accent2); }
 .beat-chip.active {
   color: #0b0e13;
@@ -364,147 +396,131 @@ code { font-family: var(--mono); font-size: 0.92em; }
   font-weight: 700;
 }
 
-.sync-hint {
-  margin: 0 0 10px;
-  color: var(--faint);
-  font-size: 12px;
-}
-
+/* sync stage: equal columns, fill leftover height, ONE scrollbar each at most */
 .sync-split {
+  min-height: 0;
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: 12px;
-  align-items: start;
-  min-height: 0;
-}
-
-.sync-col { min-width: 0; }
-
-.mmd-box {
-  width: 100%;
-  border: 1px solid var(--line);
-  border-radius: 12px;
-  background: var(--bg1);
-  overflow: auto;
-  margin-bottom: 0;
-  padding: 12px 10px 4px;
-  max-height: min(58vh, 560px);
-}
-
-.mmd-box pre.mermaid {
-  margin: 0;
-  color: var(--muted);
-  font-family: var(--mono);
-  font-size: 12px;
-  white-space: pre-wrap;
-}
-
-.mmd-box svg {
-  display: block;
-  max-width: 100%;
-  height: auto;
-  margin: 0 auto 8px;
-}
-
-.mmd-box .mmd-error {
-  margin: 0;
-  padding: 12px;
-  color: #ef6b6b;
-  font-family: var(--mono);
-  font-size: 12px;
-  white-space: pre-wrap;
-  background: rgba(239, 107, 107, 0.08);
-  border-radius: 8px;
-}
-
-.storyboard {
-  display: grid;
   gap: 10px;
+  overflow: hidden;
+}
+.sync-col {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--bg1);
+}
+.sync-col .section-label {
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--line);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--faint);
+  font-weight: 700;
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.mmd-box,
+.storyboard {
+  flex: 1 1 auto;
+  min-height: 0;
   overflow: auto;
   overscroll-behavior: contain;
   padding: 10px;
-  max-height: min(58vh, 560px);
-  background: linear-gradient(180deg, #12171f 0%, #0e1218 100%);
-  border: 1px solid var(--line);
-  border-radius: 14px;
+  max-height: none;
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
 }
 
+.mmd-box .mermaid,
+.mmd-box svg {
+  display: block;
+  width: 100% !important;
+  max-width: 100% !important;
+  height: auto !important;
+}
+.mmd-box .mmd-error {
+  margin: 0;
+  padding: 10px;
+  color: #ef6b6b;
+  font-family: var(--mono);
+  font-size: 11px;
+  white-space: pre-wrap;
+}
+
+.storyboard-stack {
+  display: block;
+}
 .storyboard-stack .panel {
-  position: relative;
-  min-width: 0;
-  padding: 8px;
-  border: 1px solid transparent;
-  border-radius: 12px;
-  cursor: pointer;
-  opacity: 0.55;
-  transition: opacity 0.15s, border-color 0.15s, background 0.15s;
-}
-
-.storyboard-stack .panel:hover { opacity: 0.85; }
-.storyboard-stack .panel.active {
+  margin: 0;
+  padding: 0;
+  border: 0;
   opacity: 1;
-  border-color: var(--accent);
-  background: rgba(240, 163, 94, 0.06);
+  background: transparent;
+  cursor: default;
 }
-
-.panel::after { display: none; }
-
 .panel .story-svg {
   display: block;
   width: 100%;
   height: auto;
-  filter: drop-shadow(0 8px 18px rgba(0, 0, 0, 0.35));
 }
-
 .panel-cap {
-  padding: 10px 11px 12px;
-  border-top: 1px solid var(--line);
+  margin-top: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.25);
   display: grid;
-  gap: 6px;
-  background: rgba(0, 0, 0, 0.2);
-  border-radius: 0 0 10px 10px;
+  gap: 5px;
 }
-
 .cap-row {
   display: grid;
-  grid-template-columns: 42px 1fr;
+  grid-template-columns: 36px 1fr;
   gap: 8px;
   font-size: 12px;
-  line-height: 1.45;
+  line-height: 1.4;
 }
-
-.cap-row .k {
-  color: var(--faint);
-  font-weight: 700;
-}
-
+.cap-row .k { color: var(--faint); font-weight: 700; }
 .cap-row .v { color: var(--muted); }
 
 .empty, .empty-detail {
-  padding: 36px 20px;
+  padding: 28px 16px;
   text-align: center;
   color: var(--faint);
-  line-height: 1.6;
+  line-height: 1.55;
+  font-size: 13px;
 }
 
 .foot {
-  height: var(--foot-h);
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 0 18px;
+  padding: 0 14px;
+  border-top: 1px solid var(--line);
   color: var(--faint);
-  font-size: 12px;
-  background: rgba(11, 14, 19, 0.95);
+  font-size: 11.5px;
+  background: #0b0e13;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
-/* mobile: stacked panes, each with own scroll */
+.sync-hint { display: none; }
+
 @media (max-width: 1100px) {
-  .sync-split { grid-template-columns: 1fr; }
-  .impl-grid { grid-template-columns: 1fr; }
+  .workspace { grid-template-columns: 180px 240px minmax(0, 1fr); }
+  .impl-line { grid-template-columns: 1fr; }
 }
 
-@media (max-width: 960px) {
+@media (max-width: 900px) {
   html, body { overflow: auto; height: auto; }
   .app {
     height: auto;
@@ -512,14 +528,21 @@ code { font-family: var(--mono); font-size: 0.92em; }
     grid-template-rows: auto auto auto;
   }
   .topbar {
-    grid-template-columns: 1fr;
-    align-items: start;
+    flex-wrap: wrap;
+    height: auto;
+    padding: 10px 12px;
   }
-  .hero-meta { justify-content: flex-start; }
+  .topbar .lead { white-space: normal; }
   .workspace {
     grid-template-columns: 1fr;
-    grid-template-rows: minmax(140px, 22vh) minmax(180px, 28vh) minmax(50vh, auto);
+    grid-template-rows: 160px 200px minmax(70vh, auto);
   }
   .pane { border-right: 0; border-bottom: 1px solid var(--line); }
-  .mmd-box, .storyboard { max-height: none; }
+  .pane-detail { min-height: 70vh; }
+  .detail-inner { overflow: auto; }
+  .sync-split {
+    grid-template-columns: 1fr;
+    min-height: 520px;
+  }
+  .sync-col { min-height: 240px; }
 }

--- a/gitbook/reference/player-action-ux/index.html
+++ b/gitbook/reference/player-action-ux/index.html
@@ -17,9 +17,7 @@
         <div class="kicker">Ludots · Player Action UX</div>
         <h1>玩家动作 UX 分镜图鉴</h1>
       </div>
-      <p class="lead">
-        左分类 · 中列表 · 右详情。详情内时序与分镜左右同步，并标注 Ludots 现状与缺口。
-      </p>
+      <p class="lead">分类 · 列表 · 详情；点拍号切换时序与分镜</p>
       <div class="hero-meta" id="stats" aria-live="polite"></div>
     </header>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述
修好图鉴排版混乱：去掉详情区双层滚动和分镜堆叠，改成「当前一拍」左右等高等宽对照。

## 改动
- 顶栏压扁；三栏固定高度，各自只滚自己的列表
- 详情主区只显示**当前拍**的 Mermaid 时序 | 分镜，等高并排
- Ludots 现状 / TODO 默认折叠，不占主视觉
- 点 T1/T2 两侧一起换

[理清后的三栏布局](https://cursor.com/agents/bc-6dbfc1fe-4147-482c-bdfd-87fe90a54211/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fplayer-action-ux-layout-fixed.webp)

## UAT
```gherkin
Scenario: 详情不乱滚
  Given 打开玩家动作 UX 分镜图鉴
  Then 右侧主区域左右两栏为当前拍时序与分镜
  And Ludots/TODO 默认折叠
  When 我点 T2
  Then 左右两栏同时换成第 2 拍
```


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6dbfc1fe-4147-482c-bdfd-87fe90a54211?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dbfc1fe-4147-482c-bdfd-87fe90a54211&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

