### PR TITLE
docs(ux): SVG 全面审查 — 补关键帧与 UI 表达

### DIFF
--- a/gitbook/reference/player-action-ux/CHECKPOINT.md
+++ b/gitbook/reference/player-action-ux/CHECKPOINT.md
@@ -6,7 +6,7 @@
 
 - 生成脚本：`scripts/generate-player-action-ux-catalog.py`
 - 实现标注：`scripts/player_action_ux_impl_notes.py`
-- 生成时 HEAD：`4c81a42c8`（以你拉取后的 `git rev-parse` 为准；合并后会变）
+- 生成时 HEAD：`e021b69b1`（以你拉取后的 `git rev-parse` 为准；合并后会变）
 - 分支语境：`cursor/wasd-locomotion-ux-4211`（含 WASD 类、三栏布局、本轮同步分栏与触控/选单）
 - 已合 main 的底座：PR #743 玩家动作图鉴初版
 
@@ -26,7 +26,7 @@
 ## 规模
 
 - cases = 168
-- beats = 318
+- beats = 339
 - categories = 28
 
 ## 分镜画面审计

--- a/gitbook/reference/player-action-ux/catalog-app.js
+++ b/gitbook/reference/player-action-ux/catalog-app.js
@@ -197,6 +197,74 @@
           <rect x="${x}" y="${y}" width="${w}" height="${h}" rx="4" fill="#0b0e13" stroke="#6ec8ff" stroke-width="1.4"/>
           ${items}`;
       }
+      if (el.t === "hotbar") {
+        const slots = el.slots || 4;
+        const w = 24, h = 24, gap = 4;
+        const total = slots * w + (slots - 1) * gap;
+        const x0 = SX + SW / 2 - total / 2;
+        const y0 = SY + SH - h - 5;
+        const off = Array.isArray(el.off) ? el.off : [];
+        const labels = ["Q", "W", "E", "R", "T"];
+        let out = "";
+        for (let i = 0; i < slots; i++) {
+          const x = x0 + i * (w + gap);
+          const isActive = el.active === i;
+          const isNew = el.extra === i;
+          const isOff = off.includes(i);
+          const stroke = isActive ? "#f0a35e" : isNew ? "#5dce8f" : "#3a4658";
+          out += `<rect x="${x}" y="${y0}" width="${w}" height="${h}" rx="4" fill="${isOff ? "#10141a" : "#1a2430"}" stroke="${stroke}" stroke-width="${isActive || isNew ? 2 : 1.2}"/>`;
+          out += `<text x="${x + w / 2}" y="${y0 + h / 2 + 4}" text-anchor="middle" fill="${isOff ? "#3a4658" : isActive ? "#f0a35e" : isNew ? "#5dce8f" : "#66758a"}" font-size="10" font-family="IBM Plex Mono, monospace" font-weight="700">${labels[i] || i + 1}</text>`;
+          if (el.cd === i) {
+            out += `<path d="M${x + w / 2} ${y0 + h / 2} L${x + w / 2} ${y0 + 2.5} A${w / 2 - 2.5} ${h / 2 - 2.5} 0 1 1 ${x + 2.5} ${y0 + h / 2} Z" fill="rgba(11,14,19,0.72)"/>`;
+          }
+          if (isOff) {
+            out += `<line x1="${x + 4}" y1="${y0 + 4}" x2="${x + w - 4}" y2="${y0 + h - 4}" stroke="#ef6b6b" stroke-width="1.6"/>`;
+          }
+          if (el.dot === i) {
+            out += `<circle cx="${x + w - 4.5}" cy="${y0 + 4.5}" r="3.2" fill="#5dce8f" stroke="#0b0e13" stroke-width="1"/>`;
+          }
+          if (el.deny === i) {
+            out += `<rect x="${x}" y="${y0}" width="${w}" height="${h}" rx="4" fill="rgba(239,107,107,0.22)" stroke="#ef6b6b" stroke-width="1.6"/>`;
+          }
+        }
+        return out;
+      }
+      if (el.t === "bar") {
+        const x = px(el.x == null ? 50 : el.x), y = py(el.y == null ? 30 : el.y);
+        const w = 56, h = 7;
+        const ratio = Math.max(0, Math.min(1, el.ratio == null ? 0.6 : el.ratio));
+        const color = el.kind === "hp" ? "#5dce8f" : el.kind === "charge" ? "#f0a35e" : "#6ec8ff";
+        let out = `
+          <rect x="${x - w / 2}" y="${y}" width="${w}" height="${h}" rx="3" fill="#0b0e13" stroke="#3a4658" stroke-width="1"/>
+          <rect x="${x - w / 2 + 1}" y="${y + 1}" width="${(w - 2) * ratio}" height="${h - 2}" rx="2" fill="${color}"/>`;
+        if (el.broken) {
+          out += `<line x1="${x - w / 2 - 3}" y1="${y + h + 3}" x2="${x + w / 2 + 3}" y2="${y - 3}" stroke="#ef6b6b" stroke-width="2"/>`;
+        }
+        if (el.label) {
+          out += `<text x="${x}" y="${y - 3}" text-anchor="middle" fill="#93a0b4" font-size="9" font-family="DM Sans, sans-serif">${esc(el.label)}</text>`;
+        }
+        return out;
+      }
+      if (el.t === "key") {
+        const x = px(el.x), y = py(el.y);
+        const label = String(el.label || "F");
+        const w = Math.max(20, 12 + label.length * 8), h = 20;
+        const state = el.state || "idle";
+        const stroke = state === "active" ? "#f0a35e" : state === "off" ? "#3a4658" : "#6ec8ff";
+        const fill = state === "active" ? "rgba(240,163,94,0.18)" : "#0b0e13";
+        const ink = state === "off" ? "#3a4658" : "#e8eef6";
+        let out = `
+          <rect x="${x - w / 2}" y="${y - h / 2}" width="${w}" height="${h}" rx="4" fill="${fill}" stroke="${stroke}" stroke-width="1.6"/>
+          <rect x="${x - w / 2}" y="${y + h / 2 - 3}" width="${w}" height="3" rx="1.5" fill="${stroke}" opacity="0.5"/>
+          <text x="${x}" y="${y + 4}" text-anchor="middle" fill="${ink}" font-size="11" font-family="IBM Plex Mono, monospace" font-weight="700">${esc(label)}</text>`;
+        if (state === "off") {
+          out += `<line x1="${x - w / 2 - 2}" y1="${y + h / 2 + 2}" x2="${x + w / 2 + 2}" y2="${y - h / 2 - 2}" stroke="#ef6b6b" stroke-width="1.6"/>`;
+        }
+        if (el.hint) {
+          out += `<text x="${x}" y="${y - h / 2 - 5}" text-anchor="middle" fill="#f0a35e" font-size="10" font-family="DM Sans, sans-serif" font-weight="700">${esc(el.hint)}</text>`;
+        }
+        return out;
+      }
       return "";
     }).join("\n");
   }
@@ -344,8 +412,8 @@
   function filtered() {
     const q = query.trim().toLowerCase();
     return data.cases.filter((c) => {
-      if (activeCategory !== "all" && c.category !== activeCategory) return false;
-      if (!q) return true;
+      // With a query, search the whole catalog; category scopes only when browsing.
+      if (!q) return activeCategory === "all" || c.category === activeCategory;
       const blob = [c.title, c.summary, c.id, ...(c.genres || []), ...c.beats.flatMap((b) => [b.input, b.screen, b.feel])].join(" ").toLowerCase();
       return blob.includes(q);
     });

--- a/gitbook/reference/player-action-ux/catalog-data.js
+++ b/gitbook/reference/player-action-ux/catalog-data.js
@@ -3,7 +3,7 @@ window.PLAYER_ACTION_UX_CATALOG = {
   "title": "玩家动作体验图鉴",
   "subtitle": "只谈手怎么动、画面怎么变、爽点在哪——分镜式报菜名。附 Ludots 现状与缺口。",
   "checkpoint": {
-    "head": "4c81a42c8",
+    "head": "e021b69b1",
     "branch_hint": "cursor/wasd-locomotion-ux-4211",
     "impl_notes": "scripts/player_action_ux_impl_notes.py",
     "note": "ludots/todos 以生成时审计为准；合并后请重新 generate 并更新 CHECKPOINT.md",
@@ -1131,9 +1131,9 @@ window.PLAYER_ACTION_UX_CATALOG = {
       ],
       "beats": [
         {
-          "title": "攻击移动",
+          "title": "下令",
           "input": "按下攻击移动键再点地面",
-          "screen": "路径带剑标；途中遇敌会停下来打",
+          "screen": "路径带剑标，单位沿线前进",
           "feel": "边走边警惕",
           "view": "topdown",
           "cast": [
@@ -1162,6 +1162,41 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "kind": "attack"
             },
             {
+              "t": "cursor",
+              "x": 75,
+              "y": 35,
+              "mode": "up"
+            },
+            {
+              "t": "badge",
+              "text": "A+点地"
+            }
+          ]
+        },
+        {
+          "title": "遇敌",
+          "input": "途中撞见敌人",
+          "screen": "自动停下转火，打完继续沿线走",
+          "feel": "见谁打谁",
+          "view": "topdown",
+          "cast": [
+            {
+              "t": "unit",
+              "x": 48,
+              "y": 48,
+              "sel": true,
+              "team": "ally",
+              "face": 10,
+              "size": 1
+            },
+            {
+              "t": "ring",
+              "x": 48,
+              "y": 48,
+              "r": 8,
+              "kind": "select"
+            },
+            {
               "t": "unit",
               "x": 60,
               "y": 40,
@@ -1171,8 +1206,30 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "size": 1
             },
             {
+              "t": "arrow",
+              "x1": 50,
+              "y1": 47,
+              "x2": 58,
+              "y2": 42,
+              "kind": "attack"
+            },
+            {
+              "t": "path",
+              "points": [
+                [
+                  48,
+                  48
+                ],
+                [
+                  75,
+                  35
+                ]
+              ],
+              "kind": "move"
+            },
+            {
               "t": "badge",
-              "text": "A+点地"
+              "text": "遇敌接战"
             }
           ]
         }
@@ -1424,8 +1481,57 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "kind": "move"
             },
             {
+              "t": "cursor",
+              "x": 75,
+              "y": 55,
+              "mode": "up"
+            },
+            {
               "t": "badge",
               "text": "Shift 排队"
+            }
+          ]
+        },
+        {
+          "title": "自动接续",
+          "input": "到达 A 点",
+          "screen": "不用再管，自动奔向 B；A 段路点消掉",
+          "feel": "自己接着走",
+          "view": "topdown",
+          "cast": [
+            {
+              "t": "unit",
+              "x": 50,
+              "y": 40,
+              "sel": true,
+              "team": "ally",
+              "face": 20,
+              "size": 1
+            },
+            {
+              "t": "ring",
+              "x": 50,
+              "y": 40,
+              "r": 8,
+              "kind": "select"
+            },
+            {
+              "t": "path",
+              "points": [
+                [
+                  50,
+                  40
+                ],
+                [
+                  75,
+                  55
+                ]
+              ],
+              "kind": "move"
+            },
+            {
+              "t": "badge",
+              "text": "自动接下一段"
             }
           ]
         }
@@ -1831,6 +1937,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "技能瞄准"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         },
@@ -1883,9 +1999,51 @@ window.PLAYER_ACTION_UX_CATALOG = {
       ],
       "beats": [
         {
+          "title": "瞄准中",
+          "input": "按技能进入瞄准",
+          "screen": "指示器亮起，跟着准星走",
+          "feel": "正在瞄",
+          "view": "moba",
+          "cast": [
+            {
+              "t": "hero",
+              "x": 45,
+              "y": 55,
+              "face": 0
+            },
+            {
+              "t": "circle",
+              "x": 62,
+              "y": 45,
+              "r": 14,
+              "ok": true
+            },
+            {
+              "t": "cursor",
+              "x": 62,
+              "y": 45,
+              "mode": "idle"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
+            },
+            {
+              "t": "badge",
+              "text": "瞄准中"
+            }
+          ]
+        },
+        {
           "title": "取消",
-          "input": "瞄准中按取消",
-          "screen": "指示器消失，回到常态",
+          "input": "按右键 / Esc 取消",
+          "screen": "指示器消失，技能不消耗、不进 CD",
           "feel": "当没按过",
           "view": "moba",
           "cast": [
@@ -1902,8 +2060,18 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "mode": "idle"
             },
             {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
+            },
+            {
               "t": "badge",
-              "text": "取消"
+              "text": "已取消"
             }
           ]
         }
@@ -2602,9 +2770,42 @@ window.PLAYER_ACTION_UX_CATALOG = {
       ],
       "beats": [
         {
-          "title": "磁吸",
-          "input": "右摇杆靠近敌人方向",
-          "screen": "准星/朝向吸到敌人",
+          "title": "粗瞄",
+          "input": "右摇杆推向敌人大致方向",
+          "screen": "朝向粗对准，还差一点",
+          "feel": "差不多了",
+          "view": "topdown",
+          "cast": [
+            {
+              "t": "hero",
+              "x": 40,
+              "y": 55,
+              "face": 25
+            },
+            {
+              "t": "unit",
+              "x": 70,
+              "y": 40,
+              "sel": false,
+              "team": "enemy",
+              "face": 0,
+              "size": 1
+            },
+            {
+              "t": "stickR",
+              "nx": 0.6,
+              "ny": -0.4
+            },
+            {
+              "t": "badge",
+              "text": "粗瞄"
+            }
+          ]
+        },
+        {
+          "title": "吸附",
+          "input": "进入磁吸角度",
+          "screen": "准星/朝向被吸到敌人身上，出现锁定圈",
           "feel": "帮你咬准",
           "view": "topdown",
           "cast": [
@@ -2637,7 +2838,40 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "badge",
-              "text": "磁吸"
+              "text": "磁吸咬住"
+            }
+          ]
+        },
+        {
+          "title": "清锁",
+          "input": "摇杆回中",
+          "screen": "锁定圈消失，回到自由朝向",
+          "feel": "松口",
+          "view": "topdown",
+          "cast": [
+            {
+              "t": "hero",
+              "x": 40,
+              "y": 55,
+              "face": 35
+            },
+            {
+              "t": "unit",
+              "x": 70,
+              "y": 40,
+              "sel": false,
+              "team": "enemy",
+              "face": 0,
+              "size": 1
+            },
+            {
+              "t": "stickR",
+              "nx": 0,
+              "ny": 0
+            },
+            {
+              "t": "badge",
+              "text": "清锁"
             }
           ]
         }
@@ -2730,6 +2964,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "自身技"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         }
@@ -2781,6 +3025,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "自身AOE"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         }
@@ -2851,9 +3105,45 @@ window.PLAYER_ACTION_UX_CATALOG = {
       "beats": [
         {
           "title": "切换",
-          "input": "按切换",
-          "screen": "造型与技能图标组切换",
+          "input": "按切换键",
+          "screen": "造型变化，技能栏整组换成新形态的招",
           "feel": "换一套招",
+          "view": "moba",
+          "cast": [
+            {
+              "t": "hero",
+              "x": 50,
+              "y": 55,
+              "face": 20
+            },
+            {
+              "t": "ring",
+              "x": 50,
+              "y": 55,
+              "r": 13,
+              "kind": "buff"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": null,
+              "extra": 0,
+              "off": [],
+              "dot": null,
+              "deny": null
+            },
+            {
+              "t": "badge",
+              "text": "切到形态B"
+            }
+          ]
+        },
+        {
+          "title": "切回",
+          "input": "再按一次",
+          "screen": "变回原形态，技能栏还原",
+          "feel": "换回来",
           "view": "moba",
           "cast": [
             {
@@ -2863,8 +3153,18 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "face": 0
             },
             {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
+            },
+            {
               "t": "badge",
-              "text": "形态切换"
+              "text": "切回形态A"
             }
           ]
         }
@@ -2907,6 +3207,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "选敌"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         },
@@ -3006,6 +3316,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "智能施法"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         }
@@ -3243,6 +3563,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "点地"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         }
@@ -3766,6 +4096,15 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "蓄力中"
+            },
+            {
+              "t": "bar",
+              "x": 50,
+              "y": 33,
+              "ratio": 0.55,
+              "kind": "charge",
+              "label": null,
+              "broken": false
             }
           ]
         },
@@ -3895,6 +4234,15 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "引导"
+            },
+            {
+              "t": "bar",
+              "x": 50,
+              "y": 33,
+              "ratio": 0.55,
+              "kind": "cast",
+              "label": null,
+              "broken": false
             }
           ]
         }
@@ -4090,21 +4438,80 @@ window.PLAYER_ACTION_UX_CATALOG = {
       ],
       "beats": [
         {
+          "title": "闪避",
+          "input": "按闪避",
+          "screen": "角色翻滚位移，身后留残影",
+          "feel": "先躲开",
+          "view": "tps",
+          "cast": [
+            {
+              "t": "hero",
+              "x": 38,
+              "y": 58,
+              "face": 20
+            },
+            {
+              "t": "path",
+              "points": [
+                [
+                  52,
+                  52
+                ],
+                [
+                  38,
+                  58
+                ]
+              ],
+              "kind": "move"
+            },
+            {
+              "t": "unit",
+              "x": 66,
+              "y": 42,
+              "sel": false,
+              "team": "enemy",
+              "face": 0,
+              "size": 1
+            },
+            {
+              "t": "badge",
+              "text": "闪避中"
+            }
+          ]
+        },
+        {
           "title": "闪攻",
-          "input": "闪避结束立刻按攻击",
-          "screen": "闪攻专属动画",
+          "input": "落地窗口内按攻击",
+          "screen": "打出闪攻专属派生动画",
           "feel": "漂亮",
           "view": "tps",
           "cast": [
             {
               "t": "hero",
-              "x": 50,
-              "y": 50,
-              "face": 40
+              "x": 42,
+              "y": 55,
+              "face": 30
+            },
+            {
+              "t": "cone",
+              "x": 42,
+              "y": 55,
+              "angle": -15,
+              "spread": 45,
+              "length": 26
+            },
+            {
+              "t": "unit",
+              "x": 66,
+              "y": 42,
+              "sel": false,
+              "team": "enemy",
+              "face": 0,
+              "size": 1
             },
             {
               "t": "badge",
-              "text": "闪攻"
+              "text": "闪攻派生"
             }
           ]
         }
@@ -4305,6 +4712,14 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "拾取"
+            },
+            {
+              "t": "key",
+              "x": 54,
+              "y": 39,
+              "label": "F",
+              "state": "active",
+              "hint": null
             }
           ]
         },
@@ -4584,9 +4999,42 @@ window.PLAYER_ACTION_UX_CATALOG = {
       ],
       "beats": [
         {
+          "title": "靠近",
+          "input": "走近载具按交互",
+          "screen": "出现上车提示",
+          "feel": "能上车",
+          "view": "tps",
+          "cast": [
+            {
+              "t": "hero",
+              "x": 35,
+              "y": 58,
+              "face": 0
+            },
+            {
+              "t": "building",
+              "x": 55,
+              "y": 52,
+              "ghost": false
+            },
+            {
+              "t": "key",
+              "x": 48,
+              "y": 40,
+              "label": "F",
+              "state": "active",
+              "hint": "上车"
+            },
+            {
+              "t": "badge",
+              "text": "靠近载具"
+            }
+          ]
+        },
+        {
           "title": "载具",
           "input": "上车完成",
-          "screen": "准星变为车炮；移动变车辆",
+          "screen": "准星变车炮，移动手感变车辆，技能栏换载具武器",
           "feel": "开炮车",
           "view": "tps",
           "cast": [
@@ -4598,13 +5046,23 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "crosshair",
-              "x": 60,
+              "x": 62,
               "y": 40,
               "locked": false
             },
             {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": null,
+              "extra": 0,
+              "off": [],
+              "dot": null,
+              "deny": null
+            },
+            {
               "t": "badge",
-              "text": "载具"
+              "text": "载具操作"
             }
           ]
         }
@@ -4697,9 +5155,51 @@ window.PLAYER_ACTION_UX_CATALOG = {
       ],
       "beats": [
         {
+          "title": "普通",
+          "input": "直接按技能",
+          "screen": "进入选目标 / 打向准星方向",
+          "feel": "要先选人",
+          "view": "moba",
+          "cast": [
+            {
+              "t": "hero",
+              "x": 50,
+              "y": 55,
+              "face": 0
+            },
+            {
+              "t": "cursor",
+              "x": 68,
+              "y": 42,
+              "mode": "idle"
+            },
+            {
+              "t": "circle",
+              "x": 68,
+              "y": 42,
+              "r": 12,
+              "ok": true
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
+            },
+            {
+              "t": "badge",
+              "text": "普通施法"
+            }
+          ]
+        },
+        {
           "title": "自施",
-          "input": "Alt+技能",
-          "screen": "技能打在自己身上",
+          "input": "按住 Alt 再按技能",
+          "screen": "跳过选目标，直接打在自己身上",
           "feel": "自我施法",
           "view": "moba",
           "cast": [
@@ -4715,6 +5215,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "y": 55,
               "r": 12,
               "kind": "buff"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             },
             {
               "t": "badge",
@@ -4740,8 +5250,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
       "beats": [
         {
           "title": "排队",
-          "input": "Shift+技能点落点",
-          "screen": "路点/技能队列出现标记",
+          "input": "正在走 A 段时 Shift+技能点落点",
+          "screen": "路点后追加技能标记，当前动作不打断",
           "feel": "排后面",
           "view": "moba",
           "cast": [
@@ -4777,6 +5287,40 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "text": "Shift排队"
             }
           ]
+        },
+        {
+          "title": "自动放",
+          "input": "走完 A 段",
+          "screen": "自动开始对排队落点施法",
+          "feel": "到点自动放",
+          "view": "moba",
+          "cast": [
+            {
+              "t": "hero",
+              "x": 50,
+              "y": 50,
+              "face": 20
+            },
+            {
+              "t": "circle",
+              "x": 70,
+              "y": 40,
+              "r": 12,
+              "ok": true
+            },
+            {
+              "t": "arrow",
+              "x1": 52,
+              "y1": 49,
+              "x2": 68,
+              "y2": 42,
+              "kind": "attack"
+            },
+            {
+              "t": "badge",
+              "text": "自动施放"
+            }
+          ]
         }
       ],
       "ludots": "同技能不同手感：ClientCastPreferenceStore（slot/form/template/global）；Alt 自施/双击/Shift 队列在 special_input 能力与 Order 队列。",
@@ -4809,6 +5353,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "双击"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         }
@@ -5504,6 +6058,94 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "一人一目标"
+            }
+          ]
+        },
+        {
+          "title": "齐发",
+          "input": "全部认领完毕",
+          "screen": "各自同时出手，三个目标同拍挨打",
+          "feel": "一波带走",
+          "view": "topdown",
+          "cast": [
+            {
+              "t": "unit",
+              "x": 20,
+              "y": 60,
+              "sel": true,
+              "team": "ally",
+              "face": 0,
+              "size": 1
+            },
+            {
+              "t": "unit",
+              "x": 32,
+              "y": 55,
+              "sel": true,
+              "team": "ally",
+              "face": 0,
+              "size": 1
+            },
+            {
+              "t": "unit",
+              "x": 44,
+              "y": 62,
+              "sel": true,
+              "team": "ally",
+              "face": 0,
+              "size": 1
+            },
+            {
+              "t": "unit",
+              "x": 68,
+              "y": 30,
+              "sel": false,
+              "team": "enemy",
+              "face": 0,
+              "size": 1
+            },
+            {
+              "t": "ring",
+              "x": 68,
+              "y": 30,
+              "r": 8,
+              "kind": "lock"
+            },
+            {
+              "t": "unit",
+              "x": 78,
+              "y": 48,
+              "sel": false,
+              "team": "enemy",
+              "face": 0,
+              "size": 1
+            },
+            {
+              "t": "ring",
+              "x": 78,
+              "y": 48,
+              "r": 8,
+              "kind": "lock"
+            },
+            {
+              "t": "unit",
+              "x": 70,
+              "y": 68,
+              "sel": false,
+              "team": "enemy",
+              "face": 0,
+              "size": 1
+            },
+            {
+              "t": "ring",
+              "x": 70,
+              "y": 68,
+              "r": 8,
+              "kind": "lock"
+            },
+            {
+              "t": "badge",
+              "text": "齐发"
             }
           ]
         }
@@ -6468,6 +7110,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "变身开始"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": null,
+              "extra": 3,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         },
@@ -6523,6 +7175,18 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "变身结束"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": null,
+              "extra": null,
+              "off": [
+                3
+              ],
+              "dot": null,
+              "deny": null
             }
           ]
         }
@@ -6559,6 +7223,25 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "+临时技"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": null,
+              "extra": 3,
+              "off": [],
+              "dot": null,
+              "deny": null
+            },
+            {
+              "t": "bar",
+              "x": 40,
+              "y": 33,
+              "ratio": 0.55,
+              "kind": "cast",
+              "label": null,
+              "broken": false
             }
           ]
         },
@@ -6610,6 +7293,27 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "临时技收回"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": null,
+              "extra": null,
+              "off": [
+                3
+              ],
+              "dot": null,
+              "deny": null
+            },
+            {
+              "t": "bar",
+              "x": 40,
+              "y": 33,
+              "ratio": 0.55,
+              "kind": "cast",
+              "label": null,
+              "broken": false
             }
           ]
         }
@@ -6655,6 +7359,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "形态命令卡"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": null,
+              "extra": 3,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         },
@@ -6684,6 +7398,18 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "恢复原卡"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": null,
+              "extra": null,
+              "off": [
+                3
+              ],
+              "dot": null,
+              "deny": null
             }
           ]
         }
@@ -6720,6 +7446,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "+饰品主动"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": null,
+              "extra": 3,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         },
@@ -6746,6 +7482,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "饰品放出"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": 0,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         },
@@ -6765,6 +7511,18 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "键收回"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": null,
+              "extra": null,
+              "off": [
+                3
+              ],
+              "dot": null,
+              "deny": null
             }
           ]
         }
@@ -6809,6 +7567,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "偷到技能"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": null,
+              "extra": 3,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         },
@@ -6975,6 +7743,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "进入座位"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         },
@@ -6994,6 +7772,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "离开座位"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         }
@@ -7099,6 +7887,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "骑乘技"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         },
@@ -7118,6 +7916,18 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "陆地技"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": null,
+              "extra": null,
+              "off": [
+                3
+              ],
+              "dot": null,
+              "deny": null
             }
           ]
         }
@@ -7179,6 +7989,14 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "已入包"
+            },
+            {
+              "t": "key",
+              "x": 59,
+              "y": 36,
+              "label": "F",
+              "state": "off",
+              "hint": null
             }
           ]
         }
@@ -7221,6 +8039,14 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "掉落窗"
+            },
+            {
+              "t": "key",
+              "x": 54,
+              "y": 39,
+              "label": "F",
+              "state": "active",
+              "hint": null
             }
           ]
         },
@@ -7293,6 +8119,15 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "掷骰窗"
+            },
+            {
+              "t": "bar",
+              "x": 40,
+              "y": 33,
+              "ratio": 0.55,
+              "kind": "cast",
+              "label": null,
+              "broken": false
             }
           ]
         },
@@ -7372,6 +8207,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "用药"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": 0,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         }
@@ -7479,10 +8324,10 @@ window.PLAYER_ACTION_UX_CATALOG = {
       ],
       "beats": [
         {
-          "title": "点地使用",
-          "input": "点物品再点地面",
-          "screen": "落点预览；确认后物品 -1，效果出现在地上",
-          "feel": "丢那儿",
+          "title": "预览",
+          "input": "点快捷栏里的物品",
+          "screen": "进入落点预览，光圈跟随鼠标",
+          "feel": "选个位置",
           "view": "topdown",
           "cast": [
             {
@@ -7505,8 +8350,53 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "mode": "idle"
             },
             {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 1,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
+            },
+            {
               "t": "badge",
-              "text": "物品点地"
+              "text": "落点预览"
+            }
+          ]
+        },
+        {
+          "title": "放置",
+          "input": "点地面确认",
+          "screen": "物品数量 -1，效果实体出现在落点",
+          "feel": "丢那儿",
+          "view": "topdown",
+          "cast": [
+            {
+              "t": "hero",
+              "x": 35,
+              "y": 60,
+              "face": 0
+            },
+            {
+              "t": "building",
+              "x": 70,
+              "y": 40,
+              "ghost": false
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": 1,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
+            },
+            {
+              "t": "badge",
+              "text": "已放置"
             }
           ]
         }
@@ -7616,6 +8506,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "拖到快捷栏"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         },
@@ -7769,10 +8669,10 @@ window.PLAYER_ACTION_UX_CATALOG = {
       ],
       "beats": [
         {
-          "title": "卖或毁",
+          "title": "确认框",
           "input": "拖到出售/摧毁区",
-          "screen": "标价或警告；确认后物品离开背包",
-          "feel": "卖掉/毁掉",
+          "screen": "弹出标价或警告确认框",
+          "feel": "再想想",
           "view": "moba",
           "cast": [
             {
@@ -7802,6 +8702,28 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "出售确认"
+            }
+          ]
+        },
+        {
+          "title": "成交",
+          "input": "点确认",
+          "screen": "物品离包，金币入账；贵重物品要再输名字/二次确认",
+          "feel": "卖掉了",
+          "view": "moba",
+          "cast": [
+            {
+              "t": "menu",
+              "x": 40,
+              "y": 45,
+              "lines": [
+                "+12G",
+                "背包 -1"
+              ]
+            },
+            {
+              "t": "badge",
+              "text": "已卖出"
             }
           ]
         }
@@ -7996,6 +8918,14 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "可交互"
+            },
+            {
+              "t": "key",
+              "x": 52,
+              "y": 42,
+              "label": "F",
+              "state": "active",
+              "hint": null
             }
           ]
         },
@@ -8015,6 +8945,14 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "打开面板"
+            },
+            {
+              "t": "key",
+              "x": 56,
+              "y": 39,
+              "label": "F",
+              "state": "active",
+              "hint": null
             }
           ]
         }
@@ -8582,6 +9520,23 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "采集读条"
+            },
+            {
+              "t": "bar",
+              "x": 40,
+              "y": 33,
+              "ratio": 0.55,
+              "kind": "cast",
+              "label": null,
+              "broken": false
+            },
+            {
+              "t": "key",
+              "x": 54,
+              "y": 39,
+              "label": "F",
+              "state": "active",
+              "hint": null
             }
           ]
         },
@@ -8601,6 +9556,15 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "采集成功"
+            },
+            {
+              "t": "bar",
+              "x": 40,
+              "y": 33,
+              "ratio": 1.0,
+              "kind": "cast",
+              "label": null,
+              "broken": false
             }
           ]
         },
@@ -8620,6 +9584,15 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "采集打断"
+            },
+            {
+              "t": "bar",
+              "x": 40,
+              "y": 33,
+              "ratio": 0.55,
+              "kind": "cast",
+              "label": null,
+              "broken": true
             }
           ]
         }
@@ -8983,6 +9956,15 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "打断"
+            },
+            {
+              "t": "bar",
+              "x": 35,
+              "y": 36,
+              "ratio": 0.55,
+              "kind": "cast",
+              "label": null,
+              "broken": true
             }
           ]
         },
@@ -9002,6 +9984,25 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "取消读条"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": 0,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
+            },
+            {
+              "t": "bar",
+              "x": 48,
+              "y": 33,
+              "ratio": 0.55,
+              "kind": "cast",
+              "label": null,
+              "broken": true
             }
           ]
         }
@@ -9059,6 +10060,40 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "追踪→地图"
+            }
+          ]
+        },
+        {
+          "title": "到达",
+          "input": "走进目标区域",
+          "screen": "追踪条目打钩或换下一步指引",
+          "feel": "到了",
+          "view": "moba",
+          "cast": [
+            {
+              "t": "hero",
+              "x": 68,
+              "y": 42,
+              "face": 0
+            },
+            {
+              "t": "circle",
+              "x": 70,
+              "y": 40,
+              "r": 12,
+              "ok": true
+            },
+            {
+              "t": "menu",
+              "x": 28,
+              "y": 65,
+              "lines": [
+                "任务：√ 已到达"
+              ]
+            },
+            {
+              "t": "badge",
+              "text": "阶段完成"
             }
           ]
         }
@@ -9710,6 +10745,14 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "按 F"
+            },
+            {
+              "t": "key",
+              "x": 59,
+              "y": 39,
+              "label": "F",
+              "state": "active",
+              "hint": null
             }
           ]
         },
@@ -9833,21 +10876,78 @@ window.PLAYER_ACTION_UX_CATALOG = {
       ],
       "beats": [
         {
-          "title": "摆放",
-          "input": "拖异形物品进包",
-          "screen": "合法格高亮，非法格拒绝",
-          "feel": "转一下才塞得进",
+          "title": "非法",
+          "input": "拖 L 形物品进包",
+          "screen": "当前姿态放不下，非法格标红",
+          "feel": "塞不进",
           "view": "moba",
           "cast": [
             {
+              "t": "card",
+              "x": 45,
+              "y": 40,
+              "label": "L形",
+              "cost": 0,
+              "dragging": true
+            },
+            {
               "t": "cursor",
-              "x": 55,
-              "y": 45,
+              "x": 45,
+              "y": 40,
               "mode": "drag"
             },
             {
+              "t": "circle",
+              "x": 62,
+              "y": 52,
+              "r": 12,
+              "ok": false
+            },
+            {
               "t": "badge",
-              "text": "异形背包"
+              "text": "放不下"
+            }
+          ]
+        },
+        {
+          "title": "旋转放入",
+          "input": "按 R 旋转再放",
+          "screen": "旋转后合法格高亮，松手放入",
+          "feel": "转一下就行",
+          "view": "moba",
+          "cast": [
+            {
+              "t": "card",
+              "x": 60,
+              "y": 50,
+              "label": "L形",
+              "cost": 0,
+              "dragging": true
+            },
+            {
+              "t": "cursor",
+              "x": 60,
+              "y": 50,
+              "mode": "drag"
+            },
+            {
+              "t": "circle",
+              "x": 60,
+              "y": 52,
+              "r": 12,
+              "ok": true
+            },
+            {
+              "t": "key",
+              "x": 40,
+              "y": 30,
+              "label": "R",
+              "state": "active",
+              "hint": "旋转"
+            },
+            {
+              "t": "badge",
+              "text": "旋转放入"
             }
           ]
         }
@@ -9870,8 +10970,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
       "beats": [
         {
           "title": "切视角",
-          "input": "观战中点队友或按键切换",
-          "screen": "相机跟到该玩家",
+          "input": "观战中点队友头像或数字键",
+          "screen": "相机切到该玩家视角",
           "feel": "换人看",
           "view": "tps",
           "cast": [
@@ -9882,8 +10982,46 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "face": 0
             },
             {
+              "t": "menu",
+              "x": 26,
+              "y": 68,
+              "lines": [
+                "1P",
+                "2P",
+                "3P"
+              ]
+            },
+            {
               "t": "badge",
               "text": "观战切换"
+            }
+          ]
+        },
+        {
+          "title": "回放",
+          "input": "回放中拖时间轴 / 暂停打点",
+          "screen": "画面跳到该时刻，可加书签",
+          "feel": "倒回去看",
+          "view": "tps",
+          "cast": [
+            {
+              "t": "hero",
+              "x": 48,
+              "y": 55,
+              "face": 0
+            },
+            {
+              "t": "bar",
+              "x": 50,
+              "y": 78,
+              "ratio": 0.4,
+              "kind": "cast",
+              "label": "时间轴",
+              "broken": false
+            },
+            {
+              "t": "badge",
+              "text": "回放打点"
             }
           ]
         }
@@ -9937,6 +11075,24 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "提示:处决"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
+            },
+            {
+              "t": "key",
+              "x": 54,
+              "y": 39,
+              "label": "F",
+              "state": "active",
+              "hint": null
             }
           ]
         },
@@ -9973,6 +11129,14 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "处决"
+            },
+            {
+              "t": "key",
+              "x": 64,
+              "y": 34,
+              "label": "F",
+              "state": "active",
+              "hint": null
             }
           ]
         },
@@ -10508,6 +11672,14 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "提示收回"
+            },
+            {
+              "t": "key",
+              "x": 44,
+              "y": 44,
+              "label": "F",
+              "state": "off",
+              "hint": null
             }
           ]
         }
@@ -10726,6 +11898,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "自动施法ON"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": 0,
+              "deny": null
             }
           ]
         },
@@ -10765,6 +11947,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "自动放出"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": 0,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         },
@@ -10977,6 +12169,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "次优先"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": 0,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         }
@@ -11110,6 +12312,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "按住"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": 0,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         },
@@ -11137,6 +12349,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "连放"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": 0,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         },
@@ -11218,6 +12440,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "自动用药"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": 0,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         },
@@ -12357,6 +13589,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "按住技能"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         },
@@ -12740,6 +13982,59 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "text": "滑动手牌"
             }
           ]
+        },
+        {
+          "title": "补牌",
+          "input": "打出焦点卡",
+          "screen": "空位从牌库自动补进下一张",
+          "feel": "又摸一张",
+          "view": "topdown",
+          "cast": [
+            {
+              "t": "unit",
+              "x": 55,
+              "y": 45,
+              "sel": true,
+              "team": "ally",
+              "face": 0,
+              "size": 1
+            },
+            {
+              "t": "ring",
+              "x": 55,
+              "y": 45,
+              "r": 8,
+              "kind": "select"
+            },
+            {
+              "t": "card",
+              "x": 25,
+              "y": 78,
+              "label": "A",
+              "cost": 2,
+              "dragging": false
+            },
+            {
+              "t": "card",
+              "x": 50,
+              "y": 78,
+              "label": "D",
+              "cost": 1,
+              "dragging": false
+            },
+            {
+              "t": "card",
+              "x": 75,
+              "y": 78,
+              "label": "C",
+              "cost": 3,
+              "dragging": false
+            },
+            {
+              "t": "badge",
+              "text": "自动补牌"
+            }
+          ]
         }
       ],
       "ludots": "触控/卡牌：玩法输入几乎无独立多指 touch pipeline；仅有指针+拖框阈值。",
@@ -12951,6 +14246,16 @@ window.PLAYER_ACTION_UX_CATALOG = {
             {
               "t": "badge",
               "text": "点技能格"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             }
           ]
         },
@@ -13091,7 +14396,7 @@ window.PLAYER_ACTION_UX_CATALOG = {
         {
           "title": "缺资源",
           "input": "资源不够时按技能",
-          "screen": "图标闪红/飘字，不进瞄准",
+          "screen": "图标闪红/飘字「魔法不足」，不进瞄准",
           "feel": "放不出",
           "view": "moba",
           "cast": [
@@ -13102,8 +14407,65 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "face": 0
             },
             {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": 0
+            },
+            {
+              "t": "bar",
+              "x": 50,
+              "y": 34,
+              "ratio": 0.15,
+              "kind": "cast",
+              "label": "蓝量",
+              "broken": false
+            },
+            {
               "t": "badge",
               "text": "资源不足"
+            }
+          ]
+        },
+        {
+          "title": "恢复",
+          "input": "回蓝攒够后再按",
+          "screen": "图标恢复亮起，正常进入施法",
+          "feel": "缓过来了",
+          "view": "moba",
+          "cast": [
+            {
+              "t": "hero",
+              "x": 50,
+              "y": 55,
+              "face": 0
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
+            },
+            {
+              "t": "bar",
+              "x": 50,
+              "y": 34,
+              "ratio": 0.85,
+              "kind": "cast",
+              "label": "蓝量",
+              "broken": false
+            },
+            {
+              "t": "badge",
+              "text": "可施放"
             }
           ]
         }
@@ -13123,9 +14485,9 @@ window.PLAYER_ACTION_UX_CATALOG = {
       ],
       "beats": [
         {
-          "title": "CD",
-          "input": "CD 未好转按技能",
-          "screen": "图标仍在转 CD，拒绝施放",
+          "title": "CD中",
+          "input": "CD 未好时按技能",
+          "screen": "图标转着遮罩拒绝施放，可有拒绝音效",
           "feel": "再等等",
           "view": "moba",
           "cast": [
@@ -13136,8 +14498,47 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "face": 0
             },
             {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": 0,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": 0
+            },
+            {
               "t": "badge",
               "text": "冷却中"
+            }
+          ]
+        },
+        {
+          "title": "转好",
+          "input": "CD 转完",
+          "screen": "图标亮起可再次施放",
+          "feel": "好了",
+          "view": "moba",
+          "cast": [
+            {
+              "t": "hero",
+              "x": 50,
+              "y": 55,
+              "face": 0
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
+            },
+            {
+              "t": "badge",
+              "text": "冷却完毕"
             }
           ]
         }
@@ -13201,7 +14602,7 @@ window.PLAYER_ACTION_UX_CATALOG = {
         {
           "title": "包满",
           "input": "包满时拾取或购买",
-          "screen": "拒绝提示，物品不进包",
+          "screen": "红字「背包已满」，物品留在原地不进包",
           "feel": "拿不下",
           "view": "moba",
           "cast": [
@@ -13212,8 +14613,49 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "face": 0
             },
             {
+              "t": "building",
+              "x": 65,
+              "y": 48,
+              "ghost": false
+            },
+            {
+              "t": "menu",
+              "x": 28,
+              "y": 62,
+              "lines": [
+                "背包已满！"
+              ]
+            },
+            {
               "t": "badge",
-              "text": "背包已满"
+              "text": "拒绝拾取"
+            }
+          ]
+        },
+        {
+          "title": "再捡",
+          "input": "清出格子再捡",
+          "screen": "物品正常进包，地上消失",
+          "feel": "腾出手了",
+          "view": "moba",
+          "cast": [
+            {
+              "t": "hero",
+              "x": 52,
+              "y": 50,
+              "face": 0
+            },
+            {
+              "t": "card",
+              "x": 60,
+              "y": 42,
+              "label": "拾得",
+              "cost": 0,
+              "dragging": false
+            },
+            {
+              "t": "badge",
+              "text": "拾取成功"
             }
           ]
         }
@@ -13317,7 +14759,7 @@ window.PLAYER_ACTION_UX_CATALOG = {
         {
           "title": "被控",
           "input": "被晕/沉默时按技能",
-          "screen": "拒绝，状态图标闪烁",
+          "screen": "整栏变灰拒绝，头顶控制图标闪烁说明控制类型",
           "feel": "动不了",
           "view": "moba",
           "cast": [
@@ -13328,8 +14770,59 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "face": 0
             },
             {
+              "t": "ring",
+              "x": 48,
+              "y": 55,
+              "r": 13,
+              "kind": "lock"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": null,
+              "cd": null,
+              "extra": null,
+              "off": [
+                0,
+                1,
+                2,
+                3
+              ],
+              "dot": null,
+              "deny": null
+            },
+            {
               "t": "badge",
-              "text": "被控"
+              "text": "沉默中"
+            }
+          ]
+        },
+        {
+          "title": "解控",
+          "input": "控制时间结束",
+          "screen": "技能栏恢复亮起，立刻能反打",
+          "feel": "缓过来了",
+          "view": "moba",
+          "cast": [
+            {
+              "t": "hero",
+              "x": 48,
+              "y": 55,
+              "face": 0
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
+            },
+            {
+              "t": "badge",
+              "text": "控制解除"
             }
           ]
         }

--- a/scripts/generate-player-action-ux-catalog.py
+++ b/scripts/generate-player-action-ux-catalog.py
@@ -107,6 +107,25 @@ def menu_box(x, y, lines):
     return {"t": "menu", "x": x, "y": y, "lines": list(lines)}
 
 
+def hotbar(active=None, cd=None, extra=None, off=None, dot=None, deny=None, slots=4):
+    """Bottom-center skill row. active=pressed slot, cd=cooldown sweep,
+    extra=temp-granted slot (green), off=removed/disabled slots, dot=autocast
+    green dot, deny=rejected press (red flash)."""
+    return {"t": "hotbar", "slots": slots, "active": active, "cd": cd,
+            "extra": extra, "off": list(off or []), "dot": dot, "deny": deny}
+
+
+def bar(x=50, y=30, ratio=0.6, kind="cast", label=None, broken=False):
+    """Progress bar: kind=cast(blue)/charge(orange)/hp(green); broken=interrupted."""
+    return {"t": "bar", "x": x, "y": y, "ratio": ratio, "kind": kind,
+            "label": label, "broken": broken}
+
+
+def keyhint(x, y, label="F", state="idle", hint=None):
+    """Key prompt cap. state=idle/active/off; hint=verb text above the key."""
+    return {"t": "key", "x": x, "y": y, "label": label, "state": state, "hint": hint}
+
+
 CATEGORIES = [
     ("select", "一、谁听我的"),
     ("basic-order", "二、常规指令（走/停/打）"),
@@ -249,9 +268,13 @@ def build_cases():
         "order-attack-move", "basic-order", "攻击移动",
         "沿路径前进，遇敌转入攻击。",
         [
-            beat("按下攻击移动键再点地面", "路径带剑标；途中遇敌会停下来打", "边走边警惕", "topdown",
+            beat("按下攻击移动键再点地面", "路径带剑标，单位沿线前进", "边走边警惕", "topdown",
                  [unit(30, 60, sel=True, face=20), ring(30, 60), arrow(30, 60, 75, 35, "attack"),
-                  unit(60, 40, team="enemy"), badge("A+点地")], title="攻击移动"),
+                  cursor(75, 35, "up"), badge("A+点地")], title="下令"),
+            beat("途中撞见敌人", "自动停下转火，打完继续沿线走", "见谁打谁", "topdown",
+                 [unit(48, 48, sel=True, face=10), ring(48, 48), unit(60, 40, team="enemy"),
+                  arrow(50, 47, 58, 42, "attack"), path([(48, 48), (75, 35)], "move"),
+                  badge("遇敌接战")], title="遇敌"),
         ], ["RTS", "SC2/War3", "MOBA"],
     ))
     c.append(case(
@@ -282,7 +305,10 @@ def build_cases():
         [
             beat("Shift+右键点 A，再点 B", "地上出现 A→B 路点链", "排好队了", "topdown",
                  [unit(25, 60, sel=True), ring(25, 60), path([(25, 60), (50, 40), (75, 55)], "move"),
-                  badge("Shift 排队")], title="队列"),
+                  cursor(75, 55, "up"), badge("Shift 排队")], title="队列"),
+            beat("到达 A 点", "不用再管，自动奔向 B；A 段路点消掉", "自己接着走", "topdown",
+                 [unit(50, 40, sel=True, face=20), ring(50, 40), path([(50, 40), (75, 55)], "move"),
+                  badge("自动接下一段")], title="自动接续"),
         ], ["SC2/War3", "RTS"],
     ))
     c.append(case(
@@ -350,8 +376,11 @@ def build_cases():
         "aim-cancel", "aim", "瞄准中取消",
         "右键或取消键退出瞄准，不放出技能。",
         [
-            beat("瞄准中按取消", "指示器消失，回到常态", "当没按过", "moba",
-                 [hero(45, 55), cursor(60, 50), badge("取消")], title="取消"),
+            beat("按技能进入瞄准", "指示器亮起，跟着准星走", "正在瞄", "moba",
+                 [hero(45, 55), circle_ind(62, 45, 14, True), cursor(62, 45),
+                  hotbar(active=0), badge("瞄准中")], title="瞄准中"),
+            beat("按右键 / Esc 取消", "指示器消失，技能不消耗、不进 CD", "当没按过", "moba",
+                 [hero(45, 55), cursor(60, 50), hotbar(), badge("已取消")], title="取消"),
         ], ["MOBA", "RTS超武"],
     ))
 
@@ -459,9 +488,15 @@ def build_cases():
         "twin-stick-magnets", "twin-stick", "右摇杆磁吸辅助",
         "摇杆推向敌人方向有吸附；回中可清锁。",
         [
-            beat("右摇杆靠近敌人方向", "准星/朝向吸到敌人", "帮你咬准", "topdown",
+            beat("右摇杆推向敌人大致方向", "朝向粗对准，还差一点", "差不多了", "topdown",
+                 [hero(40, 55, face=25), unit(70, 40, team="enemy"),
+                  stick("R", 0.6, -0.4), badge("粗瞄")], title="粗瞄"),
+            beat("进入磁吸角度", "准星/朝向被吸到敌人身上，出现锁定圈", "帮你咬准", "topdown",
                  [hero(40, 55, face=35), unit(70, 40, team="enemy"), ring(70, 40, kind="lock"),
-                  stick("R", 0.6, -0.4), badge("磁吸")], title="磁吸"),
+                  stick("R", 0.6, -0.4), badge("磁吸咬住")], title="吸附"),
+            beat("摇杆回中", "锁定圈消失，回到自由朝向", "松口", "topdown",
+                 [hero(40, 55, face=35), unit(70, 40, team="enemy"),
+                  stick("R", 0, 0), badge("清锁")], title="清锁"),
         ], ["双摇杆射击"],
     ))
     c.append(case(
@@ -503,8 +538,11 @@ def build_cases():
         "skill-toggle-form", "instant-skill", "开关姿态 / 切形态",
         "再按关掉；或锤炮切换导致技能栏变化。",
         [
-            beat("按切换", "造型与技能图标组切换", "换一套招", "moba",
-                 [hero(50, 55), badge("形态切换")], title="切换"),
+            beat("按切换键", "造型变化，技能栏整组换成新形态的招", "换一套招", "moba",
+                 [hero(50, 55, face=20), ring(50, 55, r=13, kind="buff"),
+                  hotbar(extra=0), badge("切到形态B")], title="切换"),
+            beat("再按一次", "变回原形态，技能栏还原", "换回来", "moba",
+                 [hero(50, 55), hotbar(active=0), badge("切回形态A")], title="切回"),
         ], ["MOBA", "RTS英雄"],
     ))
 
@@ -698,8 +736,12 @@ def build_cases():
         "combo-dodge-attack", "combo", "闪避后接攻击",
         "闪避结束的专属窗内按攻击出派生。",
         [
-            beat("闪避结束立刻按攻击", "闪攻专属动画", "漂亮", "tps",
-                 [hero(50, 50, face=40), badge("闪攻")], title="闪攻"),
+            beat("按闪避", "角色翻滚位移，身后留残影", "先躲开", "tps",
+                 [hero(38, 58, face=20), path([(52, 52), (38, 58)], "move"),
+                  unit(66, 42, team="enemy"), badge("闪避中")], title="闪避"),
+            beat("落地窗口内按攻击", "打出闪攻专属派生动画", "漂亮", "tps",
+                 [hero(42, 55, face=30), cone(42, 55, angle=-15, spread=45, length=26),
+                  unit(66, 42, team="enemy"), badge("闪攻派生")], title="闪攻"),
         ], ["动作RPG"],
     ))
 
@@ -782,8 +824,11 @@ def build_cases():
         "army-vehicle", "army", "上车变载具手感",
         "交互上车后，摇杆/射击变成载具武器。",
         [
-            beat("上车完成", "准星变为车炮；移动变车辆", "开炮车", "tps",
-                 [building(50, 55), crosshair(60, 40), badge("载具")], title="载具"),
+            beat("走近载具按交互", "出现上车提示", "能上车", "tps",
+                 [hero(35, 58), building(55, 52), keyhint(48, 40, "F", "active", "上车"),
+                  badge("靠近载具")], title="靠近"),
+            beat("上车完成", "准星变车炮，移动手感变车辆，技能栏换载具武器", "开炮车", "tps",
+                 [building(50, 55), crosshair(62, 40), hotbar(extra=0), badge("载具操作")], title="载具"),
         ], ["TPS", "FPS"],
     ))
 
@@ -802,17 +847,24 @@ def build_cases():
         "habit-alt-self", "cast-habit", "Alt 对自己放",
         "按住 Alt 再按技能，强制以自己为目标。",
         [
-            beat("Alt+技能", "技能打在自己身上", "自我施法", "moba",
-                 [hero(50, 55), ring(50, 55, r=12, kind="buff"), badge("Alt自施")], title="自施"),
+            beat("直接按技能", "进入选目标 / 打向准星方向", "要先选人", "moba",
+                 [hero(50, 55), cursor(68, 42), circle_ind(68, 42, 12, True),
+                  hotbar(active=0), badge("普通施法")], title="普通"),
+            beat("按住 Alt 再按技能", "跳过选目标，直接打在自己身上", "自我施法", "moba",
+                 [hero(50, 55), ring(50, 55, r=12, kind="buff"), hotbar(active=0),
+                  badge("Alt自施")], title="自施"),
         ], ["MOBA"],
     ))
     c.append(case(
         "habit-shift-queue-cast", "cast-habit", "Shift 排队施法",
         "当前动作结束后再放这个技能。",
         [
-            beat("Shift+技能点落点", "路点/技能队列出现标记", "排后面", "moba",
+            beat("正在走 A 段时 Shift+技能点落点", "路点后追加技能标记，当前动作不打断", "排后面", "moba",
                  [hero(30, 60), path([(30, 60), (50, 50)], "move"), circle_ind(70, 40, 12, True),
                   badge("Shift排队")], title="排队"),
+            beat("走完 A 段", "自动开始对排队落点施法", "到点自动放", "moba",
+                 [hero(50, 50, face=20), circle_ind(70, 40, 12, True),
+                  arrow(52, 49, 68, 42, "attack"), badge("自动施放")], title="自动放"),
         ], ["SC2", "MOBA"],
     ))
     c.append(case(
@@ -890,6 +942,12 @@ def build_cases():
                   unit(68, 30, team="enemy"), unit(78, 48, team="enemy"), unit(70, 68, team="enemy"),
                   arrow(22, 58, 66, 34, "attack"), arrow(34, 54, 76, 48, "attack"),
                   arrow(46, 60, 68, 66, "attack"), badge("一人一目标")], title="拆目标"),
+            beat("全部认领完毕", "各自同时出手，三个目标同拍挨打", "一波带走", "topdown",
+                 [unit(20, 60, sel=True), unit(32, 55, sel=True), unit(44, 62, sel=True),
+                  unit(68, 30, team="enemy"), ring(68, 30, kind="lock"),
+                  unit(78, 48, team="enemy"), ring(78, 48, kind="lock"),
+                  unit(70, 68, team="enemy"), ring(70, 68, kind="lock"),
+                  badge("齐发")], title="齐发"),
         ], ["SC2", "RA2", "RTS"],
     ))
 
@@ -1149,8 +1207,12 @@ def build_cases():
         "item-use-on-ground", "item", "对地面用物品",
         "炸弹、旗帜、营帐：点物品后点地板落下。和技能点地同一手感，消耗的是物品次数。",
         [
-            beat("点物品再点地面", "落点预览；确认后物品 -1，效果出现在地上", "丢那儿", "topdown",
-                 [hero(35, 60), circle_ind(70, 40, 14, True), cursor(70, 40), badge("物品点地")], title="点地使用"),
+            beat("点快捷栏里的物品", "进入落点预览，光圈跟随鼠标", "选个位置", "topdown",
+                 [hero(35, 60), circle_ind(70, 40, 14, True), cursor(70, 40),
+                  hotbar(active=1), badge("落点预览")], title="预览"),
+            beat("点地面确认", "物品数量 -1，效果实体出现在落点", "丢那儿", "topdown",
+                 [hero(35, 60), building(70, 40, ghost=False), hotbar(cd=1),
+                  badge("已放置")], title="放置"),
         ], ["MMO", "MOBA", "ARPG"],
     ))
     c.append(case(
@@ -1197,9 +1259,11 @@ def build_cases():
         "item-destroy-sell", "item", "摧毁 / 卖店",
         "拖到摧毁或卖店确认；贵重物品要二次确认，防止手滑。",
         [
-            beat("拖到出售/摧毁区", "标价或警告；确认后物品离开背包", "卖掉/毁掉", "moba",
+            beat("拖到出售/摧毁区", "弹出标价或警告确认框", "再想想", "moba",
                  [card(40, 50, "破装", 0, True), cursor(65, 55, "drag"),
-                  menu_box(62, 48, ["出售 12G", "摧毁", "取消"]), badge("出售确认")], title="卖或毁"),
+                  menu_box(62, 48, ["出售 12G", "摧毁", "取消"]), badge("出售确认")], title="确认框"),
+            beat("点确认", "物品离包，金币入账；贵重物品要再输名字/二次确认", "卖掉了", "moba",
+                 [menu_box(40, 45, ["+12G", "背包 -1"]), badge("已卖出")], title="成交"),
         ], ["MMO", "ARPG"],
     ))
     c.append(case(
@@ -1380,6 +1444,9 @@ def build_cases():
             beat("点击任务追踪里的目标", "地图标记或地面箭头更新", "知道去哪", "moba",
                  [hero(35, 60), cursor(40, 30), arrow(38, 55, 70, 40, "move"),
                   circle_ind(70, 40, 10, True), badge("追踪→地图")], title="点追踪"),
+            beat("走进目标区域", "追踪条目打钩或换下一步指引", "到了", "moba",
+                 [hero(68, 42), circle_ind(70, 40, 12, True),
+                  menu_box(28, 65, ["任务：√ 已到达"]), badge("阶段完成")], title="到达"),
         ], ["魔兽世界", "MMO", "ARPG"],
     ))
     c.append(case(
@@ -1502,16 +1569,23 @@ def build_cases():
         "ui-inventory-tetris", "design-ui", "背包格斗：异形体积摆放",
         "物品占多格，要旋转并找到空位才能放进；放不下明确提示，不自动“随便塞”。",
         [
-            beat("拖异形物品进包", "合法格高亮，非法格拒绝", "转一下才塞得进", "moba",
-                 [cursor(55, 45, "drag"), badge("异形背包")], title="摆放"),
+            beat("拖 L 形物品进包", "当前姿态放不下，非法格标红", "塞不进", "moba",
+                 [card(45, 40, "L形", 0, True), cursor(45, 40, "drag"),
+                  circle_ind(62, 52, 12, False), badge("放不下")], title="非法"),
+            beat("按 R 旋转再放", "旋转后合法格高亮，松手放入", "转一下就行", "moba",
+                 [card(60, 50, "L形", 0, True), cursor(60, 50, "drag"),
+                  circle_ind(60, 52, 12, True), keyhint(40, 30, "R", "active", "旋转"),
+                  badge("旋转放入")], title="旋转放入"),
         ], ["逃离塔科夫", "ARPG", "设计选项"],
     ))
     c.append(case(
         "ui-spectate-replay", "design-ui", "观战 / 回放：切视角",
         "观战点队友切换相机；回放可暂停、打点、看别人视角。只读，不改对局。",
         [
-            beat("观战中点队友或按键切换", "相机跟到该玩家", "换人看", "tps",
-                 [hero(48, 55), badge("观战切换")], title="切视角"),
+            beat("观战中点队友头像或数字键", "相机切到该玩家视角", "换人看", "tps",
+                 [hero(48, 55), menu_box(26, 68, ["1P", "2P", "3P"]), badge("观战切换")], title="切视角"),
+            beat("回放中拖时间轴 / 暂停打点", "画面跳到该时刻，可加书签", "倒回去看", "tps",
+                 [hero(48, 55), bar(50, 78, 0.4, "cast", "时间轴"), badge("回放打点")], title="回放"),
         ], ["MOBA", "FPS", "MMO"],
     ))
 
@@ -1912,6 +1986,10 @@ def build_cases():
             beat("在手牌区左右滑", "焦点卡切换，中间放大", "换一张", "topdown",
                  [card(25, 78, "A", 2), card(50, 70, "B", 4, True), card(75, 78, "C", 3),
                   badge("滑动手牌")], title="滑动"),
+            beat("打出焦点卡", "空位从牌库自动补进下一张", "又摸一张", "topdown",
+                 [unit(55, 45, sel=True), ring(55, 45),
+                  card(25, 78, "A", 2), card(50, 78, "D", 1), card(75, 78, "C", 3),
+                  badge("自动补牌")], title="补牌"),
         ], ["卡牌", "平板", "皇室战争"],
     ))
 
@@ -1963,16 +2041,22 @@ def build_cases():
         "block-resource", "blocked", "蓝 / 怒气 / 弹药不足",
         "按下后明确拒绝，并提示缺什么。",
         [
-            beat("资源不够时按技能", "图标闪红/飘字，不进瞄准", "放不出", "moba",
-                 [hero(50, 55), badge("资源不足")], title="缺资源"),
+            beat("资源不够时按技能", "图标闪红/飘字「魔法不足」，不进瞄准", "放不出", "moba",
+                 [hero(50, 55), hotbar(deny=0), bar(50, 34, 0.15, "cast", "蓝量"),
+                  badge("资源不足")], title="缺资源"),
+            beat("回蓝攒够后再按", "图标恢复亮起，正常进入施法", "缓过来了", "moba",
+                 [hero(50, 55), hotbar(active=0), bar(50, 34, 0.85, "cast", "蓝量"),
+                  badge("可施放")], title="恢复"),
         ], ["全品类"],
     ))
     c.append(case(
         "block-cooldown", "blocked", "冷却中",
         "CD 转圈，按下有拒绝音效/闪烁。",
         [
-            beat("CD 未好转按技能", "图标仍在转 CD，拒绝施放", "再等等", "moba",
-                 [hero(50, 55), badge("冷却中")], title="CD"),
+            beat("CD 未好时按技能", "图标转着遮罩拒绝施放，可有拒绝音效", "再等等", "moba",
+                 [hero(50, 55), hotbar(cd=0, deny=0), badge("冷却中")], title="CD中"),
+            beat("CD 转完", "图标亮起可再次施放", "好了", "moba",
+                 [hero(50, 55), hotbar(active=0), badge("冷却完毕")], title="转好"),
         ], ["全品类"],
     ))
     c.append(case(
@@ -1987,8 +2071,11 @@ def build_cases():
         "block-bag-full", "blocked", "背包满 / 负担不够",
         "拾取或购买时包满：明确说满了，东西留在地上或交易取消，不静默吞。",
         [
-            beat("包满时拾取或购买", "拒绝提示，物品不进包", "拿不下", "moba",
-                 [hero(48, 55), badge("背包已满")], title="包满"),
+            beat("包满时拾取或购买", "红字「背包已满」，物品留在原地不进包", "拿不下", "moba",
+                 [hero(48, 55), building(65, 48), menu_box(28, 62, ["背包已满！"]),
+                  badge("拒绝拾取")], title="包满"),
+            beat("清出格子再捡", "物品正常进包，地上消失", "腾出手了", "moba",
+                 [hero(52, 50), card(60, 42, "拾得", 0), badge("拾取成功")], title="再捡"),
         ], ["MMO", "ARPG"],
     ))
     c.append(case(
@@ -2006,8 +2093,11 @@ def build_cases():
         "block-crowd-control", "blocked", "被控：沉默 / 晕眩 / 变形",
         "被控时按键明确无效，状态图标说清是哪种控制，控结束才恢复。",
         [
-            beat("被晕/沉默时按技能", "拒绝，状态图标闪烁", "动不了", "moba",
-                 [hero(48, 55), badge("被控")], title="被控"),
+            beat("被晕/沉默时按技能", "整栏变灰拒绝，头顶控制图标闪烁说明控制类型", "动不了", "moba",
+                 [hero(48, 55), ring(48, 55, r=13, kind="lock"), hotbar(off=[0, 1, 2, 3]),
+                  badge("沉默中")], title="被控"),
+            beat("控制时间结束", "技能栏恢复亮起，立刻能反打", "缓过来了", "moba",
+                 [hero(48, 55), hotbar(active=0), badge("控制解除")], title="解控"),
         ], ["MMO", "MOBA"],
     ))
 
@@ -2023,6 +2113,71 @@ def _git_head() -> str:
         ).strip()
     except Exception:
         return "unknown"
+
+
+_HOTBAR_WORDS = ("技能栏", "快捷栏", "命令卡", "技能格", "按技能", "技能键", "技能图标",
+                 "图标亮", "图标组", "栏位", "键位提示", "多出", "新键")
+_HOTBAR_CD_WORDS = ("冷却", "CD", "转 CD", "进入物品 CD")
+_HOTBAR_DENY_WORDS = ("拒绝", "闪红", "禁止", "无效", "放不出", "不可用")
+_HOTBAR_GONE_WORDS = ("消失", "收回", "复原", "灰掉", "回到原位", "切回原")
+_HOTBAR_DOT_WORDS = ("绿点", "自动施法标记", "自动标记")
+_BAR_WORDS = ("读条", "蓄力", "引导", "倒计时")
+_BAR_BROKEN_WORDS = ("打断", "取消", "中断", "失败")
+_KEY_WORDS = ("交互键", "按 F", "按F", "交互提示", "按交互", "提示键", "键位提示")
+
+
+def _anchor(castl):
+    for el in castl:
+        if el.get("t") == "hero":
+            return el["x"], el["y"]
+    for el in castl:
+        if el.get("t") == "unit" and el.get("sel"):
+            return el["x"], el["y"]
+    return 50, 55
+
+
+def augment_ui_glyphs(cases: list) -> dict:
+    """Deterministic pass: when beat text names a UI element the cast does not
+    draw, add the matching glyph. Explicit rules, no silent guessing beyond them."""
+    added = {"hotbar": 0, "bar": 0, "key": 0}
+    for c in cases:
+        for b in c["beats"]:
+            castl = b["cast"]
+            kinds = {el.get("t") for el in castl}
+            text = f"{b['input']}{b['screen']}"
+            ax, ay = _anchor(castl)
+            if "hotbar" not in kinds and any(w in text for w in _HOTBAR_WORDS):
+                hb = hotbar(active=0)
+                if any(w in text for w in _HOTBAR_DOT_WORDS):
+                    on = not any(w in text for w in ("灭", "恢复纯手动", "OFF"))
+                    hb = hotbar(dot=0 if on else None, active=None)
+                elif any(w in text for w in _HOTBAR_GONE_WORDS):
+                    hb = hotbar(off=[3], active=None)
+                elif any(w in text for w in ("多出", "新键", "临时", "换成", "替换")):
+                    hb = hotbar(extra=3, active=None)
+                elif any(w in text for w in _HOTBAR_DENY_WORDS):
+                    hb = hotbar(deny=0, active=None)
+                elif any(w in text for w in _HOTBAR_CD_WORDS):
+                    hb = hotbar(cd=0, active=None)
+                castl.append(hb)
+                added["hotbar"] += 1
+            elif "hotbar" not in kinds and any(w in text for w in _HOTBAR_CD_WORDS) and "menu" not in kinds and "card" not in kinds:
+                castl.append(hotbar(cd=0, active=None))
+                added["hotbar"] += 1
+            if "bar" not in kinds and any(w in text for w in _BAR_WORDS):
+                broken = any(w in text for w in _BAR_BROKEN_WORDS)
+                done = any(w in text for w in ("完成", "读完", "满"))
+                castl.append(bar(ax, max(8, ay - 22),
+                                 ratio=1.0 if done else 0.55,
+                                 kind="charge" if "蓄力" in text else "cast",
+                                 broken=broken))
+                added["bar"] += 1
+            if "key" not in kinds and any(w in text for w in _KEY_WORDS):
+                gone = any(w in text for w in ("消失", "收回", "无提示"))
+                castl.append(keyhint(min(92, ax + 14), max(10, ay - 16), "F",
+                                     state="off" if gone else "active"))
+                added["key"] += 1
+    return added
 
 
 def _audit_casts(cases: list) -> list[str]:
@@ -2088,6 +2243,7 @@ def _write_checkpoint(cases: list, weak: list[str], head: str) -> None:
 def main():
     head = _git_head()
     cases = build_cases()
+    augmented = augment_ui_glyphs(cases)
     weak = _audit_casts(cases)
     payload = {
         "title": "玩家动作体验图鉴",
@@ -2113,7 +2269,8 @@ def main():
     _write_checkpoint(cases, weak, head)
     print(
         f"Wrote {OUT.relative_to(OUT.parents[2])}  cases={len(cases)}  "
-        f"beats={sum(len(x['beats']) for x in cases)}  weak_casts={len(weak)}  head={head}"
+        f"beats={sum(len(x['beats']) for x in cases)}  weak_casts={len(weak)}  "
+        f"ui_augmented={augmented}  head={head}"
     )
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述
按审计结果补齐分镜 SVG 的两类缺口：**缺关键帧**（单拍讲多段流程）与 **画面缺 UI**（文字提到技能栏/读条/交互键但没画）。

## 审计方法
- 脚本扫描：单拍但文案含「再/然后/结束/恢复/取消」等多段词 → 20 案
- 关键词对照：文案提 UI（技能栏/CD/读条/交互键）但 cast 无 UI 元件 → 61 拍

## 改动
### 新 UI 元件（SVG 渲染器 + 生成器 helper）
- `hotbar`：底部技能栏（按下高亮 / CD 扫罩 / 临时新键绿框 / 禁用红叉 / 自动施法绿点 / 拒绝红闪）
- `bar`：读条 / 蓄力 / 血量进度条（可打断态）
- `keyhint`：F 键提示帽（动词 hint / 激活 / 失效）

### 确定性 UI 补全
生成器按关键词规则给缺 UI 的拍自动补元件（**53 处**：hotbar 33、bar 10、key 10），规则显式、可审计，复查后缺口清零。

### 补关键帧（20 案 → +21 拍，318→339）
攻击移动（遇敌接战）、排队指令（自动接续）、瞄准取消（先入瞄）、磁吸（粗瞄→吸附→清锁）、切形态（切回）、闪避接攻击、上车（靠近提示）、Alt 自施（对照普通）、Shift 排队施法（到点自动放）、多目标齐发、物品点地（预览→放置）、卖店（成交）、任务追踪（到达）、异形背包（旋转放入）、观战（回放打点）、手牌（自动补牌）、缺蓝/CD/包满/被控（恢复拍）等。

### 顺手修复
搜索现在跨全部分类（原来被当前分类锁死）。

## 验证
[CD 拒绝与恢复的技能栏](https://cursor.com/agents/bc-6dbfc1fe-4147-482c-bdfd-87fe90a54211/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fplayer-action-ux-hotbar-cd.webp)
[蓄力条](https://cursor.com/agents/bc-6dbfc1fe-4147-482c-bdfd-87fe90a54211/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fplayer-action-ux-charge-bar.webp)
[F 键处决提示](https://cursor.com/agents/bc-6dbfc1fe-4147-482c-bdfd-87fe90a54211/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fplayer-action-ux-keyhint-glyph.webp)
[攻击移动两拍](https://cursor.com/agents/bc-6dbfc1fe-4147-482c-bdfd-87fe90a54211/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fplayer-action-ux-attackmove-2beats.webp)

## UAT
```gherkin
Scenario: CD 拒绝有画面表达
  Given 打开「冷却中」
  Then SHOT 01 技能栏第一格有 CD 扫罩与红色拒绝
  And SHOT 02 技能栏亮起可放

Scenario: 处决提示有按键帽
  Given 搜索「处决」并打开同一交互键案例
  Then 分镜中出现 F 键帽与「处决」动词提示

Scenario: 攻击移动补全关键帧
  Given 打开「攻击移动」
  Then 有下令与遇敌两拍
```


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6dbfc1fe-4147-482c-bdfd-87fe90a54211?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dbfc1fe-4147-482c-bdfd-87fe90a54211&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

