### PR TITLE
feat(ui): PanelProjectionReader + Tag display lookup ops (#858 UIP-2)

### DIFF
--- a/artifacts/gas-composition-gate.md
+++ b/artifacts/gas-composition-gate.md
@@ -1,54 +1,57 @@
 ﻿## GAS Composition Gate — Self Review
 
-- **Task / Issue**: #848 Graph VM — Query 与 Script 共用 ControlFlow 真引脚 IR；硬拒 Next 链（承载于 PR #859）
+- **Task / Issue**: #858 UIP-2 PanelProjectionReader + GAS L1 SelectTagInMask / LookupTagDisplayToken
 - **Date**: 2026-08-11
-- **Agent / Author**: Cloud Agent
+- **Agent / Author**: cursor cloud agent
 
 ### 1. Core judgment
 
-新变体主要交付物是（A/B/C/D）: A — 既有 graph 节点 / 编译器路径对齐（不新增 op enum）
+新变体主要交付物是（A/B/C/D）: **A**（新 graph 节点 + 既有 Attribute/GraphOutput 读口抽取）
 
-结论: PASS
+结论: **PASS**
 
-一句话理由: 把仓库在用的 Query ops 接到既有 `GraphControlFlowCompiler` 真引脚文档，并与 Script 对称硬拒 Next 链；不新增 profile/preset 开关。
+一句话理由: 面板绑定复用 AttributeBuffer / GraphOutputValueStore；Tag→展示文案补 Layer-0 原子 op + dense 查表，不新增 Presentation GraphKind / profile enum。
 
 ### 2. Layer assignment
 
 | 步骤/能力 | Layer (0/1/2/3) | 实现载体 |
 |-----------|-----------------|----------|
-| L0 指令执行 | 0 | 既有 `GraphInstruction` + `GasGraphOpHandlerTable` |
-| Query 作者文档 | 1 | `GraphControlFlowDocument` + `GraphControlFlowCompiler` |
-| 资产加载 | 2 | `GraphProgramConfigLoader`（CF 检测，拒混写；Query Next 硬拒） |
-| Showcase/测试图 | 3 | Mod `GAS/graphs.json` + GasTests fixtures |
+| PanelProjectionReader | 2（投影读口） | `src/Core/UI/PanelProjection/` |
+| SelectTagInMask | 0 | `GraphNodeOp` + handler |
+| LookupTagDisplayToken | 0 | `GraphNodeOp` + TagDisplayTableRegistry |
+| TagDisplayTable 资产 | 2 配置 | `Presentation/tag_display_tables.json` |
 
 ### 3. Reuse list
 
-- Handlers: 既有 Query/Agg/Relationship handlers（无新 opcode）
-- Queues / Systems: 无
-- Resolvers / Registries: `GraphProgramRegistry`、`GraphOutputSchemaRegistry`、`IGraphSymbolResolver`
-- Existing presets / graphs: fourx / entity_query_tactics / ui_player_aggregate / 相关测试 JSON
+- Handlers: `GasGraphOpHandlerTable`, `GasGraphRuntimeApi.HasTag` Effective 语义
+- Queues / Systems: 无新队列；图仍走 `GraphReturnWriter`
+- Resolvers / Registries: `TagRegistry`, `AttributeRegistry`, `PresentationTextCatalog`, `GraphOutputValueStore`
+- Existing presets / graphs: MVP `ui_player_aggregate_graph_mvp` Summary keys
 
 ### 4. New Layer 0 ops (if any)
 
-N/A
+| Op 名 | 单一职责 | 为何不能组合现有 op |
+|-------|----------|---------------------|
+| SelectTagInMask | 有效 tag ∩ mask → 单一 tagId | HasTag 无法表达互斥族选择/歧义 fail-closed |
+| LookupTagDisplayToken | tagId → presentationTokenId | 无查表 op；禁止 Attribute 假冒文案 |
 
 ### 5. Transaction boundary
 
-必须原子 rollback 的步骤: 无（编译期合同变更；运行时仍为 Query 只读聚合）
+必须原子 rollback 的步骤: **无**（只读 Pure ops + 投影读口）
 
 ### 6. Config SSOT
 
-行为配置落在: graph（`GAS/graphs.json` ControlFlow 文档）
+行为配置落在: graph 连线 + `Presentation/tag_display_tables.json` + 既有 text_tokens/locales
 
-是否新增 JSON schema: NO — 沿用 `controlEdges`/`valueEdges`/`outputs`；节点字段与既有 `GraphNodeConfig` 对齐
+是否新增 JSON schema: **YES** — `tag_display_tables.json`（tag→token 映射；无法用现有 Attribute/BB 表达）
 
 ### 7. Red flag scan
 
 - [x] 未新增 profile inherit/placement enum
 - [x] 未新建与 spawn 平行的物化管线
 - [x] 未把 placement 校验塞进 lifecycle op
-- [x] 未添加「说不清的」默认 fallback（Query Next 链改为硬拒，与 Script 对称）
+- [x] 未添加「说不清的」默认 fallback
 
 ### 8. Next variant test
 
-「下一个 Mod 变体」将修改: graph 连线
+「下一个 Mod 变体」将修改: **graph 连线** / table 行 / locale（不改 Core enum）

--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -16,6 +16,7 @@
   - [Mod 架构](architecture/mod-architecture.md)
   - [GAS 分层架构](architecture/gas-layered-architecture.md)
   - [图分层：Flow / Script 与行为调度](architecture/graph-layering-flow-and-behavior.md)
+  - [Tag → 展示 Token 查表（面板 curState）](architecture/tag-display-lookup.md)
   - [GAS、订单与输入运行时合同](architecture/gas-order-input-runtime-contract.md)
   - [Input Order Routing 与 Spawn Target 基建](architecture/input-order-and-spawn-target.md)
   - [Entity Lifecycle 原子 Op](architecture/entity-lifecycle-atomic-ops.md)

--- a/gitbook/architecture/tag-display-lookup.md
+++ b/gitbook/architecture/tag-display-lookup.md
@@ -1,0 +1,601 @@
+# 读表 / 查表 / 表数据聚合图节点族设计（UI Panel）
+
+## 1. 概述
+
+目标是为 UI Panel 的图作者提供一组严格分层的节点族，覆盖：
+
+```text
+选中实体 -> ReadGameplayTag(State.*) -> LookupTagDisplayText -> Panel.curState
+```
+
+以及更通用的：
+
+```text
+key/tag/entity/template id -> TableLookup -> display text token / 数值 / entity / 多字段摘要
+```
+
+核心结论：
+
+- L0 Graph VM 继续只运行数值、bool、entity、target list；不新增字符串寄存器。
+- Text 进入面板的方式是 `PresentationTextCatalog` token id 进入 `GraphOutputValueStore`，surface/projection 层按 locale 格式化成最终字符串。
+- `ReadGameplayTag` 是新的纯读原子 op；`LookupTagDisplayText` 是作者糖，运行时产物必须命名为 token id。
+- 通用表查询拆成 `ResolveTableRow` + typed field read，支持多字段聚合时复用 row handle，避免每个字段重复查 key。
+- L0 只新增必须的 GraphNodeOp，不新增 `GraphKind.Presentation`、不新增 `GraphNodeOp.Panel`、不把 Attribute 当 Tag/BB/Text/Table 的替身。
+
+对照 #858：本设计复用 `Query/Derived -> GraphOutputValueStore -> Panel binds[]`，服务 Template/Instance/Router，不创建 Presentation Graph VM。  
+对照 #848：复用同一 VM 与 `GraphKind.Query/Derived` 分层，查表 op 归类为 Pure；Query 真引脚/outputs 仍是计算图投影的 SSOT。  
+对照 `gitbook/architecture/ui-panel-authoring-form.md`：作者看见 `ReadGameplayTag`、`LookupTagDisplayText`、Panel Text 引脚；落盘不是 Panel opcode，而是 outputs/bindings。
+
+## 2. 结构
+
+```text
+Mod Config
+  Presentation/text_tokens.json
+  Presentation/text_locales.json
+  GraphTables/tag_display_tables.json
+  GraphTables/lookup_tables.json
+        |
+        v
+ConfigPipeline
+        |
+        +--> PresentationTextCatalog          (既有文案 SSOT)
+        +--> TagRegistry / AttributeRegistry  (既有 gameplay id SSOT)
+        +--> GraphLookupTableRegistry         (新增，只读 SoA 表索引)
+        |
+        v
+GraphProgramConfigLoader / GraphCompiler / SymbolPatcher
+        |
+        v
+L0 Graph VM (GraphKind.Query | Derived)
+  ReadGameplayTag -> Int tagId
+  LookupTagDisplayToken -> Int tokenId
+  ResolveTableRow -> Int rowHandle
+  TableReadFloat/Int/Entity/Token/Tag -> typed register
+        |
+        v
+GraphReturnWriter
+        |
+        v
+GraphOutputValueStore
+  Bool / Int / Float / Entity / TargetList
+  + TextToken semantic over Int (recommended as GraphOutputValueKind.TextToken)
+        |
+        v
+Panel Projection
+  variable.valueKind = Text
+  tokenId -> PresentationTextFormatter(locale) -> string
+```
+
+职责边界：
+
+| 层 | 负责 | 不负责 |
+| --- | --- | --- |
+| GameplayTag / TagOps | 状态真相、Effective tag 语义 | 玩家文案 |
+| GraphLookupTableRegistry | 已解析 id 的只读表索引 | ECS 组件读写、locale 格式化 |
+| Graph VM | 0Alloc 读取 tag/table/value id | 字符串拼接、DOM、fallback |
+| GraphOutputValueStore | scope owner + key 的 typed projection | 文案 SSOT |
+| Panel surface | Text token 格式化与展示 | 玩法状态推导 |
+
+## 3. 详情
+
+### 3.1 现有代码对照
+
+已确认可复用能力：
+
+- `GraphNodeOp` 已有 `HasTag`、`ReadBlackboardFloat/Int/Entity`、`LoadAttribute`、`GraphOutput` 相关 Query/Agg op；没有 `ReadGameplayTag`、`LookupTagDisplayText`、通用 `TableLookup`。
+- `IGraphRuntimeApi` 已承载 tag、attribute、blackboard、entity query、relationship 的只读接口，新增读表接口应挂这里。
+- `GameplayTagContainer` 是固定 256 bit；`TagRegistry` 限定 tag id 1..255；适合 dense tag display lookup。
+- Blackboard 当前只有 Float/Int/Entity buffer；没有 Text BB。不能用 `BlackboardInt` 的裸 int 偷偷表示 Text，必须有语义合同。
+- `AttributeBuffer` 是 float 属性 SoA；Text/Tag/表查询不得塞进 Attribute。
+- `GraphOutputValueStore` 当前只存 Bool/Int/Float/Entity；Text 输出需要 token 语义，不能直接存 string。
+- `EntityCollectionStore` 是实体集合 SoA，不是通用表数据仓库。
+- `PresentationTextCatalog`、`PresentationTextCatalogLoader`、`PresentationTextFormatter` 已是文案 token/locale SSOT。
+- 各领域 `DefinitionRegistry` 多为领域专用，没有可直接复用的通用 typed lookup table；新增表 registry 必须复用 `StringIntRegistry`、`ConfigPipeline`，不能各节点自建字典。
+
+### 3.2 L0 vs L1 拆分
+
+| 层 | 名称 | 形态 | 原因 |
+| --- | --- | --- | --- |
+| L1 作者节点 | `ReadGameplayTag` | 画布节点 | 作者关心 State.* 语义，不关心 bitset mask |
+| L0 op | `ReadGameplayTag` 或更精确 `SelectGameplayTag` | `GraphNodeOp` | VM 需要一个可执行纯 op |
+| L1 作者节点 | `LookupTagDisplayText` | 画布节点 | Panel 引脚是 Text |
+| L0 op | `LookupTagDisplayToken` | `GraphNodeOp` | VM 只返回 token id，不返回 string |
+| L1 作者节点 | `TableLookup` | 组合节点 | 作者按 key 查字段 |
+| L0 op | `ResolveTableRow` + `TableRead*` | 多个 `GraphNodeOp` | 多字段聚合复用 row，保持 typed register |
+
+### 3.3 ValueType / OutputKind 决策
+
+不新增 `GraphValueType.Text`。原因：
+
+- VM 热路径是寄存器 span；string 寄存器会引入托管引用、生命周期与分配问题。
+- UI 文案已有 `PresentationTextCatalog` SSOT；graph 不应拥有 locale。
+- Attribute/BB 都不是 Text 的承载层。
+
+建议新增或明确：
+
+| 类型 | 是否新增 | 说明 |
+| --- | --- | --- |
+| `GraphValueType.Text` | 否 | 禁止 L0 字符串寄存器 |
+| `GraphValueType.TableRow` | 否 | row handle 用 Int；field op 用 table/field schema 校验 |
+| `GraphOutputValueKind.TextToken` | 是，推荐 | 底层存 int，但 view kind 明确为 Text token |
+| Panel `valueKind: Text` | 复用作者模型 | source 必须是 token semantic 或 projection formatter |
+
+如果第一刀不改 `GraphOutputValueKind`，可临时用 `Int + binding.semantic = presentationToken`，但实现 issue 应优先新增 `TextToken`，避免裸 int 在 projection 层被误读。
+
+### 3.4 `ReadGameplayTag`
+
+语义：
+
+```text
+tagId = Select exactly one effective tag from entity tags within authored domain/table mask
+```
+
+输入：
+
+- Entity register。
+- `tagDomain` 或 `table` 符号；P0 推荐复用 tag display table 的 mask，减少重复配置。
+- Cardinality policy：默认 `RequireOne`。
+
+输出：
+
+- Int register：tag id。
+- 可选 Bool register：found，仅 `AllowNone` 策略可启用。
+
+策略：
+
+| 策略 | 行为 |
+| --- | --- |
+| `RequireOne` | 0 个或多个匹配 tag 直接抛错；EntityInfoCard 的 `State.*` 默认用它 |
+| `AllowNone` | 0 个返回 found=false；多个仍抛错 |
+| `LowestId` | 取最低 id，仅调试或明确排序域；UI Panel 默认不允许 |
+
+实现挂点：
+
+- `IGraphRuntimeApi.SelectGameplayTag(Entity entity, int tagDomainId, TagSelectionPolicy policy, out int tagId, out int matchCount)`。
+- `GasGraphRuntimeApi` 必须与 `HasTag` 同源，尊重 staged side-effect 视图与 `TagOps` Effective 语义。
+- 无 `GameplayTagContainer`、entity dead、domain 空 mask、ambiguous state 都失败关闭。
+
+为什么 `HasTag` 不够：
+
+- `HasTag(State.Moving)` 是谓词；`ReadGameplayTag(State.*)` 是“从互斥族选出当前状态”的读取。
+- 用 N 个 `HasTag` + branch 会把作者图变成手写 if-else，也无法统一处理“0/多个状态”的合同错误。
+
+### 3.5 `LookupTagDisplayText` / `LookupTagDisplayToken`
+
+作者节点名：`LookupTagDisplayText`。  
+运行时 op 名：`LookupTagDisplayToken`。
+
+语义：
+
+```text
+tokenId = TagDisplayTable[tableId].TokenByTagId[tagId]
+```
+
+输入/输出：
+
+- 输入：Int tagId。
+- Immediate：table id。
+- 输出：Int tokenId，或 `GraphOutputValueKind.TextToken` summary。
+
+失败关闭：
+
+- `tagId == 0` 且未通过显式 `AllowNone` 分支处理：抛错。
+- table 没有该 tag 行：抛错。
+- token 未注册或 locale 缺模板：加载期优先失败；运行期仍保留断言。
+- 禁止 fallback 到 `TagRegistry.GetName(tagId)`、英文硬编码、空串。
+
+### 3.6 通用 TableLookup
+
+为 display text、数值、多字段聚合提供一套通用表基建，而不是给每个面板造私有 dictionary。
+
+#### 3.6.1 表资产形状
+
+建议路径：
+
+- `GraphTables/tag_display_tables.json`：tag 专用表，key 固定为 tag。
+- `GraphTables/lookup_tables.json`：通用 typed table。
+
+通用表示例：
+
+```json
+[
+  {
+    "id": "entity.rank.display",
+    "keyKind": "Int",
+    "columns": [
+      { "id": "displayToken", "kind": "TextToken" },
+      { "id": "sortWeight", "kind": "Int" },
+      { "id": "powerScale", "kind": "Float" }
+    ],
+    "rows": [
+      { "key": 1, "displayToken": "rank.recruit", "sortWeight": 10, "powerScale": 1.0 },
+      { "key": 2, "displayToken": "rank.veteran", "sortWeight": 20, "powerScale": 1.2 }
+    ]
+  }
+]
+```
+
+规则：
+
+- `columns[].kind` 必须是 `Bool | Int | Float | EntityTemplate | Tag | TextToken` 中的显式类型。
+- `TextToken` 列只存 token id；loader 校验 token 与 locale 覆盖。
+- `Tag` 列只存 tag id；loader 经 `TagRegistry` 解析。
+- `EntityTemplate` 列只存 template key id；loader 经既有 `EntityTemplateKeyRegistry` 解析。
+- 重复 row key、缺列、列类型不匹配、未知 token/tag/template 全部加载失败。
+
+#### 3.6.2 L0 op 清单
+
+最小通用 op：
+
+| L0 op | 输入 | 输出 | 说明 |
+| --- | --- | --- | --- |
+| `ResolveTableRow` | key Int, table id | Int rowHandle | 一次 key 查找，多字段复用 |
+| `TableReadInt` | rowHandle, field id | Int | 读 Int/Tag/TextToken/EntityTemplate 这类 id |
+| `TableReadFloat` | rowHandle, field id | Float | 读数值 |
+| `TableReadEntity` | rowHandle, field id | Entity | 仅用于明确注册的 entity 引用表；P0 可不开放 |
+| `LookupTagDisplayToken` | tagId, table id | Int tokenId | tag display 快捷 op；内部等价 dense tag table |
+
+不建议 P0 做：
+
+- `TableReadString`。
+- `TableAggregateTextList`。
+- `TableLookupAny` 返回动态 union。
+- `TableRow` 新寄存器 bank。
+
+#### 3.6.3 查表索引结构
+
+Tag display 表：
+
+```text
+tableSlot -> mask GameplayTagContainer
+tableSlot -> tokenByTagId[256]
+```
+
+通用 int key 表：
+
+```text
+tableSlot -> rowByDenseKey?      // 当 key 域可 dense 化
+tableSlot -> open-address index  // key -> rowIndex，构建期分配，运行期只读
+rowHandle = globalRowBase + rowIndex
+fieldId -> tableSlot + columnIndex + kind
+column values:
+  intColumns[][]
+  floatColumns[][]
+  entityColumns[][]
+```
+
+字符串 key 只允许加载期解析为 int id；运行时不接收 string key。
+
+### 3.7 GraphOutput 与 Panel Text
+
+`EntityInfoCard.curState` 建议 outputs：
+
+```json
+{
+  "id": "curState",
+  "destination": "Summary",
+  "type": "TextToken",
+  "source": "stateToken",
+  "key": "panel.entity_info.curState"
+}
+```
+
+如果 `TextToken` 尚未实现，临时过渡：
+
+```json
+{
+  "id": "curState",
+  "destination": "Summary",
+  "type": "Int",
+  "source": "stateToken",
+  "key": "panel.entity_info.curState",
+  "semantic": "presentationToken"
+}
+```
+
+Panel binding：
+
+```json
+{
+  "variableId": "curState",
+  "valueKind": "Text",
+  "sourceKind": "graphOutput",
+  "graphOutputKey": "panel.entity_info.curState",
+  "sourceValueKind": "TextToken"
+}
+```
+
+Projection：
+
+- Reactive：projection 可输出 `int CurStateTokenId` 与/或格式化后的 `string CurState`；格式化发生在 UI 层。
+- WebUI：payload 可发 token id + args，由 WebUI text contract 渲染；或服务器 projection 格式化 snapshot。
+- Compose/Markup：由 code-behind 读取 token id 后调用 `PresentationTextFormatter`。
+
+### 3.8 Blackboard Text 的处理
+
+当前 Blackboard 只有 Float/Int/Entity。设计结论：
+
+- 本节点族不新增 raw Text BB。
+- 不允许把 `ReadBlackboardInt` 的返回值在作者层无标注地当 Text。
+- 如需“BB 存文案”，应另开 `BlackboardTextToken` 语义能力：仍存 token id，但 key registry 声明 value kind，GraphOutput/Panel binding 能验证类型。
+- EntityInfoCard 的 `lastKill` Text 更推荐存 `BlackboardEntity`，再由 projection 查实体显示名/insight token；不要把最终字符串写进 ECS 热路径。
+
+### 3.9 编译 / Patch / Runtime 接线
+
+必须改动的基建点（实现期）：
+
+1. `GraphNodeOp`
+   - 新增 `ReadGameplayTag` 或 `SelectGameplayTag`。
+   - 新增 `LookupTagDisplayToken`。
+   - 新增 `ResolveTableRow`、`TableReadInt`、`TableReadFloat`；`TableReadEntity` 可 L1。
+
+2. `GasGraphOpHandlerTable`
+   - 全部注册为 Pure。
+   - handler 只访问 span / readonly registry；不分配。
+
+3. `IGraphRuntimeApi`
+   - 增加 tag domain selection 和 table lookup 接口。
+   - 默认实现 throw，保持现有缺基建 fail-fast 风格。
+
+4. `GasGraphRuntimeApi`
+   - 注入 `GraphLookupTableRegistry`。
+   - `ReadGameplayTag` 与现有 `HasTag` 同源。
+
+5. `GraphCompiler`
+   - 新字段：`table`、`field`、`tagDomain` 或复用 table mask。
+   - 输出 type 映射：tag/token/rowHandle 都是 Int；float field 是 Float。
+
+6. `GraphProgramSymbolPatcher` / `IGraphSymbolResolver`
+   - 新增 `ResolveGraphLookupTable`、`ResolveGraphLookupField` 或 combined field symbol。
+
+7. `GraphOutputTypes` / `GraphOutputValueStore`
+   - 推荐新增 `TextToken` kind，底层复用 int 列。
+
+8. Panel binding / WPK
+   - Text variable 必须验证 source 是 `TextToken` 或显式 formatter，不接受裸 Float/Attribute。
+
+## 4. 场景
+
+### 4.1 EntityInfoCard 当前状态
+
+```text
+LoadExplicitTarget
+  -> ReadGameplayTag(table = entity.state.display, policy = RequireOne)
+  -> LookupTagDisplayText(table = entity.state.display)
+  -> GraphOutput curState(TextToken)
+  -> Panel.curState(Text)
+```
+
+玩家选中实体时：
+
+- 实体只有 `State.Moving`：面板显示本 locale 的“移动中”。
+- 实体没有任何 `State.*`：图执行失败；作者必须给实体初始化状态或改为显式 `AllowNone` 分支。
+- 实体同时有 `State.Idle` 与 `State.Stunned`：图执行失败，暴露玩法状态互斥性破坏。
+
+### 4.2 按 rank key 查显示名和数值
+
+```text
+ReadBlackboardInt(entity.rank)
+  -> ResolveTableRow(entity.rank.display)
+  -> TableReadInt(displayToken)
+  -> TableReadFloat(powerScale)
+  -> Panel.rankName(Text), Panel.powerScale(Float)
+```
+
+同一 rowHandle 读两个字段，避免重复 key lookup。
+
+### 4.3 跨实体聚合后展示 bucket 文案
+
+```text
+QueryFromCollection(selected)
+  -> QueryFilterTagAny(State.Stunned)
+  -> AggCount
+  -> GraphOutput stunnedCount(Int)
+
+ConstTag(State.Stunned)
+  -> LookupTagDisplayToken(entity.state.display)
+  -> GraphOutput stunnedLabel(TextToken)
+```
+
+数字聚合复用现有 Query/Agg；显示文案只查 token。
+
+### 4.4 多实例 Panel
+
+两个 EntityInfoCard 实例分别绑定不同 selected entity：
+
+- 每个 scope owner 写自己的 `panel.entity_info.curState` Summary。
+- 若两个实例绑定同一实体，应由 Router/Projection 共用 owner+key，避免重复执行。
+- 如果业务要求每实例独立 owner，则成本线性增长，但每实例状态查表仍是 O(1)。
+
+## 5. 边界
+
+允许：
+
+- Query/Derived 图内读 tag id、读 rowHandle、读 typed field。
+- GraphOutput 输出 Int/Float/Entity/TextToken。
+- Surface 在投影边界格式化 token。
+- Mod 通过表资产扩展新 tag 文案或新 rank 字段。
+
+禁止：
+
+- 新增 `GraphKind.Presentation`。
+- 新增 `GraphNodeOp.Panel`。
+- Graph handler 返回/拼接/缓存 string。
+- Attribute 假扮 Tag、BB、Text、TableLookup。
+- `TagRegistry.GetName` 作为玩家文案 fallback。
+- 缺表行、缺 token、缺 locale 时返回空串/Unknown/0。
+- 在 ECS 热路径动态添加 Text BB 组件。
+- 在 showcase/Web 层手写跨实体求和绕过 Query/Agg。
+
+未纳入本切片：
+
+- raw dynamic string 数据流。
+- 完整本地化富文本参数系统扩展。
+- 通用 SQL/JSONPath 式查询。
+- 表热重载增量 patch；P0 采用加载期 freeze。
+
+## 6. UAT（Cucumber）
+
+```gherkin
+Feature: EntityInfoCard 状态文案来自 GameplayTag 查表
+  作为玩家
+  我想在实体信息卡看到当前状态的本地化文案
+  以便理解选中实体正在做什么
+
+  Scenario: 选中实体的 State tag 被映射为 Text 引脚
+    Given 实体带有唯一有效 tag "State.Moving"
+    And 表 "entity.state.display" 将 "State.Moving" 映射到 token "entity.state.moving"
+    And 当前 locale 注册了 token "entity.state.moving"
+    When EntityInfoCard 图执行 ReadGameplayTag 和 LookupTagDisplayText
+    Then GraphOutput key "panel.entity_info.curState" 写入 TextToken
+    And Panel.curState 显示该 locale 的状态文案
+    And AttributeBuffer 中没有用于承载该 Text 的假属性
+
+  Scenario: 状态族缺失时失败关闭
+    Given EntityInfoCard 使用 RequireOne 策略读取 "State.*"
+    And 选中实体没有任何 "State.*" tag
+    When 图执行 ReadGameplayTag
+    Then 执行失败并报告缺失状态域
+    And 面板不显示空字符串
+    And 面板不显示 Unknown fallback
+
+  Scenario: 状态族冲突时失败关闭
+    Given EntityInfoCard 使用 RequireOne 策略读取 "State.*"
+    And 选中实体同时带有 "State.Idle" 和 "State.Stunned"
+    When 图执行 ReadGameplayTag
+    Then 执行失败并报告状态域歧义
+    And 作者能定位到冲突 tag id
+
+Feature: 作者按 key 查表输出多字段
+  作为面板作者
+  我想用一次 row lookup 读取显示名和数值字段
+  以便避免为同一 key 重复建查表节点
+
+  Scenario: rank key 查出 TextToken 与 Float
+    Given 表 "entity.rank.display" 有 key 2
+    And key 2 的 displayToken 为 "rank.veteran"
+    And key 2 的 powerScale 为 1.2
+    When 作者连接 ResolveTableRow 到 TableReadTextToken 和 TableReadFloat
+    Then Panel.rankName 接收到 TextToken
+    And Panel.powerScale 接收到 Float
+    And 图 VM 没有 string 寄存器
+
+  Scenario: 缺表行时不静默降级
+    Given 表 "entity.rank.display" 不存在 key 99
+    When 图执行 ResolveTableRow(key=99)
+    Then 执行失败并报告 table id 与 key
+    And 不返回 rowHandle 0 继续读默认行
+
+Feature: 跨实体聚合仍复用 Query/Agg
+  作为作者
+  我想按 tag 聚合实体数量并显示 bucket 标题
+  以便在 UI Panel 中展示状态统计
+
+  Scenario: 状态统计数字来自 Query/Agg，标题来自 token 表
+    Given 选中集合中有 3 个 State.Stunned 实体
+    When Query 图执行 QueryFilterTagAny 和 AggCount
+    Then stunnedCount Summary 为 3
+    And stunnedLabel Summary 是 State.Stunned 的 TextToken
+    And Web/Showcase 层没有手写遍历实体求和
+```
+
+## 7. 性能专章
+
+### 7.1 热路径分配预算
+
+| 路径 | 分配预算 |
+| --- | --- |
+| `ReadGameplayTag` handler | 0 alloc |
+| `LookupTagDisplayToken` handler | 0 alloc |
+| `ResolveTableRow` / `TableRead*` handler | 0 alloc |
+| Query/Agg existing ops | 继续使用 caller-owned spans / stackalloc |
+| `GraphReturnWriter` 写 Summary | 0 alloc，沿用 store SoA |
+| Surface token 格式化 | 允许 UI 边界分配；不算 ECS/Graph 热路径 |
+
+### 7.2 查表索引结构
+
+- Tag display：`int[256] tokenByTagId`，O(1)，无 hash。
+- 通用 int key：优先 dense direct index；非 dense 用构建期分配的 open addressing `int[] keys/rows`，运行期只读。
+- field：`fieldId -> tableSlot + columnIndex + kind`，读取前校验 rowHandle 属于 table。
+- Text token：始终是 int；真正 string 由 `PresentationTextCatalog` 按 locale 解析。
+
+### 7.3 是否可缓存
+
+可缓存：
+
+- table registry 是加载期构建后的只读缓存。
+- `ResolveTableRow` 的 rowHandle 可在同一 graph 中复用。
+- Panel projection 可按 `(localeId, tokenId, outputRevision)` 缓存格式化 string。
+
+不可缓存：
+
+- Graph handler 内不可缓存 locale string。
+- 不在实体组件上缓存最终 UI 文案。
+- 不为缺失行缓存 fallback。
+
+### 7.4 与 Graph 执行频率的关系
+
+- `EntityInfoCard` 应随 selection/tag dirty/绑定刷新执行，不随浏览器 paint 或 DOM render 重复执行。
+- Query 聚合仍按 #848 的 Query 物化节奏执行：simulation/projection phase，而不是 UI 帧内手写循环。
+- Derived 只写 AttributeBuffer 派生槽；Text token 不走 Derived attribute，走 Query Summary 或面板 projection。
+- 如果单实体 panel 只读一个状态 tag，单次成本是一次 tag bitset 选择 + 一次数组查表。
+
+### 7.5 多实例 Panel 代价
+
+- N 个不同 scope 的 panel：N 次 graph materialization，成本线性。
+- 同一 scope 多表面：应共享 `GraphOutputValueStore(owner,key)`，projection 多读，不重复执行图。
+- 表大小对实例数无乘法影响；lookup registry 全局只读。
+- 多实例下最贵路径仍是 QueryAll/Filter/Agg，不是 tag display lookup；应避免每个 panel 都 QueryAllMapEntities。
+
+## 8. 复用 / 新增清单
+
+### 8.1 复用
+
+- `GraphKind.Query` / `GraphKind.Derived`
+- `GraphNodeOp` / `GasGraphOpHandlerTable`
+- `GraphCompiler` / `GraphProgramConfigLoader` / `GraphProgramSymbolPatcher`
+- `IGraphRuntimeApi` / `GasGraphRuntimeApi`
+- `TagRegistry` / `GameplayTagContainer` / `TagOps`
+- `ReadBlackboardFloat/Int/Entity`
+- `LoadAttribute`
+- Query/Agg ops：`QueryFromCollection`、`QueryFilterTagAny/None`、`AggCount`、`AggSumAttribute`
+- `GraphReturnWriter`
+- `GraphOutputValueStore`
+- `EntityCollectionStore` 仅用于实体集合，不用于表数据
+- `PresentationTextCatalog` / `PresentationTextFormatter`
+- `StringIntRegistry`
+- `ConfigPipeline`
+
+### 8.2 必须新开 GraphNodeOp
+
+P0 必须：
+
+1. `ReadGameplayTag` 或 `SelectGameplayTag`
+2. `LookupTagDisplayToken`
+3. `ResolveTableRow`
+4. `TableReadInt`
+5. `TableReadFloat`
+
+P1 可选：
+
+6. `TableReadEntity`
+7. `TableReadBool`（也可由 `TableReadInt + Compare` 覆盖）
+
+不新增：
+
+- `TableReadString`
+- `LookupTagDisplayString`
+- `GraphNodeOp.Panel`
+
+### 8.3 必须新开非 op 基建
+
+- `GraphLookupTableRegistry`
+- `GraphLookupTableLoader`
+- `IGraphSymbolResolver.ResolveGraphLookupTable`
+- `IGraphSymbolResolver.ResolveGraphLookupField`
+- `GraphOutputValueKind.TextToken`（推荐）
+- Panel binding 的 TextToken validation
+
+## 9. 建议的 GitHub issue 标题
+
+`feat(graph): add ReadGameplayTag and typed TableLookup tokens for UI Panel text bindings`

--- a/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/Runtime/UiPlayerAggregateGraphMvpRuntime.cs
+++ b/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/Runtime/UiPlayerAggregateGraphMvpRuntime.cs
@@ -11,6 +11,7 @@ using Ludots.Core.Modding;
 using Ludots.Core.NodeLibraries.GASGraph;
 using Ludots.Core.NodeLibraries.GASGraph.Host;
 using Ludots.Core.Scripting;
+using Ludots.Core.UI.PanelProjection;
 using Ludots.UI;
 using UiPlayerAggregateGraphMvpShowcaseMod.Input;
 using UiPlayerAggregateGraphMvpShowcaseMod.UI;
@@ -200,30 +201,25 @@ public sealed class UiPlayerAggregateGraphMvpRuntime
 
         GraphOutputValueStore values = engine.GetService(CoreServiceKeys.GraphOutputValueStore)
             ?? throw new InvalidOperationException("GraphOutputValueStore is missing.");
-        _oreTotal = RequireSummaryFloat(values, _owner, _config.SummaryKeys.OreTotal);
-        _crystalTotal = RequireSummaryFloat(values, _owner, _config.SummaryKeys.CrystalTotal);
+        var reader = new PanelProjectionReader(engine.World, values);
+        _oreTotal = reader.ResolveFloat(
+            _owner,
+            new PanelVariableBinding(
+                "oreTotal",
+                PanelBindingSourceKind.AggregateProjection,
+                attributeId: null,
+                graphOutputKey: _config.SummaryKeys.OreTotal));
+        _crystalTotal = reader.ResolveFloat(
+            _owner,
+            new PanelVariableBinding(
+                "crystalTotal",
+                PanelBindingSourceKind.AggregateProjection,
+                attributeId: null,
+                graphOutputKey: _config.SummaryKeys.CrystalTotal));
         if (!_buildingShutDown)
         {
             _status = "Tally graph projections are live on the resource strip.";
         }
-    }
-
-    private static float RequireSummaryFloat(GraphOutputValueStore values, Entity owner, string key)
-    {
-        if (!values.TryGet(owner, key, out GraphOutputValueHandle handle) ||
-            !values.TryGetView(handle, out GraphOutputValueView view))
-        {
-            throw new InvalidOperationException(
-                $"GraphOutputValueStore is missing required summary key '{key}' on owner #{owner.Id}. Silent zero is forbidden.");
-        }
-
-        if (view.Kind != GraphOutputValueKind.Float)
-        {
-            throw new InvalidOperationException(
-                $"GraphOutputValueStore key '{key}' must be Float, found '{view.Kind}'.");
-        }
-
-        return view.FloatValue;
     }
 
     private UiPlayerAggregateGraphMvpConfig EnsureConfig(GameEngine engine)

--- a/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/Systems/UiPlayerAggregateGraphMvpPresentationSystem.cs
+++ b/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/Systems/UiPlayerAggregateGraphMvpPresentationSystem.cs
@@ -1,5 +1,13 @@
+using System.Numerics;
+using Arch.Core;
 using Arch.System;
+using Ludots.Core.Components;
 using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.Components;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Presentation.DebugDraw;
 using UiPlayerAggregateGraphMvpShowcaseMod.Runtime;
 
 namespace UiPlayerAggregateGraphMvpShowcaseMod.Systems;
@@ -8,11 +16,18 @@ internal sealed class UiPlayerAggregateGraphMvpPresentationSystem : ISystem<floa
 {
     private readonly GameEngine _engine;
     private readonly UiPlayerAggregateGraphMvpRuntime _runtime;
+    private readonly DebugDrawCommandBuffer _debugDraw;
+    private readonly QueryDescription _producerQuery = new QueryDescription()
+        .WithAll<Name, WorldPositionCm, AttributeBuffer, Team>();
 
-    public UiPlayerAggregateGraphMvpPresentationSystem(GameEngine engine, UiPlayerAggregateGraphMvpRuntime runtime)
+    public UiPlayerAggregateGraphMvpPresentationSystem(
+        GameEngine engine,
+        UiPlayerAggregateGraphMvpRuntime runtime,
+        DebugDrawCommandBuffer debugDraw)
     {
         _engine = engine;
         _runtime = runtime;
+        _debugDraw = debugDraw;
     }
 
     public void Initialize()
@@ -26,6 +41,7 @@ internal sealed class UiPlayerAggregateGraphMvpPresentationSystem : ISystem<floa
     public void Update(in float t)
     {
         _runtime.RefreshPanel(_engine);
+        DrawProducerMarkers();
     }
 
     public void AfterUpdate(in float t)
@@ -34,5 +50,72 @@ internal sealed class UiPlayerAggregateGraphMvpPresentationSystem : ISystem<floa
 
     public void Dispose()
     {
+    }
+
+    private void DrawProducerMarkers()
+    {
+        if (!UiPlayerAggregateGraphMvpIds.IsShowcaseMap(_engine.CurrentMapSession?.MapId.Value))
+        {
+            return;
+        }
+
+        int oreId = AttributeRegistry.GetId("Showcase.Resource.Ore");
+        int crystalId = AttributeRegistry.GetId("Showcase.Resource.Crystal");
+        if (oreId == AttributeRegistry.InvalidId || crystalId == AttributeRegistry.InvalidId)
+        {
+            return;
+        }
+
+        _debugDraw.Clear();
+        World world = _engine.World;
+        world.Query(
+            in _producerQuery,
+            (Entity entity, ref Name name, ref WorldPositionCm pos, ref AttributeBuffer attrs, ref Team team) =>
+            {
+                if (team.Id != 1 ||
+                    !attrs.HasAttribute(oreId) ||
+                    !attrs.HasAttribute(crystalId))
+                {
+                    return;
+                }
+
+                Vector3 meters = WorldUnits.WorldCmToVisualMeters(in pos.Value);
+                float x = meters.X;
+                float z = meters.Z;
+                float stock = attrs.GetCurrent(oreId) + attrs.GetCurrent(crystalId);
+                bool offline = stock <= 0.01f;
+
+                DebugDrawColor color = offline
+                    ? new DebugDrawColor(180, 70, 70)
+                    : new DebugDrawColor(80, 200, 140);
+
+                float half = 0.85f;
+                _debugDraw.Boxes.Add(new DebugDrawBox2D
+                {
+                    Center = new Vector2(x, z),
+                    HalfWidth = half,
+                    HalfHeight = half,
+                    Thickness = 0.1f,
+                    Color = color
+                });
+                _debugDraw.Boxes.Add(new DebugDrawBox2D
+                {
+                    Center = new Vector2(x, z),
+                    HalfWidth = half * 0.55f,
+                    HalfHeight = half * 0.55f,
+                    Thickness = 0.08f,
+                    Color = color
+                });
+                _debugDraw.Circles.Add(new DebugDrawCircle2D
+                {
+                    Center = new Vector2(x, z),
+                    Radius = offline ? 0.28f : 0.42f,
+                    Thickness = 0.08f,
+                    Color = offline ? DebugDrawColor.Red : DebugDrawColor.Yellow
+                });
+
+                _ = entity;
+                _ = name;
+            });
     }
 }

--- a/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/UiPlayerAggregateGraphMvpShowcaseModEntry.cs
+++ b/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/UiPlayerAggregateGraphMvpShowcaseModEntry.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using Ludots.Core.Engine;
 using Ludots.Core.Gameplay.GAS.Registry;
 using Ludots.Core.Modding;
+using Ludots.Core.Presentation.DebugDraw;
 using Ludots.Core.Scripting;
 using UiPlayerAggregateGraphMvpShowcaseMod.Runtime;
 using UiPlayerAggregateGraphMvpShowcaseMod.Systems;
@@ -34,8 +35,10 @@ public sealed class UiPlayerAggregateGraphMvpShowcaseModEntry : IMod
 
             engine.GlobalContext[UiPlayerAggregateGraphMvpIds.InstalledKey] = true;
             engine.GlobalContext[UiPlayerAggregateGraphMvpIds.RuntimeServiceKey] = runtime;
+            var debugDraw = engine.GetService(CoreServiceKeys.DebugDrawCommandBuffer) ?? new DebugDrawCommandBuffer();
+            engine.SetService(CoreServiceKeys.DebugDrawCommandBuffer, debugDraw);
             engine.RegisterSystem(new UiPlayerAggregateGraphMvpSimulationSystem(engine, runtime), SystemGroup.PostMovement);
-            engine.RegisterPresentationSystem(new UiPlayerAggregateGraphMvpPresentationSystem(engine, runtime));
+            engine.RegisterPresentationSystem(new UiPlayerAggregateGraphMvpPresentationSystem(engine, runtime, debugDraw));
             context.Log("[UiPlayerAggregateGraphMvpShowcaseMod] production systems registered.");
             return Task.CompletedTask;
         });

--- a/src/Core/Gameplay/GAS/Components/GameplayTagContainer.cs
+++ b/src/Core/Gameplay/GAS/Components/GameplayTagContainer.cs
@@ -181,6 +181,19 @@ namespace Ludots.Core.Gameplay.GAS.Components
             }
             return 0;
         }
+
+        /// <summary>Number of bits set in both this container and <paramref name="other"/>.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int CountCommonTags(in GameplayTagContainer other)
+        {
+            int count = 0;
+            for (int i = 0; i < ULONG_COUNT; i++)
+            {
+                count += System.Numerics.BitOperations.PopCount(Bits[i] & other.Bits[i]);
+            }
+
+            return count;
+        }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Clear()

--- a/src/Core/NodeLibraries/GASGraph/GasGraphOpHandlerTable.cs
+++ b/src/Core/NodeLibraries/GASGraph/GasGraphOpHandlerTable.cs
@@ -182,6 +182,8 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 GraphNodeOp.CompareLtInt or
                 GraphNodeOp.CompareEqInt or
                 GraphNodeOp.HasTag or
+                GraphNodeOp.SelectTagInMask or
+                GraphNodeOp.LookupTagDisplayToken or
                 GraphNodeOp.CompareEqEntity or
                 GraphNodeOp.SelectEntity or
                 GraphNodeOp.QueryRadius or
@@ -499,6 +501,8 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             Register(GraphNodeOp.CompareLtInt, HandleCompareLtInt, "CompareLtInt graph opcode.");
             Register(GraphNodeOp.CompareEqInt, HandleCompareEqInt, "CompareEqInt graph opcode.");
             Register(GraphNodeOp.HasTag, HandleHasTag, "HasTag graph opcode.");
+            Register(GraphNodeOp.SelectTagInMask, HandleSelectTagInMask, "SelectTagInMask graph opcode.");
+            Register(GraphNodeOp.LookupTagDisplayToken, HandleLookupTagDisplayToken, "LookupTagDisplayToken graph opcode.");
             Register(GraphNodeOp.CompareEqEntity, HandleCompareEqEntity, "CompareEqEntity graph opcode.");
             Register(GraphNodeOp.RandomFloat01, HandleRandomFloat01, "RandomFloat01 graph opcode.");
             Register(GraphNodeOp.QueryHexRange, HandleQueryHexRange, "QueryHexRange graph opcode.");
@@ -1189,6 +1193,18 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             // B[Dst] = E[A].HasTag(Imm) ? 1 : 0
             var entity = s.E[ins.A];
             s.B[ins.Dst] = (byte)(s.Api.HasTag(entity, ins.Imm) ? 1 : 0);
+        }
+
+        private static void HandleSelectTagInMask(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)
+        {
+            // I[Dst] = SelectEffectiveTagInMask(E[A], Imm=tableId, Flags=policy)
+            s.I[ins.Dst] = s.Api.SelectEffectiveTagInMask(s.E[ins.A], ins.Imm, ins.Flags);
+        }
+
+        private static void HandleLookupTagDisplayToken(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)
+        {
+            // I[Dst] = LookupTagDisplayToken(Imm=tableId, I[A]=tagId)
+            s.I[ins.Dst] = s.Api.LookupTagDisplayToken(ins.Imm, s.I[ins.A]);
         }
 
         private static void HandleCompareEqEntity(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)

--- a/src/Core/NodeLibraries/GASGraph/GraphCompiler.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphCompiler.cs
@@ -329,6 +329,15 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                         ins.A = RequireInput(node, 0, GraphValueType.Entity, valueMap, cfg.Id, diagnostics);
                         ins.Imm = RequireSymbol(node.Tag, "tag", node, symbolToIndex, symbols, cfg.Id, diagnostics);
                         break;
+                    case GraphNodeOp.SelectTagInMask:
+                        ins.A = RequireInput(node, 0, GraphValueType.Entity, valueMap, cfg.Id, diagnostics);
+                        ins.Imm = RequireSymbol(node.DisplayTable, "displayTable", node, symbolToIndex, symbols, cfg.Id, diagnostics);
+                        ins.Flags = ParseTagSelectPolicy(node.TagSelectPolicy, cfg.Id, node.Id, diagnostics);
+                        break;
+                    case GraphNodeOp.LookupTagDisplayToken:
+                        ins.A = RequireInput(node, 0, GraphValueType.Int, valueMap, cfg.Id, diagnostics);
+                        ins.Imm = RequireSymbol(node.DisplayTable, "displayTable", node, symbolToIndex, symbols, cfg.Id, diagnostics);
+                        break;
                     case GraphNodeOp.ModifyAttributeAdd:
                         ins.A = RequireInput(node, 0, GraphValueType.Entity, valueMap, cfg.Id, diagnostics);
                         ins.B = RequireInput(node, 1, GraphValueType.Float, valueMap, cfg.Id, diagnostics);
@@ -607,6 +616,8 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 GraphNodeOp.CompareLtInt => (GraphValueType.Bool, null),
                 GraphNodeOp.CompareEqInt => (GraphValueType.Bool, null),
                 GraphNodeOp.HasTag => (GraphValueType.Bool, null),
+                GraphNodeOp.SelectTagInMask => (GraphValueType.Int, null),
+                GraphNodeOp.LookupTagDisplayToken => (GraphValueType.Int, null),
                 GraphNodeOp.SelectEntity => (GraphValueType.Entity, null),
                 GraphNodeOp.AggCount => (GraphValueType.Int, null),
                 GraphNodeOp.AggMinByDistance => (GraphValueType.Entity, null),
@@ -886,6 +897,32 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 collectionRole: EntityCollectionRoleKind.Display,
                 title: output.Title,
                 summary: output.Summary));
+        }
+
+        private static byte ParseTagSelectPolicy(
+            string? value,
+            string graphId,
+            string nodeId,
+            List<GraphDiagnostic> diagnostics)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return (byte)Ludots.Core.Presentation.TagDisplay.TagSelectPolicy.RequireOne;
+            }
+
+            if (Enum.TryParse(value.Trim(), ignoreCase: true, out Ludots.Core.Presentation.TagDisplay.TagSelectPolicy policy) &&
+                Enum.IsDefined(typeof(Ludots.Core.Presentation.TagDisplay.TagSelectPolicy), policy))
+            {
+                return (byte)policy;
+            }
+
+            diagnostics.Add(new GraphDiagnostic(
+                GraphDiagnosticSeverity.Error,
+                GraphDiagnosticCodes.UnknownNodeOp,
+                $"Graph node '{nodeId}' has unknown tagSelectPolicy '{value}'.",
+                graphId,
+                nodeId));
+            return (byte)Ludots.Core.Presentation.TagDisplay.TagSelectPolicy.RequireOne;
         }
 
         private static bool TryParseOutputDestination(string value, out GraphOutputDestinationKind destination)

--- a/src/Core/NodeLibraries/GASGraph/GraphConfig.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphConfig.cs
@@ -25,6 +25,10 @@ namespace Ludots.Core.NodeLibraries.GASGraph
         public bool BoolValue { get; set; }
 
         public string? Tag { get; set; }
+        /// <summary>TagDisplayTable id for SelectTagInMask / LookupTagDisplayToken.</summary>
+        public string? DisplayTable { get; set; }
+        /// <summary>RequireOne | AllowNone | LowestId for SelectTagInMask (default RequireOne).</summary>
+        public string? TagSelectPolicy { get; set; }
         public string? Attribute { get; set; }
         public string? Template { get; set; }
         public string? CollectionKey { get; set; }

--- a/src/Core/NodeLibraries/GASGraph/GraphOps.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphOps.cs
@@ -40,6 +40,10 @@ namespace Ludots.Core.NodeLibraries.GASGraph
         CompareEqInt      = 32,   // B[Dst] = I[A] == I[B] ? 1 : 0
         HasTag            = 33,   // B[Dst] = E[A].HasTag(Imm) ? 1 : 0
         CompareEqEntity   = 35,   // B[Dst] = E[A] == E[B] ? 1 : 0
+        /// <summary>I[Dst] = SelectEffectiveTagInMask(E[A], Imm=tableId); Flags=TagSelectPolicy. Authoring alias: ReadGameplayTag.</summary>
+        SelectTagInMask   = 36,
+        /// <summary>I[Dst] = LookupTagDisplayToken(Imm=tableId, I[A]=tagId). Authoring alias: LookupTagDisplayText.</summary>
+        LookupTagDisplayToken = 37,
 
         SelectEntity = 40,
         QueryRadius = 100,
@@ -172,16 +176,29 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             if (string.IsNullOrWhiteSpace(op)) return false;
 
             string trimmed = op.Trim();
-            if (!Enum.TryParse(trimmed, ignoreCase: false, out GraphNodeOp v) ||
-                v == GraphNodeOp.None ||
-                !Enum.IsDefined(typeof(GraphNodeOp), v) ||
-                !string.Equals(v.ToString(), trimmed, StringComparison.Ordinal))
+            if (Enum.TryParse(trimmed, ignoreCase: false, out GraphNodeOp v) &&
+                v != GraphNodeOp.None &&
+                Enum.IsDefined(typeof(GraphNodeOp), v) &&
+                string.Equals(v.ToString(), trimmed, StringComparison.Ordinal))
             {
-                return false;
+                parsed = v;
+                return true;
             }
 
-            parsed = v;
-            return true;
+            // L1 authoring sugar → L0 opcodes (see design-tag-display-lookup).
+            if (string.Equals(trimmed, "ReadGameplayTag", StringComparison.Ordinal))
+            {
+                parsed = GraphNodeOp.SelectTagInMask;
+                return true;
+            }
+
+            if (string.Equals(trimmed, "LookupTagDisplayText", StringComparison.Ordinal))
+            {
+                parsed = GraphNodeOp.LookupTagDisplayToken;
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/Core/NodeLibraries/GASGraph/Host/GasGraphRuntimeApi.cs
+++ b/src/Core/NodeLibraries/GASGraph/Host/GasGraphRuntimeApi.cs
@@ -94,6 +94,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
         private readonly GameplayEventBus? _eventBus;
         private readonly EffectRequestQueue? _effectRequests;
         private readonly TagOps? _tagOps;
+        private readonly Ludots.Core.Presentation.TagDisplay.TagDisplayTableRegistry? _tagDisplayTables;
         private readonly RelationshipRuntime? _relationshipRuntime;
         private readonly TargetDispatchPresetRegistry? _targetDispatchPresets;
         private readonly EntityCollectionStore? _entityCollections;
@@ -208,7 +209,8 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
             RelationshipReasonRegistry? reasonRegistry = null,
             TargetDispatchPresetRegistry? targetDispatchPresets = null,
             EntityCollectionStore? entityCollections = null,
-            EntitySetQueryRuntime? entityQueries = null)
+            EntitySetQueryRuntime? entityQueries = null,
+            Ludots.Core.Presentation.TagDisplay.TagDisplayTableRegistry? tagDisplayTables = null)
         {
             _world = world ?? throw new ArgumentNullException(nameof(world));
             _spatialQueries = spatialQueries;
@@ -220,6 +222,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
             _relationshipRuntime = relationshipRuntime;
             _entityCollections = entityCollections;
             _entityQueries = entityQueries;
+            _tagDisplayTables = tagDisplayTables;
             _ = typeRegistry;
             _ = metricRegistry;
             _ = flagRegistry;
@@ -587,6 +590,63 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
             if (!_world.IsAlive(entity) || !_world.Has<GameplayTagContainer>(entity)) return false;
             ref var tags = ref _world.Get<GameplayTagContainer>(entity);
             return RequireTagOps().HasTag(ref tags, tagId, TagSense.Effective);
+        }
+
+        public int SelectEffectiveTagInMask(Entity entity, int tableId, byte policy)
+        {
+            var tables = _tagDisplayTables
+                ?? throw new InvalidOperationException("GAS.GRAPH.ERR.TagDisplaySelectUnavailable");
+
+            if (!_world.IsAlive(entity))
+            {
+                throw new InvalidOperationException(TagStateInstaller.DeadEntityError);
+            }
+
+            if (!_world.Has<GameplayTagContainer>(entity))
+            {
+                throw new InvalidOperationException(TagOps.MissingGameplayTagContainerError);
+            }
+
+            GameplayTagContainer mask = tables.GetMask(tableId);
+
+            // 0Alloc: scan dense tag id space (≤255). Uses HasTag so staged side-effects stay in sync.
+            int matchCount = 0;
+            int firstTagId = 0;
+            for (int tagId = 1; tagId <= GameplayTagContainer.MAX_TAG_ID; tagId++)
+            {
+                if (!mask.HasTag(tagId) || !HasTag(entity, tagId))
+                {
+                    continue;
+                }
+
+                matchCount++;
+                if (firstTagId == 0)
+                {
+                    firstTagId = tagId;
+                }
+            }
+
+            var selectPolicy = (Ludots.Core.Presentation.TagDisplay.TagSelectPolicy)policy;
+            return selectPolicy switch
+            {
+                Ludots.Core.Presentation.TagDisplay.TagSelectPolicy.RequireOne when matchCount == 1 => firstTagId,
+                Ludots.Core.Presentation.TagDisplay.TagSelectPolicy.RequireOne => throw new InvalidOperationException(
+                    $"GAS.GRAPH.ERR.TagSelectRequireOneFailed: entity=#{entity.Id} tableId={tableId} matchCount={matchCount}."),
+                Ludots.Core.Presentation.TagDisplay.TagSelectPolicy.AllowNone when matchCount == 0 => 0,
+                Ludots.Core.Presentation.TagDisplay.TagSelectPolicy.AllowNone when matchCount == 1 => firstTagId,
+                Ludots.Core.Presentation.TagDisplay.TagSelectPolicy.AllowNone => throw new InvalidOperationException(
+                    $"GAS.GRAPH.ERR.TagSelectAmbiguous: entity=#{entity.Id} tableId={tableId} matchCount={matchCount}."),
+                Ludots.Core.Presentation.TagDisplay.TagSelectPolicy.LowestId => firstTagId,
+                _ => throw new InvalidOperationException(
+                    $"GAS.GRAPH.ERR.UnknownTagSelectPolicy: {(byte)selectPolicy}."),
+            };
+        }
+
+        public int LookupTagDisplayToken(int tableId, int tagId)
+        {
+            var tables = _tagDisplayTables
+                ?? throw new InvalidOperationException("GAS.GRAPH.ERR.TagDisplayLookupUnavailable");
+            return tables.LookupToken(tableId, tagId);
         }
 
         public bool TryGetAttributeCurrent(Entity entity, int attributeId, out float value)

--- a/src/Core/NodeLibraries/GASGraph/Host/GasGraphSymbolResolver.cs
+++ b/src/Core/NodeLibraries/GASGraph/Host/GasGraphSymbolResolver.cs
@@ -3,6 +3,7 @@ using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Registry;
 using Ludots.Core.Gameplay.Relationships;
 using Ludots.Core.Gameplay.Spawning;
+using Ludots.Core.Presentation.TagDisplay;
 
 namespace Ludots.Core.NodeLibraries.GASGraph.Host
 {
@@ -18,6 +19,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
         private readonly RelationshipReasonRegistry _reasons;
         private readonly TargetDispatchPresetRegistry _targetDispatchPresets;
         private readonly EntityTemplateKeyRegistry? _entityTemplateKeys;
+        private readonly TagDisplayTableRegistry? _tagDisplayTables;
 
         public GasGraphSymbolResolver(
             RelationshipTypeRegistry types,
@@ -25,7 +27,8 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
             RelationshipFlagRegistry flags,
             RelationshipReasonRegistry reasons,
             TargetDispatchPresetRegistry targetDispatchPresets,
-            EntityTemplateKeyRegistry? entityTemplateKeys = null)
+            EntityTemplateKeyRegistry? entityTemplateKeys = null,
+            TagDisplayTableRegistry? tagDisplayTables = null)
         {
             _types = types ?? throw new ArgumentNullException(nameof(types));
             _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
@@ -33,6 +36,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
             _reasons = reasons ?? throw new ArgumentNullException(nameof(reasons));
             _targetDispatchPresets = targetDispatchPresets ?? throw new ArgumentNullException(nameof(targetDispatchPresets));
             _entityTemplateKeys = entityTemplateKeys;
+            _tagDisplayTables = tagDisplayTables;
         }
 
         public int ResolveTag(string name)
@@ -108,6 +112,17 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
             }
 
             return id;
+        }
+
+        public int ResolveTagDisplayTable(string name)
+        {
+            if (_tagDisplayTables == null)
+            {
+                throw new InvalidOperationException(
+                    $"Graph references tag display table '{name}', but no TagDisplayTableRegistry was provided.");
+            }
+
+            return _tagDisplayTables.GetTableId(name);
         }
     }
 }

--- a/src/Core/NodeLibraries/GASGraph/Host/GraphProgramSymbolPatcher.cs
+++ b/src/Core/NodeLibraries/GASGraph/Host/GraphProgramSymbolPatcher.cs
@@ -31,6 +31,10 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
                     case GraphNodeOp.HasTag:
                         ins.Imm = symbolResolver.ResolveTag(ResolveSymbol(symbols, ins.Imm));
                         break;
+                    case GraphNodeOp.SelectTagInMask:
+                    case GraphNodeOp.LookupTagDisplayToken:
+                        ins.Imm = symbolResolver.ResolveTagDisplayTable(ResolveSymbol(symbols, ins.Imm));
+                        break;
                     case GraphNodeOp.LoadAttribute:
                     case GraphNodeOp.ModifyAttributeAdd:
                     case GraphNodeOp.QueryFilterAttributeRange:

--- a/src/Core/NodeLibraries/GASGraph/IGraphRuntimeApi.cs
+++ b/src/Core/NodeLibraries/GASGraph/IGraphRuntimeApi.cs
@@ -322,6 +322,20 @@ namespace Ludots.Core.NodeLibraries.GASGraph
         void WriteBlackboardInt(Entity entity, int keyId, int value);
         void WriteBlackboardEntity(Entity entity, int keyId, Entity value);
 
+        /// <summary>
+        /// Select one Effective tag in the TagDisplayTable mask. Policy in
+        /// <see cref="Ludots.Core.Presentation.TagDisplay.TagSelectPolicy"/>.
+        /// </summary>
+        int SelectEffectiveTagInMask(Entity entity, int tableId, byte policy)
+        {
+            throw new InvalidOperationException("GAS.GRAPH.ERR.TagDisplaySelectUnavailable");
+        }
+
+        int LookupTagDisplayToken(int tableId, int tagId)
+        {
+            throw new InvalidOperationException("GAS.GRAPH.ERR.TagDisplayLookupUnavailable");
+        }
+
         // ── Config parameter reading (from current EffectTemplate context) ──
 
         bool TryLoadConfigFloat(int keyId, out float value);
@@ -363,5 +377,11 @@ namespace Ludots.Core.NodeLibraries.GASGraph
         int ResolveRelationshipReason(string name);
         int ResolveTargetDispatchPreset(string name);
         int ResolveEntityTemplate(string name);
+
+        int ResolveTagDisplayTable(string name)
+        {
+            throw new InvalidOperationException(
+                $"Graph references tag display table '{name}', but no TagDisplayTableRegistry resolver is available.");
+        }
     }
 }

--- a/src/Core/Presentation/TagDisplay/TagDisplayTableRegistry.cs
+++ b/src/Core/Presentation/TagDisplay/TagDisplayTableRegistry.cs
@@ -1,0 +1,170 @@
+using System;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Registry;
+
+namespace Ludots.Core.Presentation.TagDisplay
+{
+    /// <summary>
+    /// Dense tagId→presentationTokenId tables for panel/state display.
+    /// Hot path is O(1) array index; no string work at lookup time.
+    /// </summary>
+    public sealed class TagDisplayTableRegistry
+    {
+        public const string UnknownTableError = "GAS.TAG_DISPLAY.ERR.UnknownTable";
+        public const string MappingMissingError = "GAS.TAG_DISPLAY.ERR.MappingMissing";
+        public const string EmptyMaskError = "GAS.TAG_DISPLAY.ERR.EmptyMask";
+        public const string FrozenError = "GAS.TAG_DISPLAY.ERR.Frozen";
+
+        private readonly StringIntRegistry _tableIds;
+        private GameplayTagContainer[] _masks;
+        private int[][] _tokenByTagId;
+        private bool _frozen;
+
+        public TagDisplayTableRegistry(int initialTableCapacity = 8)
+        {
+            _tableIds = new StringIntRegistry(
+                capacity: Math.Max(4, initialTableCapacity),
+                startId: 1,
+                invalidId: 0,
+                comparer: StringComparer.Ordinal);
+            _masks = new GameplayTagContainer[Math.Max(4, initialTableCapacity)];
+            _tokenByTagId = new int[Math.Max(4, initialTableCapacity)][];
+        }
+
+        public bool IsFrozen => _frozen;
+
+        public int RegisterTable(string tableId, in GameplayTagContainer mask, ReadOnlySpan<(int TagId, int TokenId)> entries)
+        {
+            if (_frozen)
+            {
+                throw new InvalidOperationException(FrozenError);
+            }
+
+            if (string.IsNullOrWhiteSpace(tableId))
+            {
+                throw new ArgumentException("tableId is required.", nameof(tableId));
+            }
+
+            if (mask.IsEmpty)
+            {
+                throw new InvalidOperationException($"{EmptyMaskError}: table '{tableId}' mask is empty.");
+            }
+
+            if (_tableIds.TryGetId(tableId, out _))
+            {
+                throw new InvalidOperationException(
+                    $"Tag display table '{tableId}' is already registered.");
+            }
+
+            int id = _tableIds.Register(tableId);
+            EnsureTableSlot(id);
+
+            _masks[id] = mask;
+            int[] tokens = new int[GameplayTagContainer.MAX_TAG_ID + 1];
+            for (int i = 0; i < entries.Length; i++)
+            {
+                int tagId = entries[i].TagId;
+                int tokenId = entries[i].TokenId;
+                if (tagId <= 0 || tagId > GameplayTagContainer.MAX_TAG_ID)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(entries), $"Invalid tagId {tagId} in table '{tableId}'.");
+                }
+
+                if (tokenId <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(entries), $"Invalid tokenId {tokenId} for tag {tagId} in table '{tableId}'.");
+                }
+
+                if (!mask.HasTag(tagId))
+                {
+                    throw new InvalidOperationException(
+                        $"Tag display table '{tableId}' entry tagId {tagId} is not covered by maskTags.");
+                }
+
+                if (tokens[tagId] != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Tag display table '{tableId}' has duplicate mapping for tagId {tagId}.");
+                }
+
+                tokens[tagId] = tokenId;
+            }
+
+            _tokenByTagId[id] = tokens;
+            return id;
+        }
+
+        public void Freeze() => _frozen = true;
+
+        public int GetTableId(string tableId)
+        {
+            if (!_tableIds.TryGetId(tableId, out int id) || id <= 0)
+            {
+                throw new InvalidOperationException($"{UnknownTableError}: '{tableId}'.");
+            }
+
+            return id;
+        }
+
+        public bool TryGetTableId(string tableId, out int id) => _tableIds.TryGetId(tableId, out id) && id > 0;
+
+        public GameplayTagContainer GetMask(int tableId)
+        {
+            RequireTable(tableId);
+            return _masks[tableId];
+        }
+
+        public int LookupToken(int tableId, int tagId)
+        {
+            RequireTable(tableId);
+            if (tagId <= 0 || tagId > GameplayTagContainer.MAX_TAG_ID)
+            {
+                throw new InvalidOperationException(
+                    $"{MappingMissingError}: tableId={tableId} tagId={tagId}.");
+            }
+
+            int tokenId = _tokenByTagId[tableId][tagId];
+            if (tokenId <= 0)
+            {
+                throw new InvalidOperationException(
+                    $"{MappingMissingError}: tableId={tableId} tagId={tagId}.");
+            }
+
+            return tokenId;
+        }
+
+        private void RequireTable(int tableId)
+        {
+            if (tableId <= 0 ||
+                tableId >= _tokenByTagId.Length ||
+                _tokenByTagId[tableId] == null)
+            {
+                throw new InvalidOperationException($"{UnknownTableError}: id={tableId}.");
+            }
+        }
+
+        private void EnsureTableSlot(int id)
+        {
+            if (id < _tokenByTagId.Length)
+            {
+                return;
+            }
+
+            int newSize = Math.Max(_tokenByTagId.Length * 2, id + 1);
+            Array.Resize(ref _masks, newSize);
+            Array.Resize(ref _tokenByTagId, newSize);
+        }
+    }
+
+    public enum TagSelectPolicy : byte
+    {
+        /// <summary>Intersection must contain exactly one tag; otherwise throw.</summary>
+        RequireOne = 0,
+
+        /// <summary>Zero → tagId 0; multiple still throws.</summary>
+        AllowNone = 1,
+
+        /// <summary>Multiple → lowest tag id (non-UI / debug).</summary>
+        LowestId = 2,
+    }
+}

--- a/src/Core/Scripting/CoreServiceKeys.cs
+++ b/src/Core/Scripting/CoreServiceKeys.cs
@@ -64,6 +64,7 @@ using Ludots.Core.Presentation.Config;
 using Ludots.Core.Presentation.DebugDraw;
 using Ludots.Core.Presentation.Events;
 using Ludots.Core.Presentation.Hud;
+using Ludots.Core.Presentation.TagDisplay;
 using Ludots.Core.Presentation.Instancing;
 using Ludots.Core.Presentation.Minimap;
 using Ludots.Core.Presentation.Performers;
@@ -323,6 +324,7 @@ namespace Ludots.Core.Scripting
         public static readonly ServiceKey<WorldHudBatchBuffer> PresentationWorldHudBuffer = new("PresentationWorldHudBuffer");
         public static readonly ServiceKey<WorldHudStringTable> PresentationWorldHudStrings = new("PresentationWorldHudStrings");
         public static readonly ServiceKey<PresentationTextCatalog> PresentationTextCatalog = new("PresentationTextCatalog");
+        public static readonly ServiceKey<TagDisplayTableRegistry> TagDisplayTableRegistry = new("TagDisplayTableRegistry");
         public static readonly ServiceKey<PresentationTextLocaleSelection> PresentationTextLocaleSelection = new("PresentationTextLocaleSelection");
         public static readonly ServiceKey<ScreenHudBatchBuffer> PresentationScreenHudBuffer = new("PresentationScreenHudBuffer");
         public static readonly ServiceKey<ScreenOverlayBuffer> ScreenOverlayBuffer = new("ScreenOverlayBuffer");

--- a/src/Core/UI/PanelProjection/PanelBindingSourceKind.cs
+++ b/src/Core/UI/PanelProjection/PanelBindingSourceKind.cs
@@ -1,0 +1,28 @@
+namespace Ludots.Core.UI.PanelProjection
+{
+    /// <summary>
+    /// How a panel variable obtains its value. Projection over AttributeBuffer /
+    /// GraphOutputValueStore only — never a parallel panel value store.
+    /// </summary>
+    public enum PanelBindingSourceKind : byte
+    {
+        /// <summary>Final value from an entity AttributeBuffer slot.</summary>
+        SingleAttribute = 1,
+
+        /// <summary>
+        /// Derived attribute already written into AttributeBuffer by
+        /// AttributeAggregatorSystem / AttributeDerivedGraphBinding.
+        /// </summary>
+        DerivedAttribute = 2,
+
+        /// <summary>
+        /// Cross-entity aggregate already projected into GraphOutputValueStore Summary.
+        /// </summary>
+        AggregateProjection = 3,
+
+        /// <summary>
+        /// Graph Summary output (same read mouth as AggregateProjection; authoring alias).
+        /// </summary>
+        GraphOutput = 4,
+    }
+}

--- a/src/Core/UI/PanelProjection/PanelProjectionReader.cs
+++ b/src/Core/UI/PanelProjection/PanelProjectionReader.cs
@@ -1,0 +1,115 @@
+using System;
+using Arch.Core;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.NodeLibraries.GASGraph;
+
+namespace Ludots.Core.UI.PanelProjection
+{
+    /// <summary>
+    /// Fail-closed panel variable reader over AttributeBuffer and GraphOutputValueStore.
+    /// Shared mouth for native surfaces and WPK producers — no silent zero.
+    /// </summary>
+    public sealed class PanelProjectionReader
+    {
+        private readonly World _world;
+        private readonly GraphOutputValueStore? _graphOutputs;
+        private readonly Func<string, int> _resolveAttributeId;
+
+        public PanelProjectionReader(
+            World world,
+            GraphOutputValueStore? graphOutputs = null,
+            Func<string, int>? resolveAttributeId = null)
+        {
+            _world = world ?? throw new ArgumentNullException(nameof(world));
+            _graphOutputs = graphOutputs;
+            _resolveAttributeId = resolveAttributeId ?? AttributeRegistry.GetId;
+        }
+
+        public float ResolveFloat(Entity owner, in PanelVariableBinding binding)
+        {
+            return Resolve(owner, in binding).FloatValue;
+        }
+
+        public PanelProjectionValue Resolve(Entity owner, in PanelVariableBinding binding)
+        {
+            if (owner == Entity.Null || !_world.IsAlive(owner))
+            {
+                throw new InvalidOperationException(
+                    $"Panel binding '{binding.VariableId}' requires a live owner entity.");
+            }
+
+            return binding.SourceKind switch
+            {
+                PanelBindingSourceKind.SingleAttribute or PanelBindingSourceKind.DerivedAttribute
+                    => ResolveAttribute(owner, in binding),
+                PanelBindingSourceKind.AggregateProjection or PanelBindingSourceKind.GraphOutput
+                    => ResolveGraphOutput(owner, in binding),
+                _ => throw new InvalidOperationException(
+                    $"Panel binding '{binding.VariableId}' has unsupported sourceKind '{binding.SourceKind}'."),
+            };
+        }
+
+        private PanelProjectionValue ResolveAttribute(Entity owner, in PanelVariableBinding binding)
+        {
+            string attributeId = binding.AttributeId
+                ?? throw new InvalidOperationException(
+                    $"Panel binding '{binding.VariableId}' is missing attributeId.");
+
+            int id = _resolveAttributeId(attributeId);
+            if (id == AttributeRegistry.InvalidId || id < 0)
+            {
+                throw new InvalidOperationException(
+                    $"Panel binding '{binding.VariableId}' references unknown attribute '{attributeId}'.");
+            }
+
+            if (!_world.TryGet(owner, out AttributeBuffer buffer))
+            {
+                throw new InvalidOperationException(
+                    $"Panel binding '{binding.VariableId}' requires AttributeBuffer on owner #{owner.Id} for attribute '{attributeId}'.");
+            }
+
+            if (!buffer.HasAttribute(id))
+            {
+                throw new InvalidOperationException(
+                    $"Panel binding '{binding.VariableId}' attribute '{attributeId}' is not defined on owner #{owner.Id}.");
+            }
+
+            float value = buffer.GetCurrent(id);
+            uint revision = (uint)BitConverter.SingleToInt32Bits(value);
+            return new PanelProjectionValue(binding.VariableId, binding.SourceKind, value, revision);
+        }
+
+        private PanelProjectionValue ResolveGraphOutput(Entity owner, in PanelVariableBinding binding)
+        {
+            if (_graphOutputs == null)
+            {
+                throw new InvalidOperationException(
+                    $"Panel binding '{binding.VariableId}' requires GraphOutputValueStore for graphOutputKey '{binding.GraphOutputKey}'.");
+            }
+
+            string key = binding.GraphOutputKey
+                ?? throw new InvalidOperationException(
+                    $"Panel binding '{binding.VariableId}' is missing graphOutputKey.");
+
+            if (!_graphOutputs.TryGet(owner, key, out GraphOutputValueHandle handle) ||
+                !_graphOutputs.TryGetView(handle, out GraphOutputValueView view))
+            {
+                throw new InvalidOperationException(
+                    $"Panel binding '{binding.VariableId}' missing graph output '{key}' on owner #{owner.Id}. Silent zero is forbidden.");
+            }
+
+            float value = view.Kind switch
+            {
+                GraphOutputValueKind.Float => view.FloatValue,
+                GraphOutputValueKind.Int => view.IntValue,
+                GraphOutputValueKind.Bool => view.BoolValue ? 1f : 0f,
+                _ => throw new InvalidOperationException(
+                    $"Panel binding '{binding.VariableId}' graph output '{key}' has unsupported kind '{view.Kind}' for ResolveFloat."),
+            };
+
+            uint revision = view.Revision ^ (uint)BitConverter.SingleToInt32Bits(value);
+            return new PanelProjectionValue(binding.VariableId, binding.SourceKind, value, revision);
+        }
+    }
+}

--- a/src/Core/UI/PanelProjection/PanelProjectionValue.cs
+++ b/src/Core/UI/PanelProjection/PanelProjectionValue.cs
@@ -1,0 +1,22 @@
+namespace Ludots.Core.UI.PanelProjection
+{
+    /// <summary>
+    /// Resolved numeric panel projection value. Text/token semantics are a later slice;
+    /// this mouth carries Float/Int/Bool already materialised by Attribute or GraphOutput.
+    /// </summary>
+    public readonly struct PanelProjectionValue
+    {
+        public PanelProjectionValue(string variableId, PanelBindingSourceKind sourceKind, float floatValue, uint revision)
+        {
+            VariableId = variableId;
+            SourceKind = sourceKind;
+            FloatValue = floatValue;
+            Revision = revision;
+        }
+
+        public string VariableId { get; }
+        public PanelBindingSourceKind SourceKind { get; }
+        public float FloatValue { get; }
+        public uint Revision { get; }
+    }
+}

--- a/src/Core/UI/PanelProjection/PanelVariableBinding.cs
+++ b/src/Core/UI/PanelProjection/PanelVariableBinding.cs
@@ -1,0 +1,76 @@
+using System;
+
+namespace Ludots.Core.UI.PanelProjection
+{
+    /// <summary>
+    /// One panel variable binding contract. Fail-closed at resolve time when refs are missing.
+    /// </summary>
+    public readonly struct PanelVariableBinding
+    {
+        public PanelVariableBinding(
+            string variableId,
+            PanelBindingSourceKind sourceKind,
+            string? attributeId,
+            string? graphOutputKey)
+        {
+            if (string.IsNullOrWhiteSpace(variableId))
+            {
+                throw new ArgumentException("variableId is required.", nameof(variableId));
+            }
+
+            VariableId = variableId.Trim();
+            SourceKind = sourceKind;
+
+            switch (sourceKind)
+            {
+                case PanelBindingSourceKind.SingleAttribute:
+                case PanelBindingSourceKind.DerivedAttribute:
+                    if (string.IsNullOrWhiteSpace(attributeId))
+                    {
+                        throw new ArgumentException(
+                            $"Binding '{VariableId}' with sourceKind '{sourceKind}' requires attributeId.",
+                            nameof(attributeId));
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(graphOutputKey))
+                    {
+                        throw new ArgumentException(
+                            $"Binding '{VariableId}' with sourceKind '{sourceKind}' must not declare graphOutputKey.",
+                            nameof(graphOutputKey));
+                    }
+
+                    AttributeId = attributeId.Trim();
+                    GraphOutputKey = null;
+                    break;
+
+                case PanelBindingSourceKind.AggregateProjection:
+                case PanelBindingSourceKind.GraphOutput:
+                    if (string.IsNullOrWhiteSpace(graphOutputKey))
+                    {
+                        throw new ArgumentException(
+                            $"Binding '{VariableId}' with sourceKind '{sourceKind}' requires graphOutputKey.",
+                            nameof(graphOutputKey));
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(attributeId))
+                    {
+                        throw new ArgumentException(
+                            $"Binding '{VariableId}' with sourceKind '{sourceKind}' must not declare attributeId.",
+                            nameof(attributeId));
+                    }
+
+                    GraphOutputKey = graphOutputKey.Trim();
+                    AttributeId = null;
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(sourceKind), sourceKind, "Unknown panel binding source kind.");
+            }
+        }
+
+        public string VariableId { get; }
+        public PanelBindingSourceKind SourceKind { get; }
+        public string? AttributeId { get; }
+        public string? GraphOutputKey { get; }
+    }
+}

--- a/src/Tests/GasTests/Graph/TagDisplayGraphOpsTests.cs
+++ b/src/Tests/GasTests/Graph/TagDisplayGraphOpsTests.cs
@@ -1,0 +1,210 @@
+using System;
+using Arch.Core;
+using Ludots.Core.Gameplay.GAS;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.GraphRuntime;
+using Ludots.Core.NodeLibraries.GASGraph;
+using Ludots.Core.NodeLibraries.GASGraph.Host;
+using Ludots.Core.Presentation.TagDisplay;
+using NUnit.Framework;
+
+namespace Ludots.Tests.GAS
+{
+    [TestFixture]
+    public sealed class TagDisplayGraphOpsTests
+    {
+        private DirtyEntityQueue _dirty = null!;
+        private TagOps _tagOps = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TagRegistry.Clear();
+            _dirty = new DirtyEntityQueue(GasConstants.MAX_EFFECT_REQUESTS_PER_FRAME);
+            _tagOps = new TagOps(_dirty, new TagRuleRegistry());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            TagRegistry.Clear();
+        }
+
+        [Test]
+        public void SelectTagInMask_RequireOne_ReturnsMatchingTagId()
+        {
+            int idle = TagRegistry.Register("State.Idle");
+            int moving = TagRegistry.Register("State.Moving");
+            var tables = CreateStateTable(idle, moving, tokenIdle: 11, tokenMoving: 12);
+
+            using World world = World.Create();
+            Entity entity = world.Create(new GameplayTagContainer(), new TagCountContainer());
+            ref var tags = ref world.Get<GameplayTagContainer>(entity);
+            ref var counts = ref world.Get<TagCountContainer>(entity);
+            _tagOps.AddTag(ref tags, ref counts, moving);
+
+            var api = new GasGraphRuntimeApi(world, tagOps: _tagOps, tagDisplayTables: tables);
+            int tableId = tables.GetTableId("entity.state.display");
+            var program = new GraphInstruction[]
+            {
+                new() { Op = (ushort)GraphNodeOp.LoadCaster, Dst = 0 },
+                new() { Op = (ushort)GraphNodeOp.SelectTagInMask, Dst = 1, A = 0, Imm = tableId, Flags = (byte)TagSelectPolicy.RequireOne },
+            };
+
+            Assert.That(ExecuteInt(world, api, entity, program, intReg: 1), Is.EqualTo(moving));
+        }
+
+        [Test]
+        public void SelectTagInMask_RequireOne_ThrowsWhenMultipleMatch()
+        {
+            int idle = TagRegistry.Register("State.Idle");
+            int moving = TagRegistry.Register("State.Moving");
+            var tables = CreateStateTable(idle, moving, tokenIdle: 11, tokenMoving: 12);
+
+            using World world = World.Create();
+            Entity entity = world.Create(new GameplayTagContainer(), new TagCountContainer());
+            ref var tags = ref world.Get<GameplayTagContainer>(entity);
+            ref var counts = ref world.Get<TagCountContainer>(entity);
+            _tagOps.AddTag(ref tags, ref counts, idle);
+            _tagOps.AddTag(ref tags, ref counts, moving);
+
+            var api = new GasGraphRuntimeApi(world, tagOps: _tagOps, tagDisplayTables: tables);
+            int tableId = tables.GetTableId("entity.state.display");
+            var program = new GraphInstruction[]
+            {
+                new() { Op = (ushort)GraphNodeOp.LoadCaster, Dst = 0 },
+                new() { Op = (ushort)GraphNodeOp.SelectTagInMask, Dst = 1, A = 0, Imm = tableId, Flags = (byte)TagSelectPolicy.RequireOne },
+            };
+
+            Assert.That(
+                () => ExecuteInt(world, api, entity, program, intReg: 1),
+                Throws.InvalidOperationException.With.Message.Contains("TagSelectRequireOneFailed"));
+        }
+
+        [Test]
+        public void LookupTagDisplayToken_ReturnsMappedToken()
+        {
+            int idle = TagRegistry.Register("State.Idle");
+            int moving = TagRegistry.Register("State.Moving");
+            var tables = CreateStateTable(idle, moving, tokenIdle: 11, tokenMoving: 12);
+
+            using World world = World.Create();
+            Entity entity = world.Create();
+            var api = new GasGraphRuntimeApi(world, tagOps: _tagOps, tagDisplayTables: tables);
+            int tableId = tables.GetTableId("entity.state.display");
+            var program = new GraphInstruction[]
+            {
+                new() { Op = (ushort)GraphNodeOp.ConstInt, Dst = 0, Imm = moving },
+                new() { Op = (ushort)GraphNodeOp.LookupTagDisplayToken, Dst = 1, A = 0, Imm = tableId },
+            };
+
+            Assert.That(ExecuteInt(world, api, entity, program, intReg: 1), Is.EqualTo(12));
+        }
+
+        [Test]
+        public void LookupTagDisplayToken_MissingMapping_Throws()
+        {
+            int idle = TagRegistry.Register("State.Idle");
+            int moving = TagRegistry.Register("State.Moving");
+            int attacking = TagRegistry.Register("State.Attacking");
+            var tables = CreateStateTable(idle, moving, tokenIdle: 11, tokenMoving: 12);
+            // attacking is not in table entries (and not in mask)
+
+            using World world = World.Create();
+            Entity entity = world.Create();
+            var api = new GasGraphRuntimeApi(world, tagOps: _tagOps, tagDisplayTables: tables);
+            int tableId = tables.GetTableId("entity.state.display");
+            var program = new GraphInstruction[]
+            {
+                new() { Op = (ushort)GraphNodeOp.ConstInt, Dst = 0, Imm = attacking },
+                new() { Op = (ushort)GraphNodeOp.LookupTagDisplayToken, Dst = 1, A = 0, Imm = tableId },
+            };
+
+            Assert.That(
+                () => ExecuteInt(world, api, entity, program, intReg: 1),
+                Throws.InvalidOperationException.With.Message.Contains(TagDisplayTableRegistry.MappingMissingError));
+        }
+
+        [Test]
+        public void GraphNodeOpParser_AuthoringSugar_MapsToL0()
+        {
+            Assert.That(GraphNodeOpParser.TryParse("ReadGameplayTag", out GraphNodeOp select), Is.True);
+            Assert.That(select, Is.EqualTo(GraphNodeOp.SelectTagInMask));
+            Assert.That(GraphNodeOpParser.TryParse("LookupTagDisplayText", out GraphNodeOp lookup), Is.True);
+            Assert.That(lookup, Is.EqualTo(GraphNodeOp.LookupTagDisplayToken));
+        }
+
+        [Test]
+        public void SelectThenLookup_Chain_YieldsTokenId()
+        {
+            int idle = TagRegistry.Register("State.Idle");
+            int moving = TagRegistry.Register("State.Moving");
+            var tables = CreateStateTable(idle, moving, tokenIdle: 11, tokenMoving: 12);
+
+            using World world = World.Create();
+            Entity entity = world.Create(new GameplayTagContainer(), new TagCountContainer());
+            ref var tags = ref world.Get<GameplayTagContainer>(entity);
+            ref var counts = ref world.Get<TagCountContainer>(entity);
+            _tagOps.AddTag(ref tags, ref counts, idle);
+
+            var api = new GasGraphRuntimeApi(world, tagOps: _tagOps, tagDisplayTables: tables);
+            int tableId = tables.GetTableId("entity.state.display");
+            var program = new GraphInstruction[]
+            {
+                new() { Op = (ushort)GraphNodeOp.LoadCaster, Dst = 0 },
+                new() { Op = (ushort)GraphNodeOp.SelectTagInMask, Dst = 2, A = 0, Imm = tableId, Flags = (byte)TagSelectPolicy.RequireOne },
+                new() { Op = (ushort)GraphNodeOp.LookupTagDisplayToken, Dst = 3, A = 2, Imm = tableId },
+            };
+
+            Assert.That(ExecuteInt(world, api, entity, program, intReg: 3), Is.EqualTo(11));
+        }
+
+        private static TagDisplayTableRegistry CreateStateTable(int idle, int moving, int tokenIdle, int tokenMoving)
+        {
+            var mask = new GameplayTagContainer();
+            mask.AddTag(idle);
+            mask.AddTag(moving);
+            var tables = new TagDisplayTableRegistry();
+            tables.RegisterTable(
+                "entity.state.display",
+                in mask,
+                new (int, int)[] { (idle, tokenIdle), (moving, tokenMoving) });
+            tables.Freeze();
+            return tables;
+        }
+
+        private static int ExecuteInt(
+            World world,
+            IGraphRuntimeApi api,
+            Entity caster,
+            GraphInstruction[] program,
+            int intReg)
+        {
+            var f = new float[GraphVmLimits.MaxFloatRegisters];
+            var i = new int[GraphVmLimits.MaxIntRegisters];
+            var e = new Entity[GraphVmLimits.MaxEntityRegisters];
+            var b = new byte[GraphVmLimits.MaxBoolRegisters];
+            var targets = new Entity[GraphVmLimits.MaxTargets];
+            e[0] = caster;
+            e[1] = caster;
+            var state = new GraphExecutionState
+            {
+                World = world,
+                Api = api,
+                Caster = caster,
+                ExplicitTarget = caster,
+                F = f,
+                I = i,
+                E = e,
+                B = b,
+                Targets = targets,
+                TargetList = new GraphTargetList(targets),
+                CallStack = new int[GraphVmLimits.MaxCallStackDepth],
+                CallStackCount = 0,
+            };
+            GasGraphOpHandlerTable.Execute(ref state, program, GasGraphOpHandlerTable.Instance);
+            return state.I[intReg];
+        }
+    }
+}

--- a/src/Tests/GasTests/UI/PanelProjectionReaderTests.cs
+++ b/src/Tests/GasTests/UI/PanelProjectionReaderTests.cs
@@ -1,0 +1,117 @@
+using System;
+using Arch.Core;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.NodeLibraries.GASGraph;
+using Ludots.Core.Registry;
+using Ludots.Core.UI.PanelProjection;
+using NUnit.Framework;
+
+namespace Ludots.Tests.GasTests.UI
+{
+    [TestFixture]
+    public sealed class PanelProjectionReaderTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            AttributeRegistry.Clear();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            AttributeRegistry.Clear();
+        }
+
+        [Test]
+        public void ResolveFloat_SingleAttribute_ReadsCurrent()
+        {
+            int attrId = AttributeRegistry.Register("tests.panel.hp");
+            using World world = World.Create();
+            Entity owner = world.Create();
+            world.Add(owner, new AttributeBuffer());
+            ref AttributeBuffer buffer = ref world.Get<AttributeBuffer>(owner);
+            buffer.SetBase(attrId, 77f);
+
+            var reader = new PanelProjectionReader(world);
+            var binding = new PanelVariableBinding(
+                "hp",
+                PanelBindingSourceKind.SingleAttribute,
+                attributeId: "tests.panel.hp",
+                graphOutputKey: null);
+
+            Assert.That(reader.ResolveFloat(owner, in binding), Is.EqualTo(77f));
+        }
+
+        [Test]
+        public void ResolveFloat_AggregateProjection_ReadsSummaryFloat()
+        {
+            using World world = World.Create();
+            Entity owner = world.Create();
+            var keys = new StringIntRegistry(capacity: 8, startId: 1, invalidId: 0, comparer: StringComparer.Ordinal);
+            var outputs = new GraphOutputValueStore(keys, initialCapacity: 8);
+            outputs.SetFloat(owner, "panel.player.resource.ore.total", 1200f);
+
+            var reader = new PanelProjectionReader(world, outputs);
+            var binding = new PanelVariableBinding(
+                "oreTotal",
+                PanelBindingSourceKind.AggregateProjection,
+                attributeId: null,
+                graphOutputKey: "panel.player.resource.ore.total");
+
+            Assert.That(reader.ResolveFloat(owner, in binding), Is.EqualTo(1200f));
+        }
+
+        [Test]
+        public void ResolveFloat_MissingSummaryKey_Throws()
+        {
+            using World world = World.Create();
+            Entity owner = world.Create();
+            var keys = new StringIntRegistry(capacity: 8, startId: 1, invalidId: 0, comparer: StringComparer.Ordinal);
+            var outputs = new GraphOutputValueStore(keys, initialCapacity: 8);
+            var reader = new PanelProjectionReader(world, outputs);
+            var binding = new PanelVariableBinding(
+                "oreTotal",
+                PanelBindingSourceKind.GraphOutput,
+                attributeId: null,
+                graphOutputKey: "panel.player.resource.ore.total");
+
+            Assert.That(
+                () => reader.ResolveFloat(owner, in binding),
+                Throws.InvalidOperationException.With.Message.Contains("Silent zero is forbidden"));
+        }
+
+        [Test]
+        public void ResolveFloat_MissingAttribute_Throws()
+        {
+            AttributeRegistry.Register("tests.panel.hp");
+            using World world = World.Create();
+            Entity owner = world.Create();
+            world.Add(owner, new AttributeBuffer());
+
+            var reader = new PanelProjectionReader(world);
+            var binding = new PanelVariableBinding(
+                "hp",
+                PanelBindingSourceKind.SingleAttribute,
+                attributeId: "tests.panel.hp",
+                graphOutputKey: null);
+
+            Assert.That(
+                () => reader.ResolveFloat(owner, in binding),
+                Throws.InvalidOperationException.With.Message.Contains("not defined"));
+        }
+
+        [Test]
+        public void Binding_RejectsConflictingRefs()
+        {
+            Assert.That(
+                () => new PanelVariableBinding(
+                    "hp",
+                    PanelBindingSourceKind.SingleAttribute,
+                    attributeId: "tests.panel.hp",
+                    graphOutputKey: "panel.x"),
+                Throws.ArgumentException);
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fail-closed UI panel projection reader + Tag display lookup L0 ops for the player-aggregate graph MVP line.

Also fixes the Raylib showcase looking empty: producers had attributes but no mesh, so DebugDraw markers now mark Ore Depot / Crystal Hub so Space shut-down is visible.

## Test plan
- [x] Build `UiPlayerAggregateGraphMvpShowcaseMod`
- [ ] Virtual desktop: see two producer markers on the ground
- [ ] Space / Shut down → Crystal Hub goes offline, Ore/Crystal totals drop via graph projection
- [ ] Panel strip reads from `PanelProjectionReader` / `GraphOutputValueStore` (not UI hand-sum)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ae6b725-472c-4613-afa5-cff2488928e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ae6b725-472c-4613-afa5-cff2488928e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

