### PR TITLE
fix(docs): 图鉴滚动条统一 / 多镜全显 / 顶栏压扁

### DIFF
--- a/gitbook/reference/player-action-ux/catalog-app.js
+++ b/gitbook/reference/player-action-ux/catalog-app.js
@@ -271,7 +271,7 @@
    * Standard Mermaid sequenceDiagram:
    * 玩家 → 输入 → 画面 → 手感, one rect block per storyboard beat.
    */
-  function sequenceMermaid(beats, onlyIndex = null) {
+  function sequenceMermaid(beats) {
     const lines = [
       "sequenceDiagram",
       "  actor P as 玩家",
@@ -279,9 +279,7 @@
       "  participant S as 画面",
       "  participant F as 手感",
     ];
-    const list = beats || [];
-    list.forEach((b, i) => {
-      if (onlyIndex != null && i !== onlyIndex) return;
+    (beats || []).forEach((b, i) => {
       const title = mmdText(b.title || `步骤 ${i + 1}`);
       lines.push("  rect rgba(240, 163, 94, 0.08)");
       lines.push(`    Note over P,F: T${i + 1} ${title}`);
@@ -394,28 +392,18 @@
     });
   }
 
-  function renderBeatStage(c) {
-    const beat = c.beats[activeBeat];
-    if (!beat) return;
-    const mmd = sequenceMermaid(c.beats, activeBeat);
-    const shot = `
-      <article class="panel">
-        ${storyboardSvg(beat, activeBeat)}
-        <div class="panel-cap">
-          <div class="cap-row"><span class="k">输入</span><span class="v">${esc(beat.input)}</span></div>
-          <div class="cap-row"><span class="k">画面</span><span class="v">${esc(beat.screen)}</span></div>
-          <div class="cap-row"><span class="k">手感</span><span class="v">${esc(beat.feel)}</span></div>
-        </div>
-      </article>`;
-    const mmdHost = detailEl.querySelector("#mmd-host");
-    const shotHost = detailEl.querySelector("#shot-host");
-    if (!mmdHost || !shotHost) return;
-    mmdHost.innerHTML = `<pre class="mermaid" data-pending="1">${esc(mmd)}</pre>`;
-    shotHost.innerHTML = shot;
+  function setActiveBeat(i, scroll = true) {
+    activeBeat = i;
     detailEl.querySelectorAll(".beat-chip").forEach((el) => {
       el.classList.toggle("active", Number(el.dataset.beat) === activeBeat);
     });
-    paintDetailMermaid().catch((err) => console.error(err));
+    detailEl.querySelectorAll(".panel[data-beat]").forEach((el) => {
+      el.classList.toggle("active", Number(el.dataset.beat) === activeBeat);
+    });
+    if (scroll) {
+      const panel = detailEl.querySelector(`.panel[data-beat="${activeBeat}"]`);
+      if (panel) panel.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
   }
 
   function renderDetail() {
@@ -430,48 +418,67 @@
     const chips = c.beats.map((b, i) =>
       `<button type="button" class="beat-chip ${i === activeBeat ? "active" : ""}" data-beat="${i}">T${i + 1} ${esc(b.title || "")}</button>`
     ).join("");
+    const panels = c.beats.map((b, i) => `
+      <article class="panel ${i === activeBeat ? "active" : ""}" data-beat="${i}">
+        ${storyboardSvg(b, i)}
+        <div class="panel-cap">
+          <div class="cap-row"><span class="k">输入</span><span class="v">${esc(b.input)}</span></div>
+          <div class="cap-row"><span class="k">画面</span><span class="v">${esc(b.screen)}</span></div>
+          <div class="cap-row"><span class="k">手感</span><span class="v">${esc(b.feel)}</span></div>
+        </div>
+      </article>`).join("");
+    const mmd = sequenceMermaid(c.beats);
     detailEl.innerHTML = `
       <div class="detail-inner">
         <div class="detail-top">
           <div class="detail-head">
             <h2>${esc(c.title)}</h2>
+            <div class="tags">${tags}</div>
             <span class="case-id">${esc(c.id)}</span>
           </div>
-          <p class="summary">${esc(c.summary)}</p>
-          <div class="tags">${tags}</div>
-          <div class="beat-rail" aria-label="分镜拍号">${chips}</div>
-          <details class="impl-details">
-            <summary>Ludots 现状 / 缺口 TODO</summary>
-            <div class="impl-line">
-              <div class="impl-card">
-                <div class="section-label">Ludots 现状</div>
-                <p>${esc(c.ludots || "未标注")}</p>
+          <div class="summary-row">
+            <p class="summary">${esc(c.summary)}</p>
+            <details class="impl-details">
+              <summary>Ludots 现状 / TODO</summary>
+              <div class="impl-line">
+                <div class="impl-card">
+                  <div class="section-label">Ludots 现状</div>
+                  <p>${esc(c.ludots || "未标注")}</p>
+                </div>
+                <div class="impl-card impl-todo">
+                  <div class="section-label">缺口 TODO</div>
+                  ${todos ? `<ul>${todos}</ul>` : `<p class="ok">本条暂无额外 TODO</p>`}
+                </div>
               </div>
-              <div class="impl-card impl-todo">
-                <div class="section-label">缺口 TODO</div>
-                ${todos ? `<ul>${todos}</ul>` : `<p class="ok">本条暂无额外 TODO</p>`}
-              </div>
-            </div>
-          </details>
+            </details>
+          </div>
         </div>
         <div class="sync-split">
           <div class="sync-col">
-            <div class="section-label">时序 · 当前拍</div>
-            <div class="mmd-box" id="mmd-host"></div>
+            <div class="section-label">时序 · 全部 ${c.beats.length} 拍</div>
+            <div class="mmd-box" id="mmd-host">
+              <pre class="mermaid" data-pending="1">${esc(mmd)}</pre>
+            </div>
           </div>
           <div class="sync-col">
-            <div class="section-label">分镜 · 当前拍</div>
-            <div class="storyboard storyboard-stack" id="shot-host" aria-label="当前分镜"></div>
+            <div class="section-label">
+              <span>分镜 · ${c.beats.length} 镜</span>
+              <span class="beat-rail" aria-label="分镜拍号">${chips}</span>
+            </div>
+            <div class="storyboard storyboard-stack" id="shot-host" aria-label="分镜条">${panels}</div>
           </div>
         </div>
       </div>`;
     detailEl.querySelectorAll(".beat-chip").forEach((el) => {
-      el.addEventListener("click", () => {
-        activeBeat = Number(el.dataset.beat);
-        renderBeatStage(c);
+      el.addEventListener("click", (e) => {
+        e.stopPropagation();
+        setActiveBeat(Number(el.dataset.beat));
       });
     });
-    renderBeatStage(c);
+    detailEl.querySelectorAll(".panel[data-beat]").forEach((el) => {
+      el.addEventListener("click", () => setActiveBeat(Number(el.dataset.beat), false));
+    });
+    paintDetailMermaid().catch((err) => console.error(err));
   }
 
   function render() {

--- a/gitbook/reference/player-action-ux/catalog.css
+++ b/gitbook/reference/player-action-ux/catalog.css
@@ -16,6 +16,22 @@
 
 * { box-sizing: border-box; }
 
+/* unified scrollbars everywhere */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #3a4658 transparent;
+}
+*::-webkit-scrollbar { width: 8px; height: 8px; }
+*::-webkit-scrollbar-track { background: transparent; }
+*::-webkit-scrollbar-thumb {
+  background: #3a4658;
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+*::-webkit-scrollbar-thumb:hover { background: #4a5a70; background-clip: padding-box; }
+*::-webkit-scrollbar-corner { background: transparent; }
+
 html, body {
   margin: 0;
   height: 100%;
@@ -32,35 +48,41 @@ code { font-family: var(--mono); font-size: 0.9em; }
 .app {
   height: 100dvh;
   display: grid;
-  grid-template-rows: 56px minmax(0, 1fr) 32px;
+  grid-template-rows: 38px minmax(0, 1fr) 26px;
 }
 
-/* ===== top ===== */
+/* ===== top: single slim strip ===== */
 .topbar {
   display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 0 16px;
+  gap: 12px;
+  padding: 0 12px;
   border-bottom: 1px solid var(--line);
   background: #12161d;
   min-width: 0;
 }
 
-.brand { min-width: 0; flex: 0 1 auto; }
+.brand {
+  min-width: 0;
+  flex: 0 1 auto;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
 .kicker {
-  font-size: 10px;
-  letter-spacing: 0.16em;
+  font-size: 9px;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--accent);
   font-weight: 700;
-  line-height: 1.2;
+  white-space: nowrap;
 }
 .topbar h1 {
   margin: 0;
   font-family: var(--serif);
-  font-size: 18px;
+  font-size: 15px;
   font-weight: 650;
-  line-height: 1.2;
+  line-height: 1;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -70,14 +92,14 @@ code { font-family: var(--mono); font-size: 0.9em; }
   flex: 1 1 auto;
   min-width: 0;
   color: var(--faint);
-  font-size: 12.5px;
+  font-size: 11.5px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .hero-meta {
   display: flex;
-  gap: 6px;
+  gap: 5px;
   flex: 0 0 auto;
 }
 .chip {
@@ -85,8 +107,8 @@ code { font-family: var(--mono); font-size: 0.9em; }
   background: var(--bg1);
   color: var(--muted);
   border-radius: 999px;
-  padding: 4px 9px;
-  font-size: 11.5px;
+  padding: 2px 8px;
+  font-size: 11px;
   white-space: nowrap;
 }
 .chip strong { color: var(--ink); }
@@ -238,16 +260,27 @@ code { font-family: var(--mono); font-size: 0.9em; }
   min-height: 0;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
-  gap: 8px;
-  padding: 10px 12px 10px;
+  gap: 6px;
+  padding: 8px 10px;
   overflow: hidden;
 }
 
 .detail-top {
   display: grid;
-  gap: 6px;
+  gap: 4px;
   min-width: 0;
 }
+
+.summary-row {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+.summary-row .summary { flex: 1 1 320px; }
+.summary-row .impl-details { flex: 0 1 auto; }
+.summary-row .impl-details[open] { flex-basis: 100%; }
 
 .impl-details {
   border: 0;
@@ -290,18 +323,20 @@ code { font-family: var(--mono); font-size: 0.9em; }
 .detail-head {
   display: flex;
   align-items: baseline;
-  justify-content: space-between;
-  gap: 12px;
+  gap: 10px;
   min-width: 0;
+  flex-wrap: wrap;
 }
 .detail-head h2 {
   margin: 0;
   font-family: var(--serif);
-  font-size: 22px;
+  font-size: 19px;
   font-weight: 650;
-  line-height: 1.2;
+  line-height: 1.15;
   min-width: 0;
 }
+.detail-head .tags { flex: 1 1 auto; }
+.detail-head .case-id { margin-left: auto; }
 .case-id {
   font-family: var(--mono);
   font-size: 11px;
@@ -383,9 +418,10 @@ code { font-family: var(--mono); font-size: 0.9em; }
   background: var(--bg1);
   color: var(--muted);
   border-radius: 999px;
-  padding: 4px 10px;
+  padding: 2px 8px;
   font: inherit;
-  font-size: 12px;
+  font-size: 11px;
+  font-weight: 600;
   cursor: pointer;
 }
 .beat-chip:hover { color: var(--ink); border-color: var(--accent2); }
@@ -417,7 +453,7 @@ code { font-family: var(--mono); font-size: 0.9em; }
 .sync-col .section-label {
   flex: 0 0 auto;
   margin: 0;
-  padding: 8px 10px;
+  padding: 6px 10px;
   border-bottom: 1px solid var(--line);
   font-size: 10px;
   letter-spacing: 0.12em;
@@ -425,6 +461,16 @@ code { font-family: var(--mono); font-size: 0.9em; }
   color: var(--faint);
   font-weight: 700;
   background: rgba(0, 0, 0, 0.2);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 34px;
+  flex-wrap: wrap;
+}
+.sync-col .section-label .beat-rail {
+  margin-left: auto;
+  letter-spacing: 0;
+  text-transform: none;
 }
 
 .mmd-box,
@@ -461,11 +507,21 @@ code { font-family: var(--mono); font-size: 0.9em; }
   display: block;
 }
 .storyboard-stack .panel {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  opacity: 1;
+  margin: 0 0 12px;
+  padding: 6px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  opacity: 0.6;
   background: transparent;
+  cursor: pointer;
+  transition: opacity 0.15s, border-color 0.15s;
+}
+.storyboard-stack .panel:last-child { margin-bottom: 0; }
+.storyboard-stack .panel:hover { opacity: 0.9; }
+.storyboard-stack .panel.active {
+  opacity: 1;
+  border-color: rgba(240, 163, 94, 0.5);
+  background: rgba(240, 163, 94, 0.05);
   cursor: default;
 }
 .panel .story-svg {

--- a/gitbook/reference/player-action-ux/index.html
+++ b/gitbook/reference/player-action-ux/index.html
@@ -42,7 +42,8 @@
 
     <footer class="foot">
       <a href="../../index.html">返回门户</a>
-      · 数据 SSOT：<code>scripts/generate-player-action-ux-catalog.py</code>
+      <span>·</span>
+      <code>scripts/generate-player-action-ux-catalog.py</code>
     </footer>
   </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述
修三处体验问题：
1. **滚动条统一**：全部面板同一套细圆角深灰样式（含 Firefox thin）
2. **多镜恢复**：右侧分镜列显示全部 SHOT 叠放，当前拍高亮，点拍号或点分镜切换；左侧回到完整多拍时序
3. **顶部压扁**：顶栏收成 38px 单行条（品牌+标题+统计），底栏 26px

[总览：两镜同列可见](https://cursor.com/agents/bc-6dbfc1fe-4147-482c-bdfd-87fe90a54211/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fplayer-action-ux-polish-overview.webp)
[统一细滚动条](https://cursor.com/agents/bc-6dbfc1fe-4147-482c-bdfd-87fe90a54211/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fplayer-action-ux-polish-scrollbar.webp)

## UAT
```gherkin
Scenario: 多镜案例全部可见
  Given 打开「点一下选中一个单位」（2 镜）
  Then 右列同时能看到 SHOT 01 与 SHOT 02
  And 左列时序含 T1、T2 两拍
  When 我点 T2 拍号
  Then SHOT 02 高亮并滚入视野

Scenario: 滚动条一致
  Then 分类、列表、时序、分镜四个滚动区滚动条样式一致
```


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6dbfc1fe-4147-482c-bdfd-87fe90a54211?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dbfc1fe-4147-482c-bdfd-87fe90a54211&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

