### PR TITLE
feat(ui): CSS calc() 表达式与 viewport 单位

### DIFF
--- a/src/Libraries/Ludots.UI.Skia/UiSceneRenderer.cs
+++ b/src/Libraries/Ludots.UI.Skia/UiSceneRenderer.cs
@@ -667,20 +667,12 @@ public sealed class SkiaUiRenderer : IUiRenderer
 
 	private static float ResolveBackgroundAxisOffset(UiLength length, float available)
 	{
-		UiLengthUnit unit = length.Unit;
-		if (1 == 0)
+		if (length.IsAuto)
 		{
+			return 0f;
 		}
-		float result = unit switch
-		{
-			UiLengthUnit.Percent => available * (length.Value / 100f), 
-			UiLengthUnit.Pixel => length.Value, 
-			_ => 0f, 
-		};
-		if (1 == 0)
-		{
-		}
-		return result;
+		float resolved = length.Resolve(available);
+		return float.IsNaN(resolved) ? 0f : resolved;
 	}
 
 	private static float NormalizeRepeatStart(float start, float tileSize, float min, float max)
@@ -794,20 +786,12 @@ public sealed class SkiaUiRenderer : IUiRenderer
 
 	private static float ResolveLength(UiLength length, float available)
 	{
-		UiLengthUnit unit = length.Unit;
-		if (1 == 0)
+		if (length.IsAuto)
 		{
+			return 0f;
 		}
-		float result = unit switch
-		{
-			UiLengthUnit.Pixel => length.Value, 
-			UiLengthUnit.Percent => available * (length.Value / 100f), 
-			_ => length.Value, 
-		};
-		if (1 == 0)
-		{
-		}
-		return result;
+		float resolved = length.Resolve(available);
+		return float.IsNaN(resolved) ? 0f : resolved;
 	}
 
 	private static SKRect ResolveObjectFitRect(SKRect contentRect, float sourceWidth, float sourceHeight, UiObjectFit objectFit)

--- a/src/Libraries/Ludots.UI/Runtime/UiCalcExpression.cs
+++ b/src/Libraries/Ludots.UI/Runtime/UiCalcExpression.cs
@@ -1,0 +1,77 @@
+using System;
+
+namespace Ludots.UI.Runtime;
+
+public enum UiCalcOperator : byte
+{
+	Add,
+	Subtract,
+	Multiply,
+	Divide
+}
+
+/// <summary>
+/// Immutable binary expression tree for CSS calc(). Leaves hold a <see cref="UiLength"/>
+/// term (px/%/vw/vh/vmin/vmax). Unitless numbers in the source are stored as px-valued
+/// terms: Evaluate only uses the raw numeric value, so multiplication/division remain
+/// numerically correct under that simplification.
+/// </summary>
+public sealed class UiCalcExpression
+{
+	public UiCalcExpression? Left { get; }
+
+	public UiCalcOperator Operator { get; }
+
+	public UiCalcExpression? Right { get; }
+
+	public UiLength? Term { get; }
+
+	public bool IsLeaf => Left == null && Right == null;
+
+	public UiCalcExpression(UiLength term)
+	{
+		Term = term;
+	}
+
+	public UiCalcExpression(UiCalcExpression left, UiCalcOperator op, UiCalcExpression right)
+	{
+		Left = left;
+		Operator = op;
+		Right = right;
+	}
+
+	/// <summary>True when any leaf is a percent term; percent needs the containing-block size at evaluation.</summary>
+	public bool HasPercentTerm => HasUnitTerm(UiLengthUnit.Percent);
+
+	private bool HasUnitTerm(UiLengthUnit unit)
+	{
+		if (IsLeaf)
+		{
+			return Term?.Unit == unit;
+		}
+		return (Left != null && Left.HasUnitTerm(unit)) || (Right != null && Right.HasUnitTerm(unit));
+	}
+
+	public float Evaluate(UiLengthContext context)
+	{
+		if (IsLeaf)
+		{
+			UiLength? term = Term;
+			return term.HasValue ? term.Value.Resolve(context) : float.NaN;
+		}
+		float left = Left?.Evaluate(context) ?? float.NaN;
+		float right = Right?.Evaluate(context) ?? float.NaN;
+		if (float.IsNaN(left) || float.IsNaN(right))
+		{
+			return float.NaN;
+		}
+		return Operator switch
+		{
+			UiCalcOperator.Add => left + right,
+			UiCalcOperator.Subtract => left - right,
+			UiCalcOperator.Multiply => left * right,
+			UiCalcOperator.Divide => Math.Abs(right) < 1e-6f ? float.NaN : left / right,
+			_ => float.NaN
+		};
+	}
+}

--- a/src/Libraries/Ludots.UI/Runtime/UiCalcParser.cs
+++ b/src/Libraries/Ludots.UI/Runtime/UiCalcParser.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Globalization;
+
+namespace Ludots.UI.Runtime;
+
+/// <summary>
+/// Recursive-descent parser for CSS calc() length expressions. Grammar (simplified CSS):
+/// additive := multiplicative (('+' | '-') multiplicative)*
+/// multiplicative := factor (('*' | '/') factor)*
+/// factor := ['+' | '-'] number-unit | '(' additive ')' | 'calc(' additive ')'
+/// Unitless numbers are accepted and stored as px-valued terms.
+/// Malformed input fails deterministically (TryParse returns false, nothing is consumed globally).
+/// </summary>
+internal static class UiCalcParser
+{
+	public static bool TryParse(string text, out UiCalcExpression? expression)
+	{
+		expression = null;
+		if (string.IsNullOrWhiteSpace(text))
+		{
+			return false;
+		}
+		int pos = 0;
+		if (!TryParseAdditive(text, ref pos, out expression) || !SkipWhitespace(text, ref pos) || pos != text.Length || expression == null)
+		{
+			expression = null;
+			return false;
+		}
+		return true;
+	}
+
+	private static bool TryParseAdditive(string text, ref int pos, out UiCalcExpression? expr)
+	{
+		if (!TryParseMultiplicative(text, ref pos, out expr))
+		{
+			return false;
+		}
+		while (true)
+		{
+			SkipWhitespace(text, ref pos);
+			if (pos >= text.Length)
+			{
+				return true;
+			}
+			char op = text[pos];
+			if (op != '+' && op != '-')
+			{
+				return true;
+			}
+			pos++;
+			SkipWhitespace(text, ref pos);
+			if (!TryParseMultiplicative(text, ref pos, out UiCalcExpression? right) || right == null)
+			{
+				return false;
+			}
+			expr = new UiCalcExpression(expr, (op == '+') ? UiCalcOperator.Add : UiCalcOperator.Subtract, right);
+		}
+	}
+
+	private static bool TryParseMultiplicative(string text, ref int pos, out UiCalcExpression? expr)
+	{
+		if (!TryParseFactor(text, ref pos, out expr))
+		{
+			return false;
+		}
+		while (true)
+		{
+			SkipWhitespace(text, ref pos);
+			if (pos >= text.Length)
+			{
+				return true;
+			}
+			char op = text[pos];
+			if (op != '*' && op != '/')
+			{
+				return true;
+			}
+			pos++;
+			SkipWhitespace(text, ref pos);
+			if (!TryParseFactor(text, ref pos, out UiCalcExpression? right) || right == null)
+			{
+				return false;
+			}
+			expr = new UiCalcExpression(expr, (op == '*') ? UiCalcOperator.Multiply : UiCalcOperator.Divide, right);
+		}
+	}
+
+	private static bool TryParseFactor(string text, ref int pos, out UiCalcExpression? expr)
+	{
+		SkipWhitespace(text, ref pos);
+		if (pos >= text.Length)
+		{
+			expr = null;
+			return false;
+		}
+		if (text[pos] == '(')
+		{
+			pos++;
+			if (!TryParseAdditive(text, ref pos, out expr) || !ExpectChar(text, ref pos, ')'))
+			{
+				expr = null;
+				return false;
+			}
+			return expr != null;
+		}
+		if (pos + 5 <= text.Length && text.Substring(pos, 5).Equals("calc(", StringComparison.OrdinalIgnoreCase))
+		{
+			pos += 5;
+			if (!TryParseAdditive(text, ref pos, out expr) || !ExpectChar(text, ref pos, ')'))
+			{
+				expr = null;
+				return false;
+			}
+			return expr != null;
+		}
+		return TryParseLengthTerm(text, ref pos, out expr);
+	}
+
+	private static bool TryParseLengthTerm(string text, ref int pos, out UiCalcExpression? expr)
+	{
+		expr = null;
+		SkipWhitespace(text, ref pos);
+		int start = pos;
+		if (pos < text.Length && (text[pos] == '+' || text[pos] == '-'))
+		{
+			pos++;
+		}
+		while (pos < text.Length && (char.IsDigit(text[pos]) || text[pos] == '.'))
+		{
+			pos++;
+		}
+		if (pos == start || (pos == start + 1 && (text[start] == '+' || text[start] == '-')))
+		{
+			return false;
+		}
+		string numberPart = text.Substring(start, pos - start);
+		string unit;
+		if (pos < text.Length && text[pos] == '%')
+		{
+			pos++;
+			unit = "%";
+		}
+		else
+		{
+			unit = ReadUnitSuffix(text, ref pos).ToLowerInvariant();
+		}
+		if (!float.TryParse(numberPart, NumberStyles.Float, CultureInfo.InvariantCulture, out float value))
+		{
+			return false;
+		}
+		UiLength length;
+		switch (unit)
+		{
+		case "":
+			length = UiLength.Px(value);
+			break;
+		case "px":
+			length = UiLength.Px(value);
+			break;
+		case "%":
+			length = UiLength.Percent(value);
+			break;
+		case "vw":
+			length = new UiLength(value, UiLengthUnit.Vw);
+			break;
+		case "vh":
+			length = new UiLength(value, UiLengthUnit.Vh);
+			break;
+		case "vmin":
+			length = new UiLength(value, UiLengthUnit.Vmin);
+			break;
+		case "vmax":
+			length = new UiLength(value, UiLengthUnit.Vmax);
+			break;
+		default:
+			return false;
+		}
+		expr = new UiCalcExpression(length);
+		return true;
+	}
+
+	private static string ReadUnitSuffix(string text, ref int pos)
+	{
+		int start = pos;
+		while (pos < text.Length && char.IsLetter(text[pos]))
+		{
+			pos++;
+		}
+		return text.Substring(start, pos - start);
+	}
+
+	private static bool ExpectChar(string text, ref int pos, char expected)
+	{
+		SkipWhitespace(text, ref pos);
+		if (pos < text.Length && text[pos] == expected)
+		{
+			pos++;
+			return true;
+		}
+		return false;
+	}
+
+	private static bool SkipWhitespace(string text, ref int pos)
+	{
+		while (pos < text.Length && char.IsWhiteSpace(text[pos]))
+		{
+			pos++;
+		}
+		return true;
+	}
+}

--- a/src/Libraries/Ludots.UI/Runtime/UiLayoutEngine.cs
+++ b/src/Libraries/Ludots.UI/Runtime/UiLayoutEngine.cs
@@ -60,19 +60,28 @@ public sealed class UiLayoutEngine
 	public void Layout(UiNode root, float width, float height)
 	{
 		ArgumentNullException.ThrowIfNull(root, "root");
-		Node node = BuildFlexTree(root, isRoot: true, width, height);
+		List<Node> deferredCalcNodes = new List<Node>();
+		Node node = BuildFlexTree(root, isRoot: true, width, height, deferredCalcNodes);
 		node.CalculateLayout(width, height, Direction.LTR);
+		if (deferredCalcNodes.Count > 0)
+		{
+			foreach (Node deferredNode in deferredCalcNodes)
+			{
+				ResolveDeferredCalcLengths(deferredNode, width, height);
+			}
+			node.CalculateLayout(width, height, Direction.LTR);
+		}
 		ApplyLayout(root, node, 0f, 0f);
 		NormalizeTableLayouts(root);
 	}
 
-	private Node BuildFlexTree(UiNode node, bool isRoot, float rootWidth, float rootHeight)
+	private Node BuildFlexTree(UiNode node, bool isRoot, float rootWidth, float rootHeight, List<Node> deferredCalcNodes)
 	{
 		Node node2 = new Node
 		{
 			Context = node
 		};
-		ConfigureNodeStyle(node2, node, isRoot, rootWidth, rootHeight);
+		ConfigureNodeStyle(node2, node, isRoot, rootWidth, rootHeight, deferredCalcNodes);
 		if (ShouldMeasureAsLeaf(node))
 		{
 			node2.SetMeasureFunc((Node _, float width, MeasureMode widthMode, float height, MeasureMode heightMode) => MeasureNode(node, width, widthMode, height, heightMode));
@@ -80,14 +89,14 @@ public sealed class UiLayoutEngine
 		}
 		for (int num = 0; num < node.Children.Count; num++)
 		{
-			Node node3 = BuildFlexTree(node.Children[num], isRoot: false, rootWidth, rootHeight);
+			Node node3 = BuildFlexTree(node.Children[num], isRoot: false, rootWidth, rootHeight, deferredCalcNodes);
 			ApplyGapOffset(node3, node.Style, num);
 			node2.AddChild(node3);
 		}
 		return node2;
 	}
 
-	private void ConfigureNodeStyle(Node flexNode, UiNode node, bool isRoot, float rootWidth, float rootHeight)
+	private void ConfigureNodeStyle(Node flexNode, UiNode node, bool isRoot, float rootWidth, float rootHeight, List<Node> deferredCalcNodes)
 	{
 		UiStyle style = node.Style;
 		bool flag = style.Visible && style.Display != UiDisplay.None;
@@ -101,41 +110,43 @@ public sealed class UiLayoutEngine
 		flexNode.StyleSetPositionType((style.PositionType == UiPositionType.Absolute) ? PositionType.Absolute : PositionType.Relative);
 		flexNode.StyleSetFlexGrow(style.FlexGrow);
 		flexNode.StyleSetFlexShrink(style.FlexShrink);
-		ApplyLength(style.Width, flexNode.StyleSetWidth, flexNode.StyleSetWidthPercent, flexNode.StyleSetWidthAuto);
-		ApplyLength(style.Height, flexNode.StyleSetHeight, flexNode.StyleSetHeightPercent, flexNode.StyleSetHeightAuto);
-		ApplyLength(style.MinWidth, flexNode.StyleSetMinWidth, flexNode.StyleSetMinWidthPercent, null);
-		ApplyLength(style.MinHeight, flexNode.StyleSetMinHeight, flexNode.StyleSetMinHeightPercent, null);
-		ApplyLength(style.MaxWidth, flexNode.StyleSetMaxWidth, flexNode.StyleSetMaxWidthPercent, null);
-		ApplyLength(style.MaxHeight, flexNode.StyleSetMaxHeight, flexNode.StyleSetMaxHeightPercent, null);
-		ApplyLength(style.FlexBasis, flexNode.StyleSetFlexBasis, flexNode.StyleSetFlexBasisPercent, flexNode.NodeStyleSetFlexBasisAuto);
-		ApplyLength(style.Left, delegate(float value)
+		UiLengthContext horizontalContext = new UiLengthContext(isRoot ? rootWidth : 0f, rootWidth, rootHeight);
+		UiLengthContext verticalContext = new UiLengthContext(isRoot ? rootHeight : 0f, rootWidth, rootHeight);
+		ApplyNodeLength(style.Width, horizontalContext, isRoot, flexNode.StyleSetWidth, flexNode.StyleSetWidthPercent, flexNode.StyleSetWidthAuto, flexNode, deferredCalcNodes);
+		ApplyNodeLength(style.Height, verticalContext, isRoot, flexNode.StyleSetHeight, flexNode.StyleSetHeightPercent, flexNode.StyleSetHeightAuto, flexNode, deferredCalcNodes);
+		ApplyNodeLength(style.MinWidth, horizontalContext, isRoot, flexNode.StyleSetMinWidth, flexNode.StyleSetMinWidthPercent, null, flexNode, deferredCalcNodes);
+		ApplyNodeLength(style.MinHeight, verticalContext, isRoot, flexNode.StyleSetMinHeight, flexNode.StyleSetMinHeightPercent, null, flexNode, deferredCalcNodes);
+		ApplyNodeLength(style.MaxWidth, horizontalContext, isRoot, flexNode.StyleSetMaxWidth, flexNode.StyleSetMaxWidthPercent, null, flexNode, deferredCalcNodes);
+		ApplyNodeLength(style.MaxHeight, verticalContext, isRoot, flexNode.StyleSetMaxHeight, flexNode.StyleSetMaxHeightPercent, null, flexNode, deferredCalcNodes);
+		ApplyNodeLength(style.FlexBasis, horizontalContext, isRoot, flexNode.StyleSetFlexBasis, flexNode.StyleSetFlexBasisPercent, flexNode.NodeStyleSetFlexBasisAuto, flexNode, deferredCalcNodes);
+		ApplyNodeLength(style.Left, horizontalContext, isRoot, delegate(float value)
 		{
 			flexNode.StyleSetPosition(Edge.Left, value);
 		}, delegate(float value)
 		{
 			flexNode.StyleSetPositionPercent(Edge.Left, value);
-		}, null);
-		ApplyLength(style.Top, delegate(float value)
+		}, null, flexNode, deferredCalcNodes);
+		ApplyNodeLength(style.Top, verticalContext, isRoot, delegate(float value)
 		{
 			flexNode.StyleSetPosition(Edge.Top, value);
 		}, delegate(float value)
 		{
 			flexNode.StyleSetPositionPercent(Edge.Top, value);
-		}, null);
-		ApplyLength(style.Right, delegate(float value)
+		}, null, flexNode, deferredCalcNodes);
+		ApplyNodeLength(style.Right, horizontalContext, isRoot, delegate(float value)
 		{
 			flexNode.StyleSetPosition(Edge.Right, value);
 		}, delegate(float value)
 		{
 			flexNode.StyleSetPositionPercent(Edge.Right, value);
-		}, null);
-		ApplyLength(style.Bottom, delegate(float value)
+		}, null, flexNode, deferredCalcNodes);
+		ApplyNodeLength(style.Bottom, verticalContext, isRoot, delegate(float value)
 		{
 			flexNode.StyleSetPosition(Edge.Bottom, value);
 		}, delegate(float value)
 		{
 			flexNode.StyleSetPositionPercent(Edge.Bottom, value);
-		}, null);
+		}, null, flexNode, deferredCalcNodes);
 		ApplyThickness(style.Margin, delegate(Edge edge, float value)
 		{
 			flexNode.StyleSetMargin(edge, value);
@@ -185,7 +196,16 @@ public sealed class UiLayoutEngine
 		node.StyleSetBorder(Edge.Bottom, borderWidth);
 	}
 
-	private static void ApplyLength(UiLength length, Action<float> pointSetter, Action<float> percentSetter, Action? autoSetter)
+	private static void ApplyNodeLength(UiLength length, UiLengthContext context, bool isRoot, Action<float> pointSetter, Action<float> percentSetter, Action? autoSetter, Node flexNode, List<Node> deferredCalcNodes)
+	{
+		if (ApplyLength(length, context, isRoot, pointSetter, percentSetter, autoSetter))
+		{
+			deferredCalcNodes.Add(flexNode);
+		}
+	}
+
+	/// <summary>Applies a length to the flex node. Returns true when the length was deferred (calc with a percent term on a non-root node).</summary>
+	private static bool ApplyLength(UiLength length, UiLengthContext context, bool isRoot, Action<float> pointSetter, Action<float> percentSetter, Action? autoSetter)
 	{
 		switch (length.Unit)
 		{
@@ -195,10 +215,103 @@ public sealed class UiLayoutEngine
 		case UiLengthUnit.Percent:
 			percentSetter(length.Value);
 			break;
+		case UiLengthUnit.Vw:
+		case UiLengthUnit.Vh:
+		case UiLengthUnit.Vmin:
+		case UiLengthUnit.Vmax:
+			pointSetter(length.Resolve(context));
+			break;
+		case UiLengthUnit.Calc:
+			if (length.Calc == null)
+			{
+				autoSetter?.Invoke();
+				break;
+			}
+			if (length.Calc.HasPercentTerm && !isRoot)
+			{
+				return true;
+			}
+			float resolved = length.Calc.Evaluate(context);
+			if (float.IsNaN(resolved))
+			{
+				autoSetter?.Invoke();
+				break;
+			}
+			pointSetter(resolved);
+			break;
 		default:
 			autoSetter?.Invoke();
 			break;
 		}
+		return false;
+	}
+
+	/// <summary>
+	/// Second layout pass: resolves deferred calc lengths (percent terms) against the parent's
+	/// laid-out content size. Only runs when at least one node deferred a calc length.
+	/// </summary>
+	private static void ResolveDeferredCalcLengths(Node flexNode, float rootWidth, float rootHeight)
+	{
+		if (flexNode.Context is not UiNode node)
+		{
+			return;
+		}
+		UiStyle style = node.Style;
+		Node? parent = flexNode.GetParent();
+		float parentContentWidth = ((parent == null) ? rootWidth : Math.Max(0f, parent.LayoutGetWidth() - parent.LayoutGetPadding(Edge.Left) - parent.LayoutGetPadding(Edge.Right)));
+		float parentContentHeight = ((parent == null) ? rootHeight : Math.Max(0f, parent.LayoutGetHeight() - parent.LayoutGetPadding(Edge.Top) - parent.LayoutGetPadding(Edge.Bottom)));
+		UiLengthContext horizontalContext = new UiLengthContext(parentContentWidth, rootWidth, rootHeight);
+		UiLengthContext verticalContext = new UiLengthContext(parentContentHeight, rootWidth, rootHeight);
+		ApplyDeferredCalc(style.Width, horizontalContext, flexNode.StyleSetWidth, flexNode.StyleSetWidthPercent, flexNode.StyleSetWidthAuto);
+		ApplyDeferredCalc(style.Height, verticalContext, flexNode.StyleSetHeight, flexNode.StyleSetHeightPercent, flexNode.StyleSetHeightAuto);
+		ApplyDeferredCalc(style.MinWidth, horizontalContext, flexNode.StyleSetMinWidth, flexNode.StyleSetMinWidthPercent, null);
+		ApplyDeferredCalc(style.MinHeight, verticalContext, flexNode.StyleSetMinHeight, flexNode.StyleSetMinHeightPercent, null);
+		ApplyDeferredCalc(style.MaxWidth, horizontalContext, flexNode.StyleSetMaxWidth, flexNode.StyleSetMaxWidthPercent, null);
+		ApplyDeferredCalc(style.MaxHeight, verticalContext, flexNode.StyleSetMaxHeight, flexNode.StyleSetMaxHeightPercent, null);
+		ApplyDeferredCalc(style.FlexBasis, horizontalContext, flexNode.StyleSetFlexBasis, flexNode.StyleSetFlexBasisPercent, flexNode.NodeStyleSetFlexBasisAuto);
+		ApplyDeferredCalc(style.Left, horizontalContext, delegate(float value)
+		{
+			flexNode.StyleSetPosition(Edge.Left, value);
+		}, delegate(float value)
+		{
+			flexNode.StyleSetPositionPercent(Edge.Left, value);
+		}, null);
+		ApplyDeferredCalc(style.Top, verticalContext, delegate(float value)
+		{
+			flexNode.StyleSetPosition(Edge.Top, value);
+		}, delegate(float value)
+		{
+			flexNode.StyleSetPositionPercent(Edge.Top, value);
+		}, null);
+		ApplyDeferredCalc(style.Right, horizontalContext, delegate(float value)
+		{
+			flexNode.StyleSetPosition(Edge.Right, value);
+		}, delegate(float value)
+		{
+			flexNode.StyleSetPositionPercent(Edge.Right, value);
+		}, null);
+		ApplyDeferredCalc(style.Bottom, verticalContext, delegate(float value)
+		{
+			flexNode.StyleSetPosition(Edge.Bottom, value);
+		}, delegate(float value)
+		{
+			flexNode.StyleSetPositionPercent(Edge.Bottom, value);
+		}, null);
+	}
+
+	private static void ApplyDeferredCalc(UiLength length, UiLengthContext context, Action<float> pointSetter, Action<float> percentSetter, Action? autoSetter)
+	{
+		if (length.Unit != UiLengthUnit.Calc || length.Calc == null)
+		{
+			return;
+		}
+		float resolved = length.Calc.Evaluate(context);
+		if (float.IsNaN(resolved))
+		{
+			autoSetter?.Invoke();
+			return;
+		}
+		pointSetter(resolved);
 	}
 
 	private static Overflow MapOverflow(UiStyle style)

--- a/src/Libraries/Ludots.UI/Runtime/UiLength.cs
+++ b/src/Libraries/Ludots.UI/Runtime/UiLength.cs
@@ -1,10 +1,16 @@
+using System;
+
 namespace Ludots.UI.Runtime;
 
-public readonly record struct UiLength(float Value, UiLengthUnit Unit)
+public readonly record struct UiLength(float Value, UiLengthUnit Unit, UiCalcExpression? Calc = null)
 {
 	public static UiLength Auto => new UiLength(0f, UiLengthUnit.Auto);
 
 	public bool IsAuto => Unit == UiLengthUnit.Auto;
+
+	public bool IsCalc => Unit == UiLengthUnit.Calc;
+
+	public bool IsViewportUnit => Unit == UiLengthUnit.Vw || Unit == UiLengthUnit.Vh || Unit == UiLengthUnit.Vmin || Unit == UiLengthUnit.Vmax;
 
 	public static UiLength Px(float value)
 	{
@@ -16,7 +22,26 @@ public readonly record struct UiLength(float Value, UiLengthUnit Unit)
 		return new UiLength(value, UiLengthUnit.Percent);
 	}
 
-	public float Resolve(float available)
+	public static UiLength Viewport(float value, UiLengthUnit unit)
+	{
+		if (unit != UiLengthUnit.Vw && unit != UiLengthUnit.Vh && unit != UiLengthUnit.Vmin && unit != UiLengthUnit.Vmax)
+		{
+			throw new ArgumentOutOfRangeException(nameof(unit), "Viewport factory accepts Vw, Vh, Vmin or Vmax only.");
+		}
+		return new UiLength(value, unit);
+	}
+
+	public static UiLength CalcExpression(UiCalcExpression expression)
+	{
+		ArgumentNullException.ThrowIfNull(expression, "expression");
+		return new UiLength(0f, UiLengthUnit.Calc, expression);
+	}
+
+	/// <summary>
+	/// Resolves to pixels. Percent resolves against context.Available; viewport units resolve
+	/// against context viewport dimensions; calc evaluates the expression tree.
+	/// </summary>
+	public float Resolve(UiLengthContext context)
 	{
 		UiLengthUnit unit = Unit;
 		if (1 == 0)
@@ -24,14 +49,37 @@ public readonly record struct UiLength(float Value, UiLengthUnit Unit)
 		}
 		float result = unit switch
 		{
-			UiLengthUnit.Pixel => Value, 
-			UiLengthUnit.Percent => available * (Value / 100f), 
-			_ => float.NaN, 
+			UiLengthUnit.Pixel => Value,
+			UiLengthUnit.Percent => context.Available * (Value / 100f),
+			UiLengthUnit.Vw => ResolveViewportUnit(context.ViewportWidth, Value),
+			UiLengthUnit.Vh => ResolveViewportUnit(context.ViewportHeight, Value),
+			UiLengthUnit.Vmin => ResolveViewportUnit(context.ViewportMin, Value),
+			UiLengthUnit.Vmax => ResolveViewportUnit(context.ViewportMax, Value),
+			UiLengthUnit.Calc => Calc?.Evaluate(context) ?? float.NaN,
+			_ => float.NaN,
 		};
 		if (1 == 0)
 		{
 		}
 		return result;
+	}
+
+	/// <summary>
+	/// Legacy overload: resolves with the given containing-block size and no viewport context.
+	/// Viewport units throw (fail fast) because they cannot resolve without viewport dimensions.
+	/// </summary>
+	public float Resolve(float available)
+	{
+		return Resolve(new UiLengthContext(available));
+	}
+
+	private static float ResolveViewportUnit(float viewportDimension, float value)
+	{
+		if (viewportDimension <= 0f)
+		{
+			throw new InvalidOperationException("Viewport length cannot be resolved without viewport dimensions; pass a UiLengthContext with viewport width/height.");
+		}
+		return viewportDimension * (value / 100f);
 	}
 
 	public override string ToString()
@@ -42,9 +90,14 @@ public readonly record struct UiLength(float Value, UiLengthUnit Unit)
 		}
 		string result = unit switch
 		{
-			UiLengthUnit.Pixel => $"{Value}px", 
-			UiLengthUnit.Percent => $"{Value}%", 
-			_ => "auto", 
+			UiLengthUnit.Pixel => $"{Value}px",
+			UiLengthUnit.Percent => $"{Value}%",
+			UiLengthUnit.Vw => $"{Value}vw",
+			UiLengthUnit.Vh => $"{Value}vh",
+			UiLengthUnit.Vmin => $"{Value}vmin",
+			UiLengthUnit.Vmax => $"{Value}vmax",
+			UiLengthUnit.Calc => $"calc({Calc})",
+			_ => "auto",
 		};
 		if (1 == 0)
 		{

--- a/src/Libraries/Ludots.UI/Runtime/UiLengthContext.cs
+++ b/src/Libraries/Ludots.UI/Runtime/UiLengthContext.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Ludots.UI.Runtime;
+
+/// <summary>
+/// Explicit resolution context for <see cref="UiLength"/>. Carries the containing-block
+/// size (for %) and the scene viewport size (for vw/vh/vmin/vmax). Passed, never stored
+/// statically, so resolution stays deterministic per layout pass.
+/// </summary>
+public readonly struct UiLengthContext
+{
+	/// <summary>Containing block size along the axis being resolved (percent reference).</summary>
+	public float Available { get; }
+
+	/// <summary>Scene viewport width (100vw reference).</summary>
+	public float ViewportWidth { get; }
+
+	/// <summary>Scene viewport height (100vh reference).</summary>
+	public float ViewportHeight { get; }
+
+	public UiLengthContext(float available, float viewportWidth = 0f, float viewportHeight = 0f)
+	{
+		Available = available;
+		ViewportWidth = viewportWidth;
+		ViewportHeight = viewportHeight;
+	}
+
+	public bool HasViewport => ViewportWidth > 0f && ViewportHeight > 0f;
+
+	public float ViewportMin => MathF.Min(ViewportWidth, ViewportHeight);
+
+	public float ViewportMax => MathF.Max(ViewportWidth, ViewportHeight);
+}

--- a/src/Libraries/Ludots.UI/Runtime/UiLengthUnit.cs
+++ b/src/Libraries/Ludots.UI/Runtime/UiLengthUnit.cs
@@ -4,5 +4,10 @@ public enum UiLengthUnit : byte
 {
 	Auto,
 	Pixel,
-	Percent
+	Percent,
+	Vw,
+	Vh,
+	Vmin,
+	Vmax,
+	Calc
 }

--- a/src/Libraries/Ludots.UI/Runtime/UiStyleResolver.cs
+++ b/src/Libraries/Ludots.UI/Runtime/UiStyleResolver.cs
@@ -1175,6 +1175,17 @@ public sealed class UiStyleResolver
 			length = UiLength.Auto;
 			return true;
 		}
+		if (text.StartsWith("calc(", StringComparison.OrdinalIgnoreCase) && text.EndsWith(")", StringComparison.Ordinal))
+		{
+			string inner = text.Substring("calc(".Length, text.Length - "calc(".Length - 1);
+			if (UiCalcParser.TryParse(inner, out UiCalcExpression? expression))
+			{
+				length = UiLength.CalcExpression(expression);
+				return true;
+			}
+			length = UiLength.Auto;
+			return false;
+		}
 		if (text.EndsWith("%", StringComparison.Ordinal))
 		{
 			string text2 = text;
@@ -1183,6 +1194,10 @@ public sealed class UiStyleResolver
 				length = UiLength.Percent(result);
 				return true;
 			}
+		}
+		if (TryParseViewportUnit(text, out length))
+		{
+			return true;
 		}
 		if (text.EndsWith("px", StringComparison.OrdinalIgnoreCase))
 		{
@@ -1196,6 +1211,38 @@ public sealed class UiStyleResolver
 		}
 		length = UiLength.Auto;
 		return false;
+	}
+
+	private static bool TryParseViewportUnit(string text, out UiLength length)
+	{
+		length = UiLength.Auto;
+		if (text.EndsWith("vmin", StringComparison.OrdinalIgnoreCase) && TryParseUnitValue(text, "vmin", out float vmin))
+		{
+			length = new UiLength(vmin, UiLengthUnit.Vmin);
+			return true;
+		}
+		if (text.EndsWith("vmax", StringComparison.OrdinalIgnoreCase) && TryParseUnitValue(text, "vmax", out float vmax))
+		{
+			length = new UiLength(vmax, UiLengthUnit.Vmax);
+			return true;
+		}
+		if (text.EndsWith("vw", StringComparison.OrdinalIgnoreCase) && TryParseUnitValue(text, "vw", out float vw))
+		{
+			length = new UiLength(vw, UiLengthUnit.Vw);
+			return true;
+		}
+		if (text.EndsWith("vh", StringComparison.OrdinalIgnoreCase) && TryParseUnitValue(text, "vh", out float vh))
+		{
+			length = new UiLength(vh, UiLengthUnit.Vh);
+			return true;
+		}
+		return false;
+	}
+
+	private static bool TryParseUnitValue(string text, string suffix, out float value)
+	{
+		value = 0f;
+		return float.TryParse(text.Substring(0, text.Length - suffix.Length), NumberStyles.Float, CultureInfo.InvariantCulture, out value);
 	}
 
 	private static bool TryParseFloat(string value, out float parsed)

--- a/src/Tests/UiShowcaseTests/UiLengthTests.cs
+++ b/src/Tests/UiShowcaseTests/UiLengthTests.cs
@@ -1,0 +1,209 @@
+using Ludots.UI.HtmlEngine.Markup;
+using Ludots.UI.Runtime;
+using Ludots.UI.Skia;
+using NUnit.Framework;
+
+namespace Ludots.Tests.UiShowcase;
+
+[TestFixture]
+public sealed class UiLengthTests
+{
+	private static readonly IUiTextMeasurer TextMeasurer = new SkiaTextMeasurer();
+	private static readonly IUiImageSizeProvider ImageSizeProvider = new SkiaImageSizeProvider();
+
+	[Test]
+	public void UiLength_ResolveVw_ReturnsViewportFraction()
+	{
+		UiLength length = UiLength.Viewport(50f, UiLengthUnit.Vw);
+		float result = length.Resolve(new UiLengthContext(0f, 1000f, 800f));
+		Assert.That(result, Is.EqualTo(500f).Within(0.01f));
+	}
+
+	[Test]
+	public void UiLength_ResolveVh_ReturnsViewportFraction()
+	{
+		UiLength length = UiLength.Viewport(25f, UiLengthUnit.Vh);
+		float result = length.Resolve(new UiLengthContext(0f, 1000f, 800f));
+		Assert.That(result, Is.EqualTo(200f).Within(0.01f));
+	}
+
+	[Test]
+	public void UiLength_ResolveVmin_ReturnsSmallerViewportAxis()
+	{
+		UiLength length = UiLength.Viewport(10f, UiLengthUnit.Vmin);
+		float result = length.Resolve(new UiLengthContext(0f, 1000f, 800f));
+		Assert.That(result, Is.EqualTo(80f).Within(0.01f));
+	}
+
+	[Test]
+	public void UiLength_ResolveVmax_ReturnsLargerViewportAxis()
+	{
+		UiLength length = UiLength.Viewport(10f, UiLengthUnit.Vmax);
+		float result = length.Resolve(new UiLengthContext(0f, 1000f, 800f));
+		Assert.That(result, Is.EqualTo(100f).Within(0.01f));
+	}
+
+	[Test]
+	public void UiLength_ResolveViewportUnitWithoutContext_Throws()
+	{
+		UiLength length = UiLength.Viewport(10f, UiLengthUnit.Vw);
+		Assert.That(() => length.Resolve(500f), Throws.InvalidOperationException);
+	}
+
+	[Test]
+	public void UiLength_ResolveCalcMixedUnits_ReturnsPixelTotal()
+	{
+		UiCalcExpression expression = new UiCalcExpression(
+			new UiCalcExpression(UiLength.Percent(100f)),
+			UiCalcOperator.Subtract,
+			new UiCalcExpression(UiLength.Px(40f)));
+		UiLength length = UiLength.CalcExpression(expression);
+		float result = length.Resolve(new UiLengthContext(1000f, 0f, 0f));
+		Assert.That(result, Is.EqualTo(960f).Within(0.01f));
+	}
+
+	[Test]
+	public void UiLength_ResolveCalcNested_ReturnsExpectedTotal()
+	{
+		UiCalcExpression nested = new UiCalcExpression(
+			new UiCalcExpression(UiLength.Px(5f)),
+			UiCalcOperator.Multiply,
+			new UiCalcExpression(UiLength.Px(2f)));
+		UiCalcExpression outer = new UiCalcExpression(
+			new UiCalcExpression(UiLength.Px(10f)),
+			UiCalcOperator.Add,
+			nested);
+		UiLength length = UiLength.CalcExpression(outer);
+		float result = length.Resolve(new UiLengthContext(0f, 0f, 0f));
+		Assert.That(result, Is.EqualTo(20f).Within(0.01f));
+	}
+
+	[Test]
+	public void UiLength_ResolveCalcPrecedence_MultiplyBindsBeforeAdd()
+	{
+		UiCalcExpression expression = new UiCalcExpression(
+			new UiCalcExpression(UiLength.Px(10f)),
+			UiCalcOperator.Add,
+			new UiCalcExpression(
+				new UiCalcExpression(UiLength.Px(5f)),
+				UiCalcOperator.Multiply,
+				new UiCalcExpression(UiLength.Px(2f))));
+		UiLength length = UiLength.CalcExpression(expression);
+		float result = length.Resolve(new UiLengthContext(0f, 0f, 0f));
+		Assert.That(result, Is.EqualTo(20f).Within(0.01f));
+	}
+
+	[Test]
+	public void UiLength_ResolveCalcDivisionByZero_ReturnsNaN()
+	{
+		UiCalcExpression expression = new UiCalcExpression(
+			new UiCalcExpression(UiLength.Px(100f)),
+			UiCalcOperator.Divide,
+			new UiCalcExpression(UiLength.Px(0f)));
+		UiLength length = UiLength.CalcExpression(expression);
+		float result = length.Resolve(new UiLengthContext(0f, 0f, 0f));
+		Assert.That(float.IsNaN(result), Is.True);
+	}
+
+	private static UiScene BuildScene(string html, string css)
+	{
+		return new UiMarkupLoader().LoadScene(TextMeasurer, ImageSizeProvider, html, css);
+	}
+
+	[Test]
+	public void CssScene_CalcWidthMixedUnits_ResolvesAgainstParentContent()
+	{
+		const string html = "<div id=\"wrap\" style=\"width: 1000px\"><div id=\"box\" style=\"width: calc(100% - 40px)\"></div></div>";
+		UiScene scene = BuildScene(html, string.Empty);
+		scene.Layout(1280f, 720f);
+		UiNode? box = scene.FindByElementId("box");
+		Assert.That(box, Is.Not.Null);
+		Assert.That(box!.LayoutRect.Width, Is.EqualTo(960f).Within(0.01f));
+	}
+
+	[Test]
+	public void CssScene_NestedCalcWidth_ResolvesToPixelTotal()
+	{
+		const string html = "<div id=\"box\" style=\"width: calc(10px + calc(5px * 2))\"></div>";
+		UiScene scene = BuildScene(html, string.Empty);
+		scene.Layout(1280f, 720f);
+		UiNode? box = scene.FindByElementId("box");
+		Assert.That(box, Is.Not.Null);
+		Assert.That(box!.LayoutRect.Width, Is.EqualTo(20f).Within(0.01f));
+	}
+
+	[Test]
+	public void CssScene_CalcWithViewportTerm_ResolvesImmediately()
+	{
+		const string html = "<div id=\"box\" style=\"width: calc(50vw - 20px)\"></div>";
+		UiScene scene = BuildScene(html, string.Empty);
+		scene.Layout(1280f, 720f);
+		UiNode? box = scene.FindByElementId("box");
+		Assert.That(box, Is.Not.Null);
+		Assert.That(box!.LayoutRect.Width, Is.EqualTo(620f).Within(0.01f));
+	}
+
+	[Test]
+	public void CssScene_CalcPercentAndViewport_ResolvesAgainstParentAndViewport()
+	{
+		const string html = "<div id=\"wrap\" style=\"width: 1000px\"><div id=\"box\" style=\"width: calc(50% + 25vw)\"></div></div>";
+		UiScene scene = BuildScene(html, string.Empty);
+		scene.Layout(1280f, 720f);
+		UiNode? box = scene.FindByElementId("box");
+		Assert.That(box, Is.Not.Null);
+		Assert.That(box!.LayoutRect.Width, Is.EqualTo(820f).Within(0.01f));
+	}
+
+	[Test]
+	public void CssScene_ViewportUnits_ResolveAgainstSceneSize()
+	{
+		const string html = "<div id=\"box\" style=\"width: 50vw; height: 25vh\"></div>";
+		UiScene scene = BuildScene(html, string.Empty);
+		scene.Layout(1280f, 720f);
+		UiNode? box = scene.FindByElementId("box");
+		Assert.That(box, Is.Not.Null);
+		Assert.That(box!.LayoutRect.Width, Is.EqualTo(640f).Within(0.01f));
+		Assert.That(box.LayoutRect.Height, Is.EqualTo(180f).Within(0.01f));
+	}
+
+	[Test]
+	public void CssScene_ViewportUnits_ReResolveAfterResize()
+	{
+		const string html = "<div id=\"box\" style=\"width: 50vw; height: 25vh\"></div>";
+		UiScene scene = BuildScene(html, string.Empty);
+		scene.Layout(1280f, 720f);
+		UiNode? box = scene.FindByElementId("box");
+		Assert.That(box, Is.Not.Null);
+		scene.Layout(800f, 600f);
+		Assert.That(box!.LayoutRect.Width, Is.EqualTo(400f).Within(0.01f));
+		Assert.That(box.LayoutRect.Height, Is.EqualTo(150f).Within(0.01f));
+	}
+
+	[Test]
+	public void CssScene_MalformedCalc_DropsDeclaration()
+	{
+		const string html = "<div id=\"wrap\" style=\"width: 1000px; display: flex; flex-direction: column; align-items: flex-start;\">" +
+			"<div id=\"box\" style=\"width: calc(10px + )\"></div>" +
+			"<div id=\"ctrl\" style=\"width: 10px\"></div></div>";
+		UiScene scene = BuildScene(html, string.Empty);
+		scene.Layout(1280f, 720f);
+		UiNode? box = scene.FindByElementId("box");
+		UiNode? ctrl = scene.FindByElementId("ctrl");
+		Assert.That(box, Is.Not.Null);
+		Assert.That(ctrl, Is.Not.Null);
+		Assert.That(box!.LayoutRect.Width, Is.EqualTo(0f).Within(0.01f));
+		Assert.That(ctrl!.LayoutRect.Width, Is.EqualTo(10f).Within(0.01f));
+	}
+
+	[Test]
+	public void CssScene_CalcDivisionByZero_BehavesAsAuto()
+	{
+		const string html = "<div id=\"wrap\" style=\"width: 1000px; display: flex; flex-direction: column; align-items: flex-start;\">" +
+			"<div id=\"box\" style=\"width: calc(100px / 0)\"></div></div>";
+		UiScene scene = BuildScene(html, string.Empty);
+		scene.Layout(1280f, 720f);
+		UiNode? box = scene.FindByElementId("box");
+		Assert.That(box, Is.Not.Null);
+		Assert.That(box!.LayoutRect.Width, Is.EqualTo(0f).Within(0.01f));
+	}
+}


### PR DESCRIPTION
## 摘要

为 `Ludots.UI` 的 HTML/CSS 布局引擎补齐 `calc()` 表达式与 viewport 单位（`vw`/`vh`/`vmin`/`vmax`），提升静态 HTML 页面在现有 Flexbox 模型下的复刻度。

这是一次 UI 基建能力盘点后拆出的第一个增量。盘点结论：`Ludots.UI.HtmlEngine` 本质是"类 React Native 的 Flexbox 系统"，而非浏览器级 HTML 引擎 —— Flex 写法的页面基本可复刻，依赖传统块流 / 浮动 / 行内富文本 / CSS Grid 的页面则不行。本 PR 只处理长度求值这一层。

## 改动

**Viewport 单位**：`UiLengthUnit` 新增 `Vw` / `Vh` / `Vmin` / `Vmax`，按场景视口求值，resize 后重解析。

**calc() 表达式**：新增 `UiCalcParser`（递归下降）+ `UiCalcExpression`（不可变二叉树）

- `+` `-` `*` `/`，乘除优先于加减
- 嵌套 `calc()` 与括号分组
- px / % / viewport 混合项
- 除零返回 `NaN`，`UiStyleResolver` 据此丢弃该声明
- `TryParse` 失败不留副作用

**解析上下文**：新增 `UiLengthContext` 值类型，显式携带包含块尺寸（`%` 参照）与视口尺寸（`vw`/`vh` 参照），逐布局趟传递而非静态全局。`UiLength.Resolve(float)` 旧重载保留；viewport 单位在缺少视口上下文时**快速失败**而非静默返回 0。

`SkiaUiRenderer` 的 `ResolveLength` / `ResolveBackgroundAxisOffset` 改为复用 `UiLength.Resolve`，删掉重复的单位 switch。

## 验证

| 测试工程 | 结果 |
|---|---|
| `UiShowcaseTests` | 34/34 通过（baseline 17 + 新增 17）|
| `UiBrowserTests` | 30/30 通过 |

`Ludots.UI` 保持零平台依赖 —— 已核查无 SkiaSharp / Raylib / CEF 引用（`UiColor.cs` 两处命中为注释文字）。

新增测试覆盖：四种 viewport 单位、缺视口上下文抛错、calc 混合单位、嵌套 calc、运算优先级、除零、场景级 parent content 参照、resize 重解析、畸形 calc 丢弃声明。

> `PresentationTests` 有 68 项失败，均为 HUD / overlay 批渲染用例（Core Presentation 路径），与本 PR 触及的 HTML/CSS 布局层无关，`origin/main` 上既已存在。

## 未包含

以下缺口仍未实现，后续 PR 跟进：

- **CSS Grid**（`display: grid`、`grid-template-columns/rows`、`fr` 单位）
- **伪元素** `::before` / `::after` 与 `content` 属性
- **Inline formatting context** —— `UiLayoutEngine.ConfigureNodeStyle` 目前把所有可见节点强制为 `Display.Flex`，`display:inline` / `display:block` 被抹平，`<p>` 内的 `<strong>`/`<em>` 各自成为独立 flex item，无法行内混排。这是最重的一项，需要真正改布局模型。

本 PR 亦未附 visual showcase 页与架构文档更新。
