### PR TITLE
feat(graph): Script 控制流作者糖（#859 后可合；不含 codegen）

### DIFF
--- a/artifacts/gas-composition-gate.md
+++ b/artifacts/gas-composition-gate.md
@@ -52,3 +52,191 @@ N/A
 ### 8. Next variant test
 
 「下一个 Mod 变体」将修改: graph 连线
+
+---
+
+## GAS Composition Gate — Track B Script Wait/While sugar
+
+- **Task / Issue**: Script authoring sugar — `Wait`→`Yield`; `While`/`Until`→ JumpIfFalse + back-edge Jump（无新 opcode）；Effect/Score/Query/Validation/Derived 仍 Yield-forbidden
+- **Date**: 2026-08-11
+- **Agent / Author**: Cloud Agent (Track B)
+
+### 1. Core judgment
+
+新变体主要交付物是（A/B/C/D）: A — 既有 L0 op（Yield/Jump/JumpIfFalse）的作者层连线糖与编译展开
+
+结论: PASS
+
+一句话理由: Wait 是 Yield 的作者别名；While/Until 是 compile-time CF 糖，展开为既有 JumpIfFalse + Jump，不新增 While/Until/Wait opcode，也不把等待塞进 Effect skill。
+
+### 2. Layer assignment
+
+| 步骤/能力 | Layer (0/1/2/3) | 实现载体 |
+|-----------|-----------------|----------|
+| Yield / Jump / JumpIfFalse | 0 | 既有 `GraphNodeOp` + `GasGraphOpHandlerTable` / `ExecuteSlice` |
+| Wait / While / Until 作者节点 | 1（编译糖） | `GraphControlFlowCompiler`（Script only） |
+| Kind 禁 Yield | 1 政策 | 既有 `GraphKindOperationPolicy`（仅 Script 允许 Yield） |
+| 验收测试 | 3 | GasTests Script wait/loop fixtures |
+
+### 3. Reuse list
+
+- Handlers: `Yield`, `Jump`, `JumpIfFalse`, `Call`/`Return`（#859 L0）
+- Queues / Systems: 无
+- Resolvers / Registries: `GraphProgramRegistry`、`GraphExecutionCursor`、`GraphVmLimits.MaxInstructionsPerExecution`
+- Existing presets / graphs: `GraphScriptTestGraphs` / Script CF 文档模型
+
+### 4. New Layer 0 ops (if any)
+
+N/A — 禁止新增 While/Until/Wait opcode；Wait 编译为 Yield；While/Until 编译为 JumpIfFalse + Jump。
+
+### 5. Transaction boundary
+
+必须原子 rollback 的步骤: 无。跨帧暂停仅 Script `ExecuteSlice`；Effect 事务路径不得 Yield（政策硬拒）。
+
+### 6. Config SSOT
+
+行为配置落在: Script `GraphControlFlowDocument`（`controlEdges`/`valueEdges`）
+
+是否新增 JSON schema: NO — 仅新增作者 op 名字符串与 `body` 控制口；无 profile DSL。
+
+### 7. Red flag scan
+
+- [x] 未新增 profile inherit/placement enum
+- [x] 未新建与 spawn 平行的物化管线
+- [x] 未把 placement 校验塞进 lifecycle op
+- [x] 未添加「说不清的」默认 fallback（死循环撞 `MaxInstructionsPerExecution` 硬失败；Effect 带 Wait/Yield fail-closed）
+
+### 8. Next variant test
+
+「下一个 Mod 变体」将修改: Script graph 连线（Wait/While/Until 边），不改 Core enum / Effect skill。
+
+## GAS Composition Gate — Self Review
+
+- **Task / Issue**: #860 Track C — Roslyn/ALC codegen 控制流 IR（`Jump` / `JumpIfFalse` + `CompareLtInt` / `CompareEqInt`），叠在 R0 spike（#862）之上
+- **Date**: 2026-08-11
+- **Agent / Author**: Cursor cloud agent (bc-4cf49da4)
+
+### 1. Core judgment
+
+新变体主要交付物是（A/B/C/D）: A（执行后端扩展；同一 `GraphInstruction` IR，不新增 gameplay 变体 DSL）
+
+结论: PASS
+
+一句话理由: Track C 仅扩展 Tests 侧 emitter 白名单以发射既有控制流/比较 op 的 labels+goto C#，不新增 `BuiltinHandlerId`、`EffectPresetType`、Core GraphOps、profile enum、平行 VM 或作者糖（Tracks A/B）；仍无 Query/Effect world ops。
+
+### 2. Layer assignment
+
+| 步骤/能力 | Layer (0/1/2/3) | 实现载体 |
+|-----------|-----------------|----------|
+| 既有 IR 控制流语义 | 0（既有） | `GasGraphOpHandlerTable` Jump/JumpIfFalse/Compare*（对照基线，不改） |
+| 分支 IR → C#（labels+goto） | 工具链（非 gameplay Layer） | `LinearIntGraphCsharpEmitter`（GasTests spike 扩展） |
+| Roslyn + Collectible ALC 热换 | 工具链 | 既有 `GraphRoslynAlcCompilerHost` / `GraphGeneratedAssemblyLoadContext` |
+| 验收 | 测试 | 分支程序 ≡ interpret VM；热换；fail-closed |
+
+### 3. Reuse list
+
+- Handlers: 既有 `GasGraphOpHandlerTable`（对照基线，不改 opcode 语义）
+- Queues / Systems: N/A（不接线正式 SystemGroup）
+- Resolvers / Registries: N/A
+- Existing presets / graphs: `GraphInstruction` / `GraphExecutionState` / R0 host 合同面
+
+### 4. New Layer 0 ops (if any)
+
+N/A — 无新增 graph op；仅白名单发射既有 `Jump` / `JumpIfFalse` / `CompareLtInt` / `CompareEqInt`（外加 R0 的 `None`/`ConstInt`/`AddInt`）。非白名单仍失败关闭。
+
+### 5. Transaction boundary
+
+热重载替换：编译成功才切换执行入口；编译失败保持上一份成功实现。禁止静默回退解释器。Jump Imm 解析负 PC 失败关闭。
+
+### 6. Config SSOT
+
+行为配置落在: 既有 graph IR / 作者文档，无新 gameplay JSON schema。
+
+是否新增 JSON schema: NO — 执行后端扩展，不是新 profile DSL；不做 Tracks A/B 作者糖。
+
+### 7. Red flag scan
+
+- [x] 未新增 profile inherit/placement enum
+- [x] 未新建与 spawn 平行的物化管线
+- [x] 未把 placement 校验塞进 lifecycle op
+- [x] 未添加「说不清的」默认 fallback（unsupported op / 编译失败 fail-closed；不静默切解释器）
+
+### 8. Next variant test
+
+「下一个 Mod 变体」将修改: graph 连线 / IR 程序（改分支常量或跳转目标 → 重编 → 行为变更），不改 Core enum。后续轨再谈 Query/Effect/Yield 生成路径与正式接线。
+
+### Reuse / 新增汇总（§4.2）
+
+| 类型 | 项 |
+|------|-----|
+| 复用 | R0 emitter/host/ALC、`GraphInstruction` PC+Imm 跳转语义、`GasGraphOpHandlerTable.Execute` 对照 |
+| 新增（spike，Tests） | Jump/JumpIfFalse/Compare* → labels+goto；分支一致性与热换测试 |
+| 禁止 | 扩展 Core GraphOps；Tracks A/B 作者糖；Query/Effect world ops；静默解释器回退 |
+
+
+---
+
+## GAS Composition Gate — Self Review (Track A: BranchBool / SwitchInt sugar)
+
+- **Task / Issue**: Track A — Script CF authoring sugar BranchBool (complete) + SwitchInt (new); lower to existing L0 Jump / JumpIfFalse / CompareEqInt
+- **Date**: 2026-08-11
+- **Agent / Author**: Cloud Agent
+
+### 1. Core judgment
+
+新变体主要交付物是（A/B/C/D）: A — 既有 L0 op 的编译期连线糖（非新 GraphNodeOp enum）
+
+结论: PASS
+
+一句话理由: BranchBool / SwitchInt 仅在 `GraphControlFlowCompiler` 降为 JumpIfFalse+Jump（Switch 另加 ConstInt+CompareEqInt），不新增 L0 opcode、不平行 VM、不改 Effect/Score/Query Yield 合同。
+
+### 2. Layer assignment
+
+| 步骤/能力 | Layer (0/1/2/3) | 实现载体 |
+|-----------|-----------------|----------|
+| L0 跳转/比较 | 0 | 既有 `Jump` / `JumpIfFalse` / `CompareEqInt` / `ConstInt` |
+| 作者糖 | 1 | `GraphControlFlowCompiler` AuthoredOpKind（非 GraphNodeOp） |
+| 端口合同 | 1 | `GraphControlFlowPorts`（true/false；selector + case:{n} + default） |
+| 验收 | 3 | GasTests ci-gate（Branch / Switch） |
+
+### 3. Reuse list
+
+- Handlers: `GasGraphOpHandlerTable` 既有 Jump / JumpIfFalse / CompareEqInt / ConstInt
+- Queues / Systems: 无
+- Resolvers / Registries: `GraphProgramRegistry`（测试执行）
+- Existing presets / graphs: `GraphControlFlowDocument` + 既有 BranchBool 糖路径
+
+### 4. New Layer 0 ops (if any)
+
+N/A — 禁止新增 switch/branch opcode
+
+### 5. Transaction boundary
+
+必须原子 rollback 的步骤: 无（纯编译期糖；运行时仍单次 Script slice）
+
+### 6. Config SSOT
+
+行为配置落在: graph ControlFlow 文档（Script）
+
+是否新增 JSON schema: NO — 复用 controlEdges/valueEdges；case 值编码在控制端口名 `case:{int}`
+
+### 7. Red flag scan
+
+- [x] 未新增 profile inherit/placement enum
+- [x] 未新建与 spawn 平行的物化管线
+- [x] 未把 placement 校验塞进 lifecycle op
+- [x] 未添加「说不清的」默认 fallback（缺 default / 无 case / 非法端口 / 重复 case 值均 fail-closed）
+
+### 8. Next variant test
+
+「下一个 Mod 变体」将修改: graph 连线
+
+### Reuse / 新增表（§4.2）
+
+| 类型 | 项 |
+|------|-----|
+| 复用 | GraphControlFlowDocument、GraphControlFlowCompiler、BranchBool、Jump/JumpIfFalse/CompareEqInt/ConstInt |
+| 新增 Layer 0 op | 无 |
+| 新增 Layer 1 | SwitchInt 编译期糖（AuthoredOpKind）+ case/default 端口约定 |
+| 新增 Layer 2 | 无 |
+| 禁止 | Yield/while（Track B）、Roslyn/codegen、平行 VM、新 GraphNodeOp |

--- a/artifacts/gas-composition-gate.md
+++ b/artifacts/gas-composition-gate.md
@@ -52,3 +52,61 @@ N/A
 ### 8. Next variant test
 
 「下一个 Mod 变体」将修改: graph 连线
+
+---
+
+## GAS Composition Gate — Track B Script Wait/While sugar
+
+- **Task / Issue**: Script authoring sugar — `Wait`→`Yield`; `While`/`Until`→ JumpIfFalse + back-edge Jump（无新 opcode）；Effect/Score/Query/Validation/Derived 仍 Yield-forbidden
+- **Date**: 2026-08-11
+- **Agent / Author**: Cloud Agent (Track B)
+
+### 1. Core judgment
+
+新变体主要交付物是（A/B/C/D）: A — 既有 L0 op（Yield/Jump/JumpIfFalse）的作者层连线糖与编译展开
+
+结论: PASS
+
+一句话理由: Wait 是 Yield 的作者别名；While/Until 是 compile-time CF 糖，展开为既有 JumpIfFalse + Jump，不新增 While/Until/Wait opcode，也不把等待塞进 Effect skill。
+
+### 2. Layer assignment
+
+| 步骤/能力 | Layer (0/1/2/3) | 实现载体 |
+|-----------|-----------------|----------|
+| Yield / Jump / JumpIfFalse | 0 | 既有 `GraphNodeOp` + `GasGraphOpHandlerTable` / `ExecuteSlice` |
+| Wait / While / Until 作者节点 | 1（编译糖） | `GraphControlFlowCompiler`（Script only） |
+| Kind 禁 Yield | 1 政策 | 既有 `GraphKindOperationPolicy`（仅 Script 允许 Yield） |
+| 验收测试 | 3 | GasTests Script wait/loop fixtures |
+
+### 3. Reuse list
+
+- Handlers: `Yield`, `Jump`, `JumpIfFalse`, `Call`/`Return`（#859 L0）
+- Queues / Systems: 无
+- Resolvers / Registries: `GraphProgramRegistry`、`GraphExecutionCursor`、`GraphVmLimits.MaxInstructionsPerExecution`
+- Existing presets / graphs: `GraphScriptTestGraphs` / Script CF 文档模型
+
+### 4. New Layer 0 ops (if any)
+
+N/A — 禁止新增 While/Until/Wait opcode；Wait 编译为 Yield；While/Until 编译为 JumpIfFalse + Jump。
+
+### 5. Transaction boundary
+
+必须原子 rollback 的步骤: 无。跨帧暂停仅 Script `ExecuteSlice`；Effect 事务路径不得 Yield（政策硬拒）。
+
+### 6. Config SSOT
+
+行为配置落在: Script `GraphControlFlowDocument`（`controlEdges`/`valueEdges`）
+
+是否新增 JSON schema: NO — 仅新增作者 op 名字符串与 `body` 控制口；无 profile DSL。
+
+### 7. Red flag scan
+
+- [x] 未新增 profile inherit/placement enum
+- [x] 未新建与 spawn 平行的物化管线
+- [x] 未把 placement 校验塞进 lifecycle op
+- [x] 未添加「说不清的」默认 fallback（死循环撞 `MaxInstructionsPerExecution` 硬失败；Effect 带 Wait/Yield fail-closed）
+
+### 8. Next variant test
+
+「下一个 Mod 变体」将修改: Script graph 连线（Wait/While/Until 边），不改 Core enum / Effect skill。
+

--- a/artifacts/pr/869-audit-handoff.md
+++ b/artifacts/pr/869-audit-handoff.md
@@ -1,0 +1,49 @@
+# 审计交接：#869 Script 控制流作者糖（可合并版）
+
+**PR：** https://github.com/MightyBubble/Ludots/pull/869  
+**分支：** `cursor/graph-cf-sugar-integrate-b361`  
+**Base：** `cursor/ui-panel-graph-mvp-28e6`（#859）  
+**范围修订（相对首版交接）：** **已剥离 #860 Roslyn/ALC codegen**（回应审计：勿把 codegen 绑 #859 UI 栈）。codegen 走 [#865](https://github.com/MightyBubble/Ludots/pull/865)（main）。
+
+---
+
+## 合并结论
+
+| 项 | 状态 |
+|----|------|
+| 本 PR（糖） | **#859 放行后可合**；相对 #859 仅作者糖 + 文档 + SSOT |
+| Codegen | **不在本 PR** → [#865](https://github.com/MightyBubble/Ludots/pull/865) / [#862](https://github.com/MightyBubble/Ludots/pull/862) |
+| #866 / #867 | **勿合**（已被本 PR 取代） |
+| #863 | 合入时以 `GraphAuthoringSugar` + gitbook 糖表为名册；ParseOps 需 rebase，糖保持 Script-only |
+
+```text
+main ← #859 ← #869（本 PR，仅糖）
+main ← #865（codegen，独立）
+```
+
+---
+
+## 本 PR 交付
+
+- `BranchBool` / `SwitchInt` / `Wait`→Yield / `While` / `Until`（编译期降级，无新 L0 op）
+- `AuthoredOpKind`：1/2/3/4
+- SSOT：`GraphAuthoringSugar` + `gitbook/architecture/graph-layering-flow-and-behavior.md`「Script 作者糖」
+- Effect / Query 禁糖与禁 Yield 测试
+
+## 验证
+
+```bash
+dotnet test src/Tests/GasTests/GasTests.csproj \
+  --filter "FullyQualifiedName~GraphBranchSwitchSugarTests|FullyQualifiedName~GraphScriptWaitLoopSugarTests" \
+  -o /tmp/pr869-sugar
+```
+
+## 审计门禁对照（Cursor Automation）
+
+| 原阻断 | 本版处置 |
+|--------|----------|
+| ci-gate 夹带微基准 | codegen 已移出本 PR；在 #865 修复 |
+| codegen 绑 #859 | **已剥离** |
+| 糖 SSOT / gitbook / #863 | **已补** `GraphAuthoringSugar` + gitbook；#863 合并约定已写明 |
+| FromGraphConfig next-chain | 随 codegen 移至 #865 修复 |
+| 交接过度乐观 | 本文件改为：**糖在 #859 后可合；codegen 另线** |

--- a/gitbook/architecture/graph-layering-flow-and-behavior.md
+++ b/gitbook/architecture/graph-layering-flow-and-behavior.md
@@ -40,6 +40,22 @@ L0 GraphInstruction + handler table + Execute / ExecuteSlice
 
 跨图复用：`InvokeScript`（本切片只允许目标 Script **不含 Yield**）。
 
+### Script 作者糖（编译期降级）
+
+作者节点名 SSOT：`GraphAuthoringSugar`（非 `GraphNodeOp`）。仅 **Script** ControlFlow 文档可用；Query / Effect / Score / Validation / Derived 使用必须失败关闭。运行时仍是同一套 L0 handler 表，不新增 While/Switch opcode。
+
+| 节点 | 端口 | 降级为 L0 | Kind |
+|------|------|-----------|------|
+| `BranchBool` | `condition`（bool 值边）；`true` / `false`（控制边） | `JumpIfFalse` + `Jump` | Script only |
+| `SwitchInt` | `selector`（int 值边）；`case:{N}` / `default`（控制边） | 每臂 `ConstInt` + `CompareEqInt` + `JumpIfFalse` + `Jump`，再 `Jump(default)` | Script only |
+| `Wait` | `next`（控制边） | 作者别名 → `Yield` | Script only |
+| `While` | `condition`（bool）；`body` / `next`（控制边） | `JumpIfFalse(cond)→next` + `Jump→body`（回边由作者边闭合） | Script only |
+| `Until` | `condition`（bool）；`body` / `next`（控制边） | `JumpIfFalse(cond)→body` + `Jump→next`（条件为真时退出） | Script only |
+
+步数硬顶：`GraphVmLimits.MaxInstructionsPerExecution`（失控循环失败关闭，禁止静默截断当成功）。
+
+与 [#861](https://github.com/MightyBubble/Ludots/issues/861) / PR #863（`GraphAuthoringKindPolicy` Kind 矩阵）的合并约定：糖必须保持 **Script-only**；扩展线性 Kind 前门时不得把上述糖名放进 Effect/Score 白名单；两线改 `GraphControlFlowCompiler.ParseOps` 时以本表 + `GraphAuthoringSugar` 为名册 SSOT。
+
 ### Query ControlFlow
 
 - 列表流（`Query*` / `Relationship*` 过滤与聚合）必须用 `valueEdges` 的 `list` 显式连接；控制边 `next` 不隐含 TargetList。

--- a/src/Core/GraphRuntime/GraphControlFlowDocument.cs
+++ b/src/Core/GraphRuntime/GraphControlFlowDocument.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Ludots.Core.NodeLibraries.GASGraph;
 
 namespace Ludots.Core.GraphRuntime
@@ -98,5 +100,30 @@ namespace Ludots.Core.GraphRuntime
         public const string A = "a";
         public const string B = "b";
         public const string Condition = "condition";
+        /// <summary>Int selector input for SwitchInt compile-time sugar.</summary>
+        public const string Selector = "selector";
+        /// <summary>Default arm control port for SwitchInt compile-time sugar.</summary>
+        public const string Default = "default";
+        /// <summary>Control port prefix for SwitchInt arms; full port is case:{int}.</summary>
+        public const string CasePrefix = "case:";
+
+        public static string Case(int caseValue)
+            => CasePrefix + caseValue.ToString(CultureInfo.InvariantCulture);
+
+        public static bool TryParseCasePort(string port, out int caseValue)
+        {
+            caseValue = 0;
+            if (string.IsNullOrEmpty(port) ||
+                !port.StartsWith(CasePrefix, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            return int.TryParse(
+                port.AsSpan(CasePrefix.Length),
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out caseValue);
+        }
     }
 }

--- a/src/Core/GraphRuntime/GraphControlFlowDocument.cs
+++ b/src/Core/GraphRuntime/GraphControlFlowDocument.cs
@@ -87,6 +87,8 @@ namespace Ludots.Core.GraphRuntime
         public const string Next = "next";
         public const string True = "true";
         public const string False = "false";
+        /// <summary>Loop body entry for While/Until author sugar.</summary>
+        public const string Body = "body";
         public const string Call = "call";
         public const string Target = "target";
         public const string Value = "value";

--- a/src/Core/NodeLibraries/GASGraph/GraphAuthoringSugar.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphAuthoringSugar.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Ludots.Core.NodeLibraries.GASGraph
+{
+    /// <summary>
+    /// Script-only ControlFlow authoring sugar SSOT.
+    /// These names are compile-time sugar (not <see cref="GraphNodeOp"/> values);
+    /// they lower in <see cref="GraphControlFlowCompiler"/> to Jump / Yield / compares.
+    /// </summary>
+    public static class GraphAuthoringSugar
+    {
+        public const string BranchBool = "BranchBool";
+        public const string SwitchInt = "SwitchInt";
+        public const string Wait = "Wait";
+        public const string While = "While";
+        public const string Until = "Until";
+
+        public static bool IsScriptOnlySugar(string? opName)
+        {
+            if (string.IsNullOrWhiteSpace(opName))
+            {
+                return false;
+            }
+
+            return string.Equals(opName, BranchBool, StringComparison.Ordinal) ||
+                   string.Equals(opName, SwitchInt, StringComparison.Ordinal) ||
+                   string.Equals(opName, Wait, StringComparison.Ordinal) ||
+                   string.Equals(opName, While, StringComparison.Ordinal) ||
+                   string.Equals(opName, Until, StringComparison.Ordinal);
+        }
+
+        public static string DescribeScriptOnlySugar()
+            => $"{BranchBool}, {SwitchInt}, {Wait}, {While}, {Until}";
+    }
+}

--- a/src/Core/NodeLibraries/GASGraph/GraphControlFlowCompiler.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphControlFlowCompiler.cs
@@ -57,11 +57,36 @@ namespace Ludots.Core.NodeLibraries.GASGraph
 
     /// <summary>
     /// Compiles L1 Script and Query control-flow documents into <see cref="GraphInstruction"/> using GraphNodeOp.
-    /// BranchBool is compile-time sugar only (not a GraphNodeOp).
+    /// BranchBool and SwitchInt are compile-time sugar only (not GraphNodeOp values).
     /// </summary>
     public static partial class GraphControlFlowCompiler
     {
         public const string BranchBoolOp = "BranchBool";
+        public const string SwitchIntOp = "SwitchInt";
+
+        private readonly struct SugarScratch
+        {
+            public SugarScratch(byte intReg, byte boolReg)
+            {
+                IntReg = intReg;
+                BoolReg = boolReg;
+            }
+
+            public byte IntReg { get; }
+            public byte BoolReg { get; }
+        }
+
+        private readonly struct SwitchCaseArm
+        {
+            public SwitchCaseArm(int caseValue, string targetNodeId)
+            {
+                CaseValue = caseValue;
+                TargetNodeId = targetNodeId;
+            }
+
+            public int CaseValue { get; }
+            public string TargetNodeId { get; }
+        }
 
         private readonly struct ControlKey : IEquatable<ControlKey>
         {
@@ -116,7 +141,8 @@ namespace Ludots.Core.NodeLibraries.GASGraph
         private enum AuthoredOpKind : byte
         {
             GraphNodeOp = 0,
-            BranchBool = 1
+            BranchBool = 1,
+            SwitchInt = 2
         }
 
         private readonly struct AuthoredOp
@@ -171,6 +197,8 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             ValidateRequiredEdges(nodes, ops, graphKind, controlEdges, valueEdges, nodeIndices, outputTypes, graphId, diagnostics);
             DetectUnreachable(document.Entry, nodes, document.ControlEdges, graphId, diagnostics);
 
+            var sugarScratches = new SugarScratch[nodes.Count];
+            AllocateSugarScratches(nodes, ops, outputTypes, outputRegisters, sugarScratches, graphId, diagnostics);
             NodeLayout[] layouts = BuildLayouts(nodes, ops, graphKind, controlEdges, diagnostics);
             if (HasErrors(diagnostics))
             {
@@ -228,6 +256,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                     ops[i],
                     outputRegisters,
                     outputTypes,
+                    sugarScratches,
                     controlEdges,
                     valueEdges,
                     nodeIndices,
@@ -347,7 +376,25 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 GraphControlFlowNode node = nodes[i];
                 if (string.Equals(node.Op, BranchBoolOp, StringComparison.Ordinal))
                 {
+                    if (graphKind != GraphKind.Script)
+                    {
+                        diagnostics.Add(Error(graphId, GraphDiagnosticCodes.UnknownNodeOp,
+                            $"{BranchBoolOp} is Script compile-time sugar only.", node.Id));
+                    }
+
                     ops[i] = new AuthoredOp(AuthoredOpKind.BranchBool, GraphNodeOp.None);
+                    continue;
+                }
+
+                if (string.Equals(node.Op, SwitchIntOp, StringComparison.Ordinal))
+                {
+                    if (graphKind != GraphKind.Script)
+                    {
+                        diagnostics.Add(Error(graphId, GraphDiagnosticCodes.UnknownNodeOp,
+                            $"{SwitchIntOp} is Script compile-time sugar only.", node.Id));
+                    }
+
+                    ops[i] = new AuthoredOp(AuthoredOpKind.SwitchInt, GraphNodeOp.None);
                     continue;
                 }
 
@@ -541,7 +588,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
 
         private static GraphValueType GetOutputType(AuthoredOp op, GraphKind graphKind)
         {
-            if (op.Kind == AuthoredOpKind.BranchBool)
+            if (op.Kind is AuthoredOpKind.BranchBool or AuthoredOpKind.SwitchInt)
             {
                 return GraphValueType.Void;
             }
@@ -590,6 +637,12 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                         outputTypes,
                         graphId,
                         diagnostics);
+                    continue;
+                }
+
+                if (op.Kind == AuthoredOpKind.SwitchInt)
+                {
+                    ValidateSwitchIntEdges(node, controlEdges, valueEdges, nodeIndices, outputTypes, graphId, diagnostics);
                     continue;
                 }
 
@@ -691,6 +744,12 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 return port is GraphControlFlowPorts.True or GraphControlFlowPorts.False;
             }
 
+            if (op.Kind == AuthoredOpKind.SwitchInt)
+            {
+                return port == GraphControlFlowPorts.Default ||
+                       GraphControlFlowPorts.TryParseCasePort(port, out _);
+            }
+
             return op.NodeOp switch
             {
                 GraphNodeOp.Call => port is GraphControlFlowPorts.Call or GraphControlFlowPorts.Next,
@@ -710,6 +769,11 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             if (op.Kind == AuthoredOpKind.BranchBool || op.NodeOp == GraphNodeOp.JumpIfFalse)
             {
                 return port == GraphControlFlowPorts.Condition;
+            }
+
+            if (op.Kind == AuthoredOpKind.SwitchInt)
+            {
+                return port == GraphControlFlowPorts.Selector;
             }
 
             return op.NodeOp switch
@@ -831,6 +895,13 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 return 2; // JumpIfFalse + Jump(true)
             }
 
+            if (op.Kind == AuthoredOpKind.SwitchInt)
+            {
+                int cases = CountSwitchCaseArms(node.Id, controlEdges);
+                // per arm: ConstInt + CompareEqInt + JumpIfFalse + Jump(arm); then Jump(default)
+                return (cases * 4) + 1;
+            }
+
             return op.NodeOp switch
             {
                 GraphNodeOp.Return or GraphNodeOp.HaltReturnInt or GraphNodeOp.Jump => 1,
@@ -846,6 +917,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             AuthoredOp op,
             byte[] outputRegisters,
             GraphValueType[] outputTypes,
+            SugarScratch[] sugarScratches,
             Dictionary<ControlKey, string> controlEdges,
             Dictionary<ValueInputKey, GraphControlFlowValueEdge> valueEdges,
             Dictionary<string, int> nodeIndices,
@@ -902,6 +974,27 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 EmitRelativeJump(
                     document, node, GraphControlFlowPorts.True, bodyIndex + 1,
                     controlEdges, nodeIndices, layouts, program, sources, graphId);
+                return;
+            }
+
+            if (op.Kind == AuthoredOpKind.SwitchInt)
+            {
+                CompileSwitchInt(
+                    document,
+                    node,
+                    sugarScratches[nodeIndex],
+                    controlEdges,
+                    valueEdges,
+                    nodeIndices,
+                    layouts,
+                    program,
+                    sources,
+                    outputRegisters,
+                    outputTypes,
+                    definedInts,
+                    definedBools,
+                    graphId,
+                    diagnostics);
                 return;
             }
 
@@ -1022,6 +1115,225 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                         $"Op '{op.NodeOp}' is not supported by GraphControlFlowCompiler.", node.Id));
                     break;
             }
+        }
+
+
+        private static void AllocateSugarScratches(
+            List<GraphControlFlowNode> nodes,
+            AuthoredOp[] ops,
+            GraphValueType[] outputTypes,
+            byte[] outputRegisters,
+            SugarScratch[] sugarScratches,
+            string graphId,
+            List<GraphDiagnostic> diagnostics)
+        {
+            var usedInt = new bool[GraphVmLimits.MaxIntRegisters];
+            var usedBool = new bool[GraphVmLimits.MaxBoolRegisters];
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                if (outputTypes[i] == GraphValueType.Int)
+                {
+                    usedInt[outputRegisters[i]] = true;
+                }
+                else if (outputTypes[i] == GraphValueType.Bool)
+                {
+                    usedBool[outputRegisters[i]] = true;
+                }
+            }
+
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                if (ops[i].Kind != AuthoredOpKind.SwitchInt)
+                {
+                    continue;
+                }
+
+                byte intReg = AllocFree(usedInt, GraphVmLimits.MaxIntRegisters, graphId, nodes[i].Id, diagnostics);
+                byte boolReg = AllocFree(usedBool, GraphVmLimits.MaxBoolRegisters, graphId, nodes[i].Id, diagnostics);
+                sugarScratches[i] = new SugarScratch(intReg, boolReg);
+            }
+        }
+
+        private static byte AllocFree(
+            bool[] used,
+            int max,
+            string graphId,
+            string nodeId,
+            List<GraphDiagnostic> diagnostics)
+        {
+            for (int i = 0; i < max; i++)
+            {
+                if (!used[i])
+                {
+                    used[i] = true;
+                    return (byte)i;
+                }
+            }
+
+            diagnostics.Add(Error(graphId, GraphDiagnosticCodes.RegisterOutOfRange,
+                $"Register budget exceeded ({max}).", nodeId));
+            return 0;
+        }
+
+        private static void ValidateSwitchIntEdges(
+            GraphControlFlowNode node,
+            Dictionary<ControlKey, string> controlEdges,
+            Dictionary<ValueInputKey, GraphControlFlowValueEdge> valueEdges,
+            Dictionary<string, int> nodeIndices,
+            GraphValueType[] outputTypes,
+            string graphId,
+            List<GraphDiagnostic> diagnostics)
+        {
+            RequireControlEdge(node, GraphControlFlowPorts.Default, controlEdges, graphId, diagnostics);
+            RequireValueInput(node, GraphControlFlowPorts.Selector, GraphValueType.Int, valueEdges, nodeIndices, outputTypes, graphId, diagnostics);
+
+            var seenCases = new HashSet<int>();
+            int caseCount = 0;
+            foreach (ControlKey key in controlEdges.Keys)
+            {
+                if (!string.Equals(key.NodeId, node.Id, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (key.Port == GraphControlFlowPorts.Default)
+                {
+                    continue;
+                }
+
+                if (!GraphControlFlowPorts.TryParseCasePort(key.Port, out int caseValue))
+                {
+                    continue;
+                }
+
+                if (!seenCases.Add(caseValue))
+                {
+                    diagnostics.Add(Error(graphId, GraphDiagnosticCodes.DuplicateControlEdge,
+                        $"Duplicate SwitchInt case value {caseValue} on node '{node.Id}'.", node.Id));
+                }
+
+                caseCount++;
+            }
+
+            if (caseCount == 0)
+            {
+                diagnostics.Add(Error(graphId, GraphDiagnosticCodes.MissingControlEdge,
+                    $"SwitchInt node '{node.Id}' requires at least one case:{{n}} control edge.", node.Id));
+            }
+        }
+
+        private static int CountSwitchCaseArms(string nodeId, Dictionary<ControlKey, string> controlEdges)
+        {
+            int count = 0;
+            foreach (ControlKey key in controlEdges.Keys)
+            {
+                if (string.Equals(key.NodeId, nodeId, StringComparison.Ordinal) &&
+                    GraphControlFlowPorts.TryParseCasePort(key.Port, out _))
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        private static List<SwitchCaseArm> CollectSwitchCaseArms(
+            GraphControlFlowDocument document,
+            GraphControlFlowNode node)
+        {
+            var arms = new List<SwitchCaseArm>();
+            List<GraphControlFlowEdge> edges = document.ControlEdges ?? new List<GraphControlFlowEdge>();
+            for (int i = 0; i < edges.Count; i++)
+            {
+                GraphControlFlowEdge edge = edges[i];
+                if (!string.Equals(edge.From, node.Id, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (!GraphControlFlowPorts.TryParseCasePort(edge.FromPort, out int caseValue))
+                {
+                    continue;
+                }
+
+                arms.Add(new SwitchCaseArm(caseValue, edge.To));
+            }
+
+            return arms;
+        }
+
+        private static void CompileSwitchInt(
+            GraphControlFlowDocument document,
+            GraphControlFlowNode node,
+            SugarScratch scratch,
+            Dictionary<ControlKey, string> controlEdges,
+            Dictionary<ValueInputKey, GraphControlFlowValueEdge> valueEdges,
+            Dictionary<string, int> nodeIndices,
+            NodeLayout[] layouts,
+            GraphInstruction[] program,
+            GraphInstructionSource[] sources,
+            byte[] outputRegisters,
+            GraphValueType[] outputTypes,
+            bool[] definedInts,
+            bool[] definedBools,
+            string graphId,
+            List<GraphDiagnostic> diagnostics)
+        {
+            int nodeIndex = nodeIndices[node.Id];
+            int bodyIndex = layouts[nodeIndex].BodyIndex;
+            List<SwitchCaseArm> arms = CollectSwitchCaseArms(document, node);
+            byte selector = ResolveValueInput(
+                node, GraphControlFlowPorts.Selector, GraphValueType.Int,
+                valueEdges, nodeIndices, outputTypes, outputRegisters, definedInts, definedBools, graphId, diagnostics);
+            int defaultAbs = ResolveControlTarget(node, GraphControlFlowPorts.Default, controlEdges, nodeIndices, layouts);
+            int defaultJumpIndex = bodyIndex + (arms.Count * 4);
+
+            for (int i = 0; i < arms.Count; i++)
+            {
+                SwitchCaseArm arm = arms[i];
+                int armBase = bodyIndex + (i * 4);
+                int nextCheck = (i + 1 < arms.Count) ? bodyIndex + ((i + 1) * 4) : defaultJumpIndex;
+                int armAbs = layouts[nodeIndices[arm.TargetNodeId]].BodyIndex;
+
+                program[armBase] = new GraphInstruction
+                {
+                    Op = (ushort)GraphNodeOp.ConstInt,
+                    Dst = scratch.IntReg,
+                    Imm = arm.CaseValue
+                };
+                SetSource(sources, armBase, graphId, node, SwitchIntOp, GraphControlFlowPorts.Case(arm.CaseValue));
+
+                program[armBase + 1] = new GraphInstruction
+                {
+                    Op = (ushort)GraphNodeOp.CompareEqInt,
+                    Dst = scratch.BoolReg,
+                    A = selector,
+                    B = scratch.IntReg
+                };
+                SetSource(sources, armBase + 1, graphId, node, SwitchIntOp, GraphControlFlowPorts.Case(arm.CaseValue));
+
+                program[armBase + 2] = new GraphInstruction
+                {
+                    Op = (ushort)GraphNodeOp.JumpIfFalse,
+                    A = scratch.BoolReg,
+                    Imm = RelativeOffset(armBase + 2, nextCheck)
+                };
+                SetSource(sources, armBase + 2, graphId, node, SwitchIntOp, GraphControlFlowPorts.Case(arm.CaseValue));
+
+                program[armBase + 3] = new GraphInstruction
+                {
+                    Op = (ushort)GraphNodeOp.Jump,
+                    Imm = RelativeOffset(armBase + 3, armAbs)
+                };
+                SetSource(sources, armBase + 3, graphId, node, SwitchIntOp, GraphControlFlowPorts.Case(arm.CaseValue));
+            }
+
+            program[defaultJumpIndex] = new GraphInstruction
+            {
+                Op = (ushort)GraphNodeOp.Jump,
+                Imm = RelativeOffset(defaultJumpIndex, defaultAbs)
+            };
+            SetSource(sources, defaultJumpIndex, graphId, node, SwitchIntOp, GraphControlFlowPorts.Default);
         }
 
         private static void EmitRelativeJump(

--- a/src/Core/NodeLibraries/GASGraph/GraphControlFlowCompiler.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphControlFlowCompiler.cs
@@ -57,11 +57,15 @@ namespace Ludots.Core.NodeLibraries.GASGraph
 
     /// <summary>
     /// Compiles L1 Script and Query control-flow documents into <see cref="GraphInstruction"/> using GraphNodeOp.
-    /// BranchBool is compile-time sugar only (not a GraphNodeOp).
+    /// BranchBool / While / Until are compile-time sugar only (not GraphNodeOp values).
+    /// Wait is an author alias for <see cref="GraphNodeOp.Yield"/> (Script only).
     /// </summary>
     public static partial class GraphControlFlowCompiler
     {
         public const string BranchBoolOp = "BranchBool";
+        public const string WaitOp = "Wait";
+        public const string WhileOp = "While";
+        public const string UntilOp = "Until";
 
         private readonly struct ControlKey : IEquatable<ControlKey>
         {
@@ -116,7 +120,9 @@ namespace Ludots.Core.NodeLibraries.GASGraph
         private enum AuthoredOpKind : byte
         {
             GraphNodeOp = 0,
-            BranchBool = 1
+            BranchBool = 1,
+            While = 2,
+            Until = 3
         }
 
         private readonly struct AuthoredOp
@@ -351,6 +357,49 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                     continue;
                 }
 
+                if (string.Equals(node.Op, WhileOp, StringComparison.Ordinal))
+                {
+                    if (graphKind != GraphKind.Script)
+                    {
+                        diagnostics.Add(Error(graphId, GraphDiagnosticCodes.UnknownNodeOp,
+                            $"While is Script-only author sugar (kind='{graphKind}').", node.Id));
+                        ops[i] = new AuthoredOp(AuthoredOpKind.GraphNodeOp, GraphNodeOp.None);
+                        continue;
+                    }
+
+                    ops[i] = new AuthoredOp(AuthoredOpKind.While, GraphNodeOp.None);
+                    continue;
+                }
+
+                if (string.Equals(node.Op, UntilOp, StringComparison.Ordinal))
+                {
+                    if (graphKind != GraphKind.Script)
+                    {
+                        diagnostics.Add(Error(graphId, GraphDiagnosticCodes.UnknownNodeOp,
+                            $"Until is Script-only author sugar (kind='{graphKind}').", node.Id));
+                        ops[i] = new AuthoredOp(AuthoredOpKind.GraphNodeOp, GraphNodeOp.None);
+                        continue;
+                    }
+
+                    ops[i] = new AuthoredOp(AuthoredOpKind.Until, GraphNodeOp.None);
+                    continue;
+                }
+
+                // Wait is author alias for Yield — Script CF only; never a second waiter opcode.
+                if (string.Equals(node.Op, WaitOp, StringComparison.Ordinal))
+                {
+                    if (graphKind != GraphKind.Script)
+                    {
+                        diagnostics.Add(Error(graphId, GraphDiagnosticCodes.UnknownNodeOp,
+                            $"Wait is Script-only author alias for Yield (kind='{graphKind}').", node.Id));
+                        ops[i] = new AuthoredOp(AuthoredOpKind.GraphNodeOp, GraphNodeOp.None);
+                        continue;
+                    }
+
+                    ops[i] = new AuthoredOp(AuthoredOpKind.GraphNodeOp, GraphNodeOp.Yield);
+                    continue;
+                }
+
                 if (!GraphNodeOpParser.TryParse(node.Op, out GraphNodeOp nodeOp) ||
                     !IsControlFlowAuthorable(graphKind, nodeOp))
                 {
@@ -541,7 +590,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
 
         private static GraphValueType GetOutputType(AuthoredOp op, GraphKind graphKind)
         {
-            if (op.Kind == AuthoredOpKind.BranchBool)
+            if (op.Kind is AuthoredOpKind.BranchBool or AuthoredOpKind.While or AuthoredOpKind.Until)
             {
                 return GraphValueType.Void;
             }
@@ -597,6 +646,14 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 {
                     RequireControlEdge(node, GraphControlFlowPorts.True, controlEdges, graphId, diagnostics);
                     RequireControlEdge(node, GraphControlFlowPorts.False, controlEdges, graphId, diagnostics);
+                    RequireValueInput(node, GraphControlFlowPorts.Condition, GraphValueType.Bool, valueEdges, nodeIndices, outputTypes, graphId, diagnostics);
+                    continue;
+                }
+
+                if (op.Kind is AuthoredOpKind.While or AuthoredOpKind.Until)
+                {
+                    RequireControlEdge(node, GraphControlFlowPorts.Body, controlEdges, graphId, diagnostics);
+                    RequireControlEdge(node, GraphControlFlowPorts.Next, controlEdges, graphId, diagnostics);
                     RequireValueInput(node, GraphControlFlowPorts.Condition, GraphValueType.Bool, valueEdges, nodeIndices, outputTypes, graphId, diagnostics);
                     continue;
                 }
@@ -691,6 +748,11 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 return port is GraphControlFlowPorts.True or GraphControlFlowPorts.False;
             }
 
+            if (op.Kind is AuthoredOpKind.While or AuthoredOpKind.Until)
+            {
+                return port is GraphControlFlowPorts.Body or GraphControlFlowPorts.Next;
+            }
+
             return op.NodeOp switch
             {
                 GraphNodeOp.Call => port is GraphControlFlowPorts.Call or GraphControlFlowPorts.Next,
@@ -707,7 +769,10 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 return IsAllowedQueryInputPort(op.NodeOp, port);
             }
 
-            if (op.Kind == AuthoredOpKind.BranchBool || op.NodeOp == GraphNodeOp.JumpIfFalse)
+            if (op.Kind == AuthoredOpKind.BranchBool ||
+                op.Kind == AuthoredOpKind.While ||
+                op.Kind == AuthoredOpKind.Until ||
+                op.NodeOp == GraphNodeOp.JumpIfFalse)
             {
                 return port == GraphControlFlowPorts.Condition;
             }
@@ -826,9 +891,12 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 return controlEdges.ContainsKey(new ControlKey(node.Id, GraphControlFlowPorts.Next)) ? 2 : 1;
             }
 
-            if (op.Kind == AuthoredOpKind.BranchBool || op.NodeOp == GraphNodeOp.JumpIfFalse)
+            if (op.Kind == AuthoredOpKind.BranchBool ||
+                op.Kind == AuthoredOpKind.While ||
+                op.Kind == AuthoredOpKind.Until ||
+                op.NodeOp == GraphNodeOp.JumpIfFalse)
             {
-                return 2; // JumpIfFalse + Jump(true)
+                return 2; // JumpIfFalse + Jump(arm)
             }
 
             return op.NodeOp switch
@@ -901,6 +969,46 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 SetSource(sources, bodyIndex, graphId, node, BranchBoolOp, GraphControlFlowPorts.Enter);
                 EmitRelativeJump(
                     document, node, GraphControlFlowPorts.True, bodyIndex + 1,
+                    controlEdges, nodeIndices, layouts, program, sources, graphId);
+                return;
+            }
+
+            if (op.Kind == AuthoredOpKind.While)
+            {
+                // while (cond) body;  =>  JumpIfFalse(cond)->next; Jump->body
+                byte cond = ResolveValueInput(
+                    node, GraphControlFlowPorts.Condition, GraphValueType.Bool,
+                    valueEdges, nodeIndices, outputTypes, outputRegisters, definedInts, definedBools, graphId, diagnostics);
+                int nextAbs = ResolveControlTarget(node, GraphControlFlowPorts.Next, controlEdges, nodeIndices, layouts);
+                program[bodyIndex] = new GraphInstruction
+                {
+                    Op = (ushort)GraphNodeOp.JumpIfFalse,
+                    A = cond,
+                    Imm = RelativeOffset(bodyIndex, nextAbs)
+                };
+                SetSource(sources, bodyIndex, graphId, node, WhileOp, GraphControlFlowPorts.Enter);
+                EmitRelativeJump(
+                    document, node, GraphControlFlowPorts.Body, bodyIndex + 1,
+                    controlEdges, nodeIndices, layouts, program, sources, graphId);
+                return;
+            }
+
+            if (op.Kind == AuthoredOpKind.Until)
+            {
+                // until (cond) body;  =>  JumpIfFalse(cond)->body; Jump->next  (exit when true)
+                byte cond = ResolveValueInput(
+                    node, GraphControlFlowPorts.Condition, GraphValueType.Bool,
+                    valueEdges, nodeIndices, outputTypes, outputRegisters, definedInts, definedBools, graphId, diagnostics);
+                int bodyAbs = ResolveControlTarget(node, GraphControlFlowPorts.Body, controlEdges, nodeIndices, layouts);
+                program[bodyIndex] = new GraphInstruction
+                {
+                    Op = (ushort)GraphNodeOp.JumpIfFalse,
+                    A = cond,
+                    Imm = RelativeOffset(bodyIndex, bodyAbs)
+                };
+                SetSource(sources, bodyIndex, graphId, node, UntilOp, GraphControlFlowPorts.Enter);
+                EmitRelativeJump(
+                    document, node, GraphControlFlowPorts.Next, bodyIndex + 1,
                     controlEdges, nodeIndices, layouts, program, sources, graphId);
                 return;
             }
@@ -997,7 +1105,13 @@ namespace Ludots.Core.NodeLibraries.GASGraph
 
                 case GraphNodeOp.Yield:
                     program[bodyIndex] = new GraphInstruction { Op = (ushort)GraphNodeOp.Yield };
-                    SetSource(sources, bodyIndex, graphId, node, nameof(GraphNodeOp.Yield), GraphControlFlowPorts.Enter);
+                    SetSource(
+                        sources,
+                        bodyIndex,
+                        graphId,
+                        node,
+                        string.Equals(node.Op, WaitOp, StringComparison.Ordinal) ? WaitOp : nameof(GraphNodeOp.Yield),
+                        GraphControlFlowPorts.Enter);
                     EmitRelativeJump(document, node, GraphControlFlowPorts.Next, bodyIndex + 1, controlEdges, nodeIndices, layouts, program, sources, graphId);
                     break;
 

--- a/src/Core/NodeLibraries/GASGraph/GraphControlFlowCompiler.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphControlFlowCompiler.cs
@@ -62,11 +62,11 @@ namespace Ludots.Core.NodeLibraries.GASGraph
     /// </summary>
     public static partial class GraphControlFlowCompiler
     {
-        public const string BranchBoolOp = "BranchBool";
-        public const string SwitchIntOp = "SwitchInt";
-        public const string WaitOp = "Wait";
-        public const string WhileOp = "While";
-        public const string UntilOp = "Until";
+        public const string BranchBoolOp = GraphAuthoringSugar.BranchBool;
+        public const string SwitchIntOp = GraphAuthoringSugar.SwitchInt;
+        public const string WaitOp = GraphAuthoringSugar.Wait;
+        public const string WhileOp = GraphAuthoringSugar.While;
+        public const string UntilOp = GraphAuthoringSugar.Until;
 
         private readonly struct SugarScratch
         {

--- a/src/Tests/GasTests/Graph/GraphBranchSwitchSugarTests.cs
+++ b/src/Tests/GasTests/Graph/GraphBranchSwitchSugarTests.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Arch.Core;
+using Ludots.Core.GraphRuntime;
+using Ludots.Core.NodeLibraries.GASGraph;
+using NUnit.Framework;
+
+namespace Ludots.Tests.Gas.Graph
+{
+    [TestFixture]
+    [Category("ci-gate")]
+    public sealed class GraphBranchSwitchSugarTests
+    {
+        [Test]
+        public void BranchBool_TruePath_ReturnsTrueArmValue()
+        {
+            GraphControlFlowCompileResult compiled = GraphControlFlowCompiler.Compile(
+                CreateBranchBoolGraph(left: 1, right: 2));
+            Assert.That(compiled.Succeeded, Is.True, GraphScriptTestGraphs.FormatDiagnostics(compiled.Diagnostics));
+            Assert.That(compiled.Program.Select(i => (GraphNodeOp)i.Op), Does.Contain(GraphNodeOp.JumpIfFalse));
+            Assert.That(compiled.Program.Select(i => (GraphNodeOp)i.Op), Does.Contain(GraphNodeOp.Jump));
+
+            Assert.That(ExecuteHaltReturn(compiled.Program), Is.EqualTo(10));
+        }
+
+        [Test]
+        public void BranchBool_FalsePath_ReturnsFalseArmValue()
+        {
+            GraphControlFlowCompileResult compiled = GraphControlFlowCompiler.Compile(
+                CreateBranchBoolGraph(left: 2, right: 1));
+            Assert.That(compiled.Succeeded, Is.True, GraphScriptTestGraphs.FormatDiagnostics(compiled.Diagnostics));
+
+            Assert.That(ExecuteHaltReturn(compiled.Program), Is.EqualTo(20));
+        }
+
+        [Test]
+        public void SwitchInt_HitsMatchingCaseArm()
+        {
+            GraphControlFlowCompileResult compiled = GraphControlFlowCompiler.Compile(
+                CreateSwitchIntGraph(selectorValue: 1));
+            Assert.That(compiled.Succeeded, Is.True, GraphScriptTestGraphs.FormatDiagnostics(compiled.Diagnostics));
+            Assert.That(compiled.Program.Select(i => (GraphNodeOp)i.Op), Does.Contain(GraphNodeOp.CompareEqInt));
+            Assert.That(compiled.Program.Select(i => (GraphNodeOp)i.Op), Does.Contain(GraphNodeOp.JumpIfFalse));
+            Assert.That(compiled.Program.Select(i => (GraphNodeOp)i.Op), Does.Contain(GraphNodeOp.Jump));
+
+            Assert.That(ExecuteHaltReturn(compiled.Program), Is.EqualTo(101));
+        }
+
+        [Test]
+        public void SwitchInt_HitsDefaultWhenNoCaseMatches()
+        {
+            GraphControlFlowCompileResult compiled = GraphControlFlowCompiler.Compile(
+                CreateSwitchIntGraph(selectorValue: 99));
+            Assert.That(compiled.Succeeded, Is.True, GraphScriptTestGraphs.FormatDiagnostics(compiled.Diagnostics));
+
+            Assert.That(ExecuteHaltReturn(compiled.Program), Is.EqualTo(900));
+        }
+
+        [Test]
+        public void SwitchInt_MissingDefault_FailsClosed()
+        {
+            GraphControlFlowDocument graph = CreateSwitchIntGraph(selectorValue: 0);
+            graph.ControlEdges.RemoveAll(e =>
+                e.From == "sw" && e.FromPort == GraphControlFlowPorts.Default);
+
+            GraphControlFlowCompileResult compiled = GraphControlFlowCompiler.Compile(graph);
+            Assert.That(compiled.Succeeded, Is.False);
+            Assert.That(compiled.Diagnostics, Has.Some.Matches<GraphDiagnostic>(d =>
+                d.Code == GraphDiagnosticCodes.MissingControlEdge && d.NodeId == "sw"));
+        }
+
+        [Test]
+        public void SwitchInt_NoCaseArms_FailsClosed()
+        {
+            GraphControlFlowDocument graph = CreateSwitchIntGraph(selectorValue: 0);
+            graph.ControlEdges.RemoveAll(e =>
+                e.From == "sw" && GraphControlFlowPorts.TryParseCasePort(e.FromPort, out _));
+
+            GraphControlFlowCompileResult compiled = GraphControlFlowCompiler.Compile(graph);
+            Assert.That(compiled.Succeeded, Is.False);
+            Assert.That(compiled.Diagnostics, Has.Some.Matches<GraphDiagnostic>(d =>
+                d.Code == GraphDiagnosticCodes.MissingControlEdge &&
+                d.NodeId == "sw" &&
+                d.Message.Contains("case:", StringComparison.Ordinal)));
+        }
+
+        [Test]
+        public void SwitchInt_MalformedCasePort_FailsClosed()
+        {
+            GraphControlFlowDocument graph = CreateSwitchIntGraph(selectorValue: 0);
+            graph.ControlEdges.Add(new GraphControlFlowEdge("sw", "case:not-int", "ret0"));
+
+            GraphControlFlowCompileResult compiled = GraphControlFlowCompiler.Compile(graph);
+            Assert.That(compiled.Succeeded, Is.False);
+            Assert.That(compiled.Diagnostics, Has.Some.Matches<GraphDiagnostic>(d =>
+                d.Code == GraphDiagnosticCodes.UnexpectedControlEdge && d.NodeId == "sw"));
+        }
+
+        [Test]
+        public void SwitchInt_DuplicateCaseValue_FailsClosed()
+        {
+            GraphControlFlowDocument graph = CreateSwitchIntGraph(selectorValue: 0);
+            // Distinct port spellings that parse to the same int value.
+            graph.ControlEdges.Add(new GraphControlFlowEdge("sw", "case:01", "retDefault"));
+
+            GraphControlFlowCompileResult compiled = GraphControlFlowCompiler.Compile(graph);
+            Assert.That(compiled.Succeeded, Is.False);
+            Assert.That(compiled.Diagnostics, Has.Some.Matches<GraphDiagnostic>(d =>
+                d.Code == GraphDiagnosticCodes.DuplicateControlEdge &&
+                d.NodeId == "sw" &&
+                d.Message.Contains("case value 1", StringComparison.Ordinal)));
+        }
+
+        private static GraphControlFlowDocument CreateBranchBoolGraph(int left, int right)
+        {
+            return new GraphControlFlowDocument
+            {
+                Id = "tests.script.branch-bool-paths",
+                Entry = "left",
+                Nodes = new List<GraphControlFlowNode>
+                {
+                    new() { Id = "left", Op = nameof(GraphNodeOp.ConstInt), IntValue = left },
+                    new() { Id = "right", Op = nameof(GraphNodeOp.ConstInt), IntValue = right },
+                    new() { Id = "trueValue", Op = nameof(GraphNodeOp.ConstInt), IntValue = 10 },
+                    new() { Id = "falseValue", Op = nameof(GraphNodeOp.ConstInt), IntValue = 20 },
+                    new() { Id = "pred", Op = nameof(GraphNodeOp.CompareLtInt) },
+                    new() { Id = "branch", Op = GraphControlFlowCompiler.BranchBoolOp },
+                    new() { Id = "retTrue", Op = nameof(GraphNodeOp.HaltReturnInt) },
+                    new() { Id = "retFalse", Op = nameof(GraphNodeOp.HaltReturnInt) }
+                },
+                ControlEdges = new List<GraphControlFlowEdge>
+                {
+                    new("left", GraphControlFlowPorts.Next, "right"),
+                    new("right", GraphControlFlowPorts.Next, "trueValue"),
+                    new("trueValue", GraphControlFlowPorts.Next, "falseValue"),
+                    new("falseValue", GraphControlFlowPorts.Next, "pred"),
+                    new("pred", GraphControlFlowPorts.Next, "branch"),
+                    new("branch", GraphControlFlowPorts.True, "retTrue"),
+                    new("branch", GraphControlFlowPorts.False, "retFalse")
+                },
+                ValueEdges = new List<GraphControlFlowValueEdge>
+                {
+                    new("left", GraphControlFlowPorts.Value, "pred", GraphControlFlowPorts.A),
+                    new("right", GraphControlFlowPorts.Value, "pred", GraphControlFlowPorts.B),
+                    new("pred", GraphControlFlowPorts.Value, "branch", GraphControlFlowPorts.Condition),
+                    new("trueValue", GraphControlFlowPorts.Value, "retTrue", GraphControlFlowPorts.Value),
+                    new("falseValue", GraphControlFlowPorts.Value, "retFalse", GraphControlFlowPorts.Value)
+                }
+            };
+        }
+
+        private static GraphControlFlowDocument CreateSwitchIntGraph(int selectorValue)
+        {
+            return new GraphControlFlowDocument
+            {
+                Id = "tests.script.switch-int-arms",
+                Entry = "retV0",
+                Nodes = new List<GraphControlFlowNode>
+                {
+                    new() { Id = "retV0", Op = nameof(GraphNodeOp.ConstInt), IntValue = 100 },
+                    new() { Id = "retV1", Op = nameof(GraphNodeOp.ConstInt), IntValue = 101 },
+                    new() { Id = "retV2", Op = nameof(GraphNodeOp.ConstInt), IntValue = 102 },
+                    new() { Id = "retVD", Op = nameof(GraphNodeOp.ConstInt), IntValue = 900 },
+                    new() { Id = "sel", Op = nameof(GraphNodeOp.ConstInt), IntValue = selectorValue },
+                    new() { Id = "sw", Op = GraphControlFlowCompiler.SwitchIntOp },
+                    new() { Id = "ret0", Op = nameof(GraphNodeOp.HaltReturnInt) },
+                    new() { Id = "ret1", Op = nameof(GraphNodeOp.HaltReturnInt) },
+                    new() { Id = "ret2", Op = nameof(GraphNodeOp.HaltReturnInt) },
+                    new() { Id = "retDefault", Op = nameof(GraphNodeOp.HaltReturnInt) }
+                },
+                ControlEdges = new List<GraphControlFlowEdge>
+                {
+                    new("retV0", GraphControlFlowPorts.Next, "retV1"),
+                    new("retV1", GraphControlFlowPorts.Next, "retV2"),
+                    new("retV2", GraphControlFlowPorts.Next, "retVD"),
+                    new("retVD", GraphControlFlowPorts.Next, "sel"),
+                    new("sel", GraphControlFlowPorts.Next, "sw"),
+                    new("sw", GraphControlFlowPorts.Case(0), "ret0"),
+                    new("sw", GraphControlFlowPorts.Case(1), "ret1"),
+                    new("sw", GraphControlFlowPorts.Case(2), "ret2"),
+                    new("sw", GraphControlFlowPorts.Default, "retDefault")
+                },
+                ValueEdges = new List<GraphControlFlowValueEdge>
+                {
+                    new("sel", GraphControlFlowPorts.Value, "sw", GraphControlFlowPorts.Selector),
+                    new("retV0", GraphControlFlowPorts.Value, "ret0", GraphControlFlowPorts.Value),
+                    new("retV1", GraphControlFlowPorts.Value, "ret1", GraphControlFlowPorts.Value),
+                    new("retV2", GraphControlFlowPorts.Value, "ret2", GraphControlFlowPorts.Value),
+                    new("retVD", GraphControlFlowPorts.Value, "retDefault", GraphControlFlowPorts.Value)
+                }
+            };
+        }
+
+        private static int ExecuteHaltReturn(GraphInstruction[] program)
+        {
+            var registry = new GraphProgramRegistry();
+            registry.Register(1, program, GraphKind.Script);
+
+            using var world = World.Create();
+            Entity caster = world.Create();
+            Span<float> floats = stackalloc float[GraphVmLimits.MaxFloatRegisters];
+            Span<int> ints = stackalloc int[GraphVmLimits.MaxIntRegisters];
+            Span<byte> bools = stackalloc byte[GraphVmLimits.MaxBoolRegisters];
+            Span<Entity> entities = stackalloc Entity[GraphVmLimits.MaxEntityRegisters];
+            Span<Entity> targets = stackalloc Entity[GraphVmLimits.MaxTargets];
+            Span<int> callStack = stackalloc int[GraphVmLimits.MaxCallStackDepth];
+            var cursor = new GraphExecutionCursor();
+
+            GraphSliceResult result = GraphExecutor.ExecuteScriptSlice(
+                world, caster, Entity.Null, default, program, api: null!, registry,
+                floats, ints, bools, entities, targets, callStack, ref cursor, budgetSteps: 64);
+
+            Assert.That(result.Halted, Is.True);
+            return result.ReturnInt;
+        }
+    }
+}

--- a/src/Tests/GasTests/Graph/GraphBranchSwitchSugarTests.cs
+++ b/src/Tests/GasTests/Graph/GraphBranchSwitchSugarTests.cs
@@ -112,6 +112,41 @@ namespace Ludots.Tests.Gas.Graph
                 d.Message.Contains("case value 1", StringComparison.Ordinal)));
         }
 
+        [Test]
+        public void SwitchInt_MissingSelector_FailsClosed()
+        {
+            GraphControlFlowDocument graph = CreateSwitchIntGraph(selectorValue: 0);
+            graph.ValueEdges.RemoveAll(e =>
+                e.To == "sw" && e.ToPort == GraphControlFlowPorts.Selector);
+
+            GraphControlFlowCompileResult compiled = GraphControlFlowCompiler.Compile(graph);
+            Assert.That(compiled.Succeeded, Is.False);
+            Assert.That(compiled.Diagnostics, Has.Some.Matches<GraphDiagnostic>(d =>
+                d.Code == GraphDiagnosticCodes.MissingValueInput && d.NodeId == "sw"));
+        }
+
+        [Test]
+        public void QueryKind_RejectsBranchBoolAndSwitchInt()
+        {
+            GraphControlFlowDocument branch = CreateBranchBoolGraph(left: 1, right: 2);
+            branch.Kind = "Query";
+            GraphControlFlowCompileResult branchCompiled = GraphControlFlowCompiler.Compile(branch);
+            Assert.That(branchCompiled.Succeeded, Is.False);
+            Assert.That(branchCompiled.Diagnostics, Has.Some.Matches<GraphDiagnostic>(d =>
+                d.Code == GraphDiagnosticCodes.UnknownNodeOp &&
+                d.NodeId == "branch" &&
+                d.Message.Contains(GraphControlFlowCompiler.BranchBoolOp, StringComparison.Ordinal)));
+
+            GraphControlFlowDocument sw = CreateSwitchIntGraph(selectorValue: 1);
+            sw.Kind = "Query";
+            GraphControlFlowCompileResult switchCompiled = GraphControlFlowCompiler.Compile(sw);
+            Assert.That(switchCompiled.Succeeded, Is.False);
+            Assert.That(switchCompiled.Diagnostics, Has.Some.Matches<GraphDiagnostic>(d =>
+                d.Code == GraphDiagnosticCodes.UnknownNodeOp &&
+                d.NodeId == "sw" &&
+                d.Message.Contains(GraphControlFlowCompiler.SwitchIntOp, StringComparison.Ordinal)));
+        }
+
         private static GraphControlFlowDocument CreateBranchBoolGraph(int left, int right)
         {
             return new GraphControlFlowDocument

--- a/src/Tests/GasTests/Graph/GraphScriptTestGraphs.cs
+++ b/src/Tests/GasTests/Graph/GraphScriptTestGraphs.cs
@@ -88,6 +88,179 @@ namespace Ludots.Tests.Gas.Graph
             };
         }
 
+
+        public static GraphControlFlowDocument CreateWaitOnceThenHaltGraph(int value = 9)
+        {
+            return new GraphControlFlowDocument
+            {
+                Id = "tests.script.wait-once",
+                Kind = "Script",
+                Entry = "const",
+                Nodes = new List<GraphControlFlowNode>
+                {
+                    new() { Id = "const", Op = nameof(GraphNodeOp.ConstInt), IntValue = value },
+                    new() { Id = "wait", Op = GraphControlFlowCompiler.WaitOp },
+                    new() { Id = "done", Op = nameof(GraphNodeOp.HaltReturnInt) }
+                },
+                ControlEdges = new List<GraphControlFlowEdge>
+                {
+                    new("const", GraphControlFlowPorts.Next, "wait"),
+                    new("wait", GraphControlFlowPorts.Next, "done")
+                },
+                ValueEdges = new List<GraphControlFlowValueEdge>
+                {
+                    new("const", GraphControlFlowPorts.Value, "done", GraphControlFlowPorts.Value)
+                }
+            };
+        }
+
+        public static GraphControlFlowDocument CreateCountWhileGraph(int limit = 3)
+        {
+            // while (counter < limit) counter += 1; return counter
+            return new GraphControlFlowDocument
+            {
+                Id = "tests.script.count-while",
+                Kind = "Script",
+                Entry = "zero",
+                Nodes = new List<GraphControlFlowNode>
+                {
+                    new() { Id = "zero", Op = nameof(GraphNodeOp.ConstInt), IntValue = 0, PinRegister = 0 },
+                    new() { Id = "limit", Op = nameof(GraphNodeOp.ConstInt), IntValue = limit, PinRegister = 1 },
+                    new() { Id = "one", Op = nameof(GraphNodeOp.ConstInt), IntValue = 1, PinRegister = 2 },
+                    new() { Id = "readCounter", Op = nameof(GraphNodeOp.MoveInt) },
+                    new() { Id = "readLimit", Op = nameof(GraphNodeOp.MoveInt) },
+                    new() { Id = "pred", Op = nameof(GraphNodeOp.CompareLtInt) },
+                    new() { Id = "loop", Op = GraphControlFlowCompiler.WhileOp },
+                    new() { Id = "bodyReadCounter", Op = nameof(GraphNodeOp.MoveInt) },
+                    new() { Id = "bodyReadOne", Op = nameof(GraphNodeOp.MoveInt) },
+                    new() { Id = "bodyAdd", Op = nameof(GraphNodeOp.AddInt), PinRegister = 0 },
+                    new() { Id = "readReturn", Op = nameof(GraphNodeOp.MoveInt) },
+                    new() { Id = "done", Op = nameof(GraphNodeOp.HaltReturnInt) }
+                },
+                ControlEdges = new List<GraphControlFlowEdge>
+                {
+                    new("zero", GraphControlFlowPorts.Next, "limit"),
+                    new("limit", GraphControlFlowPorts.Next, "one"),
+                    new("one", GraphControlFlowPorts.Next, "readCounter"),
+                    new("readCounter", GraphControlFlowPorts.Next, "readLimit"),
+                    new("readLimit", GraphControlFlowPorts.Next, "pred"),
+                    new("pred", GraphControlFlowPorts.Next, "loop"),
+                    new("loop", GraphControlFlowPorts.Body, "bodyReadCounter"),
+                    new("loop", GraphControlFlowPorts.Next, "readReturn"),
+                    new("bodyReadCounter", GraphControlFlowPorts.Next, "bodyReadOne"),
+                    new("bodyReadOne", GraphControlFlowPorts.Next, "bodyAdd"),
+                    new("bodyAdd", GraphControlFlowPorts.Next, "readCounter"),
+                    new("readReturn", GraphControlFlowPorts.Next, "done")
+                },
+                ValueEdges = new List<GraphControlFlowValueEdge>
+                {
+                    new("zero", GraphControlFlowPorts.Value, "readCounter", GraphControlFlowPorts.Value),
+                    new("limit", GraphControlFlowPorts.Value, "readLimit", GraphControlFlowPorts.Value),
+                    new("readCounter", GraphControlFlowPorts.Value, "pred", GraphControlFlowPorts.A),
+                    new("readLimit", GraphControlFlowPorts.Value, "pred", GraphControlFlowPorts.B),
+                    new("pred", GraphControlFlowPorts.Value, "loop", GraphControlFlowPorts.Condition),
+                    new("zero", GraphControlFlowPorts.Value, "bodyReadCounter", GraphControlFlowPorts.Value),
+                    new("one", GraphControlFlowPorts.Value, "bodyReadOne", GraphControlFlowPorts.Value),
+                    new("bodyReadCounter", GraphControlFlowPorts.Value, "bodyAdd", GraphControlFlowPorts.A),
+                    new("bodyReadOne", GraphControlFlowPorts.Value, "bodyAdd", GraphControlFlowPorts.B),
+                    new("zero", GraphControlFlowPorts.Value, "readReturn", GraphControlFlowPorts.Value),
+                    new("readReturn", GraphControlFlowPorts.Value, "done", GraphControlFlowPorts.Value)
+                }
+            };
+        }
+
+        public static GraphControlFlowDocument CreateCountUntilGraph(int limit = 3)
+        {
+            // until (limit < counter) counter += 1; return counter
+            // exits when counter becomes > limit
+            return new GraphControlFlowDocument
+            {
+                Id = "tests.script.count-until",
+                Kind = "Script",
+                Entry = "zero",
+                Nodes = new List<GraphControlFlowNode>
+                {
+                    new() { Id = "zero", Op = nameof(GraphNodeOp.ConstInt), IntValue = 0, PinRegister = 0 },
+                    new() { Id = "limit", Op = nameof(GraphNodeOp.ConstInt), IntValue = limit, PinRegister = 1 },
+                    new() { Id = "one", Op = nameof(GraphNodeOp.ConstInt), IntValue = 1, PinRegister = 2 },
+                    new() { Id = "readCounter", Op = nameof(GraphNodeOp.MoveInt) },
+                    new() { Id = "readLimit", Op = nameof(GraphNodeOp.MoveInt) },
+                    new() { Id = "pred", Op = nameof(GraphNodeOp.CompareLtInt) },
+                    new() { Id = "loop", Op = GraphControlFlowCompiler.UntilOp },
+                    new() { Id = "bodyReadCounter", Op = nameof(GraphNodeOp.MoveInt) },
+                    new() { Id = "bodyReadOne", Op = nameof(GraphNodeOp.MoveInt) },
+                    new() { Id = "bodyAdd", Op = nameof(GraphNodeOp.AddInt), PinRegister = 0 },
+                    new() { Id = "readReturn", Op = nameof(GraphNodeOp.MoveInt) },
+                    new() { Id = "done", Op = nameof(GraphNodeOp.HaltReturnInt) }
+                },
+                ControlEdges = new List<GraphControlFlowEdge>
+                {
+                    new("zero", GraphControlFlowPorts.Next, "limit"),
+                    new("limit", GraphControlFlowPorts.Next, "one"),
+                    new("one", GraphControlFlowPorts.Next, "readCounter"),
+                    new("readCounter", GraphControlFlowPorts.Next, "readLimit"),
+                    new("readLimit", GraphControlFlowPorts.Next, "pred"),
+                    new("pred", GraphControlFlowPorts.Next, "loop"),
+                    new("loop", GraphControlFlowPorts.Body, "bodyReadCounter"),
+                    new("loop", GraphControlFlowPorts.Next, "readReturn"),
+                    new("bodyReadCounter", GraphControlFlowPorts.Next, "bodyReadOne"),
+                    new("bodyReadOne", GraphControlFlowPorts.Next, "bodyAdd"),
+                    new("bodyAdd", GraphControlFlowPorts.Next, "readCounter"),
+                    new("readReturn", GraphControlFlowPorts.Next, "done")
+                },
+                ValueEdges = new List<GraphControlFlowValueEdge>
+                {
+                    // pred = limit < counter  (CompareLtInt A=limit, B=counter)
+                    new("limit", GraphControlFlowPorts.Value, "readLimit", GraphControlFlowPorts.Value),
+                    new("zero", GraphControlFlowPorts.Value, "readCounter", GraphControlFlowPorts.Value),
+                    new("readLimit", GraphControlFlowPorts.Value, "pred", GraphControlFlowPorts.A),
+                    new("readCounter", GraphControlFlowPorts.Value, "pred", GraphControlFlowPorts.B),
+                    new("pred", GraphControlFlowPorts.Value, "loop", GraphControlFlowPorts.Condition),
+                    new("zero", GraphControlFlowPorts.Value, "bodyReadCounter", GraphControlFlowPorts.Value),
+                    new("one", GraphControlFlowPorts.Value, "bodyReadOne", GraphControlFlowPorts.Value),
+                    new("bodyReadCounter", GraphControlFlowPorts.Value, "bodyAdd", GraphControlFlowPorts.A),
+                    new("bodyReadOne", GraphControlFlowPorts.Value, "bodyAdd", GraphControlFlowPorts.B),
+                    new("zero", GraphControlFlowPorts.Value, "readReturn", GraphControlFlowPorts.Value),
+                    new("readReturn", GraphControlFlowPorts.Value, "done", GraphControlFlowPorts.Value)
+                }
+            };
+        }
+
+        public static GraphControlFlowDocument CreateInfiniteWhileGraph()
+        {
+            return new GraphControlFlowDocument
+            {
+                Id = "tests.script.infinite-while",
+                Kind = "Script",
+                Entry = "zero",
+                Nodes = new List<GraphControlFlowNode>
+                {
+                    new() { Id = "zero", Op = nameof(GraphNodeOp.ConstInt), IntValue = 0 },
+                    new() { Id = "one", Op = nameof(GraphNodeOp.ConstInt), IntValue = 1 },
+                    new() { Id = "pred", Op = nameof(GraphNodeOp.CompareLtInt) },
+                    new() { Id = "loop", Op = GraphControlFlowCompiler.WhileOp },
+                    new() { Id = "body", Op = nameof(GraphNodeOp.ConstInt), IntValue = 0 },
+                    new() { Id = "done", Op = nameof(GraphNodeOp.HaltReturnInt) }
+                },
+                ControlEdges = new List<GraphControlFlowEdge>
+                {
+                    new("zero", GraphControlFlowPorts.Next, "one"),
+                    new("one", GraphControlFlowPorts.Next, "pred"),
+                    new("pred", GraphControlFlowPorts.Next, "loop"),
+                    new("loop", GraphControlFlowPorts.Body, "body"),
+                    new("loop", GraphControlFlowPorts.Next, "done"),
+                    new("body", GraphControlFlowPorts.Next, "loop")
+                },
+                ValueEdges = new List<GraphControlFlowValueEdge>
+                {
+                    new("zero", GraphControlFlowPorts.Value, "pred", GraphControlFlowPorts.A),
+                    new("one", GraphControlFlowPorts.Value, "pred", GraphControlFlowPorts.B),
+                    new("pred", GraphControlFlowPorts.Value, "loop", GraphControlFlowPorts.Condition),
+                    new("zero", GraphControlFlowPorts.Value, "done", GraphControlFlowPorts.Value)
+                }
+            };
+        }
+
         public static string FormatDiagnostics(IReadOnlyList<GraphDiagnostic> diagnostics)
         {
             if (diagnostics.Count == 0)

--- a/src/Tests/GasTests/Graph/GraphScriptWaitLoopSugarTests.cs
+++ b/src/Tests/GasTests/Graph/GraphScriptWaitLoopSugarTests.cs
@@ -102,7 +102,7 @@ namespace Ludots.Tests.Gas.Graph
         }
 
         [Test]
-        public void GraphCompiler_EffectWithYield_CompilesThenPolicyRejects()
+        public void GraphCompiler_EffectWithYield_PolicyRejects()
         {
             var cfg = new GraphConfig
             {
@@ -114,26 +114,26 @@ namespace Ludots.Tests.Gas.Graph
                     new GraphNodeConfig
                     {
                         Id = "y",
-                        Op = nameof(GraphNodeOp.Yield)
+                        Op = nameof(GraphNodeOp.Yield),
+                        Next = "halt"
+                    },
+                    new GraphNodeConfig
+                    {
+                        Id = "halt",
+                        Op = nameof(GraphNodeOp.ConstInt),
+                        IntValue = 1
                     }
                 }
             };
 
             var (pkg, _, diags) = GraphCompiler.CompileWithOutputs(cfg);
-            // Yield may compile as an opcode on next-chain; policy must still fail-closed for Effect.
-            if (pkg.HasValue)
-            {
-                Assert.Throws<InvalidOperationException>(() =>
-                    GraphKindOperationPolicy.RequireAllowed(
-                        GraphKind.Effect,
-                        pkg.Value.Program,
-                        GasGraphOpHandlerTable.Instance));
-            }
-            else
-            {
-                Assert.That(diags, Has.Some.Matches<GraphDiagnostic>(d =>
-                    d.Severity == GraphDiagnosticSeverity.Error));
-            }
+            // Next-chain may still emit Yield as an opcode; Effect must fail at kind policy (not silently run).
+            Assert.That(pkg.HasValue, Is.True, GraphScriptTestGraphs.FormatDiagnostics(diags));
+            Assert.Throws<InvalidOperationException>(() =>
+                GraphKindOperationPolicy.RequireAllowed(
+                    GraphKind.Effect,
+                    pkg!.Value.Program,
+                    GasGraphOpHandlerTable.Instance));
         }
 
         [Test]

--- a/src/Tests/GasTests/Graph/GraphScriptWaitLoopSugarTests.cs
+++ b/src/Tests/GasTests/Graph/GraphScriptWaitLoopSugarTests.cs
@@ -236,7 +236,7 @@ namespace Ludots.Tests.Gas.Graph
         }
 
         [Test]
-        public void Compile_QueryKind_RejectsWaitAndWhile()
+        public void Compile_QueryKind_RejectsWaitWhileAndUntil()
         {
             var waitDoc = new GraphControlFlowDocument
             {
@@ -274,6 +274,28 @@ namespace Ludots.Tests.Gas.Graph
             Assert.That(whileCompiled.Succeeded, Is.False);
             Assert.That(whileCompiled.Diagnostics, Has.Some.Matches<GraphDiagnostic>(d =>
                 d.Code == GraphDiagnosticCodes.UnknownNodeOp && d.NodeId == "loop"));
+
+            var untilDoc = new GraphControlFlowDocument
+            {
+                Id = "tests.query.until-forbidden",
+                Kind = "Query",
+                Entry = "until",
+                Nodes =
+                {
+                    new GraphControlFlowNode { Id = "one", Op = nameof(GraphNodeOp.ConstInt), IntValue = 1 },
+                    new GraphControlFlowNode { Id = "until", Op = GraphControlFlowCompiler.UntilOp }
+                },
+                ControlEdges =
+                {
+                    new GraphControlFlowEdge("until", GraphControlFlowPorts.Body, "one"),
+                    new GraphControlFlowEdge("until", GraphControlFlowPorts.Next, "one"),
+                    new GraphControlFlowEdge("one", GraphControlFlowPorts.Next, "until")
+                }
+            };
+            GraphControlFlowCompileResult untilCompiled = GraphControlFlowCompiler.Compile(untilDoc);
+            Assert.That(untilCompiled.Succeeded, Is.False);
+            Assert.That(untilCompiled.Diagnostics, Has.Some.Matches<GraphDiagnostic>(d =>
+                d.Code == GraphDiagnosticCodes.UnknownNodeOp && d.NodeId == "until"));
         }
     }
 }

--- a/src/Tests/GasTests/Graph/GraphScriptWaitLoopSugarTests.cs
+++ b/src/Tests/GasTests/Graph/GraphScriptWaitLoopSugarTests.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Linq;
+using Arch.Core;
+using Ludots.Core.GraphRuntime;
+using Ludots.Core.NodeLibraries.GASGraph;
+using NUnit.Framework;
+
+namespace Ludots.Tests.Gas.Graph
+{
+    [TestFixture]
+    [Category("ci-gate")]
+    public sealed class GraphScriptWaitLoopSugarTests
+    {
+        [Test]
+        public void Compile_Wait_EmitsYieldOpcode()
+        {
+            GraphControlFlowCompileResult compiled = GraphControlFlowCompiler.Compile(
+                GraphScriptTestGraphs.CreateWaitOnceThenHaltGraph());
+            Assert.That(compiled.Succeeded, Is.True, GraphScriptTestGraphs.FormatDiagnostics(compiled.Diagnostics));
+            Assert.That(compiled.Program.Select(i => (GraphNodeOp)i.Op), Does.Contain(GraphNodeOp.Yield));
+        }
+
+        [Test]
+        public void ExecuteScriptSlice_Wait_YieldsThenResumesToHalt()
+        {
+            GraphControlFlowCompileResult compiled = GraphControlFlowCompiler.Compile(
+                GraphScriptTestGraphs.CreateWaitOnceThenHaltGraph(value: 9));
+            Assert.That(compiled.Succeeded, Is.True, GraphScriptTestGraphs.FormatDiagnostics(compiled.Diagnostics));
+
+            using var world = World.Create();
+            Entity caster = world.Create();
+            Span<float> floats = stackalloc float[GraphVmLimits.MaxFloatRegisters];
+            Span<int> ints = stackalloc int[GraphVmLimits.MaxIntRegisters];
+            Span<byte> bools = stackalloc byte[GraphVmLimits.MaxBoolRegisters];
+            Span<Entity> entities = stackalloc Entity[GraphVmLimits.MaxEntityRegisters];
+            Span<Entity> targets = stackalloc Entity[GraphVmLimits.MaxTargets];
+            Span<int> callStack = stackalloc int[GraphVmLimits.MaxCallStackDepth];
+            var cursor = new GraphExecutionCursor();
+
+            GraphSliceResult first = GraphExecutor.ExecuteScriptSlice(
+                world, caster, Entity.Null, default, compiled.Program, api: null!, programs: null,
+                floats, ints, bools, entities, targets, callStack, ref cursor, budgetSteps: 64);
+            Assert.That(first.Yielded, Is.True);
+            Assert.That(first.Halted, Is.False);
+
+            GraphSliceResult second = GraphExecutor.ExecuteScriptSlice(
+                world, caster, Entity.Null, default, compiled.Program, api: null!, programs: null,
+                floats, ints, bools, entities, targets, callStack, ref cursor, budgetSteps: 64);
+            Assert.That(second.Halted, Is.True);
+            Assert.That(second.ReturnInt, Is.EqualTo(9));
+        }
+
+        [Test]
+        public void GraphKindOperationPolicy_NonScriptKinds_RejectYield()
+        {
+            var program = new[]
+            {
+                new GraphInstruction { Op = (ushort)GraphNodeOp.Yield }
+            };
+
+            Assert.DoesNotThrow(() =>
+                GraphKindOperationPolicy.RequireAllowed(GraphKind.Script, program, GasGraphOpHandlerTable.Instance));
+
+            foreach (GraphKind kind in new[]
+                     {
+                         GraphKind.Effect,
+                         GraphKind.Query,
+                         GraphKind.Score,
+                         GraphKind.Validation,
+                         GraphKind.Derived
+                     })
+            {
+                InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() =>
+                    GraphKindOperationPolicy.RequireAllowed(kind, program, GasGraphOpHandlerTable.Instance));
+                Assert.That(ex!.Message, Does.Contain("Yield").Or.Contain("OperationNotAllowed"));
+            }
+        }
+
+        [Test]
+        public void GraphCompiler_EffectWithWait_FailsClosed()
+        {
+            var cfg = new GraphConfig
+            {
+                Id = "bad.effect.wait",
+                Kind = "Effect",
+                Entry = "wait",
+                Nodes =
+                {
+                    new GraphNodeConfig
+                    {
+                        Id = "wait",
+                        Op = GraphControlFlowCompiler.WaitOp
+                    }
+                }
+            };
+
+            var (pkg, _, diags) = GraphCompiler.CompileWithOutputs(cfg);
+            Assert.That(pkg.HasValue, Is.False);
+            Assert.That(diags, Has.Some.Matches<GraphDiagnostic>(d =>
+                d.Severity == GraphDiagnosticSeverity.Error &&
+                d.Code == GraphDiagnosticCodes.UnknownNodeOp));
+        }
+
+        [Test]
+        public void GraphCompiler_EffectWithYield_CompilesThenPolicyRejects()
+        {
+            var cfg = new GraphConfig
+            {
+                Id = "bad.effect.yield",
+                Kind = "Effect",
+                Entry = "y",
+                Nodes =
+                {
+                    new GraphNodeConfig
+                    {
+                        Id = "y",
+                        Op = nameof(GraphNodeOp.Yield)
+                    }
+                }
+            };
+
+            var (pkg, _, diags) = GraphCompiler.CompileWithOutputs(cfg);
+            // Yield may compile as an opcode on next-chain; policy must still fail-closed for Effect.
+            if (pkg.HasValue)
+            {
+                Assert.Throws<InvalidOperationException>(() =>
+                    GraphKindOperationPolicy.RequireAllowed(
+                        GraphKind.Effect,
+                        pkg.Value.Program,
+                        GasGraphOpHandlerTable.Instance));
+            }
+            else
+            {
+                Assert.That(diags, Has.Some.Matches<GraphDiagnostic>(d =>
+                    d.Severity == GraphDiagnosticSeverity.Error));
+            }
+        }
+
+        [Test]
+        public void CompileExecute_While_RunsNTimesThenExits()
+        {
+            GraphControlFlowCompileResult compiled = GraphControlFlowCompiler.Compile(
+                GraphScriptTestGraphs.CreateCountWhileGraph(limit: 3));
+            Assert.That(compiled.Succeeded, Is.True, GraphScriptTestGraphs.FormatDiagnostics(compiled.Diagnostics));
+            Assert.That(compiled.Program.Select(i => (GraphNodeOp)i.Op), Does.Contain(GraphNodeOp.JumpIfFalse));
+            Assert.That(compiled.Program.Select(i => (GraphNodeOp)i.Op), Does.Contain(GraphNodeOp.Jump));
+            // No While opcode exists — sugar only.
+            Assert.That(
+                compiled.Program.All(i => Enum.IsDefined(typeof(GraphNodeOp), (GraphNodeOp)i.Op)),
+                Is.True);
+
+            using var world = World.Create();
+            Entity caster = world.Create();
+            Span<float> floats = stackalloc float[GraphVmLimits.MaxFloatRegisters];
+            Span<int> ints = stackalloc int[GraphVmLimits.MaxIntRegisters];
+            Span<byte> bools = stackalloc byte[GraphVmLimits.MaxBoolRegisters];
+            Span<Entity> entities = stackalloc Entity[GraphVmLimits.MaxEntityRegisters];
+            Span<Entity> targets = stackalloc Entity[GraphVmLimits.MaxTargets];
+            Span<int> callStack = stackalloc int[GraphVmLimits.MaxCallStackDepth];
+            var cursor = new GraphExecutionCursor();
+
+            GraphSliceResult result = GraphExecutor.ExecuteScriptSlice(
+                world, caster, Entity.Null, default, compiled.Program, api: null!, programs: null,
+                floats, ints, bools, entities, targets, callStack, ref cursor, budgetSteps: 256);
+            Assert.That(result.Halted, Is.True);
+            Assert.That(result.ReturnInt, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void CompileExecute_Until_LoopsUntilPredicateTrue()
+        {
+            GraphControlFlowCompileResult compiled = GraphControlFlowCompiler.Compile(
+                GraphScriptTestGraphs.CreateCountUntilGraph(limit: 3));
+            Assert.That(compiled.Succeeded, Is.True, GraphScriptTestGraphs.FormatDiagnostics(compiled.Diagnostics));
+
+            using var world = World.Create();
+            Entity caster = world.Create();
+            Span<float> floats = stackalloc float[GraphVmLimits.MaxFloatRegisters];
+            Span<int> ints = stackalloc int[GraphVmLimits.MaxIntRegisters];
+            Span<byte> bools = stackalloc byte[GraphVmLimits.MaxBoolRegisters];
+            Span<Entity> entities = stackalloc Entity[GraphVmLimits.MaxEntityRegisters];
+            Span<Entity> targets = stackalloc Entity[GraphVmLimits.MaxTargets];
+            Span<int> callStack = stackalloc int[GraphVmLimits.MaxCallStackDepth];
+            var cursor = new GraphExecutionCursor();
+
+            GraphSliceResult result = GraphExecutor.ExecuteScriptSlice(
+                world, caster, Entity.Null, default, compiled.Program, api: null!, programs: null,
+                floats, ints, bools, entities, targets, callStack, ref cursor, budgetSteps: 256);
+            Assert.That(result.Halted, Is.True);
+            // until (limit < counter): body runs while false; exits when counter becomes 4
+            Assert.That(result.ReturnInt, Is.EqualTo(4));
+        }
+
+        [Test]
+        public void Execute_InfiniteWhile_HitsMaxInstructionsAndThrows()
+        {
+            GraphControlFlowCompileResult compiled = GraphControlFlowCompiler.Compile(
+                GraphScriptTestGraphs.CreateInfiniteWhileGraph());
+            Assert.That(compiled.Succeeded, Is.True, GraphScriptTestGraphs.FormatDiagnostics(compiled.Diagnostics));
+
+            using var world = World.Create();
+            Entity caster = world.Create();
+            Span<float> f = stackalloc float[GraphVmLimits.MaxFloatRegisters];
+            Span<int> i = stackalloc int[GraphVmLimits.MaxIntRegisters];
+            Span<byte> b = stackalloc byte[GraphVmLimits.MaxBoolRegisters];
+            Span<Entity> e = stackalloc Entity[GraphVmLimits.MaxEntityRegisters];
+            Span<Entity> targets = stackalloc Entity[GraphVmLimits.MaxTargets];
+            Span<int> callStack = stackalloc int[GraphVmLimits.MaxCallStackDepth];
+            e[0] = caster;
+
+            var state = new GraphExecutionState
+            {
+                World = world,
+                Caster = caster,
+                F = f,
+                I = i,
+                B = b,
+                E = e,
+                Targets = targets,
+                TargetList = new GraphTargetList(targets),
+                CallStack = callStack
+            };
+
+            string? message = null;
+            try
+            {
+                GasGraphOpHandlerTable.Execute(ref state, compiled.Program, GasGraphOpHandlerTable.Instance);
+            }
+            catch (InvalidOperationException ex)
+            {
+                message = ex.Message;
+            }
+
+            Assert.That(message, Is.Not.Null);
+            Assert.That(message, Does.Contain("MaxInstructionsPerExecution"));
+        }
+
+        [Test]
+        public void Compile_QueryKind_RejectsWaitAndWhile()
+        {
+            var waitDoc = new GraphControlFlowDocument
+            {
+                Id = "tests.query.wait-forbidden",
+                Kind = "Query",
+                Entry = "wait",
+                Nodes =
+                {
+                    new GraphControlFlowNode { Id = "wait", Op = GraphControlFlowCompiler.WaitOp }
+                }
+            };
+            GraphControlFlowCompileResult waitCompiled = GraphControlFlowCompiler.Compile(waitDoc);
+            Assert.That(waitCompiled.Succeeded, Is.False);
+            Assert.That(waitCompiled.Diagnostics, Has.Some.Matches<GraphDiagnostic>(d =>
+                d.Code == GraphDiagnosticCodes.UnknownNodeOp && d.NodeId == "wait"));
+
+            var whileDoc = new GraphControlFlowDocument
+            {
+                Id = "tests.query.while-forbidden",
+                Kind = "Query",
+                Entry = "loop",
+                Nodes =
+                {
+                    new GraphControlFlowNode { Id = "one", Op = nameof(GraphNodeOp.ConstInt), IntValue = 1 },
+                    new GraphControlFlowNode { Id = "loop", Op = GraphControlFlowCompiler.WhileOp }
+                },
+                ControlEdges =
+                {
+                    new GraphControlFlowEdge("loop", GraphControlFlowPorts.Body, "one"),
+                    new GraphControlFlowEdge("loop", GraphControlFlowPorts.Next, "one"),
+                    new GraphControlFlowEdge("one", GraphControlFlowPorts.Next, "loop")
+                }
+            };
+            GraphControlFlowCompileResult whileCompiled = GraphControlFlowCompiler.Compile(whileDoc);
+            Assert.That(whileCompiled.Succeeded, Is.False);
+            Assert.That(whileCompiled.Diagnostics, Has.Some.Matches<GraphDiagnostic>(d =>
+                d.Code == GraphDiagnosticCodes.UnknownNodeOp && d.NodeId == "loop"));
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

在 [#859](https://github.com/MightyBubble/Ludots/pull/859) 图基建之上交付 **Script 控制流作者糖**（编译期降级，无新 L0 op）。

**已剥离 #860 Roslyn/ALC codegen**（回应审计：勿绑 #859 UI 栈）。codegen 走 [#865](https://github.com/MightyBubble/Ludots/pull/865)。

**审计交接：** [`artifacts/pr/869-audit-handoff.md`](https://github.com/MightyBubble/Ludots/blob/cursor/graph-cf-sugar-integrate-b361/artifacts/pr/869-audit-handoff.md)

## 合并顺序（必读）

```text
main ← #859（先合） ← #869（本 PR，仅糖）
main ← #865（codegen，独立）
```

1. 审并合 **#859**
2. #859 进 main 后，将本 PR **retarget base=`main`**（或 rebase）再合
3. **不要合** [#866](https://github.com/MightyBubble/Ludots/pull/866) / [#867](https://github.com/MightyBubble/Ludots/pull/867)（已取代）
4. [#862](https://github.com/MightyBubble/Ludots/pull/862) / [#865](https://github.com/MightyBubble/Ludots/pull/865) **不在本 PR**；codegen 另审另合

## 本 PR 交付

- `BranchBool` / `SwitchInt` / `Wait`→Yield / `While` / `Until`
- `AuthoredOpKind`：1/2/3/4
- SSOT：`GraphAuthoringSugar` + `gitbook/architecture/graph-layering-flow-and-behavior.md`「Script 作者糖」
- Effect / Query 禁糖与禁 Yield（失败关闭）

## 与 #863

合入时以 `GraphAuthoringSugar` + gitbook 糖表为名册；ParseOps 需 rebase，糖保持 **Script-only**。

## 验证

```bash
dotnet test src/Tests/GasTests/GasTests.csproj \
  --filter "FullyQualifiedName~GraphBranchSwitchSugarTests|FullyQualifiedName~GraphScriptWaitLoopSugarTests" \
  -o /tmp/pr869-sugar
```

## Gate

`artifacts/gas-composition-gate.md`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46a7b6cc-e63d-4893-8cc7-8ff8b1e5b361?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46a7b6cc-e63d-4893-8cc7-8ff8b1e5b361&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

