### PR TITLE
feat(movement): 意图/客观身体分离与 per-entity 执行车道（#769 切片1）

### DIFF
--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -23,6 +23,7 @@
   - [通用存档系统](architecture/save-system.md)
   - [AI Utility Autocast 契约](architecture/ai-utility-autocast-contract.md)
   - [实体仿真分层与车道](architecture/entity-simulation-layering.md)
+  - [移动意图与 per-entity 执行车道](architecture/movement-intent-and-execution-lanes.md)
   - [实体仿真工作流拆分](architecture/entity-simulation-workstreams.md)
   - [实体仿真阶段验收](architecture/entity-simulation-uat.md)
   - [能力标准 Showcase](architecture/capability-standard-showcases.md)

--- a/gitbook/architecture/entity-simulation-layering.md
+++ b/gitbook/architecture/entity-simulation-layering.md
@@ -54,19 +54,23 @@
 
 ### 3.2 移动参与与位姿写权
 
-已落地以下正式组件（issue #643 阶段 0+1）：
+已落地以下正式组件（issue #643 阶段 0+1；意图/执行档扩展见 [#769](https://github.com/MightyBubble/Ludots/issues/769) 与 [`movement-intent-and-execution-lanes.md`](movement-intent-and-execution-lanes.md)）：
 
-- `MovementParticipation`（authoring，两轴参与声明）
+- `MovementParticipation`（authoring，参与声明）
+  - `Execution`：`Nav` / `Motor` / `Physics`，声明谁消费移动意图并写客观位姿
   - `PhysicsPresence`：`None` / `Kinematic` / `Dynamic`，声明物理如何感知该 entity
   - `Displacement`：`Allowed` / `HandbackSpeedThresholdCmPerSec` / `MaxDurationMs`，声明 GAS 位移窗口策略
 - `PoseAuthority`（runtime，位姿单写真相）
-  - `Nav` / `Displacement` / `Physics`，初始值由 `PhysicsPresence` 推导：`None`/`Kinematic` → `Nav`，`Dynamic` → `Physics`
+  - `Nav` / `Motor` / `Displacement` / `Physics`，初始值由 `Execution` + `PhysicsPresence` 推导
+- `MoveIntent` / `FacingIntent`（意图层；不是位置真相）
 
 解释如下：
 
 - 同一固定步内 `WorldPositionCm` 只允许当前 `PoseAuthority` 持有者写入；写权切换只在固定步边界经 `PoseAuthorityArbiter` + CommandBuffer 结算
+- 位移窗口可从 `Nav`/`Motor` 开启，结束后交还开启前的执行写权
 - 没有 `MovementParticipation` 的实体不挂 `PoseAuthority`，行为与存量路径完全一致
 - `EntityLayer + LayerMask` 继续作为统一层级过滤真相，不再新造一套 collision matrix 类型
+- 意图/客观身体/执行车道细则以 [`movement-intent-and-execution-lanes.md`](movement-intent-and-execution-lanes.md) 为准
 
 ### 3.3 Showcase-owned Formation 集群转发
 
@@ -149,11 +153,12 @@ Formation 是 Mod 业务聚合，不是 Core 仿真车道。`FormationCapability
 
 正式口径（已落地词汇）：
 
-- `MovementParticipation.physicsPresence = none | kinematic`
+- `MovementParticipation.execution = nav` 且 `physicsPresence = none | kinematic`
 - `PoseAuthority = Nav`（求解器写位姿；物理经 kinematic 存在看见 crowd）
 - 不把全量 crowd 强塞进完整动态刚体模拟
 - 热路径优先用 SoA crowd sim
 - 上层业务可以持续提交明确逐成员目标，但 MassNavigation 不理解 formation、slot 或 follower 语义
+- `execution = motor` / `physics` 不属于本车道；见 [`movement-intent-and-execution-lanes.md`](movement-intent-and-execution-lanes.md)
 
 目标：
 

--- a/gitbook/architecture/movement-intent-and-execution-lanes.md
+++ b/gitbook/architecture/movement-intent-and-execution-lanes.md
@@ -1,0 +1,104 @@
+# 移动意图与 per-entity 执行车道
+
+Epic：[#769](https://github.com/MightyBubble/Ludots/issues/769)
+
+本文是移动**意图层**、**客观身体层**与 **per-entity 执行车道**的正式合同。不含玩法角色语义；模板只选择执行档。
+
+相关：
+
+- 参与与写权基线：[`entity-simulation-layering.md`](entity-simulation-layering.md)
+- MassNavigation↔Physics2D 热区/障碍交接：[#643](https://github.com/MightyBubble/Ludots/issues/643)
+
+## 1 概述
+
+- 意图回答「想怎么动 / 想面朝哪」。
+- 客观身体回答「现在在哪 / 现在面朝哪」。
+- 执行车道回答「谁有权把意图变成客观身体」。
+- 同一固定步同一实体只有一个 `PoseAuthority` 写 `WorldPositionCm`。
+
+## 2 结构
+
+```text
+控制 / 订单 / AI
+  → MoveIntent
+  → FacingIntent
+  → LookIntent（二期）
+        ↓ 只读
+执行车道（per-entity）
+  Nav | Motor | Physics | Displacement
+        ↓
+客观身体
+  WorldPositionCm
+  FacingDirection
+  （热路径缓存）MassNav SoA / Position2D / Rotation2D / Velocity2D
+        ↓ 可选
+Kinematic 跟拍（physicsPresence=Kinematic）
+```
+
+## 3 详情
+
+### 3.1 意图组件
+
+| 组件 | 含义 | 谁写 |
+|---|---|---|
+| `MoveIntent` | `None` / `Direction` / `TargetPoint` + 期望速率 | 控制、订单适配、AI |
+| `FacingIntent` | `None` / `ExplicitYaw` / `FollowMoveDirection` | 同上 |
+| `LookIntent` | 视线偏航 | 二期 |
+
+规则：
+
+1. 意图不是位置真相。
+2. 执行器只读意图，不写意图。
+3. MassNav 步进内 `desiredVelocity` 是求解器私有量，不是意图 SSOT。
+4. MassNav per-agent 目标点与 `MoveIntent.TargetPoint` 的收敛见 Epic 切片 4；在收敛完成前，Nav 档仍可按既有目标点 API 执行，但不得再发明第三套「意图通道」。
+
+### 3.2 客观身体
+
+| 组件 | 含义 | 谁写 |
+|---|---|---|
+| `WorldPositionCm` | 在哪 | 当前 `PoseAuthority` |
+| `FacingDirection` | 身体现在朝哪 | Facing 求解按写权规则提交 |
+| `Velocity2D` / Nav 速度 | 现在怎么动 | 当前执行器热路径 |
+
+### 3.3 执行档（authoring）
+
+`MovementParticipation` 增加中性字段 `execution`：
+
+| `execution` | 允许的 `physicsPresence` | 初始 `PoseAuthority` |
+|---|---|---|
+| `nav` | `none` / `kinematic` | `Nav` |
+| `motor` | `none` / `kinematic` | `Motor` |
+| `physics` | `dynamic` | `Physics` |
+
+非法配对启动失败（fail-fast）。
+
+`PoseAuthorityKind` 增加 `Motor`。位移窗口可从 `Nav` 或 `Motor` 开启，结束后交还**开启前的执行写权**（`ResumeAuthority`），不再写死交还 Nav。
+
+### 3.4 现网路径澄清
+
+`execution=nav` + `physicsPresence=kinematic`（现网 Crowd Arena）语义是：
+
+1. MassNavigation 积分并写 `WorldPositionCm`
+2. Kinematic 桥把已提交位姿喂给物理
+3. 物理从 Δpose 派生线速度用于推挤；**不是**「Nav 出期望速度、物理积分位置」
+
+若实体需要「意图→物理积分写位置」，必须显式 `execution=physics`（并满足 #643 合同），不得静默改写 nav+kinematic 语义。
+
+### 3.5 MassNavigation 绑定
+
+仅 `execution=nav` 的实体可绑定为 nav agent。`motor` / `physics` 绑定失败。
+
+## 4 场景
+
+见 Epic #769 场景 1–5。
+
+## 5 边界
+
+- 禁止业务角色名进入 Core 执行枚举。
+- 禁止 Nav 与 Motor 同时作为同一实体位置作者。
+- 禁止意图与 `WorldPositionCm` 双真相。
+- 热路径：SoA / Chunk / 零分配；写权切换只在固定步边界经 `PoseAuthorityArbiter` 结算。
+
+## 6 UAT
+
+Epic #769 第 6 节 Cucumber 场景为本合同验收语言；实现切片须把对应场景落成生产路径测试或合同测试。

--- a/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Entities/templates.json
+++ b/mods/showcases/capability_standard/CapabilityStandardCrowdPhysicsArenaMod/assets/Entities/templates.json
@@ -96,6 +96,7 @@
         "profileId": "light"
       },
       "MovementParticipation": {
+        "execution": "nav",
         "physicsPresence": "kinematic",
         "displacement": {
           "allowed": true,
@@ -153,6 +154,7 @@
         "profileId": "heavy"
       },
       "MovementParticipation": {
+        "execution": "nav",
         "physicsPresence": "kinematic",
         "displacement": {
           "allowed": true,
@@ -210,6 +212,7 @@
         "profileId": "light"
       },
       "MovementParticipation": {
+        "execution": "nav",
         "physicsPresence": "kinematic",
         "displacement": {
           "allowed": true,
@@ -267,6 +270,7 @@
         "profileId": "heavy"
       },
       "MovementParticipation": {
+        "execution": "nav",
         "physicsPresence": "kinematic",
         "displacement": {
           "allowed": true,

--- a/src/Core/Components/MovementIntent.cs
+++ b/src/Core/Components/MovementIntent.cs
@@ -1,0 +1,118 @@
+using Ludots.Core.Mathematics.FixedPoint;
+
+namespace Ludots.Core.Components
+{
+    /// <summary>
+    /// 移动意图模式。意图不是位置真相；执行器只读消费。
+    /// </summary>
+    public enum MoveIntentMode : byte
+    {
+        None = 0,
+        Direction = 1,
+        TargetPoint = 2,
+    }
+
+    /// <summary>
+    /// 移动意图（想怎么移动）。由控制/订单/AI 写入；Nav / Motor / Physics 驱动只读。
+    /// </summary>
+    public struct MoveIntent
+    {
+        public MoveIntentMode Mode;
+
+        /// <summary>Direction 模式：逻辑平面偏航（弧度，0 = +X）。</summary>
+        public float DirectionRad;
+
+        /// <summary>TargetPoint 模式：世界厘米目标点。</summary>
+        public Fix64Vec2 TargetWorldCm;
+
+        /// <summary>期望速率（cm/s）。None 模式必须为 0；其余模式必须 &gt; 0。</summary>
+        public float DesiredSpeedCmPerSec;
+    }
+
+    /// <summary>
+    /// 面朝意图模式。与移动意图正交：可侧移同时面朝另一方向。
+    /// </summary>
+    public enum FacingIntentMode : byte
+    {
+        None = 0,
+        ExplicitYaw = 1,
+        FollowMoveDirection = 2,
+    }
+
+    /// <summary>
+    /// 身体面朝意图（想面朝哪）。不是 <see cref="FacingDirection"/> 客观朝向。
+    /// </summary>
+    public struct FacingIntent
+    {
+        public FacingIntentMode Mode;
+
+        /// <summary>ExplicitYaw 模式：目标身体偏航（弧度，0 = +X）。</summary>
+        public float YawRad;
+    }
+
+    /// <summary>
+    /// 意图组件合同校验（fail-fast，无静默纠正）。
+    /// </summary>
+    public static class MovementIntentRules
+    {
+        public static void Validate(in MoveIntent intent)
+        {
+            switch (intent.Mode)
+            {
+                case MoveIntentMode.None:
+                    if (intent.DesiredSpeedCmPerSec != 0f)
+                    {
+                        throw new System.InvalidOperationException(
+                            "MoveIntent mode None requires DesiredSpeedCmPerSec == 0.");
+                    }
+
+                    break;
+                case MoveIntentMode.Direction:
+                    RequireFinite(intent.DirectionRad, "MoveIntent.DirectionRad");
+                    RequirePositiveSpeed(intent.DesiredSpeedCmPerSec);
+                    break;
+                case MoveIntentMode.TargetPoint:
+                    RequireFinite(intent.TargetWorldCm.X.ToFloat(), "MoveIntent.TargetWorldCm.X");
+                    RequireFinite(intent.TargetWorldCm.Y.ToFloat(), "MoveIntent.TargetWorldCm.Y");
+                    RequirePositiveSpeed(intent.DesiredSpeedCmPerSec);
+                    break;
+                default:
+                    throw new System.InvalidOperationException(
+                        $"MoveIntent mode {(byte)intent.Mode} is not configured.");
+            }
+        }
+
+        public static void Validate(in FacingIntent intent)
+        {
+            switch (intent.Mode)
+            {
+                case FacingIntentMode.None:
+                case FacingIntentMode.FollowMoveDirection:
+                    break;
+                case FacingIntentMode.ExplicitYaw:
+                    RequireFinite(intent.YawRad, "FacingIntent.YawRad");
+                    break;
+                default:
+                    throw new System.InvalidOperationException(
+                        $"FacingIntent mode {(byte)intent.Mode} is not configured.");
+            }
+        }
+
+        private static void RequirePositiveSpeed(float speedCmPerSec)
+        {
+            if (!(speedCmPerSec > 0f) || !float.IsFinite(speedCmPerSec))
+            {
+                throw new System.InvalidOperationException(
+                    "MoveIntent DesiredSpeedCmPerSec must be finite and > 0 for Direction/TargetPoint modes.");
+            }
+        }
+
+        private static void RequireFinite(float value, string name)
+        {
+            if (!float.IsFinite(value))
+            {
+                throw new System.InvalidOperationException($"{name} must be finite.");
+            }
+        }
+    }
+}

--- a/src/Core/Components/MovementParticipation.cs
+++ b/src/Core/Components/MovementParticipation.cs
@@ -17,12 +17,30 @@ namespace Ludots.Core.Components
     }
 
     /// <summary>
+    /// 移动执行档（参与模型轴三，authoring 声明）。
+    /// 中性执行器名，不含玩法角色语义。决定初始 <see cref="PoseAuthority"/>。
+    /// </summary>
+    public enum MovementExecutionKind : byte
+    {
+        /// <summary>MassNavigation 消费移动意图并写客观位姿。</summary>
+        Nav = 1,
+
+        /// <summary>运动电机消费意图矢量并写客观位姿。</summary>
+        Motor = 2,
+
+        /// <summary>Physics2D 积分写客观位姿；意图经力/速度桥进入物理。</summary>
+        Physics = 3,
+    }
+
+    /// <summary>
     /// 移动参与 authoring 明文（参与模型）。模板级声明，缺字段 fail-fast。
-    /// 初始位姿写权由 <see cref="PhysicsPresence"/> 推导（None/Kinematic → Nav；Dynamic → Physics），
+    /// 初始位姿写权由 <see cref="Execution"/> + <see cref="PhysicsPresence"/> 推导，
     /// 见 <see cref="MovementParticipationRules.DeriveInitialPoseAuthority"/>。
     /// </summary>
     public struct MovementParticipation
     {
+        public MovementExecutionKind Execution;
+
         public PhysicsPresenceKind PhysicsPresence;
 
         /// <summary>该实体是否允许进入 GAS 位移写权窗口。</summary>
@@ -49,6 +67,9 @@ namespace Ludots.Core.Components
 
         /// <summary>Physics2D 积分产出位姿结果。</summary>
         Physics = 3,
+
+        /// <summary>运动电机产出位姿结果。</summary>
+        Motor = 4,
     }
 
     /// <summary>
@@ -65,16 +86,51 @@ namespace Ludots.Core.Components
     /// </summary>
     public static class MovementParticipationRules
     {
-        public static PoseAuthorityKind DeriveInitialPoseAuthority(PhysicsPresenceKind presence)
+        public static PoseAuthorityKind DeriveInitialPoseAuthority(
+            MovementExecutionKind execution,
+            PhysicsPresenceKind presence)
         {
-            return presence switch
+            return execution switch
             {
-                PhysicsPresenceKind.None => PoseAuthorityKind.Nav,
-                PhysicsPresenceKind.Kinematic => PoseAuthorityKind.Nav,
-                PhysicsPresenceKind.Dynamic => PoseAuthorityKind.Physics,
+                MovementExecutionKind.Nav => presence switch
+                {
+                    PhysicsPresenceKind.None => PoseAuthorityKind.Nav,
+                    PhysicsPresenceKind.Kinematic => PoseAuthorityKind.Nav,
+                    PhysicsPresenceKind.Dynamic => throw new System.InvalidOperationException(
+                        "MovementParticipation execution 'nav' cannot pair with physicsPresence 'dynamic'; use execution 'physics'."),
+                    _ => throw new System.InvalidOperationException(
+                        $"MovementParticipation physicsPresence value {(byte)presence} has no configured initial pose authority for execution nav."),
+                },
+                MovementExecutionKind.Motor => presence switch
+                {
+                    PhysicsPresenceKind.None => PoseAuthorityKind.Motor,
+                    PhysicsPresenceKind.Kinematic => PoseAuthorityKind.Motor,
+                    PhysicsPresenceKind.Dynamic => throw new System.InvalidOperationException(
+                        "MovementParticipation execution 'motor' cannot pair with physicsPresence 'dynamic'; use execution 'physics'."),
+                    _ => throw new System.InvalidOperationException(
+                        $"MovementParticipation physicsPresence value {(byte)presence} has no configured initial pose authority for execution motor."),
+                },
+                MovementExecutionKind.Physics => presence switch
+                {
+                    PhysicsPresenceKind.Dynamic => PoseAuthorityKind.Physics,
+                    PhysicsPresenceKind.None or PhysicsPresenceKind.Kinematic => throw new System.InvalidOperationException(
+                        "MovementParticipation execution 'physics' requires physicsPresence 'dynamic'."),
+                    _ => throw new System.InvalidOperationException(
+                        $"MovementParticipation physicsPresence value {(byte)presence} has no configured initial pose authority for execution physics."),
+                },
                 _ => throw new System.InvalidOperationException(
-                    $"MovementParticipation physicsPresence value {(byte)presence} has no configured initial pose authority."),
+                    $"MovementParticipation execution value {(byte)execution} has no configured initial pose authority."),
             };
+        }
+
+        public static PoseAuthorityKind DeriveInitialPoseAuthority(in MovementParticipation participation)
+        {
+            return DeriveInitialPoseAuthority(participation.Execution, participation.PhysicsPresence);
+        }
+
+        public static bool CanOpenDisplacementWindow(PoseAuthorityKind current)
+        {
+            return current == PoseAuthorityKind.Nav || current == PoseAuthorityKind.Motor;
         }
     }
 }

--- a/src/Core/Config/ComponentRegistry.cs
+++ b/src/Core/Config/ComponentRegistry.cs
@@ -1359,7 +1359,9 @@ namespace Ludots.Core.Config
                 throw new InvalidOperationException("MovementParticipation requires an object payload.");
             }
 
-            ValidateProperties(obj, "MovementParticipation", "physicsPresence", "displacement");
+            ValidateProperties(obj, "MovementParticipation", "execution", "physicsPresence", "displacement");
+            MovementExecutionKind execution = ParseMovementExecutionKind(
+                RequireStringProperty(obj, "execution", "MovementParticipation"));
             PhysicsPresenceKind physicsPresence = ParsePhysicsPresenceKind(
                 RequireStringProperty(obj, "physicsPresence", "MovementParticipation"));
 
@@ -1393,20 +1395,35 @@ namespace Ludots.Core.Config
                 throw new InvalidOperationException("MovementParticipation.displacement.maxDurationMs must be > 0.");
             }
 
-            entity.Add(new MovementParticipation
+            var participation = new MovementParticipation
             {
+                Execution = execution,
                 PhysicsPresence = physicsPresence,
                 DisplacementAllowed = displacementAllowed,
                 DisplacementHandbackSpeedThresholdCmPerSec = handbackSpeedThresholdCmPerSec,
                 DisplacementMaxDurationMs = maxDurationMs,
-            });
+            };
+
+            entity.Add(participation);
 
             // poseAuthority is runtime state, never authored: derive the initial owner from the
-            // declared physics presence so the entity enters the world with exactly one pose writer.
+            // declared execution + physics presence so the entity enters with exactly one pose writer.
             entity.Add(new PoseAuthority
             {
-                Value = MovementParticipationRules.DeriveInitialPoseAuthority(physicsPresence),
+                Value = MovementParticipationRules.DeriveInitialPoseAuthority(participation),
             });
+        }
+
+        private static MovementExecutionKind ParseMovementExecutionKind(string raw)
+        {
+            return raw switch
+            {
+                "nav" => MovementExecutionKind.Nav,
+                "motor" => MovementExecutionKind.Motor,
+                "physics" => MovementExecutionKind.Physics,
+                _ => throw new InvalidOperationException(
+                    $"MovementParticipation.execution '{raw}' is not configured (expected 'nav', 'motor' or 'physics').")
+            };
         }
 
         private static PhysicsPresenceKind ParsePhysicsPresenceKind(string raw)

--- a/src/Core/Gameplay/GAS/Systems/DisplacementRuntimeSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/DisplacementRuntimeSystem.cs
@@ -193,7 +193,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
         /// <summary>窗口正常结束：在固定步边界把写权交还 Nav，并撤销移动抑制。</summary>
         private void EndPoseWindow(ref DisplacementState disp)
         {
-            _poseAuthorityArbiter.RequestNavHandback(World, disp.TargetEntity);
+            _poseAuthorityArbiter.RequestDisplacementHandback(World, disp.TargetEntity);
             disp.PoseWindowRequested = false;
             ClearMovementSuppression(ref disp);
         }

--- a/src/Core/MassNavigation/Runtime/MassNavigationSimulationRuntime.cs
+++ b/src/Core/MassNavigation/Runtime/MassNavigationSimulationRuntime.cs
@@ -1139,13 +1139,21 @@ public sealed class MassNavigationSimulationRuntime
                 $"MassNavigation spawned agent entity {entity.Id} requires a resolved positive profileId.");
         }
 
-        // Participation contract: a Dynamic physics presence derives Physics pose
-        // authority, which cannot coexist with a nav-agent binding in this increment.
-        if (world.TryGet(entity, out Ludots.Core.Components.MovementParticipation participation) &&
-            participation.PhysicsPresence == Ludots.Core.Components.PhysicsPresenceKind.Dynamic)
+        // Participation contract: only execution=nav may bind as a nav agent.
+        // Motor/Physics pose writers cannot coexist with MassNavigation integration.
+        if (world.TryGet(entity, out Ludots.Core.Components.MovementParticipation participation))
         {
-            throw new InvalidOperationException(
-                $"MassNavigation cannot bind entity {entity.Id} as a nav agent: MovementParticipation.physicsPresence 'dynamic' assigns pose authority to Physics.");
+            if (participation.Execution != Ludots.Core.Components.MovementExecutionKind.Nav)
+            {
+                throw new InvalidOperationException(
+                    $"MassNavigation cannot bind entity {entity.Id} as a nav agent: MovementParticipation.execution is '{participation.Execution}', expected Nav.");
+            }
+
+            if (participation.PhysicsPresence == Ludots.Core.Components.PhysicsPresenceKind.Dynamic)
+            {
+                throw new InvalidOperationException(
+                    $"MassNavigation cannot bind entity {entity.Id} as a nav agent: MovementParticipation.physicsPresence 'dynamic' assigns pose authority to Physics.");
+            }
         }
 
         if (!allowExistingRuntimeBinding)

--- a/src/Core/Movement/PoseAuthorityArbiter.cs
+++ b/src/Core/Movement/PoseAuthorityArbiter.cs
@@ -35,6 +35,8 @@ namespace Ludots.Core.Movement
         {
             public Entity Entity;
             public PoseAuthorityKind Holder;
+            /// <summary>位移窗口结束后交还的执行写权（开启窗口时的 Nav/Motor）。</summary>
+            public PoseAuthorityKind ResumeAuthority;
             public float HeldSeconds;
             public int MaxDurationMs;
         }
@@ -44,6 +46,7 @@ namespace Ludots.Core.Movement
             public Entity Entity;
             public PoseAuthorityKind From;
             public PoseAuthorityKind To;
+            public PoseAuthorityKind ResumeAuthority;
             public int MaxDurationMs;
         }
 
@@ -67,8 +70,9 @@ namespace Ludots.Core.Movement
         }
 
         /// <summary>
-        /// 申请把实体写权从 Nav 切到 Displacement（GAS 位移窗口开启）。
+        /// 申请把实体写权从 Nav/Motor 切到 Displacement（GAS 位移窗口开启）。
         /// 切换在下一个固定步边界生效；窗口上限取自实体的 MovementParticipation 声明。
+        /// 交还目标记为开启时的执行写权（ResumeAuthority）。
         /// </summary>
         public void RequestDisplacementAuthority(World world, Entity entity)
         {
@@ -94,10 +98,10 @@ namespace Ludots.Core.Movement
             }
 
             PoseAuthority authority = world.Get<PoseAuthority>(entity);
-            if (authority.Value != PoseAuthorityKind.Nav)
+            if (!MovementParticipationRules.CanOpenDisplacementWindow(authority.Value))
             {
                 throw new InvalidOperationException(
-                    $"PoseAuthorityArbiter cannot open a displacement window for entity {entity.Id}: current pose authority is {authority.Value}, expected Nav.");
+                    $"PoseAuthorityArbiter cannot open a displacement window for entity {entity.Id}: current pose authority is {authority.Value}, expected Nav or Motor.");
             }
 
             if (TryFindWindowIndex(entity, out _) || HasPendingTransition(entity))
@@ -109,17 +113,18 @@ namespace Ludots.Core.Movement
             _pending.Add(new PendingTransition
             {
                 Entity = entity,
-                From = PoseAuthorityKind.Nav,
+                From = authority.Value,
                 To = PoseAuthorityKind.Displacement,
+                ResumeAuthority = authority.Value,
                 MaxDurationMs = participation.DisplacementMaxDurationMs,
             });
         }
 
         /// <summary>
-        /// 申请把实体写权从 Displacement 交还 Nav（位移窗口正常结束）。
+        /// 申请把实体写权从 Displacement 交还开启窗口前的执行写权（Nav 或 Motor）。
         /// 切换在下一个固定步边界生效。
         /// </summary>
-        public void RequestNavHandback(World world, Entity entity)
+        public void RequestDisplacementHandback(World world, Entity entity)
         {
             ArgumentNullException.ThrowIfNull(world);
             ThrowIfCommitting();
@@ -149,11 +154,19 @@ namespace Ludots.Core.Movement
                     $"PoseAuthorityArbiter cannot hand back entity {entity.Id}: current pose authority is {authority.Value}, expected Displacement.");
             }
 
+            PoseAuthorityKind resume = _activeWindows[windowIndex].ResumeAuthority;
+            if (!MovementParticipationRules.CanOpenDisplacementWindow(resume))
+            {
+                throw new InvalidOperationException(
+                    $"PoseAuthorityArbiter cannot hand back entity {entity.Id}: stored resume authority is {resume}, expected Nav or Motor.");
+            }
+
             _pending.Add(new PendingTransition
             {
                 Entity = entity,
                 From = PoseAuthorityKind.Displacement,
-                To = PoseAuthorityKind.Nav,
+                To = resume,
+                ResumeAuthority = resume,
                 MaxDurationMs = 0,
             });
         }
@@ -183,11 +196,18 @@ namespace Ludots.Core.Movement
             }
 
             PoseAuthorityKind holder = _activeWindows[windowIndex].Holder;
+            PoseAuthorityKind resume = _activeWindows[windowIndex].ResumeAuthority;
             _activeWindows.RemoveAt(windowIndex);
+
+            if (!MovementParticipationRules.CanOpenDisplacementWindow(resume))
+            {
+                throw new InvalidOperationException(
+                    $"PoseAuthorityArbiter cannot cancel window for entity {entity.Id}: stored resume authority is {resume}, expected Nav or Motor.");
+            }
 
             if (world.IsAlive(entity) && world.Has<PoseAuthority>(entity))
             {
-                world.Set(entity, new PoseAuthority { Value = PoseAuthorityKind.Nav });
+                world.Set(entity, new PoseAuthority { Value = resume });
             }
 
             for (int listenerIndex = 0; listenerIndex < _listeners.Count; listenerIndex++)
@@ -208,11 +228,18 @@ namespace Ludots.Core.Movement
             {
                 Entity entity = _activeWindows[_activeWindows.Count - 1].Entity;
                 PoseAuthorityKind holder = _activeWindows[_activeWindows.Count - 1].Holder;
+                PoseAuthorityKind resume = _activeWindows[_activeWindows.Count - 1].ResumeAuthority;
                 _activeWindows.RemoveAt(_activeWindows.Count - 1);
+
+                if (!MovementParticipationRules.CanOpenDisplacementWindow(resume))
+                {
+                    throw new InvalidOperationException(
+                        $"PoseAuthorityArbiter cannot cancel window for entity {entity.Id}: stored resume authority is {resume}, expected Nav or Motor.");
+                }
 
                 if (world.IsAlive(entity) && world.Has<PoseAuthority>(entity))
                 {
-                    world.Set(entity, new PoseAuthority { Value = PoseAuthorityKind.Nav });
+                    world.Set(entity, new PoseAuthority { Value = resume });
                 }
 
                 for (int listenerIndex = 0; listenerIndex < _listeners.Count; listenerIndex++)
@@ -321,10 +348,17 @@ namespace Ludots.Core.Movement
                     PendingTransition transition = _pending[i];
                     if (transition.To == PoseAuthorityKind.Displacement)
                     {
+                        if (!MovementParticipationRules.CanOpenDisplacementWindow(transition.ResumeAuthority))
+                        {
+                            throw new InvalidOperationException(
+                                $"PoseAuthorityArbiter cannot open displacement window for entity {transition.Entity.Id}: resume authority is {transition.ResumeAuthority}, expected Nav or Motor.");
+                        }
+
                         _activeWindows.Add(new WindowState
                         {
                             Entity = transition.Entity,
                             Holder = PoseAuthorityKind.Displacement,
+                            ResumeAuthority = transition.ResumeAuthority,
                             HeldSeconds = 0f,
                             MaxDurationMs = transition.MaxDurationMs,
                         });

--- a/src/Tests/PresentationTests/MassNavigation/MassNavigationDisplacementWindowTests.cs
+++ b/src/Tests/PresentationTests/MassNavigation/MassNavigationDisplacementWindowTests.cs
@@ -378,6 +378,7 @@ namespace Ludots.Tests.Presentation
         {
             return new MovementParticipation
             {
+                Execution = MovementExecutionKind.Nav,
                 PhysicsPresence = PhysicsPresenceKind.None,
                 DisplacementAllowed = allowed,
                 DisplacementHandbackSpeedThresholdCmPerSec = handbackThresholdCmPerSec,
@@ -460,7 +461,7 @@ namespace Ludots.Tests.Presentation
                         World.Add(entity, spec.Participation.Value);
                         World.Add(entity, new PoseAuthority
                         {
-                            Value = MovementParticipationRules.DeriveInitialPoseAuthority(spec.Participation.Value.PhysicsPresence),
+                            Value = MovementParticipationRules.DeriveInitialPoseAuthority(spec.Participation.Value),
                         });
                     }
 

--- a/src/Tests/PresentationTests/Movement/MassNavKinematicBridgeTests.cs
+++ b/src/Tests/PresentationTests/Movement/MassNavKinematicBridgeTests.cs
@@ -245,6 +245,7 @@ namespace Ludots.Tests.Presentation.Movement
         {
             return new MovementParticipation
             {
+                Execution = MovementExecutionKind.Nav,
                 PhysicsPresence = PhysicsPresenceKind.Kinematic,
                 DisplacementAllowed = true,
                 DisplacementHandbackSpeedThresholdCmPerSec = 1f,
@@ -371,7 +372,7 @@ namespace Ludots.Tests.Presentation.Movement
                         World.Add(entity, spec.Participation.Value);
                         World.Add(entity, new PoseAuthority
                         {
-                            Value = MovementParticipationRules.DeriveInitialPoseAuthority(spec.Participation.Value.PhysicsPresence),
+                            Value = MovementParticipationRules.DeriveInitialPoseAuthority(spec.Participation.Value),
                         });
                     }
 

--- a/src/Tests/PresentationTests/Movement/MovementIntentAndExecutionLaneContractTests.cs
+++ b/src/Tests/PresentationTests/Movement/MovementIntentAndExecutionLaneContractTests.cs
@@ -1,0 +1,119 @@
+using Ludots.Core.Components;
+using Ludots.Core.Mathematics.FixedPoint;
+using Ludots.Core.Movement;
+using NUnit.Framework;
+
+namespace Ludots.PresentationTests.Movement;
+
+[TestFixture]
+public sealed class MovementIntentAndExecutionLaneContractTests
+{
+    [TestCase(MovementExecutionKind.Nav, PhysicsPresenceKind.None, PoseAuthorityKind.Nav)]
+    [TestCase(MovementExecutionKind.Nav, PhysicsPresenceKind.Kinematic, PoseAuthorityKind.Nav)]
+    [TestCase(MovementExecutionKind.Motor, PhysicsPresenceKind.None, PoseAuthorityKind.Motor)]
+    [TestCase(MovementExecutionKind.Motor, PhysicsPresenceKind.Kinematic, PoseAuthorityKind.Motor)]
+    [TestCase(MovementExecutionKind.Physics, PhysicsPresenceKind.Dynamic, PoseAuthorityKind.Physics)]
+    public void DeriveInitialPoseAuthority_ValidPairs(
+        MovementExecutionKind execution,
+        PhysicsPresenceKind presence,
+        PoseAuthorityKind expected)
+    {
+        Assert.That(
+            MovementParticipationRules.DeriveInitialPoseAuthority(execution, presence),
+            Is.EqualTo(expected));
+    }
+
+    [TestCase(MovementExecutionKind.Nav, PhysicsPresenceKind.Dynamic)]
+    [TestCase(MovementExecutionKind.Motor, PhysicsPresenceKind.Dynamic)]
+    [TestCase(MovementExecutionKind.Physics, PhysicsPresenceKind.None)]
+    [TestCase(MovementExecutionKind.Physics, PhysicsPresenceKind.Kinematic)]
+    public void DeriveInitialPoseAuthority_InvalidPairs_Throw(
+        MovementExecutionKind execution,
+        PhysicsPresenceKind presence)
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            MovementParticipationRules.DeriveInitialPoseAuthority(execution, presence));
+    }
+
+    [Test]
+    public void MoveIntent_NoneRequiresZeroSpeed()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            MovementIntentRules.Validate(new MoveIntent
+            {
+                Mode = MoveIntentMode.None,
+                DesiredSpeedCmPerSec = 1f,
+            }));
+    }
+
+    [Test]
+    public void MoveIntent_DirectionRequiresPositiveSpeed()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            MovementIntentRules.Validate(new MoveIntent
+            {
+                Mode = MoveIntentMode.Direction,
+                DirectionRad = 0f,
+                DesiredSpeedCmPerSec = 0f,
+            }));
+
+        Assert.DoesNotThrow(() =>
+            MovementIntentRules.Validate(new MoveIntent
+            {
+                Mode = MoveIntentMode.Direction,
+                DirectionRad = 1.5f,
+                DesiredSpeedCmPerSec = 120f,
+            }));
+    }
+
+    [Test]
+    public void MoveIntent_TargetPointRequiresFinitePointAndSpeed()
+    {
+        Assert.DoesNotThrow(() =>
+            MovementIntentRules.Validate(new MoveIntent
+            {
+                Mode = MoveIntentMode.TargetPoint,
+                TargetWorldCm = Fix64Vec2.FromFloat(100f, 200f),
+                DesiredSpeedCmPerSec = 80f,
+            }));
+    }
+
+    [Test]
+    public void FacingIntent_ExplicitYawRequiresFinite()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            MovementIntentRules.Validate(new FacingIntent
+            {
+                Mode = FacingIntentMode.ExplicitYaw,
+                YawRad = float.NaN,
+            }));
+    }
+
+    [Test]
+    public void PoseAuthorityArbiter_DisplacementHandbackRestoresMotor()
+    {
+        using var world = Arch.Core.World.Create();
+        var entity = world.Create(
+            new MovementParticipation
+            {
+                Execution = MovementExecutionKind.Motor,
+                PhysicsPresence = PhysicsPresenceKind.None,
+                DisplacementAllowed = true,
+                DisplacementHandbackSpeedThresholdCmPerSec = 1f,
+                DisplacementMaxDurationMs = 5_000,
+            },
+            new PoseAuthority { Value = PoseAuthorityKind.Motor });
+
+        var arbiter = new PoseAuthorityArbiter();
+        using var commit = new PoseAuthorityCommitSystem(world, arbiter);
+        float dt = 1f / 30f;
+
+        arbiter.RequestDisplacementAuthority(world, entity);
+        commit.Update(in dt);
+        Assert.That(world.Get<PoseAuthority>(entity).Value, Is.EqualTo(PoseAuthorityKind.Displacement));
+
+        arbiter.RequestDisplacementHandback(world, entity);
+        commit.Update(in dt);
+        Assert.That(world.Get<PoseAuthority>(entity).Value, Is.EqualTo(PoseAuthorityKind.Motor));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

- 变更目标：落地 Epic [#769](https://github.com/MightyBubble/Ludots/issues/769) 第一刀——意图层组件、per-entity 执行档（`nav`/`motor`/`physics`）、`PoseAuthorityKind.Motor`，以及位移窗口交还开启前写权。
- 影响范围：Core 移动参与合同、Crowd Physics Arena 模板 authoring、MassNavigation 绑定校验、gitbook 架构文档。

误开占位 [#768](https://github.com/MightyBubble/Ludots/issues/768)（`test`）可忽略/关闭，以 #769 为准。

## SSOT 落点

- 正式架构：`gitbook/architecture/movement-intent-and-execution-lanes.md`
- 同步：`gitbook/architecture/entity-simulation-layering.md`、`gitbook/SUMMARY.md`
- 关联：#643（热区/障碍交接仍归该单；本单不另造平行意图通道）

## 设计与挂靠点

- 挂靠点：`MovementParticipation` / `PoseAuthority` / `PoseAuthorityArbiter`
- 复用清单：既有位移窗口、MassNav 绑定、Kinematic 跟拍语义不变（nav+kinematic 仍是 Nav 写位置）
- 新增清单：
  - `MoveIntent` / `FacingIntent` + 校验规则
  - `MovementExecutionKind` + `PoseAuthorityKind.Motor`
  - 位移 `ResumeAuthority`（Nav/Motor）
  - authoring 必填 `execution`

## 验证证据

- 命令：`dotnet test src/Tests/PresentationTests/PresentationTests.csproj --filter "FullyQualifiedName~MovementIntentAndExecutionLaneContractTests|FullyQualifiedName~MassNavKinematicBridgeTests|FullyQualifiedName~MassNavigationDisplacementWindowTests"`
- 结果：Passed 35 / Failed 0

## 文档同步

- [x] `gitbook/` 正式文档已更新
- [x] `SUMMARY.md` 已同步
- [ ] 入口 README 无需变更

## 后续切片（仍在 #769）

- Facing 求解（Intent → FacingDirection）
- Motor 最小执行器
- MoveIntent 与 MassNav 目标点 SSOT 收敛

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86136d3a-4626-40ab-a0ca-c5833cdf94e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86136d3a-4626-40ab-a0ca-c5833cdf94e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

