### PR TITLE
fix(docs): 分镜画面要画出文案承诺的东西（UX-080 及同类）

### DIFF
--- a/gitbook/reference/player-action-ux/CHECKPOINT.md
+++ b/gitbook/reference/player-action-ux/CHECKPOINT.md
@@ -8,7 +8,7 @@
 - 逻辑文案：`scripts/player_action_ux_beat_logic.py`
 - 实现标注：`scripts/player_action_ux_impl_notes.py`
 - 动作编号/平台变体：`scripts/player_action_ux_action_index.py`
-- 生成时 HEAD：`4a5716505`（以你拉取后的 `git rev-parse` 为准；合并后会变）
+- 生成时 HEAD：`06963e09b`（以你拉取后的 `git rev-parse` 为准；合并后会变）
 - 分支语境：`cursor/ux-action-id-platform-tabs-4211`（unique 动作编号 + 主机/键鼠/触控 tab）
 - 已合 main：图鉴 #743–#755（含按游戏分类、时序三参与者、一镜一对、双人审核）
 
@@ -64,6 +64,9 @@
 
 - 仅 badge / 空 cast 的弱分镜拍数：0
 - 弱分镜不阻断生成，但改数据时应补单位/光标/指示器，禁止「只有字没有画面」
+- `_audit_storyboard()` 是硬闸：镜位未登记、光标状态渲染器画不出、箭头压住单位、说「变准星」却没准星、说「点菜单项」却没菜单 —— 任一命中直接 fail 生成
+- 光标状态白名单：idle / down / drag / up / aim；`aim`=施法准星，`up`=松手波纹
+- 镜位角标只出人话：俯视战场、斜俯视、越肩视角、第一人称
 
 ## 高频 TODO（去重）
 

--- a/gitbook/reference/player-action-ux/CHECKPOINT.md
+++ b/gitbook/reference/player-action-ux/CHECKPOINT.md
@@ -8,7 +8,7 @@
 - 逻辑文案：`scripts/player_action_ux_beat_logic.py`
 - 实现标注：`scripts/player_action_ux_impl_notes.py`
 - 动作编号/平台变体：`scripts/player_action_ux_action_index.py`
-- 生成时 HEAD：`06963e09b`（以你拉取后的 `git rev-parse` 为准；合并后会变）
+- 生成时 HEAD：`fbf04fd1c`（以你拉取后的 `git rev-parse` 为准；合并后会变）
 - 分支语境：`cursor/ux-action-id-platform-tabs-4211`（unique 动作编号 + 主机/键鼠/触控 tab）
 - 已合 main：图鉴 #743–#755（含按游戏分类、时序三参与者、一镜一对、双人审核）
 

--- a/gitbook/reference/player-action-ux/catalog-app.js
+++ b/gitbook/reference/player-action-ux/catalog-app.js
@@ -20,6 +20,21 @@
   const casesById = Object.fromEntries(data.cases.map((c) => [c.id, c]));
   const actionsByKey = Object.fromEntries(data.actions.map((a) => [a.key, a]));
 
+  if (!Array.isArray(data.views) || !data.views.length) {
+    throw new Error("PLAYER_ACTION_UX_CATALOG.views missing — regenerate catalog-data.js");
+  }
+  if (!Array.isArray(data.cursorModes) || !data.cursorModes.length) {
+    throw new Error("PLAYER_ACTION_UX_CATALOG.cursorModes missing — regenerate catalog-data.js");
+  }
+  const VIEW_LABEL = Object.fromEntries(data.views.map((v) => [v.id, v.label]));
+  const CURSOR_MODES = data.cursorModes.slice();
+
+  function viewLabel(view) {
+    const label = VIEW_LABEL[view];
+    if (!label) throw new Error(`分镜视角未知：${view} — 修 catalog 生成脚本`);
+    return label;
+  }
+
   /** Default to first real category so the page is not a 150-card dump. */
   let activeCategory = (data.categories[0] && data.categories[0].id) || "all";
   let selectedActionKey = null;
@@ -108,11 +123,33 @@
       }
       if (el.t === "cursor") {
         const x = px(el.x), y = py(el.y);
-        const down = el.mode === "down" || el.mode === "drag";
+        const mode = el.mode || "idle";
+        if (!CURSOR_MODES.includes(mode)) {
+          throw new Error(`分镜光标状态未知：${mode}（只允许 ${CURSOR_MODES.join(" / ")}）— 修 catalog 生成脚本`);
+        }
+        if (mode === "aim") {
+          // 施法专属光标：鼠标已变成技能准星，和 FPS 大准星区分开
+          return `
+            <g transform="translate(${x},${y})">
+              <circle r="7.5" fill="none" stroke="#f0a35e" stroke-width="1.8"/>
+              <line x1="-13" y1="0" x2="-9" y2="0" stroke="#f0a35e" stroke-width="1.8"/>
+              <line x1="9" y1="0" x2="13" y2="0" stroke="#f0a35e" stroke-width="1.8"/>
+              <line x1="0" y1="-13" x2="0" y2="-9" stroke="#f0a35e" stroke-width="1.8"/>
+              <line x1="0" y1="9" x2="0" y2="13" stroke="#f0a35e" stroke-width="1.8"/>
+              <circle r="1.8" fill="#f0a35e"/>
+            </g>`;
+        }
+        const down = mode === "down" || mode === "drag";
+        // 松手那一拍要看得出「刚点下去」：在落点画外扩的确认波纹
+        const release = mode === "up"
+          ? `<circle r="8" fill="none" stroke="#f0a35e" stroke-width="1.8" opacity="0.95"/>
+             <circle r="13.5" fill="none" stroke="#f0a35e" stroke-width="1.1" opacity="0.45"/>`
+          : "";
         return `
           <g transform="translate(${x},${y})">
+            ${release}
             <path d="M0 0 L0 16 L4.5 13 L8 20 L11 18.5 L7.5 11.5 L13 11 Z" fill="${down ? "#f0a35e" : "#e8eef6"}" stroke="#0b0e13" stroke-width="1"/>
-            ${el.mode === "drag" ? `<circle cx="2" cy="2" r="10" fill="none" stroke="#f0a35e" stroke-dasharray="2 2" opacity="0.7"/>` : ""}
+            ${mode === "drag" ? `<circle cx="2" cy="2" r="10" fill="none" stroke="#f0a35e" stroke-dasharray="2 2" opacity="0.7"/>` : ""}
           </g>`;
       }
       if (el.t === "box") {
@@ -163,8 +200,9 @@
       if (el.t === "building") {
         const x = px(el.x), y = py(el.y);
         const fill = el.ghost ? "rgba(110,200,255,0.2)" : "#8aa0b8";
-        const stroke = el.ghost ? "#6ec8ff" : "#0b0e13";
-        return `<rect x="${x - 12}" y="${y - 12}" width="24" height="24" rx="3" fill="${fill}" stroke="${stroke}" stroke-width="1.5" stroke-dasharray="${el.ghost ? "3 2" : "0"}"/>`;
+        const stroke = el.ghost ? "#6ec8ff" : el.team ? teamColor(el.team) : "#0b0e13";
+        const width = el.ghost || el.team ? 2 : 1.5;
+        return `<rect x="${x - 12}" y="${y - 12}" width="24" height="24" rx="3" fill="${fill}" stroke="${stroke}" stroke-width="${width}" stroke-dasharray="${el.ghost ? "3 2" : "0"}"/>`;
       }
       if (el.t === "stickL" || el.t === "stickR") {
         const left = el.t === "stickL";
@@ -200,9 +238,13 @@
         const lines = el.lines || [];
         const h = 16 + lines.length * 16;
         const w = 72;
-        const items = lines.map((ln, i) =>
-          `<text x="${x + 8}" y="${y + 18 + i * 16}" fill="#e8eef6" font-size="11" font-family="DM Sans, sans-serif">${esc(ln)}</text>`
-        ).join("");
+        const items = lines.map((ln, i) => {
+          const on = el.active === i;
+          const hit = on
+            ? `<rect x="${x + 3}" y="${y + 6 + i * 16}" width="${w - 6}" height="15" rx="2" fill="rgba(240,163,94,0.22)" stroke="#f0a35e" stroke-width="1.2"/>`
+            : "";
+          return `${hit}<text x="${x + 8}" y="${y + 18 + i * 16}" fill="${on ? "#f0a35e" : "#e8eef6"}" font-size="11" font-family="DM Sans, sans-serif" font-weight="${on ? 700 : 400}">${esc(ln)}</text>`;
+        }).join("");
         return `
           <rect x="${x}" y="${y}" width="${w}" height="${h}" rx="4" fill="#0b0e13" stroke="#6ec8ff" stroke-width="1.4"/>
           ${items}`;
@@ -291,6 +333,8 @@
     const id = `sb${++uid}`;
     const shot = String(index + 1).padStart(2, "0");
     const title = beat.title || `步骤 ${index + 1}`;
+    if (!beat.view) throw new Error(`分镜缺 view（第 ${index + 1} 拍）— 修 catalog 生成脚本`);
+    const stageLabel = viewLabel(beat.view);
     const cap = `${beat.input} → ${beat.screen}`;
     const shortCap = cap.length > 42 ? `${cap.slice(0, 41)}…` : cap;
     return `
@@ -316,14 +360,14 @@
         <rect x="14" y="8" width="292" height="22" fill="#0d1117"/>
         <text x="22" y="23" fill="#f0a35e" font-size="12" font-family="IBM Plex Mono, monospace" font-weight="700">SHOT ${shot}</text>
         <text x="88" y="23" fill="#e8eef6" font-size="12" font-family="DM Sans, sans-serif" font-weight="600">${esc(title)}</text>
-        <text x="298" y="23" text-anchor="end" fill="#66758a" font-size="10" font-family="IBM Plex Mono, monospace">${esc(beat.view || "topdown")}</text>
+        <text x="298" y="23" text-anchor="end" fill="#93a0b4" font-size="10" font-family="DM Sans, sans-serif">${esc(stageLabel)}</text>
 
         <!-- comic outer / inner frame -->
         <rect x="14" y="32" width="292" height="158" fill="none" stroke="#0b0e13" stroke-width="4"/>
         <rect x="16" y="34" width="288" height="154" fill="none" stroke="#c9a27a" stroke-width="1.2" opacity="0.55"/>
 
         <g clip-path="url(#clip-${id})">
-          ${drawStage(beat.view || "topdown", `gnd-${id}`)}
+          ${drawStage(beat.view, `gnd-${id}`)}
           ${renderCast(beat.cast || [], id)}
         </g>
 

--- a/gitbook/reference/player-action-ux/catalog-data.js
+++ b/gitbook/reference/player-action-ux/catalog-data.js
@@ -48,7 +48,7 @@ window.PLAYER_ACTION_UX_CATALOG = {
     "aim"
   ],
   "checkpoint": {
-    "head": "06963e09b",
+    "head": "fbf04fd1c",
     "branch_hint": "cursor/ux-action-id-platform-tabs-4211",
     "impl_notes": "scripts/player_action_ux_impl_notes.py",
     "beat_logic": "scripts/player_action_ux_beat_logic.py",
@@ -9407,8 +9407,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "unit",
-              "x": 70,
-              "y": 38,
+              "x": 68,
+              "y": 36,
               "sel": false,
               "team": "enemy",
               "face": 0,
@@ -9416,8 +9416,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "unit",
-              "x": 80,
-              "y": 55,
+              "x": 84,
+              "y": 60,
               "sel": false,
               "team": "enemy",
               "face": 0,
@@ -9425,8 +9425,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 56,
-              "y": 44,
+              "x": 54,
+              "y": 46,
               "mode": "aim"
             },
             {
@@ -9460,8 +9460,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "unit",
-              "x": 70,
-              "y": 38,
+              "x": 68,
+              "y": 36,
               "sel": false,
               "team": "enemy",
               "face": 0,
@@ -9469,15 +9469,15 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "ring",
-              "x": 70,
-              "y": 38,
+              "x": 68,
+              "y": 36,
               "r": 12,
               "kind": "lock"
             },
             {
               "t": "unit",
-              "x": 80,
-              "y": 55,
+              "x": 84,
+              "y": 60,
               "sel": false,
               "team": "enemy",
               "face": 0,
@@ -9487,14 +9487,14 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "arrow",
               "x1": 40,
               "y1": 55,
-              "x2": 66,
-              "y2": 40,
+              "x2": 64,
+              "y2": 39,
               "kind": "attack"
             },
             {
               "t": "cursor",
-              "x": 66.48,
-              "y": 44.67,
+              "x": 74,
+              "y": 44,
               "mode": "up"
             },
             {

--- a/gitbook/reference/player-action-ux/catalog-data.js
+++ b/gitbook/reference/player-action-ux/catalog-data.js
@@ -22,8 +22,33 @@ window.PLAYER_ACTION_UX_CATALOG = {
       "label": "触控"
     }
   ],
+  "views": [
+    {
+      "id": "topdown",
+      "label": "俯视战场"
+    },
+    {
+      "id": "moba",
+      "label": "斜俯视"
+    },
+    {
+      "id": "tps",
+      "label": "越肩视角"
+    },
+    {
+      "id": "fps",
+      "label": "第一人称"
+    }
+  ],
+  "cursorModes": [
+    "idle",
+    "down",
+    "drag",
+    "up",
+    "aim"
+  ],
   "checkpoint": {
-    "head": "4a5716505",
+    "head": "06963e09b",
     "branch_hint": "cursor/ux-action-id-platform-tabs-4211",
     "impl_notes": "scripts/player_action_ux_impl_notes.py",
     "beat_logic": "scripts/player_action_ux_beat_logic.py",
@@ -5151,8 +5176,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 62,
-              "y": 42,
+              "x": 65.52,
+              "y": 48.67,
               "mode": "idle"
             },
             {
@@ -5204,8 +5229,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 62,
-              "y": 42,
+              "x": 65.52,
+              "y": 48.67,
               "mode": "up"
             },
             {
@@ -5307,8 +5332,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 30,
-              "y": 30,
+              "x": 38.52,
+              "y": 46.67,
               "mode": "down"
             },
             {
@@ -5639,8 +5664,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 35,
-              "y": 35,
+              "x": 36.48,
+              "y": 51.67,
               "mode": "up"
             }
           ],
@@ -5721,8 +5746,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 65,
-              "y": 48,
+              "x": 68.52,
+              "y": 54.67,
               "mode": "up"
             },
             {
@@ -5765,8 +5790,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 40,
-              "y": 50,
+              "x": 43.52,
+              "y": 56.67,
               "mode": "up"
             },
             {
@@ -5825,8 +5850,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 50,
-              "y": 52,
+              "x": 53.52,
+              "y": 58.67,
               "mode": "up"
             },
             {
@@ -5944,8 +5969,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 45,
-              "y": 55,
+              "x": 48.52,
+              "y": 61.67,
               "mode": "up"
             },
             {
@@ -6221,6 +6246,13 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "team": "ally",
               "face": 0,
               "size": 1.5
+            },
+            {
+              "t": "ring",
+              "x": 65,
+              "y": 55,
+              "r": 16,
+              "kind": "buff"
             },
             {
               "t": "key",
@@ -6885,8 +6917,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 70,
-              "y": 40,
+              "x": 73.52,
+              "y": 46.67,
               "mode": "up"
             },
             {
@@ -6922,7 +6954,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 70,
               "y": 45,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "arrow",
@@ -6934,8 +6967,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 70,
-              "y": 45,
+              "x": 74.93,
+              "y": 54.33,
               "mode": "up"
             },
             {
@@ -7169,7 +7202,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 35,
               "y": 50,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "arrow",
@@ -8417,8 +8451,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 70,
-              "y": 40,
+              "x": 73.52,
+              "y": 46.67,
               "mode": "up"
             },
             {
@@ -9362,42 +9396,7 @@ window.PLAYER_ACTION_UX_CATALOG = {
         {
           "title": "进入",
           "input": "按技能",
-          "screen": "鼠标变专属准星",
-          "view": "moba",
-          "cast": [
-            {
-              "t": "hero",
-              "x": 35,
-              "y": 60,
-              "face": 0
-            },
-            {
-              "t": "cursor",
-              "x": 60,
-              "y": 40,
-              "mode": "idle"
-            },
-            {
-              "t": "badge",
-              "text": "选敌"
-            },
-            {
-              "t": "hotbar",
-              "slots": 4,
-              "active": 0,
-              "cd": null,
-              "extra": null,
-              "off": [],
-              "dot": null,
-              "deny": null
-            }
-          ],
-          "logic": "进入点选敌方目标的瞄准态"
-        },
-        {
-          "title": "点中",
-          "input": "点敌人",
-          "screen": "技能飞向该单位",
+          "screen": "鼠标变专属准星，场上敌人可点",
           "view": "moba",
           "cast": [
             {
@@ -9408,8 +9407,77 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "unit",
-              "x": 65,
-              "y": 40,
+              "x": 70,
+              "y": 38,
+              "sel": false,
+              "team": "enemy",
+              "face": 0,
+              "size": 1
+            },
+            {
+              "t": "unit",
+              "x": 80,
+              "y": 55,
+              "sel": false,
+              "team": "enemy",
+              "face": 0,
+              "size": 1
+            },
+            {
+              "t": "cursor",
+              "x": 56,
+              "y": 44,
+              "mode": "aim"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
+            },
+            {
+              "t": "badge",
+              "text": "选敌"
+            }
+          ],
+          "logic": "进入点选敌方目标的瞄准态"
+        },
+        {
+          "title": "点中",
+          "input": "点敌人",
+          "screen": "被点的那个敌人套上锁定圈，技能飞向它",
+          "view": "moba",
+          "cast": [
+            {
+              "t": "hero",
+              "x": 35,
+              "y": 60,
+              "face": 0
+            },
+            {
+              "t": "unit",
+              "x": 70,
+              "y": 38,
+              "sel": false,
+              "team": "enemy",
+              "face": 0,
+              "size": 1
+            },
+            {
+              "t": "ring",
+              "x": 70,
+              "y": 38,
+              "r": 12,
+              "kind": "lock"
+            },
+            {
+              "t": "unit",
+              "x": 80,
+              "y": 55,
               "sel": false,
               "team": "enemy",
               "face": 0,
@@ -9419,15 +9487,25 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "arrow",
               "x1": 40,
               "y1": 55,
-              "x2": 62,
-              "y2": 42,
+              "x2": 66,
+              "y2": 40,
               "kind": "attack"
             },
             {
               "t": "cursor",
-              "x": 65,
-              "y": 40,
+              "x": 66.48,
+              "y": 44.67,
               "mode": "up"
+            },
+            {
+              "t": "hotbar",
+              "slots": 4,
+              "active": 0,
+              "cd": null,
+              "extra": null,
+              "off": [],
+              "dot": null,
+              "deny": null
             },
             {
               "t": "badge",
@@ -9493,7 +9571,7 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "cursor",
               "x": 65,
               "y": 42,
-              "mode": "idle"
+              "mode": "aim"
             },
             {
               "t": "arrow",
@@ -9707,8 +9785,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 50,
-              "y": 40,
+              "x": 53.52,
+              "y": 46.67,
               "mode": "up"
             },
             {
@@ -10032,7 +10110,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 48,
               "y": 42,
-              "ghost": true
+              "ghost": true,
+              "team": null
             },
             {
               "t": "circle",
@@ -10045,7 +10124,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 72,
               "y": 58,
-              "ghost": true
+              "ghost": true,
+              "team": null
             },
             {
               "t": "circle",
@@ -10056,8 +10136,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 48,
-              "y": 42,
+              "x": 52.93,
+              "y": 51.33,
               "mode": "idle"
             },
             {
@@ -10077,7 +10157,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 48,
               "y": 42,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "badge",
@@ -10561,7 +10642,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 72,
               "y": 32,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "badge",
@@ -10586,7 +10668,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 72,
               "y": 32,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "badge",
@@ -11971,7 +12054,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 70,
               "y": 48,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "badge",
@@ -12032,7 +12116,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 60,
               "y": 50,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "arrow",
@@ -13260,7 +13345,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 72,
               "y": 42,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "arrow",
@@ -13800,7 +13886,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 70,
               "y": 42,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "ring",
@@ -13819,8 +13906,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 70,
-              "y": 42,
+              "x": 74.93,
+              "y": 51.33,
               "mode": "up"
             },
             {
@@ -13856,7 +13943,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 70,
               "y": 42,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "circle",
@@ -13927,8 +14015,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 72,
-              "y": 40,
+              "x": 75.52,
+              "y": 46.67,
               "mode": "up"
             },
             {
@@ -14052,7 +14140,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 70,
               "y": 42,
-              "ghost": false
+              "ghost": false,
+              "team": "enemy"
             },
             {
               "t": "arrow",
@@ -14064,8 +14153,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 70,
-              "y": 42,
+              "x": 74.93,
+              "y": 51.33,
               "mode": "up"
             },
             {
@@ -14101,7 +14190,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 70,
               "y": 42,
-              "ghost": false
+              "ghost": false,
+              "team": "ally"
             },
             {
               "t": "arrow",
@@ -14151,7 +14241,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 70,
               "y": 42,
-              "ghost": false
+              "ghost": false,
+              "team": "enemy"
             },
             {
               "t": "arrow",
@@ -14378,8 +14469,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 72,
-              "y": 40,
+              "x": 75.52,
+              "y": 46.67,
               "mode": "up"
             },
             {
@@ -14423,7 +14514,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 68,
               "y": 38,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "arrow",
@@ -14479,7 +14571,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 68,
               "y": 38,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "arrow",
@@ -14498,8 +14591,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 68,
-              "y": 38,
+              "x": 72.93,
+              "y": 47.33,
               "mode": "up"
             },
             {
@@ -14587,7 +14680,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 72,
               "y": 40,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "arrow",
@@ -14716,7 +14810,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 72,
               "y": 42,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "arrow",
@@ -14937,7 +15032,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "冲锋",
                 "震地",
                 "处决"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "hotbar",
@@ -14994,7 +15090,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "冲锋",
                 "震地",
                 "处决"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "hotbar",
@@ -15252,7 +15349,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "冲击波",
                 "护盾",
                 "冲锋"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "hotbar",
@@ -15302,7 +15400,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "移动",
                 "攻击",
                 "技能"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "hotbar",
@@ -16048,7 +16147,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "y": 58,
               "lines": [
                 "精良 护腕"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "key",
@@ -16091,7 +16191,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "y": 68,
               "lines": [
                 "背包 +1"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -16151,7 +16252,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "y": 62,
               "lines": [
                 "背包已满！"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "key",
@@ -16241,7 +16343,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "铁矿×3",
                 "破剑",
                 "布料"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -16278,7 +16381,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "lines": [
                 "铁矿×3",
                 "布料"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "card",
@@ -16356,7 +16460,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "需求",
                 "贪婪",
                 "放弃"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -16577,8 +16682,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 65,
-              "y": 45,
+              "x": 68.52,
+              "y": 51.67,
               "mode": "idle"
             },
             {
@@ -16692,7 +16797,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 70,
               "y": 40,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "hotbar",
@@ -16781,7 +16887,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "lines": [
                 "武器槽←剑",
                 "旧斧→包"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -16816,7 +16923,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "lines": [
                 "武器槽：（空）",
                 "ATK -12"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -17100,7 +17208,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "lines": [
                 "包里 剑 +12",
                 "暴击 +5"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "menu",
@@ -17109,7 +17218,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "lines": [
                 "已穿 剑 +8",
                 "暴击 +2"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -17181,7 +17291,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "出售 12G",
                 "摧毁",
                 "取消"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -17203,7 +17314,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "lines": [
                 "+12G",
                 "背包 -1"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -17284,7 +17396,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "y": 68,
               "lines": [
                 "次数 3→2"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -17321,7 +17434,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "耐久 0",
                 "属性失效",
                 "去修理"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -17443,7 +17557,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "[我]",
                 "[友A]←",
                 "[友B]"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "cursor",
@@ -17556,7 +17671,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "接受任务",
                 "商店",
                 "再见"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "key",
@@ -17632,7 +17748,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "lines": [
                 "……旁白……",
                 "[跳过]"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -17670,7 +17787,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "接受任务",
                 "再看看",
                 "再见"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -17741,7 +17859,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "组队邀请",
                 "接受",
                 "拒绝"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -17786,7 +17905,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "y": 70,
               "lines": [
                 "队伍 2/5"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -17813,7 +17933,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "y": 70,
               "lines": [
                 "队伍 1/5"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -17997,7 +18118,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "你的报价",
                 "(空)",
                 "金币 0"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "menu",
@@ -18007,7 +18129,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "对方报价",
                 "(空)",
                 "金币 0"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -18045,7 +18168,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "你的报价",
                 "矿石",
                 "金币 20"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "menu",
@@ -18055,7 +18179,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "对方报价",
                 "币袋",
                 "金币 0"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "card",
@@ -18184,7 +18309,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "y": 70,
               "lines": [
                 "密语: 你好"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -18276,7 +18402,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "挥手",
                 "跳舞",
                 "比心"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -18337,7 +18464,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "胸甲",
                 "武器 +12",
                 "饰品"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "card",
@@ -18411,7 +18539,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 65,
               "y": 45,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "badge",
@@ -18453,7 +18582,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 65,
               "y": 45,
-              "ghost": true
+              "ghost": true,
+              "team": null
             },
             {
               "t": "card",
@@ -18495,7 +18625,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 65,
               "y": 45,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "bar",
@@ -18575,7 +18706,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "药水 5G",
                 "面包 1G",
                 "箭袋 3G"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -18645,7 +18777,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "lines": [
                 "回购页",
                 "破剑 6G"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -18766,7 +18899,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "暴风城",
                 "铁炉堡",
                 "取消"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -18824,7 +18958,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 70,
               "y": 40,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "arrow",
@@ -19173,7 +19308,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "y": 65,
               "lines": [
                 "任务：√ 已到达"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -19231,7 +19367,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 65,
               "y": 45,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "card",
@@ -19248,7 +19385,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "lines": [
                 "收件箱",
                 "取附件"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -19284,7 +19422,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "lines": [
                 "一口价",
                 "上架"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -19506,8 +19645,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 48,
-              "y": 55,
+              "x": 51.87,
+              "y": 62.33,
               "mode": "idle"
             },
             {
@@ -19574,8 +19713,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 55,
-              "y": 45,
+              "x": 58.52,
+              "y": 51.67,
               "mode": "idle"
             },
             {
@@ -19586,7 +19725,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "交易",
                 "检查",
                 "跟随"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -19598,7 +19738,7 @@ window.PLAYER_ACTION_UX_CATALOG = {
         {
           "title": "选中",
           "input": "点菜单项",
-          "screen": "执行该项，菜单关闭",
+          "screen": "点中的那项亮一下，随即收起菜单并执行",
           "view": "moba",
           "cast": [
             {
@@ -19614,15 +19754,26 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "arrow",
               "x1": 58,
               "y1": 45,
-              "x2": 78,
+              "x2": 88,
               "y2": 45,
               "kind": "move"
             },
             {
+              "t": "menu",
+              "x": 62,
+              "y": 40,
+              "lines": [
+                "交易",
+                "检查",
+                "跟随"
+              ],
+              "active": 2
+            },
+            {
               "t": "cursor",
-              "x": 70,
-              "y": 52,
-              "mode": "idle"
+              "x": 66,
+              "y": 72,
+              "mode": "up"
             },
             {
               "t": "badge",
@@ -19688,7 +19839,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "技能库",
                 "火球",
                 "闪现"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "card",
@@ -19742,7 +19894,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "技能库",
                 "火球",
                 "闪现"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "card",
@@ -19849,7 +20002,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "lines": [
                 "删除角色？",
                 "不可恢复"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -19877,7 +20031,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "lines": [
                 "确认",
                 "取消"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "cursor",
@@ -19949,7 +20104,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "来这里",
                 "小心",
                 "进攻"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -19991,7 +20147,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "来这里",
                 "小心",
                 "进攻"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "box",
@@ -20432,7 +20589,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 62,
               "y": 48,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "ring",
@@ -20497,7 +20655,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 28,
               "y": 50,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "menu",
@@ -20506,7 +20665,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "lines": [
                 "步兵 50矿",
                 "坦克 150"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "card",
@@ -20548,7 +20708,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 40,
               "y": 50,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "menu",
@@ -20557,7 +20718,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "lines": [
                 "步兵 x2",
                 "取消一项"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "cursor",
@@ -20742,7 +20904,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "1P",
                 "2P",
                 "3P"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -20930,7 +21093,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 65,
               "y": 48,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "badge",
@@ -21027,7 +21191,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 68,
               "y": 55,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "unit",
@@ -21061,12 +21226,13 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 68,
               "y": 55,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "cursor",
-              "x": 68,
-              "y": 55,
+              "x": 72.93,
+              "y": 64.33,
               "mode": "idle"
             },
             {
@@ -21405,7 +21571,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 62,
               "y": 48,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "key",
@@ -21445,7 +21612,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 62,
               "y": 48,
-              "ghost": true
+              "ghost": true,
+              "team": null
             },
             {
               "t": "key",
@@ -21486,7 +21654,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 65,
               "y": 45,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "key",
@@ -21556,7 +21725,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 58,
               "y": 50,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "badge",
@@ -21581,7 +21751,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 55,
               "y": 50,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "badge",
@@ -21669,7 +21840,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 62,
               "y": 48,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "badge",
@@ -21738,7 +21910,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 66,
               "y": 46,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "key",
@@ -22336,7 +22509,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "lines": [
                 "宠技",
                 "自动 ON"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -22585,7 +22759,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "lines": [
                 "生命<30% → 用药",
                 "见硬控 → 减伤"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -23964,7 +24139,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 70,
               "y": 30,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "unit",
@@ -24331,8 +24507,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 40,
-              "y": 55,
+              "x": 43.52,
+              "y": 61.67,
               "mode": "down"
             },
             {
@@ -24383,8 +24559,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 72,
-              "y": 40,
+              "x": 75.52,
+              "y": 46.67,
               "mode": "up"
             },
             {
@@ -24478,8 +24654,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
             },
             {
               "t": "cursor",
-              "x": 58,
-              "y": 52,
+              "x": 59.93,
+              "y": 59.33,
               "mode": "down"
             },
             {
@@ -24866,7 +25042,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "攻击",
                 "计策",
                 "待命"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -25002,7 +25179,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
                 "移动",
                 "攻击",
                 "计策"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -25187,7 +25365,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "lines": [
                 "执行",
                 "取消"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -25561,7 +25740,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 65,
               "y": 48,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "menu",
@@ -25569,7 +25749,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "y": 62,
               "lines": [
                 "背包已满！"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",
@@ -25675,7 +25856,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "t": "building",
               "x": 52,
               "y": 42,
-              "ghost": false
+              "ghost": false,
+              "team": null
             },
             {
               "t": "path",
@@ -25731,7 +25913,8 @@ window.PLAYER_ACTION_UX_CATALOG = {
               "y": 45,
               "lines": [
                 "交易已取消"
-              ]
+              ],
+              "active": null
             },
             {
               "t": "badge",

--- a/gitbook/reference/player-action-ux/index.html
+++ b/gitbook/reference/player-action-ux/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,600;0,9..40,700;1,9..40,400&family=Fraunces:opsz,wght@9..144,500;9..144,650&family=IBM+Plex+Mono:wght@500;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="catalog.css?v=action-tabs-1" />
+  <link rel="stylesheet" href="catalog.css?v=story-fix-1" />
 </head>
 <body>
   <div class="app">
@@ -48,7 +48,7 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
-  <script src="catalog-data.js?v=action-tabs-1"></script>
-  <script src="catalog-app.js?v=action-tabs-1"></script>
+  <script src="catalog-data.js?v=story-fix-1"></script>
+  <script src="catalog-app.js?v=story-fix-1"></script>
 </body>
 </html>

--- a/scripts/generate-player-action-ux-catalog.py
+++ b/scripts/generate-player-action-ux-catalog.py
@@ -782,12 +782,12 @@ def build_cases():
         "先按技能，再点合法敌方目标放出。",
         [
             beat("按技能", "鼠标变专属准星，场上敌人可点", "选目标", "moba",
-                 [hero(35, 60), unit(70, 38, team="enemy"), unit(80, 55, team="enemy"),
-                  cursor(56, 44, "aim"), hotbar(active=0), badge("选敌")], title="进入"),
+                 [hero(35, 60), unit(68, 36, team="enemy"), unit(84, 60, team="enemy"),
+                  cursor(54, 46, "aim"), hotbar(active=0), badge("选敌")], title="进入"),
             beat("点敌人", "被点的那个敌人套上锁定圈，技能飞向它", "点到了", "moba",
-                 [hero(35, 60), unit(70, 38, team="enemy"), ring(70, 38, r=12, kind="lock"),
-                  unit(80, 55, team="enemy"), arrow(40, 55, 66, 40, "attack"),
-                  cursor(70, 38, "up"), hotbar(active=0), badge("确认")], title="点中"),
+                 [hero(35, 60), unit(68, 36, team="enemy"), ring(68, 36, r=12, kind="lock"),
+                  unit(84, 60, team="enemy"), arrow(40, 55, 64, 39, "attack"),
+                  cursor(74, 44, "up"), hotbar(active=0), badge("确认")], title="点中"),
         ], ["MOBA", "RTS", "War3"],
     ))
     c.append(case(

--- a/scripts/generate-player-action-ux-catalog.py
+++ b/scripts/generate-player-action-ux-catalog.py
@@ -26,6 +26,46 @@ from player_action_ux_impl_notes import enrich_all  # noqa: E402
 OUT = Path(__file__).resolve().parent.parent / "gitbook/reference/player-action-ux/catalog-data.js"
 CHECKPOINT_MD = Path(__file__).resolve().parent.parent / "gitbook/reference/player-action-ux/CHECKPOINT.md"
 
+# 分镜镜位（角标用人话，不给玩家看英文代号）
+VIEW_LABELS = {
+    "topdown": "俯视战场",
+    "moba": "斜俯视",
+    "tps": "越肩视角",
+    "fps": "第一人称",
+}
+
+# 光标状态：渲染器逐个都画得出来，未列出的状态直接 fail
+CURSOR_MODES = ("idle", "down", "drag", "up", "aim")
+
+# 光标是箭头时会压住脚下的东西，这些状态要让位；aim 是准星、drag 是抓着，压着才对
+CURSOR_MODES_OFFSET = ("idle", "down", "up")
+CURSOR_OCCLUDERS = ("unit", "hero", "building")
+
+# 舞台像素尺寸必须和 catalog-app.js 的 SW / SH 一致
+STAGE_W_PX = 284.0
+STAGE_H_PX = 150.0
+# 箭头图形从箭尖（0,0）往右下伸展出的包围盒
+CURSOR_BODY_PX = (13.0, 20.0)
+
+
+def _entity_radius_px(e: dict) -> float:
+    t = e.get("t")
+    if t == "unit":
+        return 8.0 * (e.get("size") or 1)
+    if t == "hero":
+        return 9.0
+    if t == "building":
+        return 12.0
+    raise SystemExit(f"未登记的遮挡体半径: {t}")
+
+
+def _cursor_covers(cur: dict, ent: dict) -> bool:
+    """箭头光标是否把这个实体压住（按箭头真实包围盒 + 实体半径算）。"""
+    dx = (ent["x"] - cur["x"]) / 100.0 * STAGE_W_PX
+    dy = (ent["y"] - cur["y"]) / 100.0 * STAGE_H_PX
+    r = _entity_radius_px(ent)
+    return -r <= dx <= CURSOR_BODY_PX[0] + r and -r <= dy <= CURSOR_BODY_PX[1] + r
+
 
 def beat(input_text, screen, _author_note, view, cast, title=None):
     """Build one storyboard beat.
@@ -98,8 +138,9 @@ def circle_ind(x, y, r=16, ok=True):
     return {"t": "circle", "x": x, "y": y, "r": r, "ok": ok}
 
 
-def building(x, y, ghost=False):
-    return {"t": "building", "x": x, "y": y, "ghost": ghost}
+def building(x, y, ghost=False, team=None):
+    """team 标出阵营描边（敌方红 / 己方绿），不给就是中立灰。"""
+    return {"t": "building", "x": x, "y": y, "ghost": ghost, "team": team}
 
 
 def badge(text):
@@ -118,8 +159,9 @@ def card(x, y, label="卡", cost=None, dragging=False):
     return {"t": "card", "x": x, "y": y, "label": label, "cost": cost, "dragging": dragging}
 
 
-def menu_box(x, y, lines):
-    return {"t": "menu", "x": x, "y": y, "lines": list(lines)}
+def menu_box(x, y, lines, active=None):
+    """active = 被点中的那一项（0 起），用于「点了哪一项」看得见。"""
+    return {"t": "menu", "x": x, "y": y, "lines": list(lines), "active": active}
 
 
 def hotbar(active=None, cd=None, extra=None, off=None, dot=None, deny=None, slots=4):
@@ -403,8 +445,8 @@ def build_cases():
         "附身、上车、切英雄、观战跟随时，操控跟到新主体。",
         [
             beat("靠近载具，按交互键", "载具高亮，出现上车提示", "能上车", "tps",
-                 [hero(40, 60), unit(65, 55, size=1.5), keyhint(65, 38, "F", "active", "上车"),
-                  badge("可交互")], title="靠近"),
+                 [hero(40, 60), unit(65, 55, size=1.5), ring(65, 55, r=16, kind="buff"),
+                  keyhint(65, 38, "F", "active", "上车"), badge("可交互")], title="靠近"),
             beat("按下确认上车", "镜头切到载具视角/操控", "你变成车", "tps",
                  [unit(55, 55, size=1.5, sel=True), ring(55, 55), keyhint(55, 38, "F", "active", "上车"),
                   badge("切入")], title="切换"),
@@ -739,11 +781,13 @@ def build_cases():
         "skill-pick-enemy", "unit-skill", "技能后点敌人",
         "先按技能，再点合法敌方目标放出。",
         [
-            beat("按技能", "鼠标变专属准星", "选目标", "moba",
-                 [hero(35, 60), cursor(60, 40), badge("选敌")], title="进入"),
-            beat("点敌人", "技能飞向该单位", "点到了", "moba",
-                 [hero(35, 60), unit(65, 40, team="enemy"), arrow(40, 55, 62, 42, "attack"),
-                  cursor(65, 40, "up"), badge("确认")], title="点中"),
+            beat("按技能", "鼠标变专属准星，场上敌人可点", "选目标", "moba",
+                 [hero(35, 60), unit(70, 38, team="enemy"), unit(80, 55, team="enemy"),
+                  cursor(56, 44, "aim"), hotbar(active=0), badge("选敌")], title="进入"),
+            beat("点敌人", "被点的那个敌人套上锁定圈，技能飞向它", "点到了", "moba",
+                 [hero(35, 60), unit(70, 38, team="enemy"), ring(70, 38, r=12, kind="lock"),
+                  unit(80, 55, team="enemy"), arrow(40, 55, 66, 40, "attack"),
+                  cursor(70, 38, "up"), hotbar(active=0), badge("确认")], title="点中"),
         ], ["MOBA", "RTS", "War3"],
     ))
     c.append(case(
@@ -751,8 +795,8 @@ def build_cases():
         "按键当下自动对准星下单位施放，不进瞄准态。",
         [
             beat("准星已在敌人上时按技能", "立刻出手，无指示器阶段", "又快又险", "moba",
-                 [hero(35, 60), unit(65, 42, team="enemy"), cursor(65, 42), arrow(40, 55, 62, 44, "attack"),
-                  badge("智能施法")], title="瞬放"),
+                 [hero(35, 60), unit(65, 42, team="enemy"), cursor(65, 42, "aim"),
+                  arrow(40, 55, 62, 44, "attack"), badge("智能施法")], title="瞬放"),
         ], ["MOBA"],
     ))
     c.append(case(
@@ -1227,14 +1271,14 @@ def build_cases():
         "同样右键点建筑/单位，工程师是占领或修理，间谍是潜入，普通坦克是攻击或移动，消融步兵是抹除。",
         [
             beat("选工程师，右键敌方建筑", "冲去占领，不是炮击", "去抢房子", "topdown",
-                 [unit(28, 58, sel=True), ring(28, 58), building(70, 42),
+                 [unit(28, 58, sel=True), ring(28, 58), building(70, 42, team="enemy"),
                   arrow(32, 56, 66, 44, "move"), cursor(70, 42, "up"), badge("工兵×敌建筑")], title="占领"),
             beat("选工程师，右键己方损伤建筑", "过去修理", "去修", "topdown",
-                 [unit(28, 58, sel=True), ring(28, 58), building(70, 42),
+                 [unit(28, 58, sel=True), ring(28, 58), building(70, 42, team="ally"),
                   arrow(32, 56, 66, 44, "move"), ring(70, 42, r=12, kind="buff"),
                   badge("工兵×己建筑")], title="修理"),
             beat("选坦克，右键同一敌建筑", "开炮攻击建筑", "轰平它", "topdown",
-                 [unit(28, 58, sel=True, size=1.15), ring(28, 58), building(70, 42),
+                 [unit(28, 58, sel=True, size=1.15), ring(28, 58), building(70, 42, team="enemy"),
                   arrow(34, 56, 66, 44, "attack"), badge("坦克×敌建筑")], title="炮击"),
             beat("选消融步兵，右键敌单位", "擦除目标，不是普通射击", "抹掉", "topdown",
                  [unit(30, 58, sel=True), ring(30, 58), unit(72, 42, team="enemy"),
@@ -1804,9 +1848,10 @@ def build_cases():
             beat("对对象右键/长按", "弹出上下文菜单", "还能干这些", "moba",
                  [unit(55, 45, team="ally"), cursor(55, 45),
                   menu_box(62, 40, ["交易", "检查", "跟随"]), badge("上下文菜单")], title="打开菜单"),
-            beat("点菜单项", "执行该项，菜单关闭", "选这项", "moba",
-                 [unit(55, 45, team="ally"), arrow(58, 45, 78, 45, "move"),
-                  cursor(70, 52), badge("执行·跟随")], title="选中"),
+            beat("点菜单项", "点中的那项亮一下，随即收起菜单并执行", "选这项", "moba",
+                 [unit(55, 45, team="ally"), arrow(58, 45, 88, 45, "move"),
+                  menu_box(62, 40, ["交易", "检查", "跟随"], active=2),
+                  cursor(66, 72, "up"), badge("执行·跟随")], title="选中"),
         ], ["MMO", "RTS", "ARPG"],
     ))
     c.append(case(
@@ -2637,6 +2682,106 @@ def apply_action_index(cases: list) -> list[dict]:
     return actions
 
 
+def _cursor_candidates(hit: dict) -> list[tuple[float, float]]:
+    """按「箭尖贴着目标、箭身朝空处」给出候选落点，从最自然的右下开始试。"""
+    r = _entity_radius_px(hit)
+    ux = lambda p: p / STAGE_W_PX * 100.0  # noqa: E731
+    uy = lambda p: p / STAGE_H_PX * 100.0  # noqa: E731
+    bw, bh = CURSOR_BODY_PX
+    return [
+        (hit["x"] + ux(r + 2), hit["y"] + uy(r + 2)),          # 右下：目标在左上
+        (hit["x"] - ux(r + 2), hit["y"] + uy(r + 2)),          # 左下：目标在正上
+        (hit["x"] + ux(r + 2), hit["y"]),                       # 正右：目标在正左
+        (hit["x"] - ux(bw + r + 3), hit["y"]),                  # 左侧：箭身在目标前收住
+        (hit["x"], hit["y"] - uy(bh + r + 3)),                  # 上方：箭身在目标前收住
+    ]
+
+
+def deocclude_cursors(cases: list) -> int:
+    """箭头光标压在单位/建筑身上时，把箭尖挪到目标的右下边缘外。
+
+    箭头图形从箭尖往右下伸展，压在正中就把目标盖掉（玩家看不见自己点的是谁）。
+    箭尖落在目标右下角外侧时，箭尖依旧贴着目标，箭身朝空地伸展。
+    """
+    moved = 0
+    for c in cases:
+        for b in c["beats"]:
+            cast = b.get("cast") or []
+            bodies = [e for e in cast if e.get("t") in CURSOR_OCCLUDERS]
+            for cur in cast:
+                if cur.get("t") != "cursor":
+                    continue
+                if cur.get("mode") not in CURSOR_MODES_OFFSET:
+                    continue
+                hit = next((e for e in bodies if _cursor_covers(cur, e)), None)
+                if hit is None:
+                    continue
+                spot = next(
+                    (
+                        (x, y)
+                        for x, y in _cursor_candidates(hit)
+                        if 3.0 <= x <= 94.0 and 4.0 <= y <= 88.0
+                        and not any(_cursor_covers({"x": x, "y": y}, e) for e in bodies)
+                    ),
+                    None,
+                )
+                if spot is None:
+                    raise SystemExit(
+                        f"{c['id']} 这一拍摆不下光标：目标太挤，手工调 cast 坐标 "
+                        f"(光标 {cur['x']},{cur['y']})"
+                    )
+                cur["x"], cur["y"] = round(spot[0], 2), round(spot[1], 2)
+                moved += 1
+    return moved
+
+
+def _audit_storyboard(cases: list) -> None:
+    """画面必须画出文案承诺的东西；对不上就 fail，不许悄悄糊过去。"""
+    bad_view: list[str] = []
+    bad_cursor: list[str] = []
+    occluded: list[str] = []
+    missing_reticle: list[str] = []
+    missing_menu: list[str] = []
+    for c in cases:
+        for i, b in enumerate(c["beats"]):
+            tag = f"{c.get('actionNo') or c['id']} {c['id']}#T{i+1}"
+            cast = b.get("cast") or []
+            kinds = {e.get("t") for e in cast}
+            if b.get("view") not in VIEW_LABELS:
+                bad_view.append(f"{tag} view={b.get('view')}")
+            cursors = [e for e in cast if e.get("t") == "cursor"]
+            for cur in cursors:
+                if cur.get("mode") not in CURSOR_MODES:
+                    bad_cursor.append(f"{tag} mode={cur.get('mode')}")
+            bodies = [e for e in cast if e.get("t") in CURSOR_OCCLUDERS]
+            for cur in cursors:
+                if cur.get("mode") not in CURSOR_MODES_OFFSET:
+                    continue
+                if any(_cursor_covers(cur, e) for e in bodies):
+                    occluded.append(tag)
+                    break
+            blob = f"{b['input']} {b.get('logic') or ''} {b['screen']}"
+            if ("专属准星" in blob or "变准星" in blob) and not (
+                "crosshair" in kinds or any(e.get("mode") == "aim" for e in cursors)
+            ):
+                missing_reticle.append(tag)
+            if "菜单项" in blob and "menu" not in kinds:
+                missing_menu.append(tag)
+    problems = []
+    if bad_view:
+        problems.append(f"未知镜位（VIEW_LABELS 未登记）: {bad_view}")
+    if bad_cursor:
+        problems.append(f"未知光标状态（渲染器画不出）: {bad_cursor}")
+    if occluded:
+        problems.append(f"箭头光标压住单位: {occluded}")
+    if missing_reticle:
+        problems.append(f"文案说变准星但画面没准星: {missing_reticle}")
+    if missing_menu:
+        problems.append(f"文案说点菜单项但画面没菜单: {missing_menu}")
+    if problems:
+        raise SystemExit("分镜画面与文案对不上：\n- " + "\n- ".join(problems))
+
+
 def _write_checkpoint(cases: list, weak: list[str], head: str, actions: list[dict] | None = None) -> None:
     todos = sorted({t for c in cases for t in c.get("todos") or []})
     from collections import Counter
@@ -2703,6 +2848,10 @@ def _write_checkpoint(cases: list, weak: list[str], head: str, actions: list[dic
         "",
         f"- 仅 badge / 空 cast 的弱分镜拍数：{len(weak)}",
         "- 弱分镜不阻断生成，但改数据时应补单位/光标/指示器，禁止「只有字没有画面」",
+        "- `_audit_storyboard()` 是硬闸：镜位未登记、光标状态渲染器画不出、箭头压住单位、"
+        "说「变准星」却没准星、说「点菜单项」却没菜单 —— 任一命中直接 fail 生成",
+        f"- 光标状态白名单：{' / '.join(CURSOR_MODES)}；`aim`=施法准星，`up`=松手波纹",
+        f"- 镜位角标只出人话：{'、'.join(VIEW_LABELS.values())}",
         "",
         "## 高频 TODO（去重）",
         "",
@@ -2720,6 +2869,8 @@ def main():
     apply_beat_logic(cases)
     actions = apply_action_index(cases)
     augmented = augment_ui_glyphs(cases)
+    nudged = deocclude_cursors(cases)
+    _audit_storyboard(cases)
     weak = _audit_casts(cases)
     empty = [c["id"] for c in cases if not c.get("targets")]
     if empty:
@@ -2743,6 +2894,8 @@ def main():
         "platforms": [
             {"id": pid, "label": PLATFORM_LABEL[pid]} for pid in PLATFORM_ORDER
         ],
+        "views": [{"id": vid, "label": label} for vid, label in VIEW_LABELS.items()],
+        "cursorModes": list(CURSOR_MODES),
         "checkpoint": {
             "head": head,
             "branch_hint": "cursor/ux-action-id-platform-tabs-4211",
@@ -2774,7 +2927,8 @@ def main():
         f"Wrote {OUT.relative_to(OUT.parents[2])}  actions={len(actions)}  "
         f"cases={len(cases)}  beats={sum(len(x['beats']) for x in cases)}  "
         f"multi_platform={sum(1 for a in actions if a['caseCount'] > 1)}  "
-        f"weak_casts={len(weak)}  ui_augmented={augmented}  head={head}"
+        f"weak_casts={len(weak)}  ui_augmented={augmented}  "
+        f"cursor_nudged={nudged}  head={head}"
     )
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# 概要

- 变更目标：玩家动作图鉴里「文案说的事」和「画面画的事」对不上。以 UX-080「技能后点敌人」为例：文案说「鼠标变专属准星」，画的还是普通箭头；说「点敌人」，画面里根本没有敌人；到了确认那一拍，敌人被鼠标箭头整个盖住。
- 影响范围：`gitbook/reference/player-action-ux/` 分镜渲染 + 生成管线 + 少量分镜数据；不动运行时 ECS。

# SSOT 落点

- 正式规则：无
- 正式架构：无
- 正式查表或操作：`gitbook/reference/player-action-ux/`（`CHECKPOINT.md` 已记录新硬闸）
- 仓库深度材料：无
- 审计或提案：无

# 设计与挂靠点

- 挂靠点：`generate-player-action-ux-catalog.py` → `catalog-data.js` → `catalog-app.js` 既有分镜管线
- 复用清单：现有 `cast` 元件表（unit / hero / cursor / ring / menu / hotbar）、一镜一对详情、平台 tab
- 新增清单：光标状态白名单、镜位人话标签表、光标遮挡几何函数、`_audit_storyboard()` 硬闸

## 查出来的两类系统性缺陷

- **松手那一拍看不出来**：数据里用了 `cursor mode="up"`（松手/点下去），渲染器根本不认这个状态，静默退化成普通箭头。**40 拍**受影响，玩家看不出「点了」和「没点」的差别。
- **鼠标把目标盖住**：箭头图形从箭尖往右下伸展，数据把箭尖直接摆在单位正中，单位被箭身盖掉。**25 拍**受影响，包括 UX-080 确认那一拍。

## 改法

- 渲染器：`up` 画松手波纹、`aim` 画施法专属准星；遇到没登记的光标状态或镜位**直接抛错**，不再悄悄画成默认样子
- 渲染器：菜单支持「被点中的那一项」高亮；建筑支持阵营描边
- 分镜角标从 `moba` / `topdown` 改成 `斜俯视` / `俯视战场` / `越肩视角` / `第一人称`
- 生成器：按箭头真实包围盒算遮挡，自动把箭尖挪到目标边缘外（箭尖仍贴着目标）；摆不下就 fail 让人工调坐标
- 生成器：`_audit_storyboard()` 成为硬闸——镜位未登记 / 光标状态画不出 / 箭头压住单位 / 说「变准星」却没准星 / 说「点菜单项」却没菜单，任一命中就 fail 生成
- 数据：UX-080 补上可点的敌人、被点目标的锁定圈、真正的施法准星；UX-005 菜单项高亮、UX-027 载具高亮、UX-007 敌方建筑阵营色一并补齐

# 验证证据

- 命令：`python3 scripts/generate-player-action-ux-catalog.py`（硬闸通过）、`node --check gitbook/reference/player-action-ux/catalog-app.js`
- 结果：`actions=163 cases=168 beats=357 weak_casts=0 cursor_nudged=25`；改前审计报 25 拍遮挡 + 40 拍未知光标状态，改后为 0
- 演示（搜 UX-080 → 两拍分镜 → UX-005 平台 tab 与菜单高亮 → UX-002 光标不再压住单位）：

[ux080_storyboard_matches_caption_and_platform_tabs.mp4](https://cursor.com/agents/bc-6dbfc1fe-4147-482c-bdfd-87fe90a54211/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fux080_storyboard_matches_caption_and_platform_tabs.mp4)

[UX-080 第一拍：施法准星 + 可点敌人 + 技能栏](https://cursor.com/agents/bc-6dbfc1fe-4147-482c-bdfd-87fe90a54211/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fux080_shot01_reticle_and_enemies.webp)
[UX-005 第二拍：点中的菜单项高亮](https://cursor.com/agents/bc-6dbfc1fe-4147-482c-bdfd-87fe90a54211/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fux005_context_menu_pick_highlight.webp)

# 文档同步

- [x] 行为变更已同步更新 `gitbook/` 正式文档（`CHECKPOINT.md` 记录光标白名单、镜位人话表、硬闸规则）
- [ ] 所属目录 `README.md` 或 `SUMMARY.md` 已同步（本页既有入口，无需改导航）
- [ ] 若影响入口或导航，`README.md` / `README_CN.md` / `AGENTS.md` / `CLAUDE.md` 已同步


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6dbfc1fe-4147-482c-bdfd-87fe90a54211?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dbfc1fe-4147-482c-bdfd-87fe90a54211&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

