### PR TITLE
feat(ui): 布局与样式热路径零分配架构

### DIFF
--- a/src/Libraries/Ludots.UI/FlexLayoutSharp/Flex.cs
+++ b/src/Libraries/Ludots.UI/FlexLayoutSharp/Flex.cs
@@ -2726,15 +2726,40 @@ public class Flex
 	{
 		assertWithNode(node, node.Children.Count == 0, "Cannot reset a node which still has children attached");
 		assertWithNode(node, node.Parent == null, "Cannot reset a node still attached to a parent");
-		node.Children.Clear();
 		Config config = node.config;
-		node = CreateDefaultNode();
+		ResetInPlace(node);
 		if (config.UseWebDefaults)
 		{
 			node.nodeStyle.FlexDirection = FlexDirection.Row;
 			node.nodeStyle.AlignContent = Align.Stretch;
 		}
 		node.config = config;
+	}
+
+	public static void ResetInPlace(Node node)
+	{
+		assertWithNode(node, node != null, "Cannot reset a null node");
+		for (int i = node.Children.Count - 1; i >= 0; i--)
+		{
+			Node child = node.Children[i];
+			child.Parent = null;
+			child.NextChild = null;
+		}
+		node.Children.Clear();
+		node.Parent = null;
+		node.NextChild = null;
+		node.lineIndex = 0;
+		node.measureFunc = null;
+		node.baselineFunc = null;
+		node.printFunc = null;
+		node.hasNewLayout = true;
+		node.NodeType = NodeType.Default;
+		node.IsDirty = false;
+		node.Context = null;
+		node.nodeStyle.ResetInPlace();
+		node.nodeLayout.ResetToDefault();
+		node.resolvedDimensions[0].SetUndefined();
+		node.resolvedDimensions[1].SetUndefined();
 	}
 
 	public static Node CreateDefaultNode()

--- a/src/Libraries/Ludots.UI/FlexLayoutSharp/Node.cs
+++ b/src/Libraries/Ludots.UI/FlexLayoutSharp/Node.cs
@@ -31,8 +31,8 @@ public class Node
 
 	internal readonly Value[] resolvedDimensions = new Value[2]
 	{
-		Flex.ValueUndefined,
-		Flex.ValueUndefined
+		new Value(float.NaN, Unit.Undefined),
+		new Value(float.NaN, Unit.Undefined)
 	};
 
 	public object Context;

--- a/src/Libraries/Ludots.UI/FlexLayoutSharp/Size.cs
+++ b/src/Libraries/Ludots.UI/FlexLayoutSharp/Size.cs
@@ -1,6 +1,6 @@
 namespace FlexLayoutSharp;
 
-public class Size
+public struct Size
 {
 	public float Width;
 

--- a/src/Libraries/Ludots.UI/FlexLayoutSharp/Style.cs
+++ b/src/Libraries/Ludots.UI/FlexLayoutSharp/Style.cs
@@ -103,4 +103,33 @@ internal class Style
 		Value.CopyValue(dest.MaxDimensions, src.MaxDimensions);
 		dest.AspectRatio = src.AspectRatio;
 	}
+
+	internal void ResetInPlace()
+	{
+		Direction = Direction.Inherit;
+		FlexDirection = FlexDirection.Column;
+		JustifyContent = Justify.FlexStart;
+		AlignContent = Align.FlexStart;
+		AlignItems = Align.Stretch;
+		AlignSelf = Align.Auto;
+		PositionType = PositionType.Relative;
+		FlexWrap = Wrap.NoWrap;
+		Overflow = Overflow.Visible;
+		Display = Display.Flex;
+		Flex = float.NaN;
+		FlexGrow = float.NaN;
+		FlexShrink = float.NaN;
+		FlexBasis.SetAuto();
+		Value.ResetEdgeValues(Margin);
+		Value.ResetEdgeValues(Position);
+		Value.ResetEdgeValues(Padding);
+		Value.ResetEdgeValues(Border);
+		Dimensions[0].SetAuto();
+		Dimensions[1].SetAuto();
+		MinDimensions[0].SetUndefined();
+		MinDimensions[1].SetUndefined();
+		MaxDimensions[0].SetUndefined();
+		MaxDimensions[1].SetUndefined();
+		AspectRatio = float.NaN;
+	}
 }

--- a/src/Libraries/Ludots.UI/FlexLayoutSharp/Value.cs
+++ b/src/Libraries/Ludots.UI/FlexLayoutSharp/Value.cs
@@ -14,12 +14,38 @@ public class Value
 		unit = u;
 	}
 
+	public void Set(float v, Unit u)
+	{
+		value = v;
+		unit = u;
+	}
+
+	public void SetUndefined()
+	{
+		value = float.NaN;
+		unit = Unit.Undefined;
+	}
+
+	public void SetAuto()
+	{
+		value = float.NaN;
+		unit = Unit.Auto;
+	}
+
 	public static void CopyValue(Value[] dest, Value[] src)
 	{
 		for (int i = 0; i < src.Length; i++)
 		{
 			dest[i].value = src[i].value;
 			dest[i].unit = src[i].unit;
+		}
+	}
+
+	public static void ResetEdgeValues(Value[] values)
+	{
+		for (int i = 0; i < values.Length; i++)
+		{
+			values[i].SetUndefined();
 		}
 	}
 }

--- a/src/Libraries/Ludots.UI/Runtime/UiFlexNodePool.cs
+++ b/src/Libraries/Ludots.UI/Runtime/UiFlexNodePool.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using FlexLayoutSharp;
+
+namespace Ludots.UI.Runtime;
+
+internal sealed class UiFlexNodePool
+{
+	private readonly Stack<Node> _free = new Stack<Node>(128);
+	private readonly List<Node> _rented = new List<Node>(128);
+
+	public Node Rent()
+	{
+		Node node = _free.Count > 0 ? _free.Pop() : Flex.CreateDefaultNode();
+		Flex.ResetInPlace(node);
+		_rented.Add(node);
+		return node;
+	}
+
+	public void ReleaseAll()
+	{
+		for (int i = 0; i < _rented.Count; i++)
+		{
+			Node node = _rented[i];
+			Flex.ResetInPlace(node);
+			_free.Push(node);
+		}
+		_rented.Clear();
+	}
+}

--- a/src/Libraries/Ludots.UI/Runtime/UiGridLayoutEngine.cs
+++ b/src/Libraries/Ludots.UI/Runtime/UiGridLayoutEngine.cs
@@ -5,26 +5,27 @@ namespace Ludots.UI.Runtime;
 
 public static class UiGridLayoutEngine
 {
-	public static void LayoutSubtree(UiNode root, Action<UiNode> layoutNested)
+	internal static void LayoutSubtree(UiNode root, UiLayoutEngine layoutEngine, UiLayoutScratch scratch)
 	{
 		ArgumentNullException.ThrowIfNull(root, nameof(root));
-		ArgumentNullException.ThrowIfNull(layoutNested, nameof(layoutNested));
-		LayoutNode(root, layoutNested);
+		ArgumentNullException.ThrowIfNull(layoutEngine, nameof(layoutEngine));
+		ArgumentNullException.ThrowIfNull(scratch, nameof(scratch));
+		LayoutNode(root, layoutEngine, scratch);
 	}
 
-	private static void LayoutNode(UiNode node, Action<UiNode> layoutNested)
+	private static void LayoutNode(UiNode node, UiLayoutEngine layoutEngine, UiLayoutScratch scratch)
 	{
 		if (node.Style.Display == UiDisplay.Grid && node.Style.Visible)
 		{
-			LayoutGrid(node, layoutNested);
+			LayoutGrid(node, layoutEngine, scratch);
 		}
 		for (int i = 0; i < node.Children.Count; i++)
 		{
-			LayoutNode(node.Children[i], layoutNested);
+			LayoutNode(node.Children[i], layoutEngine, scratch);
 		}
 	}
 
-	private static void LayoutGrid(UiNode grid, Action<UiNode> layoutNested)
+	private static void LayoutGrid(UiNode grid, UiLayoutEngine layoutEngine, UiLayoutScratch scratch)
 	{
 		UiStyle style = grid.Style;
 		float contentWidth = Math.Max(0f, grid.LayoutRect.Width - style.Padding.Horizontal - style.BorderWidth * 2f);
@@ -32,7 +33,7 @@ public static class UiGridLayoutEngine
 		float columnGap = style.ColumnGap > 0f ? style.ColumnGap : style.Gap;
 		float rowGap = style.RowGap > 0f ? style.RowGap : style.Gap;
 
-		List<UiNode> items = new List<UiNode>();
+		List<UiNode> items = scratch.BeginGridItems();
 		for (int i = 0; i < grid.Children.Count; i++)
 		{
 			UiNode child = grid.Children[i];
@@ -44,30 +45,33 @@ public static class UiGridLayoutEngine
 
 		IReadOnlyList<UiGridTrack> columnTracks = style.GridTemplateColumns.Count > 0
 			? style.GridTemplateColumns
-			: new[] { UiGridTrack.Fr(1f) };
-		IReadOnlyList<UiGridTrack> rowTracksTemplate = style.GridTemplateRows;
+			: UiLayoutScratch.SharedDefaultSingleFr;
 
-		List<ItemPlacement> placements = PlaceItems(items, columnTracks.Count, style.GridAutoFlow);
+		List<UiGridPlacementSlot> placements = PlaceItems(items, columnTracks.Count, style.GridAutoFlow, scratch);
 		int columnCount = Math.Max(columnTracks.Count, MaxEnd(placements, column: true));
-		int rowCount = Math.Max(rowTracksTemplate.Count, MaxEnd(placements, column: false));
+		int rowCount = Math.Max(style.GridTemplateRows.Count, MaxEnd(placements, column: false));
 		if (rowCount < 1)
 		{
 			rowCount = 1;
 		}
 
-		float[] columnSizes = ResolveTracks(ExpandTracks(columnTracks, columnCount), contentWidth, columnGap);
-		List<UiGridTrack> resolvedRowTracks = ExpandTracks(rowTracksTemplate, rowCount);
-		float[] rowSizes = ResolveTracks(resolvedRowTracks, contentHeight, rowGap);
+		List<UiGridTrack> expandedColumns = ExpandTracks(columnTracks, columnCount, scratch.BeginColumnTracks());
+		Span<float> columnSizes = scratch.BeginColumnSizes(columnCount);
+		ResolveTracks(expandedColumns, contentWidth, columnGap, columnSizes);
+
+		List<UiGridTrack> expandedRows = ExpandTracks(style.GridTemplateRows, rowCount, scratch.BeginRowTracks());
+		Span<float> rowSizes = scratch.BeginRowSizes(rowCount);
+		ResolveTracks(expandedRows, contentHeight, rowGap, rowSizes);
 
 		for (int r = 0; r < rowCount; r++)
 		{
-			if (resolvedRowTracks[r].Sizing == UiGridTrackSizing.Auto ||
-				(resolvedRowTracks[r].Sizing == UiGridTrackSizing.Fr && contentHeight <= 0.01f))
+			if (expandedRows[r].Sizing == UiGridTrackSizing.Auto ||
+				(expandedRows[r].Sizing == UiGridTrackSizing.Fr && contentHeight <= 0.01f))
 			{
 				float maxContent = 0f;
 				for (int i = 0; i < placements.Count; i++)
 				{
-					ItemPlacement placement = placements[i];
+					UiGridPlacementSlot placement = placements[i];
 					if (placement.RowStart <= r + 1 && placement.RowStart + placement.RowSpan - 1 >= r + 1)
 					{
 						maxContent = Math.Max(maxContent, EstimateContentHeight(placement.Node));
@@ -77,14 +81,16 @@ public static class UiGridLayoutEngine
 			}
 		}
 
+		Span<float> columnOffsets = scratch.BeginColumnOffsets(columnCount);
+		BuildOffsets(columnSizes, columnGap, columnOffsets);
+		Span<float> rowOffsets = scratch.BeginRowOffsets(rowCount);
+		BuildOffsets(rowSizes, rowGap, rowOffsets);
+
 		float originX = grid.LayoutRect.X + style.Padding.Left + style.BorderWidth;
 		float originY = grid.LayoutRect.Y + style.Padding.Top + style.BorderWidth;
-		float[] columnOffsets = BuildOffsets(columnSizes, columnGap);
-		float[] rowOffsets = BuildOffsets(rowSizes, rowGap);
-
 		for (int i = 0; i < placements.Count; i++)
 		{
-			ItemPlacement placement = placements[i];
+			UiGridPlacementSlot placement = placements[i];
 			int colIndex = placement.ColumnStart - 1;
 			int rowIndex = placement.RowStart - 1;
 			float x = originX + columnOffsets[colIndex];
@@ -93,21 +99,21 @@ public static class UiGridLayoutEngine
 			float height = SumRange(rowSizes, rowIndex, placement.RowSpan, rowGap);
 			placement.Node.SetLayout(new UiRect(x, y, width, height));
 			placement.Node.SetScrollMetrics(width, height);
-			layoutNested(placement.Node);
+			layoutEngine.LayoutNestedContent(placement.Node);
 		}
 
-		float usedWidth = columnOffsets.Length == 0 ? 0f : columnOffsets[^1] + (columnSizes.Length == 0 ? 0f : columnSizes[^1]);
-		float usedHeight = rowOffsets.Length == 0 ? 0f : rowOffsets[^1] + (rowSizes.Length == 0 ? 0f : rowSizes[^1]);
+		float usedWidth = columnCount == 0 ? 0f : columnOffsets[columnCount - 1] + columnSizes[columnCount - 1];
+		float usedHeight = rowCount == 0 ? 0f : rowOffsets[rowCount - 1] + rowSizes[rowCount - 1];
 		grid.SetScrollMetrics(
 			style.Padding.Horizontal + style.BorderWidth * 2f + usedWidth,
 			style.Padding.Vertical + style.BorderWidth * 2f + usedHeight);
 	}
 
-	private static List<ItemPlacement> PlaceItems(List<UiNode> items, int explicitColumnCount, UiGridAutoFlow autoFlow)
+	private static List<UiGridPlacementSlot> PlaceItems(List<UiNode> items, int explicitColumnCount, UiGridAutoFlow autoFlow, UiLayoutScratch scratch)
 	{
 		int columns = Math.Max(1, explicitColumnCount);
-		List<ItemPlacement> result = new List<ItemPlacement>(items.Count);
-		HashSet<long> occupied = new HashSet<long>();
+		List<UiGridPlacementSlot> result = scratch.BeginGridPlacements();
+		HashSet<long> occupied = scratch.BeginOccupied();
 		int cursorRow = 1;
 		int cursorColumn = 1;
 
@@ -142,7 +148,14 @@ public static class UiGridLayoutEngine
 			}
 
 			MarkOccupied(occupied, columnStart, rowStart, columnSpan, rowSpan);
-			result.Add(new ItemPlacement(item, columnStart, columnSpan, rowStart, rowSpan));
+			result.Add(new UiGridPlacementSlot
+			{
+				Node = item,
+				ColumnStart = columnStart,
+				ColumnSpan = columnSpan,
+				RowStart = rowStart,
+				RowSpan = rowSpan
+			});
 			if (autoFlow == UiGridAutoFlow.Column)
 			{
 				cursorColumn = columnStart;
@@ -246,12 +259,12 @@ public static class UiGridLayoutEngine
 
 	private static long Pack(int column, int row) => ((long)column << 32) | (uint)row;
 
-	private static int MaxEnd(List<ItemPlacement> placements, bool column)
+	private static int MaxEnd(List<UiGridPlacementSlot> placements, bool column)
 	{
 		int max = 0;
 		for (int i = 0; i < placements.Count; i++)
 		{
-			ItemPlacement placement = placements[i];
+			UiGridPlacementSlot placement = placements[i];
 			int end = column
 				? placement.ColumnStart + placement.ColumnSpan - 1
 				: placement.RowStart + placement.RowSpan - 1;
@@ -263,9 +276,8 @@ public static class UiGridLayoutEngine
 		return max;
 	}
 
-	private static List<UiGridTrack> ExpandTracks(IReadOnlyList<UiGridTrack> template, int count)
+	private static List<UiGridTrack> ExpandTracks(IReadOnlyList<UiGridTrack> template, int count, List<UiGridTrack> tracks)
 	{
-		List<UiGridTrack> tracks = new List<UiGridTrack>(count);
 		for (int i = 0; i < count; i++)
 		{
 			tracks.Add(i < template.Count ? template[i] : UiGridTrack.Auto);
@@ -273,12 +285,11 @@ public static class UiGridLayoutEngine
 		return tracks;
 	}
 
-	private static float[] ResolveTracks(IReadOnlyList<UiGridTrack> tracks, float available, float gap)
+	private static void ResolveTracks(IReadOnlyList<UiGridTrack> tracks, float available, float gap, Span<float> sizes)
 	{
-		float[] sizes = new float[tracks.Count];
 		if (tracks.Count == 0)
 		{
-			return sizes;
+			return;
 		}
 		float gapTotal = gap * Math.Max(0, tracks.Count - 1);
 		float remaining = Math.Max(0f, available - gapTotal);
@@ -315,12 +326,10 @@ public static class UiGridLayoutEngine
 				}
 			}
 		}
-		return sizes;
 	}
 
-	private static float[] BuildOffsets(float[] sizes, float gap)
+	private static void BuildOffsets(ReadOnlySpan<float> sizes, float gap, Span<float> offsets)
 	{
-		float[] offsets = new float[sizes.Length];
 		float cursor = 0f;
 		for (int i = 0; i < sizes.Length; i++)
 		{
@@ -331,10 +340,9 @@ public static class UiGridLayoutEngine
 				cursor += gap;
 			}
 		}
-		return offsets;
 	}
 
-	private static float SumRange(float[] sizes, int start, int span, float gap)
+	private static float SumRange(ReadOnlySpan<float> sizes, int start, int span, float gap)
 	{
 		float total = 0f;
 		int end = Math.Min(sizes.Length, start + span);
@@ -360,23 +368,5 @@ public static class UiGridLayoutEngine
 			return node.Style.Height.Value;
 		}
 		return Math.Max(0f, node.LayoutRect.Height);
-	}
-
-	private readonly struct ItemPlacement
-	{
-		public UiNode Node { get; }
-		public int ColumnStart { get; }
-		public int ColumnSpan { get; }
-		public int RowStart { get; }
-		public int RowSpan { get; }
-
-		public ItemPlacement(UiNode node, int columnStart, int columnSpan, int rowStart, int rowSpan)
-		{
-			Node = node;
-			ColumnStart = columnStart;
-			ColumnSpan = columnSpan;
-			RowStart = rowStart;
-			RowSpan = rowSpan;
-		}
 	}
 }

--- a/src/Libraries/Ludots.UI/Runtime/UiInlineFlowEngine.cs
+++ b/src/Libraries/Ludots.UI/Runtime/UiInlineFlowEngine.cs
@@ -62,10 +62,12 @@ public static class UiInlineFlowEngine
 		return node.Style.Display is UiDisplay.Block or UiDisplay.Flex or UiDisplay.Grid;
 	}
 
-	public static Size Measure(UiNode node, IUiTextMeasurer textMeasurer, IUiImageSizeProvider imageSizeProvider, float width, MeasureMode widthMode, float height, MeasureMode heightMode)
+	internal static Size Measure(UiNode node, IUiTextMeasurer textMeasurer, IUiImageSizeProvider imageSizeProvider, float width, MeasureMode widthMode, float height, MeasureMode heightMode, UiLayoutScratch scratch)
 	{
 		float available = widthMode == MeasureMode.Undefined ? float.PositiveInfinity : Math.Max(0f, width - node.Style.Padding.Horizontal);
-		List<LineBox> lines = BuildLines(node, textMeasurer, imageSizeProvider, available);
+		List<UiInlineItem> items = scratch.BeginLineItems();
+		List<UiInlineLineBox> lines = scratch.BeginLines();
+		BuildLines(node, textMeasurer, imageSizeProvider, available, items, lines);
 		float contentWidth = 0f;
 		float contentHeight = 0f;
 		for (int i = 0; i < lines.Count; i++)
@@ -94,38 +96,41 @@ public static class UiInlineFlowEngine
 		return new Size(measuredWidth, measuredHeight);
 	}
 
-	public static void LayoutSubtree(UiNode root, IUiTextMeasurer textMeasurer, IUiImageSizeProvider imageSizeProvider)
+	internal static void LayoutSubtree(UiNode root, IUiTextMeasurer textMeasurer, IUiImageSizeProvider imageSizeProvider, UiLayoutScratch scratch)
 	{
 		ArgumentNullException.ThrowIfNull(root, nameof(root));
-		LayoutNode(root, textMeasurer, imageSizeProvider);
+		LayoutNode(root, textMeasurer, imageSizeProvider, scratch);
 	}
 
-	private static void LayoutNode(UiNode node, IUiTextMeasurer textMeasurer, IUiImageSizeProvider imageSizeProvider)
+	private static void LayoutNode(UiNode node, IUiTextMeasurer textMeasurer, IUiImageSizeProvider imageSizeProvider, UiLayoutScratch scratch)
 	{
 		if (IsInlineFormattingContext(node))
 		{
-			LayoutInlineContext(node, textMeasurer, imageSizeProvider);
+			LayoutInlineContext(node, textMeasurer, imageSizeProvider, scratch);
 		}
 		for (int i = 0; i < node.Children.Count; i++)
 		{
-			LayoutNode(node.Children[i], textMeasurer, imageSizeProvider);
+			LayoutNode(node.Children[i], textMeasurer, imageSizeProvider, scratch);
 		}
 	}
 
-	private static void LayoutInlineContext(UiNode node, IUiTextMeasurer textMeasurer, IUiImageSizeProvider imageSizeProvider)
+	private static void LayoutInlineContext(UiNode node, IUiTextMeasurer textMeasurer, IUiImageSizeProvider imageSizeProvider, UiLayoutScratch scratch)
 	{
 		float available = Math.Max(0f, node.LayoutRect.Width - node.Style.Padding.Horizontal);
-		List<LineBox> lines = BuildLines(node, textMeasurer, imageSizeProvider, available);
+		List<UiInlineItem> items = scratch.BeginLineItems();
+		List<UiInlineLineBox> lines = scratch.BeginLines();
+		BuildLines(node, textMeasurer, imageSizeProvider, available, items, lines);
 		float x0 = node.LayoutRect.X + node.Style.Padding.Left;
 		float y = node.LayoutRect.Y + node.Style.Padding.Top;
 		for (int lineIndex = 0; lineIndex < lines.Count; lineIndex++)
 		{
-			LineBox line = lines[lineIndex];
+			UiInlineLineBox line = lines[lineIndex];
 			float x = x0;
 			float baseline = y + line.MaxAscent;
-			for (int i = 0; i < line.Items.Count; i++)
+			int end = line.ItemStart + line.ItemCount;
+			for (int i = line.ItemStart; i < end; i++)
 			{
-				InlineItem item = line.Items[i];
+				UiInlineItem item = items[i];
 				float itemY = baseline - item.Ascent;
 				item.Node.SetLayout(new UiRect(x, itemY, item.Width, item.Height));
 				item.Node.SetScrollMetrics(item.Width, item.Height);
@@ -136,11 +141,11 @@ public static class UiInlineFlowEngine
 		node.SetScrollMetrics(node.LayoutRect.Width, Math.Max(node.LayoutRect.Height, y - node.LayoutRect.Y + node.Style.Padding.Bottom));
 	}
 
-	private static List<LineBox> BuildLines(UiNode node, IUiTextMeasurer textMeasurer, IUiImageSizeProvider imageSizeProvider, float availableWidth)
+	private static void BuildLines(UiNode node, IUiTextMeasurer textMeasurer, IUiImageSizeProvider imageSizeProvider, float availableWidth, List<UiInlineItem> items, List<UiInlineLineBox> lines)
 	{
-		List<LineBox> lines = new List<LineBox>();
-		LineBox current = new LineBox();
 		float maxWidth = float.IsInfinity(availableWidth) ? float.MaxValue : Math.Max(0f, availableWidth);
+		UiInlineLineBox current = default;
+		bool hasCurrent = false;
 
 		for (int i = 0; i < node.Children.Count; i++)
 		{
@@ -150,31 +155,47 @@ public static class UiInlineFlowEngine
 				continue;
 			}
 
-			InlineItem item = MeasureInlineItem(child, textMeasurer, imageSizeProvider, maxWidth);
-			bool fits = current.Items.Count == 0 || current.Width + item.Width <= maxWidth + 0.01f || maxWidth >= float.MaxValue - 1f;
+			UiInlineItem item = MeasureInlineItem(child, textMeasurer, imageSizeProvider, maxWidth);
+			bool fits = !hasCurrent || current.Width + item.Width <= maxWidth + 0.01f || maxWidth >= float.MaxValue - 1f;
 			if (!fits)
 			{
 				lines.Add(current);
-				current = new LineBox();
+				current = default;
+				hasCurrent = false;
 				item = MeasureInlineItem(child, textMeasurer, imageSizeProvider, maxWidth);
 			}
-			current.Add(item);
+			if (!hasCurrent)
+			{
+				current.ItemStart = items.Count;
+				hasCurrent = true;
+			}
+			items.Add(item);
+			current.ItemCount++;
+			current.Width += item.Width;
+			current.MaxAscent = Math.Max(current.MaxAscent, item.Ascent);
+			current.MaxDescent = Math.Max(current.MaxDescent, item.Descent);
 		}
 
-		if (current.Items.Count > 0 || lines.Count == 0)
+		if (hasCurrent || lines.Count == 0)
 		{
 			lines.Add(current);
 		}
-		return lines;
 	}
 
-	private static InlineItem MeasureInlineItem(UiNode node, IUiTextMeasurer textMeasurer, IUiImageSizeProvider imageSizeProvider, float maxWidth)
+	private static UiInlineItem MeasureInlineItem(UiNode node, IUiTextMeasurer textMeasurer, IUiImageSizeProvider imageSizeProvider, float maxWidth)
 	{
 		if (node.Kind == UiNodeKind.Image)
 		{
 			(float width, float height) = ResolveImageSize(node, imageSizeProvider);
 			float ascent = height * 0.8f;
-			return new InlineItem(node, width, height, ascent, height - ascent);
+			return new UiInlineItem
+			{
+				Node = node,
+				Width = width,
+				Height = height,
+				Ascent = ascent,
+				Descent = height - ascent
+			};
 		}
 
 		if (node.Children.Count > 0)
@@ -188,7 +209,7 @@ public static class UiInlineFlowEngine
 				{
 					continue;
 				}
-				InlineItem nested = MeasureInlineItem(node.Children[i], textMeasurer, imageSizeProvider, maxWidth);
+				UiInlineItem nested = MeasureInlineItem(node.Children[i], textMeasurer, imageSizeProvider, maxWidth);
 				width += nested.Width;
 				ascent = Math.Max(ascent, nested.Ascent);
 				descent = Math.Max(descent, nested.Descent);
@@ -197,10 +218,16 @@ public static class UiInlineFlowEngine
 			{
 				if (!string.IsNullOrEmpty(node.TextContent))
 				{
-					float textWidth = textMeasurer.MeasureWidth(node.TextContent, node.Style);
-					width += textWidth;
+					width += textMeasurer.MeasureWidth(node.TextContent, node.Style);
 				}
-				return new InlineItem(node, width, ascent + descent, ascent, descent);
+				return new UiInlineItem
+				{
+					Node = node,
+					Width = width,
+					Height = ascent + descent,
+					Ascent = ascent,
+					Descent = descent
+				};
 			}
 		}
 
@@ -209,7 +236,14 @@ public static class UiInlineFlowEngine
 		{
 			float emptyHeight = Math.Max(node.Style.FontSize * 1.4f, 1f);
 			float emptyAscent = node.Style.FontSize;
-			return new InlineItem(node, 0f, emptyHeight, emptyAscent, emptyHeight - emptyAscent);
+			return new UiInlineItem
+			{
+				Node = node,
+				Width = 0f,
+				Height = emptyHeight,
+				Ascent = emptyAscent,
+				Descent = emptyHeight - emptyAscent
+			};
 		}
 
 		bool constrain = node.Style.WhiteSpace != UiWhiteSpace.NoWrap && maxWidth < float.MaxValue - 1f;
@@ -217,12 +251,14 @@ public static class UiInlineFlowEngine
 		float measureWidth = constrain ? Math.Min(preferred, maxWidth) : preferred;
 		UiTextLayoutResult measured = textMeasurer.Measure(text, node.Style, measureWidth, constrain);
 		float ascentMetric = measured.Ascent > 0f ? measured.Ascent : node.Style.FontSize;
-		float descentMetric = measured.Descent > 0f ? measured.Descent : Math.Max(0f, measured.LineHeight - ascentMetric);
-		if (measured.Lines.Count > 1)
+		return new UiInlineItem
 		{
-			descentMetric = Math.Max(descentMetric, measured.Height - ascentMetric);
-		}
-		return new InlineItem(node, measured.Width, measured.Height, ascentMetric, Math.Max(0f, measured.Height - ascentMetric));
+			Node = node,
+			Width = measured.Width,
+			Height = measured.Height,
+			Ascent = ascentMetric,
+			Descent = Math.Max(0f, measured.Height - ascentMetric)
+		};
 	}
 
 	private static (float Width, float Height) ResolveImageSize(UiNode node, IUiImageSizeProvider imageSizeProvider)
@@ -249,40 +285,5 @@ public static class UiInlineFlowEngine
 		float fallbackWidth = node.Style.Width.Unit == UiLengthUnit.Pixel ? node.Style.Width.Value : 16f;
 		float fallbackHeight = node.Style.Height.Unit == UiLengthUnit.Pixel ? node.Style.Height.Value : 16f;
 		return (fallbackWidth, fallbackHeight);
-	}
-
-	private sealed class LineBox
-	{
-		public List<InlineItem> Items { get; } = new List<InlineItem>();
-		public float Width { get; private set; }
-		public float MaxAscent { get; private set; }
-		public float MaxDescent { get; private set; }
-		public float Height => Math.Max(MaxAscent + MaxDescent, 0f);
-
-		public void Add(InlineItem item)
-		{
-			Items.Add(item);
-			Width += item.Width;
-			MaxAscent = Math.Max(MaxAscent, item.Ascent);
-			MaxDescent = Math.Max(MaxDescent, item.Descent);
-		}
-	}
-
-	private sealed class InlineItem
-	{
-		public UiNode Node { get; }
-		public float Width { get; }
-		public float Height { get; }
-		public float Ascent { get; }
-		public float Descent { get; }
-
-		public InlineItem(UiNode node, float width, float height, float ascent, float descent)
-		{
-			Node = node;
-			Width = width;
-			Height = height;
-			Ascent = ascent;
-			Descent = descent;
-		}
 	}
 }

--- a/src/Libraries/Ludots.UI/Runtime/UiLayoutEngine.cs
+++ b/src/Libraries/Ludots.UI/Runtime/UiLayoutEngine.cs
@@ -1,29 +1,46 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using FlexLayoutSharp;
 
 namespace Ludots.UI.Runtime;
 
 public sealed class UiLayoutEngine
 {
+	private enum LengthTarget : byte
+	{
+		Width,
+		Height,
+		MinWidth,
+		MinHeight,
+		MaxWidth,
+		MaxHeight,
+		FlexBasis,
+		Left,
+		Top,
+		Right,
+		Bottom
+	}
+
 	private readonly IUiTextMeasurer _textMeasurer;
 	private readonly IUiImageSizeProvider _imageSizeProvider;
+	private readonly UiLayoutScratch _scratch = new UiLayoutScratch();
+	private readonly UiFlexNodePool _flexPool = new UiFlexNodePool();
+	private readonly MeasureFunc _leafMeasureFunc;
+	private readonly MeasureFunc _inlineMeasureFunc;
 
 	public UiLayoutEngine(IUiTextMeasurer textMeasurer, IUiImageSizeProvider imageSizeProvider)
 	{
 		_textMeasurer = textMeasurer ?? throw new ArgumentNullException(nameof(textMeasurer));
 		_imageSizeProvider = imageSizeProvider ?? throw new ArgumentNullException(nameof(imageSizeProvider));
+		_leafMeasureFunc = MeasureLeafNode;
+		_inlineMeasureFunc = MeasureInlineNode;
 	}
 
 	private sealed class TableRowInfo
 	{
 		public UiNode? Section { get; }
-
 		public UiNode Row { get; }
-
 		public int RowIndex { get; }
-
 		public TableRowInfo(UiNode? section, UiNode row, int rowIndex)
 		{
 			Section = section;
@@ -35,17 +52,11 @@ public sealed class UiLayoutEngine
 	private sealed class TableCellPlacement
 	{
 		public UiNode Cell { get; }
-
 		public UiNode Row { get; }
-
 		public int RowIndex { get; }
-
 		public int ColumnIndex { get; }
-
 		public int ColumnSpan { get; }
-
 		public int RowSpan { get; }
-
 		public TableCellPlacement(UiNode cell, UiNode row, int rowIndex, int columnIndex, int columnSpan, int rowSpan)
 		{
 			Cell = cell;
@@ -60,50 +71,55 @@ public sealed class UiLayoutEngine
 	public void Layout(UiNode root, float width, float height)
 	{
 		ArgumentNullException.ThrowIfNull(root, "root");
-		List<Node> deferredCalcNodes = new List<Node>();
+		List<Node> deferredCalcNodes = _scratch.BeginDeferredCalc();
 		Node node = BuildFlexTree(root, isRoot: true, width, height, deferredCalcNodes);
 		node.CalculateLayout(width, height, Direction.LTR);
 		if (deferredCalcNodes.Count > 0)
 		{
-			foreach (Node deferredNode in deferredCalcNodes)
+			for (int i = 0; i < deferredCalcNodes.Count; i++)
 			{
-				ResolveDeferredCalcLengths(deferredNode, width, height);
+				ResolveDeferredCalcLengths(deferredCalcNodes[i], width, height);
 			}
 			node.CalculateLayout(width, height, Direction.LTR);
 		}
 		ApplyLayout(root, node, 0f, 0f);
 		NormalizeTableLayouts(root);
-		UiGridLayoutEngine.LayoutSubtree(root, LayoutNestedContent);
-		UiInlineFlowEngine.LayoutSubtree(root, _textMeasurer, _imageSizeProvider);
+		UiGridLayoutEngine.LayoutSubtree(root, this, _scratch);
+		UiInlineFlowEngine.LayoutSubtree(root, _textMeasurer, _imageSizeProvider, _scratch);
+		_flexPool.ReleaseAll();
 	}
 
 	internal void LayoutNestedContent(UiNode node)
 	{
-		if (node.Children.Count == 0)
+		if (node.Children.Count == 0 || node.Style.Display == UiDisplay.Grid || UiInlineFlowEngine.IsInlineFormattingContext(node))
 		{
 			return;
 		}
-		if (node.Style.Display == UiDisplay.Grid)
-		{
-			return;
-		}
-		if (UiInlineFlowEngine.IsInlineFormattingContext(node))
-		{
-			return;
-		}
-		List<Node> deferredCalcNodes = new List<Node>();
-		Node flexRoot = new Node { Context = node };
-		ConfigureNodeStyle(flexRoot, node, isRoot: true, node.LayoutRect.Width, node.LayoutRect.Height, deferredCalcNodes);
-		flexRoot.StyleSetWidth(node.LayoutRect.Width);
-		flexRoot.StyleSetHeight(node.LayoutRect.Height);
+		List<Node> deferredCalcNodes = _scratch.BeginDeferredCalc();
+		float width = node.LayoutRect.Width;
+		float height = node.LayoutRect.Height;
+		Node flexRoot = _flexPool.Rent();
+		flexRoot.Context = node;
+		ConfigureNodeStyle(flexRoot, node, isRoot: true, width, height, deferredCalcNodes);
+		flexRoot.StyleSetWidth(width);
+		flexRoot.StyleSetHeight(height);
 		for (int i = 0; i < node.Children.Count; i++)
 		{
-			Node child = BuildFlexTree(node.Children[i], isRoot: false, node.LayoutRect.Width, node.LayoutRect.Height, deferredCalcNodes);
+			Node child = BuildFlexTree(node.Children[i], isRoot: false, width, height, deferredCalcNodes);
 			ApplyGapOffset(child, node.Style, i);
 			flexRoot.AddChild(child);
 		}
-		flexRoot.CalculateLayout(node.LayoutRect.Width, node.LayoutRect.Height, Direction.LTR);
-		for (int i = 0; i < Math.Min(node.Children.Count, flexRoot.ChildrenCount); i++)
+		flexRoot.CalculateLayout(width, height, Direction.LTR);
+		if (deferredCalcNodes.Count > 0)
+		{
+			for (int i = 0; i < deferredCalcNodes.Count; i++)
+			{
+				ResolveDeferredCalcLengths(deferredCalcNodes[i], width, height);
+			}
+			flexRoot.CalculateLayout(width, height, Direction.LTR);
+		}
+		int count = Math.Min(node.Children.Count, flexRoot.ChildrenCount);
+		for (int i = 0; i < count; i++)
 		{
 			ApplyLayout(node.Children[i], flexRoot.GetChild(i), node.LayoutRect.X, node.LayoutRect.Y);
 		}
@@ -111,128 +127,100 @@ public sealed class UiLayoutEngine
 
 	private Node BuildFlexTree(UiNode node, bool isRoot, float rootWidth, float rootHeight, List<Node> deferredCalcNodes)
 	{
-		Node node2 = new Node
-		{
-			Context = node
-		};
-		ConfigureNodeStyle(node2, node, isRoot, rootWidth, rootHeight, deferredCalcNodes);
+		Node flexNode = _flexPool.Rent();
+		flexNode.Context = node;
+		ConfigureNodeStyle(flexNode, node, isRoot, rootWidth, rootHeight, deferredCalcNodes);
 		if (node.Style.Display == UiDisplay.Grid)
 		{
-			return node2;
+			return flexNode;
 		}
 		if (UiInlineFlowEngine.IsInlineFormattingContext(node))
 		{
-			node2.SetMeasureFunc((Node _, float width, MeasureMode widthMode, float height, MeasureMode heightMode) =>
-				UiInlineFlowEngine.Measure(node, _textMeasurer, _imageSizeProvider, width, widthMode, height, heightMode));
-			return node2;
+			flexNode.SetMeasureFunc(_inlineMeasureFunc);
+			return flexNode;
 		}
 		if (ShouldMeasureAsLeaf(node))
 		{
-			node2.SetMeasureFunc((Node _, float width, MeasureMode widthMode, float height, MeasureMode heightMode) => MeasureNode(node, width, widthMode, height, heightMode));
-			return node2;
+			flexNode.SetMeasureFunc(_leafMeasureFunc);
+			return flexNode;
 		}
-		for (int num = 0; num < node.Children.Count; num++)
+		for (int i = 0; i < node.Children.Count; i++)
 		{
-			Node node3 = BuildFlexTree(node.Children[num], isRoot: false, rootWidth, rootHeight, deferredCalcNodes);
-			ApplyGapOffset(node3, node.Style, num);
-			node2.AddChild(node3);
+			Node child = BuildFlexTree(node.Children[i], isRoot: false, rootWidth, rootHeight, deferredCalcNodes);
+			ApplyGapOffset(child, node.Style, i);
+			flexNode.AddChild(child);
 		}
-		return node2;
+		return flexNode;
+	}
+
+	private Size MeasureLeafNode(Node flexNode, float width, MeasureMode widthMode, float height, MeasureMode heightMode)
+	{
+		return flexNode.Context is UiNode node
+			? MeasureNode(node, width, widthMode, height, heightMode)
+			: default;
+	}
+
+	private Size MeasureInlineNode(Node flexNode, float width, MeasureMode widthMode, float height, MeasureMode heightMode)
+	{
+		return flexNode.Context is UiNode node
+			? UiInlineFlowEngine.Measure(node, _textMeasurer, _imageSizeProvider, width, widthMode, height, heightMode, _scratch)
+			: default;
 	}
 
 	private void ConfigureNodeStyle(Node flexNode, UiNode node, bool isRoot, float rootWidth, float rootHeight, List<Node> deferredCalcNodes)
 	{
 		UiStyle style = node.Style;
-		bool flag = style.Visible && style.Display != UiDisplay.None;
-		flexNode.StyleSetDisplay((!flag) ? Display.None : Display.Flex);
-		UiFlexDirection flexDirection = style.Display == UiDisplay.Block
-			? UiFlexDirection.Column
-			: style.FlexDirection;
-		flexNode.StyleSetFlexDirection((flexDirection == UiFlexDirection.Row) ? FlexDirection.Row : FlexDirection.Column);
+		bool visible = style.Visible && style.Display != UiDisplay.None;
+		flexNode.StyleSetDisplay(visible ? Display.Flex : Display.None);
+		UiFlexDirection flexDirection = style.Display == UiDisplay.Block ? UiFlexDirection.Column : style.FlexDirection;
+		flexNode.StyleSetFlexDirection(flexDirection == UiFlexDirection.Row ? FlexDirection.Row : FlexDirection.Column);
 		flexNode.StyleSetJustifyContent(MapJustify(style.JustifyContent));
 		flexNode.StyleSetAlignItems(MapAlign(style.AlignItems));
 		flexNode.StyleSetAlignContent(MapAlignContent(style.AlignContent));
 		flexNode.StyleSetFlexWrap(MapWrap(style.FlexWrap));
 		flexNode.StyleSetOverflow(MapOverflow(style));
-		flexNode.StyleSetPositionType((style.PositionType == UiPositionType.Absolute) ? PositionType.Absolute : PositionType.Relative);
+		flexNode.StyleSetPositionType(style.PositionType == UiPositionType.Absolute ? PositionType.Absolute : PositionType.Relative);
 		flexNode.StyleSetFlexGrow(style.FlexGrow);
 		flexNode.StyleSetFlexShrink(style.FlexShrink);
 		UiLengthContext horizontalContext = new UiLengthContext(isRoot ? rootWidth : 0f, rootWidth, rootHeight);
 		UiLengthContext verticalContext = new UiLengthContext(isRoot ? rootHeight : 0f, rootWidth, rootHeight);
-		ApplyNodeLength(style.Width, horizontalContext, isRoot, flexNode.StyleSetWidth, flexNode.StyleSetWidthPercent, flexNode.StyleSetWidthAuto, flexNode, deferredCalcNodes);
-		ApplyNodeLength(style.Height, verticalContext, isRoot, flexNode.StyleSetHeight, flexNode.StyleSetHeightPercent, flexNode.StyleSetHeightAuto, flexNode, deferredCalcNodes);
-		ApplyNodeLength(style.MinWidth, horizontalContext, isRoot, flexNode.StyleSetMinWidth, flexNode.StyleSetMinWidthPercent, null, flexNode, deferredCalcNodes);
-		ApplyNodeLength(style.MinHeight, verticalContext, isRoot, flexNode.StyleSetMinHeight, flexNode.StyleSetMinHeightPercent, null, flexNode, deferredCalcNodes);
-		ApplyNodeLength(style.MaxWidth, horizontalContext, isRoot, flexNode.StyleSetMaxWidth, flexNode.StyleSetMaxWidthPercent, null, flexNode, deferredCalcNodes);
-		ApplyNodeLength(style.MaxHeight, verticalContext, isRoot, flexNode.StyleSetMaxHeight, flexNode.StyleSetMaxHeightPercent, null, flexNode, deferredCalcNodes);
-		ApplyNodeLength(style.FlexBasis, horizontalContext, isRoot, flexNode.StyleSetFlexBasis, flexNode.StyleSetFlexBasisPercent, flexNode.NodeStyleSetFlexBasisAuto, flexNode, deferredCalcNodes);
-		ApplyNodeLength(style.Left, horizontalContext, isRoot, delegate(float value)
-		{
-			flexNode.StyleSetPosition(Edge.Left, value);
-		}, delegate(float value)
-		{
-			flexNode.StyleSetPositionPercent(Edge.Left, value);
-		}, null, flexNode, deferredCalcNodes);
-		ApplyNodeLength(style.Top, verticalContext, isRoot, delegate(float value)
-		{
-			flexNode.StyleSetPosition(Edge.Top, value);
-		}, delegate(float value)
-		{
-			flexNode.StyleSetPositionPercent(Edge.Top, value);
-		}, null, flexNode, deferredCalcNodes);
-		ApplyNodeLength(style.Right, horizontalContext, isRoot, delegate(float value)
-		{
-			flexNode.StyleSetPosition(Edge.Right, value);
-		}, delegate(float value)
-		{
-			flexNode.StyleSetPositionPercent(Edge.Right, value);
-		}, null, flexNode, deferredCalcNodes);
-		ApplyNodeLength(style.Bottom, verticalContext, isRoot, delegate(float value)
-		{
-			flexNode.StyleSetPosition(Edge.Bottom, value);
-		}, delegate(float value)
-		{
-			flexNode.StyleSetPositionPercent(Edge.Bottom, value);
-		}, null, flexNode, deferredCalcNodes);
-		ApplyThickness(style.Margin, delegate(Edge edge, float value)
-		{
-			flexNode.StyleSetMargin(edge, value);
-		}, delegate(Edge edge, float value)
-		{
-			flexNode.StyleSetMarginPercent(edge, value);
-		});
-		ApplyThickness(style.Padding, delegate(Edge edge, float value)
-		{
-			flexNode.StyleSetPadding(edge, value);
-		}, delegate(Edge edge, float value)
-		{
-			flexNode.StyleSetPaddingPercent(edge, value);
-		});
+		if (ApplyNodeLength(flexNode, style.Width, horizontalContext, isRoot, LengthTarget.Width)) deferredCalcNodes.Add(flexNode);
+		if (ApplyNodeLength(flexNode, style.Height, verticalContext, isRoot, LengthTarget.Height)) deferredCalcNodes.Add(flexNode);
+		if (ApplyNodeLength(flexNode, style.MinWidth, horizontalContext, isRoot, LengthTarget.MinWidth)) deferredCalcNodes.Add(flexNode);
+		if (ApplyNodeLength(flexNode, style.MinHeight, verticalContext, isRoot, LengthTarget.MinHeight)) deferredCalcNodes.Add(flexNode);
+		if (ApplyNodeLength(flexNode, style.MaxWidth, horizontalContext, isRoot, LengthTarget.MaxWidth)) deferredCalcNodes.Add(flexNode);
+		if (ApplyNodeLength(flexNode, style.MaxHeight, verticalContext, isRoot, LengthTarget.MaxHeight)) deferredCalcNodes.Add(flexNode);
+		if (ApplyNodeLength(flexNode, style.FlexBasis, horizontalContext, isRoot, LengthTarget.FlexBasis)) deferredCalcNodes.Add(flexNode);
+		if (ApplyNodeLength(flexNode, style.Left, horizontalContext, isRoot, LengthTarget.Left)) deferredCalcNodes.Add(flexNode);
+		if (ApplyNodeLength(flexNode, style.Top, verticalContext, isRoot, LengthTarget.Top)) deferredCalcNodes.Add(flexNode);
+		if (ApplyNodeLength(flexNode, style.Right, horizontalContext, isRoot, LengthTarget.Right)) deferredCalcNodes.Add(flexNode);
+		if (ApplyNodeLength(flexNode, style.Bottom, verticalContext, isRoot, LengthTarget.Bottom)) deferredCalcNodes.Add(flexNode);
+		ApplyThicknessPoints(flexNode, style.Margin, isPadding: false);
+		ApplyThicknessPoints(flexNode, style.Padding, isPadding: true);
 		ApplyBorder(style.BorderWidth, flexNode);
 		if (isRoot)
 		{
-			if (style.Width.IsAuto)
-			{
-				flexNode.StyleSetWidth(rootWidth);
-			}
-			if (style.Height.IsAuto)
-			{
-				flexNode.StyleSetHeight(rootHeight);
-			}
+			if (style.Width.IsAuto) flexNode.StyleSetWidth(rootWidth);
+			if (style.Height.IsAuto) flexNode.StyleSetHeight(rootHeight);
 		}
 	}
 
-	private static void ApplyThickness(UiThickness thickness, Action<Edge, float> pointSetter, Action<Edge, float> percentSetter)
+	private static void ApplyThicknessPoints(Node node, UiThickness thickness, bool isPadding)
 	{
-		SetThicknessEdge(Edge.Left, thickness.Left, pointSetter, percentSetter);
-		SetThicknessEdge(Edge.Top, thickness.Top, pointSetter, percentSetter);
-		SetThicknessEdge(Edge.Right, thickness.Right, pointSetter, percentSetter);
-		SetThicknessEdge(Edge.Bottom, thickness.Bottom, pointSetter, percentSetter);
-	}
-
-	private static void SetThicknessEdge(Edge edge, float value, Action<Edge, float> pointSetter, Action<Edge, float> percentSetter)
-	{
-		pointSetter(edge, value);
+		if (isPadding)
+		{
+			node.StyleSetPadding(Edge.Left, thickness.Left);
+			node.StyleSetPadding(Edge.Top, thickness.Top);
+			node.StyleSetPadding(Edge.Right, thickness.Right);
+			node.StyleSetPadding(Edge.Bottom, thickness.Bottom);
+		}
+		else
+		{
+			node.StyleSetMargin(Edge.Left, thickness.Left);
+			node.StyleSetMargin(Edge.Top, thickness.Top);
+			node.StyleSetMargin(Edge.Right, thickness.Right);
+			node.StyleSetMargin(Edge.Bottom, thickness.Bottom);
+		}
 	}
 
 	private static void ApplyBorder(float borderWidth, Node node)
@@ -243,36 +231,27 @@ public sealed class UiLayoutEngine
 		node.StyleSetBorder(Edge.Bottom, borderWidth);
 	}
 
-	private static void ApplyNodeLength(UiLength length, UiLengthContext context, bool isRoot, Action<float> pointSetter, Action<float> percentSetter, Action? autoSetter, Node flexNode, List<Node> deferredCalcNodes)
-	{
-		if (ApplyLength(length, context, isRoot, pointSetter, percentSetter, autoSetter))
-		{
-			deferredCalcNodes.Add(flexNode);
-		}
-	}
-
-	/// <summary>Applies a length to the flex node. Returns true when the length was deferred (calc with a percent term on a non-root node).</summary>
-	private static bool ApplyLength(UiLength length, UiLengthContext context, bool isRoot, Action<float> pointSetter, Action<float> percentSetter, Action? autoSetter)
+	private static bool ApplyNodeLength(Node flexNode, UiLength length, UiLengthContext context, bool isRoot, LengthTarget target)
 	{
 		switch (length.Unit)
 		{
 		case UiLengthUnit.Pixel:
-			pointSetter(length.Value);
-			break;
+			SetPoint(flexNode, target, length.Value);
+			return false;
 		case UiLengthUnit.Percent:
-			percentSetter(length.Value);
-			break;
+			SetPercent(flexNode, target, length.Value);
+			return false;
 		case UiLengthUnit.Vw:
 		case UiLengthUnit.Vh:
 		case UiLengthUnit.Vmin:
 		case UiLengthUnit.Vmax:
-			pointSetter(length.Resolve(context));
-			break;
+			SetPoint(flexNode, target, length.Resolve(context));
+			return false;
 		case UiLengthUnit.Calc:
 			if (length.Calc == null)
 			{
-				autoSetter?.Invoke();
-				break;
+				SetAuto(flexNode, target);
+				return false;
 			}
 			if (length.Calc.HasPercentTerm && !isRoot)
 			{
@@ -281,22 +260,63 @@ public sealed class UiLayoutEngine
 			float resolved = length.Calc.Evaluate(context);
 			if (float.IsNaN(resolved))
 			{
-				autoSetter?.Invoke();
-				break;
+				SetAuto(flexNode, target);
+				return false;
 			}
-			pointSetter(resolved);
-			break;
+			SetPoint(flexNode, target, resolved);
+			return false;
 		default:
-			autoSetter?.Invoke();
-			break;
+			SetAuto(flexNode, target);
+			return false;
 		}
-		return false;
 	}
 
-	/// <summary>
-	/// Second layout pass: resolves deferred calc lengths (percent terms) against the parent's
-	/// laid-out content size. Only runs when at least one node deferred a calc length.
-	/// </summary>
+	private static void SetPoint(Node node, LengthTarget target, float value)
+	{
+		switch (target)
+		{
+		case LengthTarget.Width: node.StyleSetWidth(value); break;
+		case LengthTarget.Height: node.StyleSetHeight(value); break;
+		case LengthTarget.MinWidth: node.StyleSetMinWidth(value); break;
+		case LengthTarget.MinHeight: node.StyleSetMinHeight(value); break;
+		case LengthTarget.MaxWidth: node.StyleSetMaxWidth(value); break;
+		case LengthTarget.MaxHeight: node.StyleSetMaxHeight(value); break;
+		case LengthTarget.FlexBasis: node.StyleSetFlexBasis(value); break;
+		case LengthTarget.Left: node.StyleSetPosition(Edge.Left, value); break;
+		case LengthTarget.Top: node.StyleSetPosition(Edge.Top, value); break;
+		case LengthTarget.Right: node.StyleSetPosition(Edge.Right, value); break;
+		case LengthTarget.Bottom: node.StyleSetPosition(Edge.Bottom, value); break;
+		}
+	}
+
+	private static void SetPercent(Node node, LengthTarget target, float value)
+	{
+		switch (target)
+		{
+		case LengthTarget.Width: node.StyleSetWidthPercent(value); break;
+		case LengthTarget.Height: node.StyleSetHeightPercent(value); break;
+		case LengthTarget.MinWidth: node.StyleSetMinWidthPercent(value); break;
+		case LengthTarget.MinHeight: node.StyleSetMinHeightPercent(value); break;
+		case LengthTarget.MaxWidth: node.StyleSetMaxWidthPercent(value); break;
+		case LengthTarget.MaxHeight: node.StyleSetMaxHeightPercent(value); break;
+		case LengthTarget.FlexBasis: node.StyleSetFlexBasisPercent(value); break;
+		case LengthTarget.Left: node.StyleSetPositionPercent(Edge.Left, value); break;
+		case LengthTarget.Top: node.StyleSetPositionPercent(Edge.Top, value); break;
+		case LengthTarget.Right: node.StyleSetPositionPercent(Edge.Right, value); break;
+		case LengthTarget.Bottom: node.StyleSetPositionPercent(Edge.Bottom, value); break;
+		}
+	}
+
+	private static void SetAuto(Node node, LengthTarget target)
+	{
+		switch (target)
+		{
+		case LengthTarget.Width: node.StyleSetWidthAuto(); break;
+		case LengthTarget.Height: node.StyleSetHeightAuto(); break;
+		case LengthTarget.FlexBasis: node.NodeStyleSetFlexBasisAuto(); break;
+		}
+	}
+
 	private static void ResolveDeferredCalcLengths(Node flexNode, float rootWidth, float rootHeight)
 	{
 		if (flexNode.Context is not UiNode node)
@@ -305,60 +325,36 @@ public sealed class UiLayoutEngine
 		}
 		UiStyle style = node.Style;
 		Node? parent = flexNode.GetParent();
-		float parentContentWidth = ((parent == null) ? rootWidth : Math.Max(0f, parent.LayoutGetWidth() - parent.LayoutGetPadding(Edge.Left) - parent.LayoutGetPadding(Edge.Right)));
-		float parentContentHeight = ((parent == null) ? rootHeight : Math.Max(0f, parent.LayoutGetHeight() - parent.LayoutGetPadding(Edge.Top) - parent.LayoutGetPadding(Edge.Bottom)));
+		float parentContentWidth = parent == null ? rootWidth : Math.Max(0f, parent.LayoutGetWidth() - parent.LayoutGetPadding(Edge.Left) - parent.LayoutGetPadding(Edge.Right));
+		float parentContentHeight = parent == null ? rootHeight : Math.Max(0f, parent.LayoutGetHeight() - parent.LayoutGetPadding(Edge.Top) - parent.LayoutGetPadding(Edge.Bottom));
 		UiLengthContext horizontalContext = new UiLengthContext(parentContentWidth, rootWidth, rootHeight);
 		UiLengthContext verticalContext = new UiLengthContext(parentContentHeight, rootWidth, rootHeight);
-		ApplyDeferredCalc(style.Width, horizontalContext, flexNode.StyleSetWidth, flexNode.StyleSetWidthPercent, flexNode.StyleSetWidthAuto);
-		ApplyDeferredCalc(style.Height, verticalContext, flexNode.StyleSetHeight, flexNode.StyleSetHeightPercent, flexNode.StyleSetHeightAuto);
-		ApplyDeferredCalc(style.MinWidth, horizontalContext, flexNode.StyleSetMinWidth, flexNode.StyleSetMinWidthPercent, null);
-		ApplyDeferredCalc(style.MinHeight, verticalContext, flexNode.StyleSetMinHeight, flexNode.StyleSetMinHeightPercent, null);
-		ApplyDeferredCalc(style.MaxWidth, horizontalContext, flexNode.StyleSetMaxWidth, flexNode.StyleSetMaxWidthPercent, null);
-		ApplyDeferredCalc(style.MaxHeight, verticalContext, flexNode.StyleSetMaxHeight, flexNode.StyleSetMaxHeightPercent, null);
-		ApplyDeferredCalc(style.FlexBasis, horizontalContext, flexNode.StyleSetFlexBasis, flexNode.StyleSetFlexBasisPercent, flexNode.NodeStyleSetFlexBasisAuto);
-		ApplyDeferredCalc(style.Left, horizontalContext, delegate(float value)
-		{
-			flexNode.StyleSetPosition(Edge.Left, value);
-		}, delegate(float value)
-		{
-			flexNode.StyleSetPositionPercent(Edge.Left, value);
-		}, null);
-		ApplyDeferredCalc(style.Top, verticalContext, delegate(float value)
-		{
-			flexNode.StyleSetPosition(Edge.Top, value);
-		}, delegate(float value)
-		{
-			flexNode.StyleSetPositionPercent(Edge.Top, value);
-		}, null);
-		ApplyDeferredCalc(style.Right, horizontalContext, delegate(float value)
-		{
-			flexNode.StyleSetPosition(Edge.Right, value);
-		}, delegate(float value)
-		{
-			flexNode.StyleSetPositionPercent(Edge.Right, value);
-		}, null);
-		ApplyDeferredCalc(style.Bottom, verticalContext, delegate(float value)
-		{
-			flexNode.StyleSetPosition(Edge.Bottom, value);
-		}, delegate(float value)
-		{
-			flexNode.StyleSetPositionPercent(Edge.Bottom, value);
-		}, null);
+		ApplyDeferredCalc(flexNode, style.Width, horizontalContext, LengthTarget.Width);
+		ApplyDeferredCalc(flexNode, style.Height, verticalContext, LengthTarget.Height);
+		ApplyDeferredCalc(flexNode, style.MinWidth, horizontalContext, LengthTarget.MinWidth);
+		ApplyDeferredCalc(flexNode, style.MinHeight, verticalContext, LengthTarget.MinHeight);
+		ApplyDeferredCalc(flexNode, style.MaxWidth, horizontalContext, LengthTarget.MaxWidth);
+		ApplyDeferredCalc(flexNode, style.MaxHeight, verticalContext, LengthTarget.MaxHeight);
+		ApplyDeferredCalc(flexNode, style.FlexBasis, horizontalContext, LengthTarget.FlexBasis);
+		ApplyDeferredCalc(flexNode, style.Left, horizontalContext, LengthTarget.Left);
+		ApplyDeferredCalc(flexNode, style.Top, verticalContext, LengthTarget.Top);
+		ApplyDeferredCalc(flexNode, style.Right, horizontalContext, LengthTarget.Right);
+		ApplyDeferredCalc(flexNode, style.Bottom, verticalContext, LengthTarget.Bottom);
 	}
 
-	private static void ApplyDeferredCalc(UiLength length, UiLengthContext context, Action<float> pointSetter, Action<float> percentSetter, Action? autoSetter)
+	private static void ApplyDeferredCalc(Node flexNode, UiLength length, UiLengthContext context, LengthTarget target)
 	{
-		if (length.Unit != UiLengthUnit.Calc || length.Calc == null)
+		if (length.Unit != UiLengthUnit.Calc || length.Calc == null || !length.Calc.HasPercentTerm)
 		{
 			return;
 		}
 		float resolved = length.Calc.Evaluate(context);
 		if (float.IsNaN(resolved))
 		{
-			autoSetter?.Invoke();
+			SetAuto(flexNode, target);
 			return;
 		}
-		pointSetter(resolved);
+		SetPoint(flexNode, target, resolved);
 	}
 
 	private static Overflow MapOverflow(UiStyle style)
@@ -368,9 +364,6 @@ public sealed class UiLayoutEngine
 			return Overflow.Hidden;
 		}
 		UiOverflow overflow = style.Overflow;
-		if (1 == 0)
-		{
-		}
 		Overflow result;
 		switch (overflow)
 		{
@@ -385,17 +378,11 @@ public sealed class UiLayoutEngine
 			result = Overflow.Visible;
 			break;
 		}
-		if (1 == 0)
-		{
-		}
 		return result;
 	}
 
 	private static Justify MapJustify(UiJustifyContent justifyContent)
 	{
-		if (1 == 0)
-		{
-		}
 		Justify result = justifyContent switch
 		{
 			UiJustifyContent.Center => Justify.Center, 
@@ -405,17 +392,11 @@ public sealed class UiLayoutEngine
 			UiJustifyContent.SpaceEvenly => Justify.SpaceAround, 
 			_ => Justify.FlexStart, 
 		};
-		if (1 == 0)
-		{
-		}
 		return result;
 	}
 
 	private static Align MapAlign(UiAlignItems alignItems)
 	{
-		if (1 == 0)
-		{
-		}
 		Align result = alignItems switch
 		{
 			UiAlignItems.Start => Align.FlexStart, 
@@ -423,17 +404,11 @@ public sealed class UiLayoutEngine
 			UiAlignItems.End => Align.FlexEnd, 
 			_ => Align.Stretch, 
 		};
-		if (1 == 0)
-		{
-		}
 		return result;
 	}
 
 	private static Align MapAlignContent(UiAlignContent alignContent)
 	{
-		if (1 == 0)
-		{
-		}
 		Align result;
 		switch (alignContent)
 		{
@@ -457,26 +432,17 @@ public sealed class UiLayoutEngine
 			result = Align.Stretch;
 			break;
 		}
-		if (1 == 0)
-		{
-		}
 		return result;
 	}
 
 	private static Wrap MapWrap(UiFlexWrap wrap)
 	{
-		if (1 == 0)
-		{
-		}
 		Wrap result = wrap switch
 		{
 			UiFlexWrap.Wrap => Wrap.Wrap, 
 			UiFlexWrap.WrapReverse => Wrap.WrapReverse, 
 			_ => Wrap.NoWrap, 
 		};
-		if (1 == 0)
-		{
-		}
 		return result;
 	}
 
@@ -486,16 +452,12 @@ public sealed class UiLayoutEngine
 		{
 			return false;
 		}
-		if (node.Kind == UiNodeKind.Text)
+		if (node.Kind == UiNodeKind.Text || !string.IsNullOrWhiteSpace(node.TextContent))
 		{
 			return true;
 		}
-		if (!string.IsNullOrWhiteSpace(node.TextContent))
-		{
-			return true;
-		}
-		UiNodeKind kind = node.Kind;
-		return (kind - 2 <= UiNodeKind.Text || kind - 7 <= UiNodeKind.Column) ? true : false;
+		return node.Kind is UiNodeKind.Button or UiNodeKind.Image or UiNodeKind.Input or UiNodeKind.Select
+			or UiNodeKind.TextArea or UiNodeKind.Checkbox or UiNodeKind.Radio or UiNodeKind.Toggle or UiNodeKind.Slider;
 	}
 
 	private static void ApplyGapOffset(Node childNode, UiStyle parentStyle, int childIndex)
@@ -518,6 +480,7 @@ public sealed class UiLayoutEngine
 	{
 		return (parentStyle.FlexDirection != UiFlexDirection.Row) ? ((parentStyle.RowGap > 0f) ? parentStyle.RowGap : parentStyle.Gap) : ((parentStyle.ColumnGap > 0f) ? parentStyle.ColumnGap : parentStyle.Gap);
 	}
+
 
 	private void ApplyLayout(UiNode uiNode, Node flexNode, float parentX, float parentY)
 	{
@@ -572,8 +535,10 @@ public sealed class UiLayoutEngine
 			return;
 		}
 		float[] array = new float[num];
-		foreach (TableCellPlacement item in list3.OrderBy((TableCellPlacement placement) => placement.ColumnSpan))
+		list3.Sort(static (left, right) => left.ColumnSpan.CompareTo(right.ColumnSpan));
+		for (int i = 0; i < list3.Count; i++)
 		{
+			TableCellPlacement item = list3[i];
 			float num3 = MeasureTableCellPreferredWidth(item.Cell);
 			float num4 = SumTableRange(array, item.ColumnIndex, item.ColumnSpan);
 			if (num3 > num4 + 0.01f)
@@ -591,8 +556,10 @@ public sealed class UiLayoutEngine
 		{
 			array2[item2.RowIndex] = Math.Max(24f, item2.Row.LayoutRect.Height);
 		}
-		foreach (TableCellPlacement item3 in list3.OrderBy((TableCellPlacement placement) => placement.RowSpan))
+		list3.Sort(static (left, right) => left.RowSpan.CompareTo(right.RowSpan));
+		for (int i = 0; i < list3.Count; i++)
 		{
+			TableCellPlacement item3 = list3[i];
 			float width = SumTableRange(array, item3.ColumnIndex, item3.ColumnSpan);
 			Size size = MeasureNode(item3.Cell, width, MeasureMode.AtMost, 0f, MeasureMode.Undefined);
 			float num7 = Math.Max(24f, Math.Max(item3.Cell.LayoutRect.Height, size.Height));
@@ -626,15 +593,29 @@ public sealed class UiLayoutEngine
 			item5.Cell.SetLayout(new UiRect(x, y, num14, num15));
 			item5.Cell.SetScrollMetrics(num14, num15);
 		}
-		Dictionary<UiNode, TableRowInfo> dictionary = list2.ToDictionary((TableRowInfo info) => info.Row);
 		foreach (var (uiNode, list4) in list)
 		{
 			if (uiNode != null && list4.Count != 0)
 			{
-				TableRowInfo tableRowInfo = dictionary[list4[0]];
-				TableRowInfo tableRowInfo2 = dictionary[list4[list4.Count - 1]];
-				float y2 = array3[tableRowInfo.RowIndex];
-				float num16 = SumTableRange(array2, tableRowInfo.RowIndex, tableRowInfo2.RowIndex - tableRowInfo.RowIndex + 1);
+				int firstRowIndex = -1;
+				int lastRowIndex = -1;
+				for (int i = 0; i < list2.Count; i++)
+				{
+					if (list2[i].Row == list4[0])
+					{
+						firstRowIndex = list2[i].RowIndex;
+					}
+					if (list2[i].Row == list4[list4.Count - 1])
+					{
+						lastRowIndex = list2[i].RowIndex;
+					}
+				}
+				if (firstRowIndex < 0 || lastRowIndex < 0)
+				{
+					throw new InvalidOperationException("Table section rows are missing from the layout model.");
+				}
+				float y2 = array3[firstRowIndex];
+				float num16 = SumTableRange(array2, firstRowIndex, lastRowIndex - firstRowIndex + 1);
 				uiNode.SetLayout(new UiRect(num11, y2, num2, num16));
 				uiNode.SetScrollMetrics(num2, num16);
 			}
@@ -655,6 +636,7 @@ public sealed class UiLayoutEngine
 		}
 		List<TableCellPlacement> list3 = new List<TableCellPlacement>();
 		List<int> list4 = new List<int>();
+		List<UiNode> cells = new List<UiNode>();
 		bool flag = true;
 		foreach (TableRowInfo item3 in list)
 		{
@@ -664,8 +646,10 @@ public sealed class UiLayoutEngine
 			}
 			flag = false;
 			int startColumn = 0;
-			foreach (UiNode tableCell in GetTableCells(item3.Row))
+			CollectTableCells(item3.Row, cells);
+			for (int cellIndex = 0; cellIndex < cells.Count; cellIndex++)
 			{
+				UiNode tableCell = cells[cellIndex];
 				int tableSpan = GetTableSpan(tableCell.Attributes["colspan"]);
 				int tableSpan2 = GetTableSpan(tableCell.Attributes["rowspan"]);
 				int num = Math.Max(1, Math.Min(tableSpan2, list.Count - item3.RowIndex));
@@ -679,7 +663,15 @@ public sealed class UiLayoutEngine
 				startColumn = num2 + tableSpan;
 			}
 		}
-		int item = ((list3.Count != 0) ? list3.Max((TableCellPlacement placement) => placement.ColumnIndex + placement.ColumnSpan) : 0);
+		int item = 0;
+		for (int i = 0; i < list3.Count; i++)
+		{
+			int end = list3[i].ColumnIndex + list3[i].ColumnSpan;
+			if (end > item)
+			{
+				item = end;
+			}
+		}
 		return (RowInfos: list, Placements: list3, ColumnCount: item);
 	}
 
@@ -694,10 +686,16 @@ public sealed class UiLayoutEngine
 				list2.Add(child);
 				continue;
 			}
-			UiNodeKind kind = child.Kind;
-			if (kind - 18 <= UiNodeKind.Button)
+			if (child.Kind is UiNodeKind.TableHeader or UiNodeKind.TableBody or UiNodeKind.TableFooter)
 			{
-				List<UiNode> list3 = child.Children.Where((UiNode node) => node.Kind == UiNodeKind.TableRow).ToList();
+				List<UiNode> list3 = new List<UiNode>();
+				for (int i = 0; i < child.Children.Count; i++)
+				{
+					if (child.Children[i].Kind == UiNodeKind.TableRow)
+					{
+						list3.Add(child.Children[i]);
+					}
+				}
 				if (list3.Count > 0)
 				{
 					list.Add((child, list3));
@@ -711,13 +709,17 @@ public sealed class UiLayoutEngine
 		return list;
 	}
 
-	private static IReadOnlyList<UiNode> GetTableCells(UiNode row)
+	private static void CollectTableCells(UiNode row, List<UiNode> cells)
 	{
-		return row.Children.Where(delegate(UiNode child)
+		cells.Clear();
+		for (int i = 0; i < row.Children.Count; i++)
 		{
-			UiNodeKind kind = child.Kind;
-			return kind - 22 <= UiNodeKind.Text;
-		}).ToArray();
+			UiNode child = row.Children[i];
+			if (child.Kind is UiNodeKind.TableCell or UiNodeKind.TableHeaderCell)
+			{
+				cells.Add(child);
+			}
+		}
 	}
 
 	private static void AdvanceTableRowOccupancy(List<int> occupiedColumns)
@@ -806,7 +808,7 @@ public sealed class UiLayoutEngine
 		{
 			return;
 		}
-		float num = columnWidths.Sum();
+		float num = SumTableRange(columnWidths, 0, columnWidths.Length);
 		if (num <= 0.01f)
 		{
 			float num2 = availableWidth / (float)columnWidths.Length;
@@ -830,7 +832,7 @@ public sealed class UiLayoutEngine
 		{
 			columnWidths[k] = Math.Max(36f, columnWidths[k] * num4);
 		}
-		float num5 = columnWidths.Sum();
+		float num5 = SumTableRange(columnWidths, 0, columnWidths.Length);
 		if (columnWidths.Length != 0)
 		{
 			columnWidths[^1] += availableWidth - num5;
@@ -850,9 +852,6 @@ public sealed class UiLayoutEngine
 			return new Size(ResolveMeasuredAxis(measured, width, widthMode), ResolveMeasuredAxis(measured2, height, heightMode));
 		}
 		UiNodeKind kind = node.Kind;
-		if (1 == 0)
-		{
-		}
 		(float, float) tuple;
 		switch (kind)
 		{
@@ -879,27 +878,18 @@ public sealed class UiLayoutEngine
 			tuple = ((!string.Equals(node.TagName, "canvas", StringComparison.OrdinalIgnoreCase)) ? (0f, 0f) : ResolveCanvasIntrinsicSize(node));
 			break;
 		}
-		if (1 == 0)
-		{
-		}
 		var (measured3, measured4) = tuple;
 		return new Size(ResolveMeasuredAxis(measured3, width, widthMode), ResolveMeasuredAxis(measured4, height, heightMode));
 	}
 
 	private static float ResolveMeasuredAxis(float measured, float available, MeasureMode mode)
 	{
-		if (1 == 0)
-		{
-		}
 		float result = mode switch
 		{
 			MeasureMode.Exactly => available, 
 			MeasureMode.AtMost => Math.Min(measured, available), 
 			_ => measured, 
 		};
-		if (1 == 0)
-		{
-		}
 		return result;
 	}
 

--- a/src/Libraries/Ludots.UI/Runtime/UiLayoutScratch.cs
+++ b/src/Libraries/Ludots.UI/Runtime/UiLayoutScratch.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using FlexLayoutSharp;
+
+namespace Ludots.UI.Runtime;
+
+internal sealed class UiLayoutScratch
+{
+	private readonly List<Node> _deferredCalc = new List<Node>(64);
+	private readonly List<UiNode> _gridItems = new List<UiNode>(64);
+	private readonly List<UiGridPlacementSlot> _gridPlacements = new List<UiGridPlacementSlot>(64);
+	private readonly List<UiGridTrack> _columnTracks = new List<UiGridTrack>(32);
+	private readonly List<UiGridTrack> _rowTracks = new List<UiGridTrack>(32);
+	private readonly HashSet<long> _occupied = new HashSet<long>();
+	private readonly List<UiInlineLineBox> _lines = new List<UiInlineLineBox>(16);
+	private readonly List<UiInlineItem> _lineItems = new List<UiInlineItem>(64);
+	private readonly List<UiNode> _tableCells = new List<UiNode>(64);
+	private float[] _columnSizes = new float[32];
+	private float[] _rowSizes = new float[32];
+	private float[] _columnOffsets = new float[32];
+	private float[] _rowOffsets = new float[32];
+	private static readonly UiGridTrack[] DefaultSingleFr = { UiGridTrack.Fr(1f) };
+
+	public static UiGridTrack[] SharedDefaultSingleFr => DefaultSingleFr;
+
+	public List<Node> BeginDeferredCalc()
+	{
+		_deferredCalc.Clear();
+		return _deferredCalc;
+	}
+
+	public List<UiNode> BeginGridItems()
+	{
+		_gridItems.Clear();
+		return _gridItems;
+	}
+
+	public List<UiGridPlacementSlot> BeginGridPlacements()
+	{
+		_gridPlacements.Clear();
+		return _gridPlacements;
+	}
+
+	public List<UiGridTrack> BeginColumnTracks()
+	{
+		_columnTracks.Clear();
+		return _columnTracks;
+	}
+
+	public List<UiGridTrack> BeginRowTracks()
+	{
+		_rowTracks.Clear();
+		return _rowTracks;
+	}
+
+	public HashSet<long> BeginOccupied()
+	{
+		_occupied.Clear();
+		return _occupied;
+	}
+
+	public List<UiInlineLineBox> BeginLines()
+	{
+		_lines.Clear();
+		return _lines;
+	}
+
+	public List<UiInlineItem> BeginLineItems()
+	{
+		_lineItems.Clear();
+		return _lineItems;
+	}
+
+	public List<UiNode> BeginTableCells()
+	{
+		_tableCells.Clear();
+		return _tableCells;
+	}
+
+	public Span<float> BeginColumnSizes(int count) => BeginFloatBuffer(ref _columnSizes, count);
+
+	public Span<float> BeginRowSizes(int count) => BeginFloatBuffer(ref _rowSizes, count);
+
+	public Span<float> BeginColumnOffsets(int count) => BeginFloatBuffer(ref _columnOffsets, count);
+
+	public Span<float> BeginRowOffsets(int count) => BeginFloatBuffer(ref _rowOffsets, count);
+
+	private static Span<float> BeginFloatBuffer(ref float[] buffer, int count)
+	{
+		if (count < 0)
+		{
+			throw new ArgumentOutOfRangeException(nameof(count));
+		}
+		if (buffer.Length < count)
+		{
+			int size = Math.Max(32, buffer.Length);
+			while (size < count)
+			{
+				size *= 2;
+			}
+			buffer = new float[size];
+		}
+		buffer.AsSpan(0, count).Clear();
+		return buffer.AsSpan(0, count);
+	}
+}
+
+internal struct UiGridPlacementSlot
+{
+	public UiNode Node;
+	public int ColumnStart;
+	public int ColumnSpan;
+	public int RowStart;
+	public int RowSpan;
+}
+
+internal struct UiInlineItem
+{
+	public UiNode Node;
+	public float Width;
+	public float Height;
+	public float Ascent;
+	public float Descent;
+}
+
+internal struct UiInlineLineBox
+{
+	public int ItemStart;
+	public int ItemCount;
+	public float Width;
+	public float MaxAscent;
+	public float MaxDescent;
+
+	public readonly float Height => MaxAscent + MaxDescent;
+}

--- a/src/Libraries/Ludots.UI/Runtime/UiScene.cs
+++ b/src/Libraries/Ludots.UI/Runtime/UiScene.cs
@@ -20,6 +20,10 @@ public sealed class UiScene
 
 	private readonly List<UiStyleSheet> _styleSheets = new List<UiStyleSheet>();
 
+	private readonly List<UiStyleSheet> _effectiveStyleSheets = new List<UiStyleSheet>();
+
+	private bool _effectiveStyleSheetsDirty = true;
+
 	private readonly Dictionary<string, UiVirtualWindow> _virtualWindows = new Dictionary<string, UiVirtualWindow>(StringComparer.Ordinal);
 
 	private Func<bool>? _reactiveRuntimeRefresh;
@@ -90,6 +94,7 @@ public sealed class UiScene
 		Theme = theme;
 		_styleSheets.Clear();
 		_styleSheets.AddRange(document.StyleSheets);
+		_effectiveStyleSheetsDirty = true;
 		_nextNodeId = 1;
 		Root = BuildNode(document.Root);
 		TrackNextNodeId(Root);
@@ -102,6 +107,7 @@ public sealed class UiScene
 	public void SetTheme(UiThemePack? theme)
 	{
 		Theme = theme;
+		_effectiveStyleSheetsDirty = true;
 		Version++;
 		IsDirty = true;
 	}
@@ -113,6 +119,7 @@ public sealed class UiScene
 		{
 			_styleSheets.AddRange(styleSheets);
 		}
+		_effectiveStyleSheetsDirty = true;
 		Version++;
 		IsDirty = true;
 	}
@@ -496,13 +503,18 @@ public sealed class UiScene
 
 	private IReadOnlyList<UiStyleSheet> GetEffectiveStyleSheets()
 	{
-		List<UiStyleSheet> list = new List<UiStyleSheet>(_styleSheets.Count + (Theme?.StyleSheets.Count ?? 0));
-		list.AddRange(_styleSheets);
+		if (!_effectiveStyleSheetsDirty)
+		{
+			return _effectiveStyleSheets;
+		}
+		_effectiveStyleSheets.Clear();
+		_effectiveStyleSheets.AddRange(_styleSheets);
 		if (Theme != null)
 		{
-			list.AddRange(Theme.StyleSheets);
+			_effectiveStyleSheets.AddRange(Theme.StyleSheets);
 		}
-		return list;
+		_effectiveStyleSheetsDirty = false;
+		return _effectiveStyleSheets;
 	}
 
 	private UiNode? ResolveTarget(UiEvent evt)

--- a/src/Libraries/Ludots.UI/Runtime/UiStyleBuilder.cs
+++ b/src/Libraries/Ludots.UI/Runtime/UiStyleBuilder.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ludots.UI.Runtime;
+
+internal sealed class UiStyleBuilder
+{
+	public string? Id;
+	public string? ClassName;
+	public UiDisplay Display = UiDisplay.Flex;
+	public UiFlexDirection FlexDirection = UiFlexDirection.Column;
+	public UiJustifyContent JustifyContent = UiJustifyContent.Start;
+	public UiAlignItems AlignItems = UiAlignItems.Stretch;
+	public UiAlignContent AlignContent = UiAlignContent.Stretch;
+	public UiFlexWrap FlexWrap = UiFlexWrap.NoWrap;
+	public UiPositionType PositionType = UiPositionType.Relative;
+	public UiOverflow Overflow = UiOverflow.Visible;
+	public UiPointerEvents PointerEvents = UiPointerEvents.Auto;
+	public UiLength Left = UiLength.Auto;
+	public UiLength Top = UiLength.Auto;
+	public UiLength Right = UiLength.Auto;
+	public UiLength Bottom = UiLength.Auto;
+	public UiLength Width = UiLength.Auto;
+	public UiLength Height = UiLength.Auto;
+	public UiLength MinWidth = UiLength.Auto;
+	public UiLength MinHeight = UiLength.Auto;
+	public UiLength MaxWidth = UiLength.Auto;
+	public UiLength MaxHeight = UiLength.Auto;
+	public UiLength FlexBasis = UiLength.Auto;
+	public float FlexGrow;
+	public float FlexShrink;
+	public float Gap;
+	public float RowGap;
+	public float ColumnGap;
+	public IReadOnlyList<UiGridTrack> GridTemplateColumns = Array.Empty<UiGridTrack>();
+	public IReadOnlyList<UiGridTrack> GridTemplateRows = Array.Empty<UiGridTrack>();
+	public UiGridAutoFlow GridAutoFlow = UiGridAutoFlow.Row;
+	public UiGridPlacement GridColumn = UiGridPlacement.Auto;
+	public UiGridPlacement GridRow = UiGridPlacement.Auto;
+	public UiThickness Margin = UiThickness.Zero;
+	public UiThickness Padding = UiThickness.Zero;
+	public float BorderWidth;
+	public float BorderRadius;
+	public float OutlineWidth;
+	public int ZIndex;
+	public UiColor BackgroundColor = UiColor.Transparent;
+	public UiLinearGradient? BackgroundGradient;
+	public IReadOnlyList<UiBackgroundLayer> BackgroundLayers = Array.Empty<UiBackgroundLayer>();
+	public IReadOnlyList<UiBackgroundSize> BackgroundSizes = Array.Empty<UiBackgroundSize>();
+	public IReadOnlyList<UiBackgroundPosition> BackgroundPositions = Array.Empty<UiBackgroundPosition>();
+	public IReadOnlyList<UiBackgroundRepeat> BackgroundRepeats = Array.Empty<UiBackgroundRepeat>();
+	public UiColor BorderColor = UiColor.Transparent;
+	public UiBorderStyle BorderStyle = UiBorderStyle.Solid;
+	public UiColor OutlineColor = UiColor.Transparent;
+	public UiShadow? BoxShadow;
+	public IReadOnlyList<UiShadow> BoxShadows = Array.Empty<UiShadow>();
+	public float FilterBlurRadius;
+	public float BackdropBlurRadius;
+	public UiColor Color = UiColor.White;
+	public UiShadow? TextShadow;
+	public float FontSize = 16f;
+	public string? FontFamily;
+	public bool Bold;
+	public UiTextDirection Direction = UiTextDirection.Ltr;
+	public UiTextAlign TextAlign = UiTextAlign.Start;
+	public UiTextDecorationLine TextDecorationLine = UiTextDecorationLine.None;
+	public UiTextOverflow TextOverflow = UiTextOverflow.Clip;
+	public UiWhiteSpace WhiteSpace = UiWhiteSpace.Normal;
+	public UiObjectFit ObjectFit = UiObjectFit.Fill;
+	public UiThickness ImageSlice = UiThickness.Zero;
+	public UiTransform Transform = UiTransform.Identity;
+	public UiClipPath? ClipPath;
+	public UiLinearGradient? MaskGradient;
+	public UiTransitionSpec? Transition;
+	public UiAnimationSpec? Animation;
+	public float Opacity = 1f;
+	public bool Visible = true;
+	public bool ClipContent;
+
+	public void CopyFrom(UiStyle style)
+	{
+		ArgumentNullException.ThrowIfNull(style);
+		Id = style.Id;
+		ClassName = style.ClassName;
+		Display = style.Display;
+		FlexDirection = style.FlexDirection;
+		JustifyContent = style.JustifyContent;
+		AlignItems = style.AlignItems;
+		AlignContent = style.AlignContent;
+		FlexWrap = style.FlexWrap;
+		PositionType = style.PositionType;
+		Overflow = style.Overflow;
+		PointerEvents = style.PointerEvents;
+		Left = style.Left;
+		Top = style.Top;
+		Right = style.Right;
+		Bottom = style.Bottom;
+		Width = style.Width;
+		Height = style.Height;
+		MinWidth = style.MinWidth;
+		MinHeight = style.MinHeight;
+		MaxWidth = style.MaxWidth;
+		MaxHeight = style.MaxHeight;
+		FlexBasis = style.FlexBasis;
+		FlexGrow = style.FlexGrow;
+		FlexShrink = style.FlexShrink;
+		Gap = style.Gap;
+		RowGap = style.RowGap;
+		ColumnGap = style.ColumnGap;
+		GridTemplateColumns = style.GridTemplateColumns;
+		GridTemplateRows = style.GridTemplateRows;
+		GridAutoFlow = style.GridAutoFlow;
+		GridColumn = style.GridColumn;
+		GridRow = style.GridRow;
+		Margin = style.Margin;
+		Padding = style.Padding;
+		BorderWidth = style.BorderWidth;
+		BorderRadius = style.BorderRadius;
+		OutlineWidth = style.OutlineWidth;
+		ZIndex = style.ZIndex;
+		BackgroundColor = style.BackgroundColor;
+		BackgroundGradient = style.BackgroundGradient;
+		BackgroundLayers = style.BackgroundLayers;
+		BackgroundSizes = style.BackgroundSizes;
+		BackgroundPositions = style.BackgroundPositions;
+		BackgroundRepeats = style.BackgroundRepeats;
+		BorderColor = style.BorderColor;
+		BorderStyle = style.BorderStyle;
+		OutlineColor = style.OutlineColor;
+		BoxShadow = style.BoxShadow;
+		BoxShadows = style.BoxShadows;
+		FilterBlurRadius = style.FilterBlurRadius;
+		BackdropBlurRadius = style.BackdropBlurRadius;
+		Color = style.Color;
+		TextShadow = style.TextShadow;
+		FontSize = style.FontSize;
+		FontFamily = style.FontFamily;
+		Bold = style.Bold;
+		Direction = style.Direction;
+		TextAlign = style.TextAlign;
+		TextDecorationLine = style.TextDecorationLine;
+		TextOverflow = style.TextOverflow;
+		WhiteSpace = style.WhiteSpace;
+		ObjectFit = style.ObjectFit;
+		ImageSlice = style.ImageSlice;
+		Transform = style.Transform;
+		ClipPath = style.ClipPath;
+		MaskGradient = style.MaskGradient;
+		Transition = style.Transition;
+		Animation = style.Animation;
+		Opacity = style.Opacity;
+		Visible = style.Visible;
+		ClipContent = style.ClipContent;
+	}
+
+	public UiStyle ToStyle()
+	{
+		return new UiStyle
+		{
+			Id = Id,
+			ClassName = ClassName,
+			Display = Display,
+			FlexDirection = FlexDirection,
+			JustifyContent = JustifyContent,
+			AlignItems = AlignItems,
+			AlignContent = AlignContent,
+			FlexWrap = FlexWrap,
+			PositionType = PositionType,
+			Overflow = Overflow,
+			PointerEvents = PointerEvents,
+			Left = Left,
+			Top = Top,
+			Right = Right,
+			Bottom = Bottom,
+			Width = Width,
+			Height = Height,
+			MinWidth = MinWidth,
+			MinHeight = MinHeight,
+			MaxWidth = MaxWidth,
+			MaxHeight = MaxHeight,
+			FlexBasis = FlexBasis,
+			FlexGrow = FlexGrow,
+			FlexShrink = FlexShrink,
+			Gap = Gap,
+			RowGap = RowGap,
+			ColumnGap = ColumnGap,
+			GridTemplateColumns = GridTemplateColumns,
+			GridTemplateRows = GridTemplateRows,
+			GridAutoFlow = GridAutoFlow,
+			GridColumn = GridColumn,
+			GridRow = GridRow,
+			Margin = Margin,
+			Padding = Padding,
+			BorderWidth = BorderWidth,
+			BorderRadius = BorderRadius,
+			OutlineWidth = OutlineWidth,
+			ZIndex = ZIndex,
+			BackgroundColor = BackgroundColor,
+			BackgroundGradient = BackgroundGradient,
+			BackgroundLayers = BackgroundLayers,
+			BackgroundSizes = BackgroundSizes,
+			BackgroundPositions = BackgroundPositions,
+			BackgroundRepeats = BackgroundRepeats,
+			BorderColor = BorderColor,
+			BorderStyle = BorderStyle,
+			OutlineColor = OutlineColor,
+			BoxShadow = BoxShadow,
+			BoxShadows = BoxShadows,
+			FilterBlurRadius = FilterBlurRadius,
+			BackdropBlurRadius = BackdropBlurRadius,
+			Color = Color,
+			TextShadow = TextShadow,
+			FontSize = FontSize,
+			FontFamily = FontFamily,
+			Bold = Bold,
+			Direction = Direction,
+			TextAlign = TextAlign,
+			TextDecorationLine = TextDecorationLine,
+			TextOverflow = TextOverflow,
+			WhiteSpace = WhiteSpace,
+			ObjectFit = ObjectFit,
+			ImageSlice = ImageSlice,
+			Transform = Transform,
+			ClipPath = ClipPath,
+			MaskGradient = MaskGradient,
+			Transition = Transition,
+			Animation = Animation,
+			Opacity = Opacity,
+			Visible = Visible,
+			ClipContent = ClipContent,
+		};
+	}
+}

--- a/src/Libraries/Ludots.UI/Runtime/UiStyleDeclaration.cs
+++ b/src/Libraries/Ludots.UI/Runtime/UiStyleDeclaration.cs
@@ -60,10 +60,15 @@ public sealed class UiStyleDeclaration : IEnumerable<KeyValuePair<string, string
 		{
 			return;
 		}
-		foreach (KeyValuePair<string, string> item in other)
+		foreach (KeyValuePair<string, string> item in other._values)
 		{
 			_values[item.Key] = item.Value;
 		}
+	}
+
+	internal Dictionary<string, string>.Enumerator EnumerateValues()
+	{
+		return _values.GetEnumerator();
 	}
 
 	public IEnumerator<KeyValuePair<string, string>> GetEnumerator()

--- a/src/Libraries/Ludots.UI/Runtime/UiStyleResolver.cs
+++ b/src/Libraries/Ludots.UI/Runtime/UiStyleResolver.cs
@@ -7,12 +7,34 @@ namespace Ludots.UI.Runtime;
 
 public sealed class UiStyleResolver
 {
+	private static readonly Comparison<(int Specificity, int Order, UiStyleDeclaration Declaration)> MatchComparison =
+		static (left, right) =>
+		{
+			int bySpecificity = left.Specificity.CompareTo(right.Specificity);
+			return bySpecificity != 0 ? bySpecificity : left.Order.CompareTo(right.Order);
+		};
+
+	private readonly List<(int Specificity, int Order, UiStyleDeclaration Declaration)> _matchBuffer = new List<(int, int, UiStyleDeclaration)>(64);
+	private readonly UiStyleDeclaration _cascadeBuffer = new UiStyleDeclaration();
+	private readonly UiStyleBuilder _styleBuilder = new UiStyleBuilder();
+	private readonly Dictionary<string, string> _rootVariables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+	private readonly List<Dictionary<string, string>> _variableFramePool = new List<Dictionary<string, string>>();
+	private readonly List<Dictionary<string, string>> _variableFramesRented = new List<Dictionary<string, string>>();
+
 	public void ResolveTree(UiNode root, IReadOnlyList<UiStyleSheet>? styleSheets)
 	{
 		ArgumentNullException.ThrowIfNull(root, "root");
 		IReadOnlyList<UiStyleSheet> styleSheets2 = styleSheets ?? Array.Empty<UiStyleSheet>();
 		IReadOnlyDictionary<string, UiKeyframeDefinition> keyframes = BuildKeyframeIndex(styleSheets2);
-		ResolveNode(root, styleSheets2, keyframes, null, null, isRoot: true);
+		_rootVariables.Clear();
+		try
+		{
+			ResolveNode(root, styleSheets2, keyframes, null, _rootVariables, isRoot: true);
+		}
+		finally
+		{
+			ReleaseVariableFrames();
+		}
 	}
 
 	internal static bool TryResolveGeneratedContent(UiElement host, UiPseudoElement pseudoElement, IReadOnlyList<UiStyleSheet> styleSheets, out string text)
@@ -102,7 +124,7 @@ public sealed class UiStyleResolver
 			.Replace("\\\\", "\\", StringComparison.Ordinal);
 	}
 
-	private void ResolveNode(UiNode node, IReadOnlyList<UiStyleSheet> styleSheets, IReadOnlyDictionary<string, UiKeyframeDefinition> keyframes, UiStyle? parentStyle, IReadOnlyDictionary<string, string>? inheritedVariables, bool isRoot)
+	private void ResolveNode(UiNode node, IReadOnlyList<UiStyleSheet> styleSheets, IReadOnlyDictionary<string, UiKeyframeDefinition> keyframes, UiStyle? parentStyle, Dictionary<string, string> inheritedVariables, bool isRoot)
 	{
 		if (isRoot)
 		{
@@ -112,48 +134,90 @@ public sealed class UiStyleResolver
 		{
 			node.RemovePseudoState(UiPseudoState.Root);
 		}
-		List<(int, int, UiStyleDeclaration)> list = new List<(int, int, UiStyleDeclaration)>();
-		int num = 0;
+		_matchBuffer.Clear();
+		int sequence = 0;
 		for (int i = 0; i < styleSheets.Count; i++)
 		{
-			foreach (UiStyleRule rule in styleSheets[i].Rules)
+			IReadOnlyList<UiStyleRule> rules = styleSheets[i].Rules;
+			for (int r = 0; r < rules.Count; r++)
 			{
+				UiStyleRule rule = rules[r];
 				if (UiSelectorMatcher.Matches(node, rule.Selector))
 				{
-					list.Add((rule.Selector.Specificity, i * 10000 + rule.Order + num++, rule.Declaration));
+					_matchBuffer.Add((rule.Selector.Specificity, i * 10000 + rule.Order + sequence++, rule.Declaration));
 				}
 			}
 		}
-		list.Sort(delegate((int Specificity, int Order, UiStyleDeclaration Declaration) left, (int Specificity, int Order, UiStyleDeclaration Declaration) right)
+		_matchBuffer.Sort(MatchComparison);
+		_cascadeBuffer.Clear();
+		for (int i = 0; i < _matchBuffer.Count; i++)
 		{
-			int num3 = left.Specificity.CompareTo(right.Specificity);
-			return (num3 != 0) ? num3 : left.Order.CompareTo(right.Order);
-		});
-		UiStyleDeclaration uiStyleDeclaration = new UiStyleDeclaration();
-		for (int num2 = 0; num2 < list.Count; num2++)
-		{
-			uiStyleDeclaration.Merge(list[num2].Item3);
+			_cascadeBuffer.Merge(_matchBuffer[i].Declaration);
 		}
-		uiStyleDeclaration.Merge(node.InlineStyle);
-		Dictionary<string, string> dictionary = ((inheritedVariables != null) ? new Dictionary<string, string>(inheritedVariables, StringComparer.OrdinalIgnoreCase) : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
-		ApplyCustomProperties(uiStyleDeclaration, dictionary);
-		UiStyle localStyle = node.LocalStyle;
-		localStyle = ApplyDeclaration(localStyle, uiStyleDeclaration, dictionary);
-		localStyle = ApplyUserAgentTagDefaults(node, localStyle, uiStyleDeclaration);
-		localStyle = ApplyInheritance(node, localStyle, parentStyle, uiStyleDeclaration);
-		if (node.Kind == UiNodeKind.Text && localStyle.Display == UiDisplay.Flex)
+		_cascadeBuffer.Merge(node.InlineStyle);
+		Dictionary<string, string> variables = inheritedVariables;
+		if (HasCustomProperties(_cascadeBuffer))
 		{
-			localStyle = localStyle with
-			{
-				Display = UiDisplay.Text
-			};
+			variables = RentVariableFrame(inheritedVariables);
+			ApplyCustomProperties(_cascadeBuffer, variables);
 		}
-		UiAnimationSpec animation = ResolveAnimationSpec(localStyle.Animation, keyframes, dictionary);
+		_styleBuilder.CopyFrom(node.LocalStyle);
+		ApplyDeclaration(_styleBuilder, _cascadeBuffer, variables);
+		ApplyUserAgentTagDefaults(node, _styleBuilder, _cascadeBuffer);
+		ApplyInheritance(node, _styleBuilder, parentStyle, _cascadeBuffer);
+		if (node.Kind == UiNodeKind.Text && _styleBuilder.Display == UiDisplay.Flex)
+		{
+			_styleBuilder.Display = UiDisplay.Text;
+		}
+		UiStyle localStyle = _styleBuilder.ToStyle();
+		UiAnimationSpec animation = ResolveAnimationSpec(localStyle.Animation, keyframes, variables);
 		node.SetComputedStyle(localStyle, animation);
-		foreach (UiNode child in node.Children)
+		for (int i = 0; i < node.Children.Count; i++)
 		{
-			ResolveNode(child, styleSheets, keyframes, localStyle, dictionary, isRoot: false);
+			ResolveNode(node.Children[i], styleSheets, keyframes, localStyle, variables, isRoot: false);
 		}
+	}
+
+	private Dictionary<string, string> RentVariableFrame(Dictionary<string, string> parent)
+	{
+		Dictionary<string, string> frame = _variableFramePool.Count > 0
+			? _variableFramePool[_variableFramePool.Count - 1]
+			: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		if (_variableFramePool.Count > 0)
+		{
+			_variableFramePool.RemoveAt(_variableFramePool.Count - 1);
+		}
+		frame.Clear();
+		foreach (KeyValuePair<string, string> item in parent)
+		{
+			frame[item.Key] = item.Value;
+		}
+		_variableFramesRented.Add(frame);
+		return frame;
+	}
+
+	private void ReleaseVariableFrames()
+	{
+		for (int i = 0; i < _variableFramesRented.Count; i++)
+		{
+			Dictionary<string, string> frame = _variableFramesRented[i];
+			frame.Clear();
+			_variableFramePool.Add(frame);
+		}
+		_variableFramesRented.Clear();
+	}
+
+	private static bool HasCustomProperties(UiStyleDeclaration declaration)
+	{
+		Dictionary<string, string>.Enumerator enumerator = declaration.EnumerateValues();
+		while (enumerator.MoveNext())
+		{
+			if (enumerator.Current.Key.StartsWith("--", StringComparison.Ordinal))
+			{
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private static IReadOnlyDictionary<string, UiKeyframeDefinition> BuildKeyframeIndex(IReadOnlyList<UiStyleSheet> styleSheets)
@@ -208,8 +272,10 @@ public sealed class UiStyleResolver
 
 	private static void ApplyCustomProperties(UiStyleDeclaration declaration, IDictionary<string, string> variables)
 	{
-		foreach (KeyValuePair<string, string> item in declaration)
+		Dictionary<string, string>.Enumerator enumerator = declaration.EnumerateValues();
+		while (enumerator.MoveNext())
 		{
+			KeyValuePair<string, string> item = enumerator.Current;
 			if (item.Key.StartsWith("--", StringComparison.Ordinal))
 			{
 				variables[item.Key] = ResolveValue(item.Value, (IReadOnlyDictionary<string, string>)variables);
@@ -217,18 +283,18 @@ public sealed class UiStyleResolver
 		}
 	}
 
-	private static UiStyle ApplyUserAgentTagDefaults(UiNode node, UiStyle style, UiStyleDeclaration declaration)
+	private static void ApplyUserAgentTagDefaults(UiNode node, UiStyleBuilder style, UiStyleDeclaration declaration)
 	{
 		string tag = node.TagName ?? string.Empty;
 		if (tag.Equals("strong", StringComparison.OrdinalIgnoreCase) || tag.Equals("b", StringComparison.OrdinalIgnoreCase))
 		{
 			if (!HasExplicitValue(declaration, "display"))
 			{
-				style = style with { Display = UiDisplay.Inline };
+				style.Display = UiDisplay.Inline;
 			}
 			if (!HasExplicitValue(declaration, "font-weight"))
 			{
-				style = style with { Bold = true };
+				style.Bold = true;
 			}
 		}
 		else if (tag.Equals("em", StringComparison.OrdinalIgnoreCase) ||
@@ -238,7 +304,7 @@ public sealed class UiStyleResolver
 		{
 			if (!HasExplicitValue(declaration, "display"))
 			{
-				style = style with { Display = UiDisplay.Inline };
+				style.Display = UiDisplay.Inline;
 			}
 		}
 		else if (tag.Equals("p", StringComparison.OrdinalIgnoreCase) ||
@@ -251,76 +317,53 @@ public sealed class UiStyleResolver
 		{
 			if (!HasExplicitValue(declaration, "display"))
 			{
-				style = style with { Display = UiDisplay.Block };
+				style.Display = UiDisplay.Block;
 			}
 		}
 		else if (tag.Equals("img", StringComparison.OrdinalIgnoreCase))
 		{
 			if (!HasExplicitValue(declaration, "display"))
 			{
-				style = style with { Display = UiDisplay.Inline };
+				style.Display = UiDisplay.Inline;
 			}
 		}
-		return style;
 	}
 
-	private static UiStyle ApplyInheritance(UiNode node, UiStyle style, UiStyle? parentStyle, UiStyleDeclaration declaration)
+	private static void ApplyInheritance(UiNode node, UiStyleBuilder style, UiStyle? parentStyle, UiStyleDeclaration declaration)
 	{
 		if (parentStyle == null)
 		{
-			return style;
+			return;
 		}
 		UiStyle implicitStyle = GetImplicitStyle(node.Kind);
 		if (!HasExplicitValue(declaration, "color") && style.Color == implicitStyle.Color)
 		{
-			style = style with
-			{
-				Color = parentStyle.Color
-			};
+			style.Color = parentStyle.Color;
 		}
 		if (!HasExplicitValue(declaration, "font-size") && Math.Abs(style.FontSize - implicitStyle.FontSize) < 0.01f)
 		{
-			style = style with
-			{
-				FontSize = parentStyle.FontSize
-			};
+			style.FontSize = parentStyle.FontSize;
 		}
 		if (!HasExplicitValue(declaration, "font-weight") && style.Bold == implicitStyle.Bold)
 		{
-			style = style with
-			{
-				Bold = parentStyle.Bold
-			};
+			style.Bold = parentStyle.Bold;
 		}
 		if (!HasExplicitValue(declaration, "font-family") && string.Equals(style.FontFamily, implicitStyle.FontFamily, StringComparison.Ordinal))
 		{
-			style = style with
-			{
-				FontFamily = parentStyle.FontFamily
-			};
+			style.FontFamily = parentStyle.FontFamily;
 		}
 		if (!HasExplicitValue(declaration, "white-space") && style.WhiteSpace == implicitStyle.WhiteSpace)
 		{
-			style = style with
-			{
-				WhiteSpace = parentStyle.WhiteSpace
-			};
+			style.WhiteSpace = parentStyle.WhiteSpace;
 		}
 		if (!HasExplicitValue(declaration, "direction") && style.Direction == implicitStyle.Direction)
 		{
-			style = style with
-			{
-				Direction = parentStyle.Direction
-			};
+			style.Direction = parentStyle.Direction;
 		}
 		if (!HasExplicitValue(declaration, "text-align") && style.TextAlign == implicitStyle.TextAlign)
 		{
-			style = style with
-			{
-				TextAlign = parentStyle.TextAlign
-			};
+			style.TextAlign = parentStyle.TextAlign;
 		}
-		return style;
 	}
 
 	private static bool HasExplicitValue(UiStyleDeclaration declaration, string propertyName)
@@ -328,11 +371,31 @@ public sealed class UiStyleResolver
 		return declaration[propertyName] != null;
 	}
 
+	private static readonly UiStyle[] ImplicitStylesByKind = CreateImplicitStylesByKind();
+
+	private static UiStyle[] CreateImplicitStylesByKind()
+	{
+		int count = Enum.GetValues<UiNodeKind>().Length;
+		UiStyle[] styles = new UiStyle[count];
+		for (int i = 0; i < count; i++)
+		{
+			styles[i] = CreateImplicitStyle((UiNodeKind)i);
+		}
+		return styles;
+	}
+
 	private static UiStyle GetImplicitStyle(UiNodeKind kind)
 	{
-		if (1 == 0)
+		int index = (int)kind;
+		if ((uint)index < (uint)ImplicitStylesByKind.Length)
 		{
+			return ImplicitStylesByKind[index];
 		}
+		return UiStyle.Default;
+	}
+
+	private static UiStyle CreateImplicitStyle(UiNodeKind kind)
+	{
 		UiStyle result;
 		switch (kind)
 		{
@@ -442,23 +505,21 @@ public sealed class UiStyleResolver
 			result = UiStyle.Default;
 			break;
 		}
-		if (1 == 0)
-		{
-		}
 		return result;
 	}
 
-	private static UiStyle ApplyDeclaration(UiStyle style, UiStyleDeclaration declaration, IReadOnlyDictionary<string, string> variables)
+	private static void ApplyDeclaration(UiStyleBuilder style, UiStyleDeclaration declaration, IReadOnlyDictionary<string, string> variables)
 	{
-		foreach (KeyValuePair<string, string> item in declaration)
+		Dictionary<string, string>.Enumerator enumerator = declaration.EnumerateValues();
+		while (enumerator.MoveNext())
 		{
+			KeyValuePair<string, string> item = enumerator.Current;
 			if (!item.Key.StartsWith("--", StringComparison.Ordinal))
 			{
 				string rawValue = ResolveValue(item.Value, variables);
-				style = ApplyProperty(style, item.Key, rawValue);
+				ApplyProperty(style, item.Key, rawValue);
 			}
 		}
-		return style;
 	}
 
 	private static string ResolveValue(string rawValue, IReadOnlyDictionary<string, string> variables, int depth = 0)
@@ -551,526 +612,542 @@ public sealed class UiStyleResolver
 
 	internal static UiStyle ApplyProperty(UiStyle style, string propertyName, string rawValue)
 	{
+		UiStyleBuilder builder = new UiStyleBuilder();
+		builder.CopyFrom(style);
+		ApplyProperty(builder, propertyName, rawValue);
+		return builder.ToStyle();
+	}
+
+	internal static void ApplyProperty(UiStyleBuilder builder, string propertyName, string rawValue)
+	{
 		string text = rawValue.Trim();
 		switch (propertyName.Trim().ToLowerInvariant())
 		{
 		case "display":
-			return style with
-			{
-				Display = ParseDisplay(text)
-			};
+			builder.Display = ParseDisplay(text);
+			return;
 		case "flex-direction":
-			return style with
-			{
-				FlexDirection = ParseFlexDirection(text)
-			};
+			builder.FlexDirection = ParseFlexDirection(text);
+			return;
 		case "justify-content":
-			return style with
-			{
-				JustifyContent = ParseJustifyContent(text)
-			};
+			builder.JustifyContent = ParseJustifyContent(text);
+			return;
 		case "align-items":
-			return style with
-			{
-				AlignItems = ParseAlignItems(text)
-			};
+			builder.AlignItems = ParseAlignItems(text);
+			return;
 		case "align-content":
-			return style with
-			{
-				AlignContent = ParseAlignContent(text)
-			};
+			builder.AlignContent = ParseAlignContent(text);
+			return;
 		case "flex-wrap":
-			return style with
-			{
-				FlexWrap = ParseFlexWrap(text)
-			};
+			builder.FlexWrap = ParseFlexWrap(text);
+			return;
 		case "position":
-			return style with
-			{
-				PositionType = ParsePositionType(text)
-			};
+			builder.PositionType = ParsePositionType(text);
+			return;
 		case "left":
 		{
 			UiLength length;
-			return TryParseLength(text, out length) ? style with
+			if (TryParseLength(text, out length))
 			{
-				Left = length
-			} : style;
+				builder.Left = length;
+			}
+			return;
 		}
 		case "top":
 		{
 			UiLength length2;
-			return TryParseLength(text, out length2) ? style with
+			if (TryParseLength(text, out length2))
 			{
-				Top = length2
-			} : style;
+				builder.Top = length2;
+			}
+			return;
 		}
 		case "right":
 		{
 			UiLength length4;
-			return TryParseLength(text, out length4) ? style with
+			if (TryParseLength(text, out length4))
 			{
-				Right = length4
-			} : style;
+				builder.Right = length4;
+			}
+			return;
 		}
 		case "bottom":
 		{
 			UiLength length10;
-			return TryParseLength(text, out length10) ? style with
+			if (TryParseLength(text, out length10))
 			{
-				Bottom = length10
-			} : style;
+				builder.Bottom = length10;
+			}
+			return;
 		}
 		case "width":
 		{
 			UiLength length9;
-			return TryParseLength(text, out length9) ? style with
+			if (TryParseLength(text, out length9))
 			{
-				Width = length9
-			} : style;
+				builder.Width = length9;
+			}
+			return;
 		}
 		case "height":
 		{
 			UiLength length6;
-			return TryParseLength(text, out length6) ? style with
+			if (TryParseLength(text, out length6))
 			{
-				Height = length6
-			} : style;
+				builder.Height = length6;
+			}
+			return;
 		}
 		case "min-width":
 		{
 			UiLength length3;
-			return TryParseLength(text, out length3) ? style with
+			if (TryParseLength(text, out length3))
 			{
-				MinWidth = length3
-			} : style;
+				builder.MinWidth = length3;
+			}
+			return;
 		}
 		case "min-height":
 		{
 			UiLength length11;
-			return TryParseLength(text, out length11) ? style with
+			if (TryParseLength(text, out length11))
 			{
-				MinHeight = length11
-			} : style;
+				builder.MinHeight = length11;
+			}
+			return;
 		}
 		case "max-width":
 		{
 			UiLength length8;
-			return TryParseLength(text, out length8) ? style with
+			if (TryParseLength(text, out length8))
 			{
-				MaxWidth = length8
-			} : style;
+				builder.MaxWidth = length8;
+			}
+			return;
 		}
 		case "max-height":
 		{
 			UiLength length7;
-			return TryParseLength(text, out length7) ? style with
+			if (TryParseLength(text, out length7))
 			{
-				MaxHeight = length7
-			} : style;
+				builder.MaxHeight = length7;
+			}
+			return;
 		}
 		case "flex-basis":
 		{
 			UiLength length5;
-			return TryParseLength(text, out length5) ? style with
+			if (TryParseLength(text, out length5))
 			{
-				FlexBasis = length5
-			} : style;
+				builder.FlexBasis = length5;
+			}
+			return;
 		}
 		case "flex-grow":
 		{
 			float parsed;
-			return TryParseFloat(text, out parsed) ? style with
+			if (TryParseFloat(text, out parsed))
 			{
-				FlexGrow = parsed
-			} : style;
+				builder.FlexGrow = parsed;
+			}
+			return;
 		}
 		case "flex-shrink":
 		{
 			float parsed2;
-			return TryParseFloat(text, out parsed2) ? style with
+			if (TryParseFloat(text, out parsed2))
 			{
-				FlexShrink = parsed2
-			} : style;
+				builder.FlexShrink = parsed2;
+			}
+			return;
 		}
 		case "gap":
 		{
 			float gap;
 			float rowGap;
 			float columnGap;
-			return TryParseGap(text, out gap, out rowGap, out columnGap) ? style with
+			if (TryParseGap(text, out gap, out rowGap, out columnGap))
 			{
-				Gap = gap,
-				RowGap = rowGap,
-				ColumnGap = columnGap
-			} : style;
+				builder.Gap = gap;
+				builder.RowGap = rowGap;
+				builder.ColumnGap = columnGap;
+			}
+			return;
 		}
 		case "row-gap":
 		{
 			float parsed6;
-			return TryParseFloat(text, out parsed6) ? style with
+			if (TryParseFloat(text, out parsed6))
 			{
-				RowGap = parsed6
-			} : style;
+				builder.RowGap = parsed6;
+			}
+			return;
 		}
 		case "column-gap":
 		{
 			float parsed4;
-			return TryParseFloat(text, out parsed4) ? style with
+			if (TryParseFloat(text, out parsed4))
 			{
-				ColumnGap = parsed4
-			} : style;
+				builder.ColumnGap = parsed4;
+			}
+			return;
 		}
 		case "margin":
 		{
 			UiThickness thickness3;
-			return TryParseThickness(text, out thickness3) ? style with
+			if (TryParseThickness(text, out thickness3))
 			{
-				Margin = thickness3
-			} : style;
+				builder.Margin = thickness3;
+			}
+			return;
 		}
 		case "padding":
 		{
 			UiThickness thickness;
-			return TryParseThickness(text, out thickness) ? style with
+			if (TryParseThickness(text, out thickness))
 			{
-				Padding = thickness
-			} : style;
+				builder.Padding = thickness;
+			}
+			return;
 		}
 		case "border-width":
 		{
 			float parsed9;
-			return TryParseFloat(text, out parsed9) ? style with
+			if (TryParseFloat(text, out parsed9))
 			{
-				BorderWidth = parsed9
-			} : style;
+				builder.BorderWidth = parsed9;
+			}
+			return;
 		}
 		case "border-radius":
 		{
 			float parsed8;
-			return TryParseFloat(text, out parsed8) ? style with
+			if (TryParseFloat(text, out parsed8))
 			{
-				BorderRadius = parsed8
-			} : style;
+				builder.BorderRadius = parsed8;
+			}
+			return;
 		}
 		case "border-style":
-			return style with
-			{
-				BorderStyle = ParseBorderStyle(text)
-			};
+			builder.BorderStyle = ParseBorderStyle(text);
+			return;
 		case "z-index":
 		{
 			int result;
-			return int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out result) ? style with
+			if (int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out result))
 			{
-				ZIndex = result
-			} : style;
+				builder.ZIndex = result;
+			}
+			return;
 		}
 		case "background":
 		{
 			if (TryParseBackgroundLayers(text, out IReadOnlyList<UiBackgroundLayer> layers))
 			{
-				return style with
-				{
-					BackgroundLayers = layers,
-					BackgroundGradient = layers.Select((UiBackgroundLayer layer) => layer.Gradient).FirstOrDefault((UiLinearGradient uiLinearGradient) => uiLinearGradient != null),
-					BackgroundColor = ((layers.Count == 1 && layers[0].Gradient == null) ? layers[0].Color : style.BackgroundColor)
-				};
+				builder.BackgroundLayers = layers;
+			builder.BackgroundGradient = layers.Select((UiBackgroundLayer layer) => layer.Gradient).FirstOrDefault((UiLinearGradient uiLinearGradient) => uiLinearGradient != null);
+			builder.BackgroundColor = ((layers.Count == 1 && layers[0].Gradient == null) ? layers[0].Color : builder.BackgroundColor);
+			return;
 			}
 			UiColor color3;
-			return TryParseColor(text, out color3) ? style with
+			if (TryParseColor(text, out color3))
 			{
-				BackgroundColor = color3,
-				BackgroundLayers = Array.Empty<UiBackgroundLayer>(),
-				BackgroundGradient = null
-			} : style;
+				builder.BackgroundColor = color3;
+				builder.BackgroundLayers = Array.Empty<UiBackgroundLayer>();
+				builder.BackgroundGradient = null;
+			}
+			return;
 		}
 		case "background-color":
 		{
 			UiColor color;
-			return TryParseColor(text, out color) ? style with
+			if (TryParseColor(text, out color))
 			{
-				BackgroundColor = color
-			} : style;
+				builder.BackgroundColor = color;
+			}
+			return;
 		}
 		case "background-image":
 		{
 			IReadOnlyList<UiBackgroundLayer> layers2;
-			return TryParseBackgroundLayers(text, out layers2) ? style with
+			if (TryParseBackgroundLayers(text, out layers2))
 			{
-				BackgroundLayers = layers2,
-				BackgroundGradient = layers2.Select((UiBackgroundLayer layer) => layer.Gradient).FirstOrDefault((UiLinearGradient uiLinearGradient) => uiLinearGradient != null)
-			} : style;
+				builder.BackgroundLayers = layers2;
+				builder.BackgroundGradient = layers2.Select((UiBackgroundLayer layer) => layer.Gradient).FirstOrDefault((UiLinearGradient uiLinearGradient) => uiLinearGradient != null);
+			}
+			return;
 		}
 		case "background-size":
 		{
 			IReadOnlyList<UiBackgroundSize> sizes;
-			return TryParseBackgroundSizeList(text, out sizes) ? style with
+			if (TryParseBackgroundSizeList(text, out sizes))
 			{
-				BackgroundSizes = sizes
-			} : style;
+				builder.BackgroundSizes = sizes;
+			}
+			return;
 		}
 		case "background-position":
 		{
 			IReadOnlyList<UiBackgroundPosition> positions;
-			return TryParseBackgroundPositionList(text, out positions) ? style with
+			if (TryParseBackgroundPositionList(text, out positions))
 			{
-				BackgroundPositions = positions
-			} : style;
+				builder.BackgroundPositions = positions;
+			}
+			return;
 		}
 		case "background-repeat":
 		{
 			IReadOnlyList<UiBackgroundRepeat> repeats;
-			return TryParseBackgroundRepeatList(text, out repeats) ? style with
+			if (TryParseBackgroundRepeatList(text, out repeats))
 			{
-				BackgroundRepeats = repeats
-			} : style;
+				builder.BackgroundRepeats = repeats;
+			}
+			return;
 		}
 		case "border-color":
 		{
 			UiColor color4;
-			return TryParseColor(text, out color4) ? style with
+			if (TryParseColor(text, out color4))
 			{
-				BorderColor = color4
-			} : style;
+				builder.BorderColor = color4;
+			}
+			return;
 		}
 		case "outline":
 		{
 			float outlineWidth;
 			UiColor outlineColor;
-			return TryParseOutline(text, style.Color, out outlineWidth, out outlineColor) ? style with
+			if (TryParseOutline(text, builder.Color, out outlineWidth, out outlineColor))
 			{
-				OutlineWidth = outlineWidth,
-				OutlineColor = outlineColor
-			} : style;
+				builder.OutlineWidth = outlineWidth;
+				builder.OutlineColor = outlineColor;
+			}
+			return;
 		}
 		case "outline-width":
 		{
 			float parsed5;
-			return TryParseFloat(text, out parsed5) ? style with
+			if (TryParseFloat(text, out parsed5))
 			{
-				OutlineWidth = parsed5
-			} : style;
+				builder.OutlineWidth = parsed5;
+			}
+			return;
 		}
 		case "outline-color":
 		{
 			UiColor color2;
-			return TryParseColor(text, out color2) ? style with
+			if (TryParseColor(text, out color2))
 			{
-				OutlineColor = color2
-			} : style;
+				builder.OutlineColor = color2;
+			}
+			return;
 		}
 		case "box-shadow":
 		{
 			IReadOnlyList<UiShadow> shadows;
-			return TryParseShadowList(text, out shadows) ? style with
+			if (TryParseShadowList(text, out shadows))
 			{
-				BoxShadow = shadows[0],
-				BoxShadows = shadows
-			} : style;
+				builder.BoxShadow = shadows[0];
+				builder.BoxShadows = shadows;
+			}
+			return;
 		}
 		case "filter":
 		{
 			float blurRadius;
-			return TryParseBlurFunction(text, out blurRadius) ? style with
+			if (TryParseBlurFunction(text, out blurRadius))
 			{
-				FilterBlurRadius = blurRadius
-			} : style;
+				builder.FilterBlurRadius = blurRadius;
+			}
+			return;
 		}
 		case "backdrop-filter":
 		{
 			float blurRadius2;
-			return TryParseBlurFunction(text, out blurRadius2) ? style with
+			if (TryParseBlurFunction(text, out blurRadius2))
 			{
-				BackdropBlurRadius = blurRadius2
-			} : style;
+				builder.BackdropBlurRadius = blurRadius2;
+			}
+			return;
 		}
 		case "mask":
 		case "mask-image":
 		{
 			UiLinearGradient gradient;
-			return TryParseMaskGradient(text, out gradient) ? style with
+			if (TryParseMaskGradient(text, out gradient))
 			{
-				MaskGradient = gradient
-			} : style;
+				builder.MaskGradient = gradient;
+			}
+			return;
 		}
 		case "clip-path":
 		{
 			UiClipPath clipPath;
-			return TryParseClipPath(text, out clipPath) ? style with
+			if (TryParseClipPath(text, out clipPath))
 			{
-				ClipPath = clipPath
-			} : style;
+				builder.ClipPath = clipPath;
+			}
+			return;
 		}
 		case "text-shadow":
 		{
 			UiShadow shadow;
-			return TryParseShadow(text, out shadow) ? style with
+			if (TryParseShadow(text, out shadow))
 			{
-				TextShadow = shadow
-			} : style;
+				builder.TextShadow = shadow;
+			}
+			return;
 		}
 		case "color":
 		{
 			UiColor color5;
-			return TryParseColor(text, out color5) ? style with
+			if (TryParseColor(text, out color5))
 			{
-				Color = color5
-			} : style;
+				builder.Color = color5;
+			}
+			return;
 		}
 		case "font-size":
 		{
 			float parsed7;
-			return TryParseFloat(text, out parsed7) ? style with
+			if (TryParseFloat(text, out parsed7))
 			{
-				FontSize = parsed7
-			} : style;
+				builder.FontSize = parsed7;
+			}
+			return;
 		}
 		case "font-family":
-			return style with
-			{
-				FontFamily = ParseFontFamily(text)
-			};
+			builder.FontFamily = ParseFontFamily(text);
+			return;
 		case "font-weight":
-			return style with
-			{
-				Bold = IsBold(text)
-			};
+			builder.Bold = IsBold(text);
+			return;
 		case "white-space":
-			return style with
-			{
-				WhiteSpace = ParseWhiteSpace(text)
-			};
+			builder.WhiteSpace = ParseWhiteSpace(text);
+			return;
 		case "direction":
-			return style with
-			{
-				Direction = ParseTextDirection(text)
-			};
+			builder.Direction = ParseTextDirection(text);
+			return;
 		case "text-align":
-			return style with
-			{
-				TextAlign = ParseTextAlign(text)
-			};
+			builder.TextAlign = ParseTextAlign(text);
+			return;
 		case "text-decoration":
 		case "text-decoration-line":
-			return style with
-			{
-				TextDecorationLine = ParseTextDecorationLine(text)
-			};
+			builder.TextDecorationLine = ParseTextDecorationLine(text);
+			return;
 		case "text-overflow":
-			return style with
-			{
-				TextOverflow = ParseTextOverflow(text)
-			};
+			builder.TextOverflow = ParseTextOverflow(text);
+			return;
 		case "object-fit":
-			return style with
-			{
-				ObjectFit = ParseObjectFit(text)
-			};
+			builder.ObjectFit = ParseObjectFit(text);
+			return;
 		case "image-slice":
 		case "nine-slice":
 		case "border-image-slice":
 		{
 			UiThickness thickness2;
-			return TryParseThickness(text, out thickness2) ? style with
+			if (TryParseThickness(text, out thickness2))
 			{
-				ImageSlice = thickness2
-			} : style;
+				builder.ImageSlice = thickness2;
+			}
+			return;
 		}
 		case "transform":
 		{
 			UiTransform transform;
-			return TryParseTransform(text, out transform) ? style with
+			if (TryParseTransform(text, out transform))
 			{
-				Transform = (transform ?? UiTransform.Identity)
-			} : style;
+				builder.Transform = (transform ?? UiTransform.Identity);
+			}
+			return;
 		}
 		case "animation":
 		{
 			UiAnimationSpec animation;
-			return TryParseAnimationSpec(text, out animation) ? style with
+			if (TryParseAnimationSpec(text, out animation))
 			{
-				Animation = animation
-			} : style;
+				builder.Animation = animation;
+			}
+			return;
 		}
 		case "transition":
 		{
 			UiTransitionSpec transition;
-			return TryParseTransitionSpec(text, out transition) ? style with
+			if (TryParseTransitionSpec(text, out transition))
 			{
-				Transition = transition
-			} : style;
+				builder.Transition = transition;
+			}
+			return;
 		}
 		case "opacity":
 		{
 			float parsed3;
-			return TryParseFloat(text, out parsed3) ? style with
+			if (TryParseFloat(text, out parsed3))
 			{
-				Opacity = Math.Clamp(parsed3, 0f, 1f)
-			} : style;
+				builder.Opacity = Math.Clamp(parsed3, 0f, 1f);
+			}
+			return;
 		}
 		case "visibility":
-			return style with
-			{
-				Visible = !string.Equals(text, "hidden", StringComparison.OrdinalIgnoreCase)
-			};
+			builder.Visible = !string.Equals(text, "hidden", StringComparison.OrdinalIgnoreCase);
+			return;
 		case "pointer-events":
-			return style with
-			{
-				PointerEvents = ParsePointerEvents(text)
-			};
+			builder.PointerEvents = ParsePointerEvents(text);
+			return;
 		case "overflow":
 		{
 			UiOverflow uiOverflow = ParseOverflow(text);
-			UiStyle uiStyle = style with
-			{
-				Overflow = uiOverflow
-			};
-			UiStyle uiStyle2 = uiStyle;
-			bool clipContent = ((uiOverflow == UiOverflow.Hidden || uiOverflow == UiOverflow.Clip) ? true : false);
-			uiStyle2.ClipContent = clipContent;
-			return uiStyle;
+			builder.Overflow = uiOverflow;
+			builder.ClipContent = uiOverflow == UiOverflow.Hidden || uiOverflow == UiOverflow.Clip;
+			return;
 		}
 		case "clip-content":
 		case "overflow-clip":
 		{
 			bool flag = ParseBoolean(text);
-			return style with
-			{
-				ClipContent = flag,
-				Overflow = (flag ? UiOverflow.Clip : style.Overflow)
-			};
+			builder.ClipContent = flag;
+			builder.Overflow = (flag ? UiOverflow.Clip : builder.Overflow);
+			return;
 		}
 		case "grid-template-columns":
 		{
-			return TryParseGridTemplate(text, out IReadOnlyList<UiGridTrack> columns)
-				? style with { GridTemplateColumns = columns }
-				: style;
+			if (TryParseGridTemplate(text, out IReadOnlyList<UiGridTrack> columns))
+			{
+				builder.GridTemplateColumns = columns;
+			}
+			return;
 		}
 		case "grid-template-rows":
 		{
-			return TryParseGridTemplate(text, out IReadOnlyList<UiGridTrack> rows)
-				? style with { GridTemplateRows = rows }
-				: style;
+			if (TryParseGridTemplate(text, out IReadOnlyList<UiGridTrack> rows))
+			{
+				builder.GridTemplateRows = rows;
+			}
+			return;
 		}
 		case "grid-auto-flow":
-			return style with { GridAutoFlow = ParseGridAutoFlow(text) };
+			builder.GridAutoFlow = ParseGridAutoFlow(text);
+			return;
 		case "grid-column":
 		{
-			return TryParseGridPlacement(text, out UiGridPlacement placement)
-				? style with { GridColumn = placement }
-				: style;
+			if (TryParseGridPlacement(text, out UiGridPlacement placement))
+			{
+				builder.GridColumn = placement;
+			}
+			return;
 		}
 		case "grid-row":
 		{
-			return TryParseGridPlacement(text, out UiGridPlacement placement)
-				? style with { GridRow = placement }
-				: style;
+			if (TryParseGridPlacement(text, out UiGridPlacement placement))
+			{
+				builder.GridRow = placement;
+			}
+			return;
 		}
 		case "float":
-			return style;
+			return;
 		default:
-			return style;
+			return;
 		}
 	}
 

--- a/src/Tests/UiShowcaseTests/UiLayoutAllocationTests.cs
+++ b/src/Tests/UiShowcaseTests/UiLayoutAllocationTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using Ludots.UI.HtmlEngine.Markup;
+using Ludots.UI.Runtime;
+using NUnit.Framework;
+
+namespace Ludots.Tests.UiShowcase;
+
+[TestFixture]
+public sealed class UiLayoutAllocationTests
+{
+	[Test]
+	public void UiLayout_ResizeOnly_AfterWarmup_StaysUnderAllocationBudget()
+	{
+		UiScene scene = BuildHundredNodeFlexScene();
+		WarmupLayout(scene);
+
+		long before = GC.GetAllocatedBytesForCurrentThread();
+		for (int i = 0; i < 20; i++)
+		{
+			scene.Layout(1280f + i, 720f + i);
+		}
+		long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+		Assert.That(allocated, Is.LessThan(4 * 1024),
+			$"resize-only layout allocated {allocated} bytes over 20 passes; flex nodes and scratch must be reused");
+	}
+
+	[Test]
+	public void UiGrid_ResizeOnly_AfterWarmup_StaysUnderAllocationBudget()
+	{
+		UiScene scene = BuildHundredNodeGridScene();
+		WarmupLayout(scene);
+
+		long before = GC.GetAllocatedBytesForCurrentThread();
+		for (int i = 0; i < 20; i++)
+		{
+			scene.Layout(1280f + i, 720f + i);
+		}
+		long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+		Assert.That(allocated, Is.LessThan(4 * 1024),
+			$"grid resize-only layout allocated {allocated} bytes over 20 passes");
+	}
+
+	[Test]
+	public void UiStyleResolve_DirtyRelayout_UsesPooledMatchBuffers()
+	{
+		const string html = """
+			<div class="root">
+			  <div class="item">A</div>
+			  <div class="item">B</div>
+			  <div class="item">C</div>
+			</div>
+			""";
+		const string css = """
+			.root { display: flex; flex-direction: column; width: 200px; height: 200px; }
+			.item { height: 20px; color: #fff; }
+			.item:hover { color: #0f0; }
+			""";
+		UiScene scene = new UiMarkupLoader().LoadScene(new ConstantTextMeasurer(), new ConstantImageSizeProvider(), html, css);
+		scene.Layout(800f, 600f);
+		UiStyleSheet[] sheets = scene.Document!.StyleSheets.ToArray();
+
+		long before = GC.GetAllocatedBytesForCurrentThread();
+		for (int i = 0; i < 30; i++)
+		{
+			scene.SetStyleSheets(sheets);
+			scene.Layout(800f, 600f);
+		}
+		long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+		Assert.That(allocated, Is.LessThan(512 * 1024),
+			$"dirty resolve+layout allocated {allocated} bytes over 30 passes; match/cascade buffers should be pooled");
+	}
+
+	private static void WarmupLayout(UiScene scene)
+	{
+		for (int i = 0; i < 5; i++)
+		{
+			scene.Layout(1280f + i, 720f + i);
+		}
+		GC.Collect();
+		GC.WaitForPendingFinalizers();
+		GC.Collect();
+	}
+
+	private static UiScene BuildHundredNodeFlexScene()
+	{
+		List<UiNode> children = new List<UiNode>(100);
+		for (int i = 0; i < 100; i++)
+		{
+			children.Add(new UiNode(
+				new UiNodeId(i + 2),
+				UiNodeKind.Container,
+				UiStyle.Default with { Width = UiLength.Px(10f), Height = UiLength.Px(10f) },
+				i.ToString(),
+				tagName: "div"));
+		}
+		UiNode root = new UiNode(
+			new UiNodeId(1),
+			UiNodeKind.Container,
+			UiStyle.Default with
+			{
+				Display = UiDisplay.Flex,
+				FlexDirection = UiFlexDirection.Row,
+				FlexWrap = UiFlexWrap.Wrap,
+				Width = UiLength.Px(1000f),
+				Height = UiLength.Px(1000f),
+				Gap = 2f
+			},
+			null,
+			children,
+			tagName: "div",
+			elementId: "root");
+		UiScene scene = new UiScene(new ConstantTextMeasurer(), new ConstantImageSizeProvider());
+		scene.Mount(root);
+		return scene;
+	}
+
+	private static UiScene BuildHundredNodeGridScene()
+	{
+		UiGridTrack[] columns = new UiGridTrack[10];
+		for (int i = 0; i < columns.Length; i++)
+		{
+			columns[i] = UiGridTrack.Fr(1f);
+		}
+		List<UiNode> cells = new List<UiNode>(100);
+		for (int i = 0; i < 100; i++)
+		{
+			cells.Add(new UiNode(
+				new UiNodeId(i + 2),
+				UiNodeKind.Container,
+				UiStyle.Default with { Width = UiLength.Px(10f), Height = UiLength.Px(10f) },
+				i.ToString(),
+				tagName: "div"));
+		}
+		UiNode grid = new UiNode(
+			new UiNodeId(1),
+			UiNodeKind.Container,
+			UiStyle.Default with
+			{
+				Display = UiDisplay.Grid,
+				GridTemplateColumns = columns,
+				Width = UiLength.Px(1000f),
+				Height = UiLength.Px(1000f),
+				Gap = 2f
+			},
+			null,
+			cells,
+			tagName: "div",
+			elementId: "grid");
+		UiScene scene = new UiScene(new ConstantTextMeasurer(), new ConstantImageSizeProvider());
+		scene.Mount(grid);
+		return scene;
+	}
+
+	private sealed class ConstantTextMeasurer : IUiTextMeasurer
+	{
+		public UiTextLayoutResult Measure(string? text, UiStyle style, float availableWidth, bool constrainWidth)
+		{
+			float width = (text?.Length ?? 0) * style.FontSize * 0.5f;
+			float lineHeight = style.FontSize * 1.4f;
+			return new UiTextLayoutResult(new[] { text ?? string.Empty }, width, lineHeight, lineHeight, style.FontSize, Math.Max(0f, lineHeight - style.FontSize));
+		}
+
+		public float MeasureWidth(string? text, UiStyle style) => (text?.Length ?? 0) * style.FontSize * 0.5f;
+	}
+
+	private sealed class ConstantImageSizeProvider : IUiImageSizeProvider
+	{
+		public bool TryGetSize(string? source, out float width, out float height)
+		{
+			width = 16f;
+			height = 16f;
+			return true;
+		}
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
把 Ludots UI 的布局/样式热路径从「每帧重建」推进到可复用的零分配架构，而不是功能层面的 MVP 拼装。

- **Flex 节点池**：`UiFlexNodePool` + `Flex.ResetInPlace`，布局不再每帧 `new Node`
- **布局 scratch**：Grid / IFC / deferred `calc` 共用可清空缓冲；`MeasureFunc` 缓存并通过 `Node.Context` 回挂 `UiNode`
- **样式级联**：`UiStyleBuilder` 就地写属性；匹配列表 / cascade declaration / CSS 变量帧池化；有效样式表缓存
- **表格路径**：去掉 `OrderBy`/`Where`/`ToDictionary` 等热路径 LINQ
- **回归**：`UiLayoutAllocationTests` 锁定 resize-only ≈ 640B/20 次、dirty resolve 有预算上限

## 验证
- `dotnet test src/Tests/UiShowcaseTests/UiShowcaseTests.csproj` → **66/66 passed**

## 叠栈说明
基于 #849（伪元素 + Grid + IFC）。合并顺序：#847 → #849 → 本 PR。

## 已知后续（本 PR 未假装做完）
- 子树级 dirty（hover 不必全树 resolve）
- 真正持久化 Flex 镜像树（跨帧零重建，而不只是池化）
- 动画通道里 `ApplyProperty(UiStyle)` 包装仍会临时建 builder
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ae6b725-472c-4613-afa5-cff2488928e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ae6b725-472c-4613-afa5-cff2488928e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

