### PR TITLE
feat(editor): panel authoring config export + player showcase

### DIFF
--- a/gitbook/architecture/ui-panel-authoring-form.md
+++ b/gitbook/architecture/ui-panel-authoring-form.md
@@ -116,9 +116,10 @@ Instance = templateId + scope（多开；Router 另册）
 ## 4. 场景
 
 1. **实体信息卡**：变量 `hp` / `lastKill` / `curState`；选中实体后 — `LoadAttribute`(血量)、`ReadBlackboard`(上次击杀)、`ReadGameplayTag`→`LookupTagDisplayText`(状态文案)；Reactive `TState` 三字段同构。  
-   > 债务：L0 今日仅有 BB Float/Int/Entity 与 `HasTag`；Text BB 读与 Tag→文案查表节点需按作者意图补齐，禁止用 Attribute 假冒。  
+   > Tag 快捷 L0（`SelectTagInMask` / `LookupTagDisplayToken`）见运行时线 #868；编辑器仍是作者糖。仍欠：Text BB、表资产装载、表面 token→文案。禁止 Attribute 假冒。  
 2. **资源总览条**：变量 `oreTotal` / `crystalTotal`；Query 聚合 → Summary；WebUI `aggregateProjection`。  
-3. **切换表面**：同一模板把 `surfaceKind` 从 Reactive 换成 WebUI，变量与图不变，仅右侧投影形态变。
+3. **切换表面**：同一模板把 `surfaceKind` 从 Reactive 换成 WebUI，变量与图不变，仅右侧投影形态变。  
+4. **试玩 / 配置**：编辑器工作区含「试玩」（玩家情景）与「配置」（导出 `ludots.ui.panel_template/v1` JSON，样例见 `Ludots.Editor.React/public/samples/panel_templates.json`）。
 
 ## 5. 边界
 
@@ -153,4 +154,17 @@ Feature: 四种表面共用面板变量与计算图
     When 我查看 WebUI 投影
     Then 我看到 fields[].sourceKind 为 aggregateProjection
     And Markup 投影不假装存在引擎级 {{oreTotal}} 绑定
+
+  Scenario: 试玩里玩家看到信息卡随情景变化
+    Given 我打开实体信息卡模板的试玩工作区
+    When 我点「刚击杀敌军」
+    Then 信息卡显示上一次击杀对象与更新后的血量
+    And 旁白说明数字来自变量表而非界面自编
+
+  Scenario: 导出作者配置可给运行时消费
+    Given 我打开配置工作区
+    When 我下载当前模板 JSON
+    Then 文件含 schema ludots.ui.panel_template/v1
+    And 含 variables / bindings / outputs / surfaceKind
+    And 不含 GraphNodeOp.Panel
 ```

--- a/src/Tools/Ludots.Editor.React/public/samples/panel_templates.json
+++ b/src/Tools/Ludots.Editor.React/public/samples/panel_templates.json
@@ -1,0 +1,91 @@
+{
+  "schema": "ludots.ui.panel_template/v1",
+  "templates": [
+    {
+      "templateId": "panel.entity_info",
+      "label": "实体信息卡",
+      "blurb": "一张图多出口 → Panel 多引脚（像 Shader Graph）",
+      "surfaceKind": "reactive",
+      "defaultGraphId": "graph.entity_info",
+      "variables": [
+        { "variableId": "hp", "label": "血量", "valueKind": "Float" },
+        { "variableId": "lastKill", "label": "上一次击杀", "valueKind": "Text" },
+        { "variableId": "curState", "label": "当前状态", "valueKind": "Text" }
+      ],
+      "bindings": [
+        {
+          "variableId": "hp",
+          "sourceKind": "graphOutput",
+          "graphOutputKey": "panel.entity_info.hp",
+          "attributeId": "attribute.health.current"
+        },
+        {
+          "variableId": "lastKill",
+          "sourceKind": "graphOutput",
+          "graphOutputKey": "panel.entity_info.lastKill",
+          "semantic": "presentationToken"
+        },
+        {
+          "variableId": "curState",
+          "sourceKind": "graphOutput",
+          "graphOutputKey": "panel.entity_info.curState",
+          "semantic": "presentationToken"
+        }
+      ],
+      "outputs": [
+        { "id": "hp", "type": "Float", "key": "panel.entity_info.hp", "source": "hpAttr" },
+        {
+          "id": "lastKill",
+          "type": "TextToken",
+          "key": "panel.entity_info.lastKill",
+          "source": "bbKill"
+        },
+        {
+          "id": "curState",
+          "type": "TextToken",
+          "key": "panel.entity_info.curState",
+          "source": "tagLookup"
+        }
+      ],
+      "copyTemplate": "血量: {hp}\n上一次击杀的对象: {lastKill}\n当前状态: {curState}"
+    },
+    {
+      "templateId": "panel.player_aggregate",
+      "label": "玩家资源总览",
+      "blurb": "一张 Query 图双出口 → Panel 双引脚",
+      "surfaceKind": "webui",
+      "defaultGraphId": "graph.player_aggregate",
+      "variables": [
+        { "variableId": "oreTotal", "label": "矿石合计", "valueKind": "Float" },
+        { "variableId": "crystalTotal", "label": "晶体合计", "valueKind": "Float" }
+      ],
+      "bindings": [
+        {
+          "variableId": "oreTotal",
+          "sourceKind": "aggregateProjection",
+          "graphOutputKey": "ui.panel.player.ore.total"
+        },
+        {
+          "variableId": "crystalTotal",
+          "sourceKind": "aggregateProjection",
+          "graphOutputKey": "ui.panel.player.crystal.total"
+        }
+      ],
+      "outputs": [
+        {
+          "id": "oreTotal",
+          "type": "Float",
+          "key": "ui.panel.player.ore.total",
+          "source": "sumOre"
+        },
+        {
+          "id": "crystalTotal",
+          "type": "Float",
+          "key": "ui.panel.player.crystal.total",
+          "source": "sumCrystal"
+        }
+      ],
+      "copyTemplate": "矿 {oreTotal} · 晶 {crystalTotal}"
+    }
+  ]
+}

--- a/src/Tools/Ludots.Editor.React/src/pages/UiPanelAuthoringPage.tsx
+++ b/src/Tools/Ludots.Editor.React/src/pages/UiPanelAuthoringPage.tsx
@@ -10,7 +10,11 @@ import {
   type PanelVariable,
 } from './ui-panel-authoring/model';
 import { ShaderGraphCanvas } from './ui-panel-authoring/ShaderGraphCanvas';
+import { PlayerShowcase } from './ui-panel-authoring/PlayerShowcase';
+import { authoringConfigJson, toAuthoringTemplate } from './ui-panel-authoring/authoringConfig';
 import './ui-panel-authoring/authoring.css';
+
+type WorkspaceMode = 'author' | 'play' | 'config';
 
 function renderCopy(template: string, vars: PanelVariable[], demo: Record<string, string>) {
   let text = template;
@@ -115,14 +119,36 @@ ${fields}
   );
 }
 
+async function copyText(text: string): Promise<void> {
+  await navigator.clipboard.writeText(text);
+}
+
+function downloadJson(filename: string, text: string) {
+  const blob = new Blob([text], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 export function UiPanelAuthoringPage() {
   const [templateId, setTemplateId] = useState(TEMPLATES[0].id);
   const [surface, setSurface] = useState<SurfaceKind>('reactive');
   const [selectedVar, setSelectedVar] = useState<string | null>('hp');
+  const [mode, setMode] = useState<WorkspaceMode>('author');
+  const [copied, setCopied] = useState(false);
 
   const tpl = useMemo(
     () => TEMPLATES.find((t) => t.id === templateId) ?? TEMPLATES[0],
     [templateId],
+  );
+
+  const configJson = useMemo(() => authoringConfigJson(TEMPLATES), []);
+  const activeConfigJson = useMemo(
+    () => JSON.stringify({ schema: 'ludots.ui.panel_template/v1', templates: [toAuthoringTemplate(tpl)] }, null, 2),
+    [tpl],
   );
 
   const activeVar =
@@ -152,7 +178,7 @@ export function UiPanelAuthoringPage() {
           </h1>
           <p className="upa-lede">
             像编 Shader Graph：一张图、多种类型、右边一个带多引脚的 Panel
-            汇入。引脚就是面板变量；表面（Compose / Markup / Reactive / Web UI）只决定怎么画。
+            汇入。引脚就是面板变量；表面只决定怎么画。可导出作者配置，也可切到试玩看玩家视角。
           </p>
         </div>
         <aside className="upa-contract" aria-label="第一性原则">
@@ -165,6 +191,27 @@ export function UiPanelAuthoringPage() {
           </ol>
         </aside>
       </header>
+
+      <div className="upa-mode-row" role="tablist" aria-label="工作区">
+        {(
+          [
+            ['author', '编排'],
+            ['play', '试玩'],
+            ['config', '配置'],
+          ] as const
+        ).map(([id, label]) => (
+          <button
+            key={id}
+            type="button"
+            role="tab"
+            aria-selected={mode === id}
+            className={`upa-mode ${mode === id ? 'is-active' : ''}`}
+            onClick={() => setMode(id)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
 
       <div className="upa-tpl-row" role="tablist" aria-label="模板">
         {TEMPLATES.map((t) => (
@@ -199,99 +246,132 @@ export function UiPanelAuthoringPage() {
         ))}
       </div>
 
-      <div className="upa-stage upa-stage-shader">
-        <section className="upa-col upa-col-graph" aria-labelledby="upa-graph-h">
-          <div className="upa-col-h">
-            <h3 id="upa-graph-h">计算图 · 多引脚 Panel 汇入</h3>
-            <small>一眼看完：像材质输出节点</small>
-          </div>
-          <div className="upa-col-b upa-col-b-canvas">
-            <ShaderGraphCanvas tpl={tpl} activeVar={activeVar} onSelectVar={setSelectedVar} />
-          </div>
-        </section>
+      {mode === 'play' ? <PlayerShowcase tpl={tpl} surface={surface} /> : null}
 
-        <aside className="upa-side">
-          <section className="upa-col" aria-labelledby="upa-vars-h">
+      {mode === 'config' ? (
+        <div className="upa-config-panel">
+          <div className="upa-config-actions">
+            <button
+              type="button"
+              onClick={async () => {
+                await copyText(activeConfigJson);
+                setCopied(true);
+                window.setTimeout(() => setCopied(false), 1200);
+              }}
+            >
+              {copied ? '已复制当前模板' : '复制当前模板 JSON'}
+            </button>
+            <button type="button" onClick={() => downloadJson(`${tpl.id}.json`, activeConfigJson)}>
+              下载当前模板
+            </button>
+            <button type="button" onClick={() => downloadJson('panel_templates.json', configJson)}>
+              下载全部模板
+            </button>
+          </div>
+          <p className="upa-play-footnote">
+            schema <code>ludots.ui.panel_template/v1</code> — variables / bindings / outputs /
+            surfaceKind；运行时读这份配置，不读画布糖节点。
+          </p>
+          <pre className="upa-config-json">{activeConfigJson}</pre>
+        </div>
+      ) : null}
+
+      {mode === 'author' ? (
+        <div className="upa-stage upa-stage-shader">
+          <section className="upa-col upa-col-graph" aria-labelledby="upa-graph-h">
             <div className="upa-col-h">
-              <h3 id="upa-vars-h">引脚 = 变量</h3>
-              <small>点引脚高亮连线</small>
+              <h3 id="upa-graph-h">计算图 · 多引脚 Panel 汇入</h3>
+              <small>一眼看完：像材质输出节点</small>
             </div>
-            <div className="upa-col-b">
-              <ul className="upa-var-list">
-                {tpl.variables.map((v) => {
-                  const b = tpl.bindings[v.id];
-                  return (
-                    <li key={v.id}>
-                      <button
-                        type="button"
-                        className={`upa-var ${activeVar === v.id ? 'is-active' : ''}`}
-                        onClick={() => setSelectedVar(v.id)}
-                      >
-                        <span className="upa-var-id">{v.id}</span>
-                        <span className="upa-var-label">{v.label}</span>
-                        <span className="upa-var-meta">
-                          {v.valueKind}
-                          {b ? ` · ← ${b.fromNodeId ?? b.sourceKind}` : ''}
-                        </span>
-                      </button>
-                    </li>
-                  );
-                })}
-              </ul>
-              <div className="upa-preview">
-                <div className="upa-preview-label">模板文案 · {'{引脚}'}</div>
-                <pre>{renderCopy(tpl.copyTemplate, tpl.variables, demo)}</pre>
+            <div className="upa-col-b upa-col-b-canvas">
+              <ShaderGraphCanvas tpl={tpl} activeVar={activeVar} onSelectVar={setSelectedVar} />
+            </div>
+          </section>
+
+          <aside className="upa-side">
+            <section className="upa-col" aria-labelledby="upa-vars-h">
+              <div className="upa-col-h">
+                <h3 id="upa-vars-h">引脚 = 变量</h3>
+                <small>点引脚高亮连线</small>
               </div>
-              {binding ? (
-                <div className="upa-bind-card">
-                  <h4>选中引脚 · {activeVar}</h4>
-                  <dl>
-                    <div>
-                      <dt>sourceKind</dt>
-                      <dd>{binding.sourceKind}</dd>
-                    </div>
-                    {binding.fromNodeId ? (
-                      <div>
-                        <dt>from node</dt>
-                        <dd>{binding.fromNodeId}</dd>
-                      </div>
-                    ) : null}
-                    {binding.graphOutputKey ? (
-                      <div>
-                        <dt>output key</dt>
-                        <dd>{binding.graphOutputKey}</dd>
-                      </div>
-                    ) : null}
-                  </dl>
-                  {activeVar === 'lastKill' ? (
-                    <p className="upa-debt">
-                      作者意图：实体 BB 读上次击杀文案。现有 L0 仅有 Float/Int/Entity 黑板读；Text
-                      BB 读需补 op（勿用 Attribute 假装）。
-                    </p>
-                  ) : null}
-                  {activeVar === 'curState' ? (
-                    <p className="upa-debt">
-                      作者意图：读当前 GameplayTag → LookupTagDisplayText
-                      查表成文案。HasTag 只做是否拥有；完整「取态 tag + 查表」需补节点。
-                    </p>
-                  ) : null}
+              <div className="upa-col-b">
+                <ul className="upa-var-list">
+                  {tpl.variables.map((v) => {
+                    const b = tpl.bindings[v.id];
+                    return (
+                      <li key={v.id}>
+                        <button
+                          type="button"
+                          className={`upa-var ${activeVar === v.id ? 'is-active' : ''}`}
+                          onClick={() => setSelectedVar(v.id)}
+                        >
+                          <span className="upa-var-id">{v.id}</span>
+                          <span className="upa-var-label">{v.label}</span>
+                          <span className="upa-var-meta">
+                            {v.valueKind}
+                            {b ? ` · ← ${b.fromNodeId ?? b.sourceKind}` : ''}
+                          </span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+                <div className="upa-preview">
+                  <div className="upa-preview-label">模板文案 · {'{引脚}'}</div>
+                  <pre>{renderCopy(tpl.copyTemplate, tpl.variables, demo)}</pre>
                 </div>
-              ) : null}
-            </div>
-          </section>
+                {binding ? (
+                  <div className="upa-bind-card">
+                    <h4>选中引脚 · {activeVar}</h4>
+                    <dl>
+                      <div>
+                        <dt>sourceKind</dt>
+                        <dd>{binding.sourceKind}</dd>
+                      </div>
+                      {binding.fromNodeId ? (
+                        <div>
+                          <dt>from node</dt>
+                          <dd>{binding.fromNodeId}</dd>
+                        </div>
+                      ) : null}
+                      {binding.graphOutputKey ? (
+                        <div>
+                          <dt>output key</dt>
+                          <dd>{binding.graphOutputKey}</dd>
+                        </div>
+                      ) : null}
+                    </dl>
+                    {activeVar === 'lastKill' ? (
+                      <p className="upa-debt">
+                        作者意图：实体 BB 读上次击杀文案。现有 L0 仅有 Float/Int/Entity
+                        黑板读；Text BB 仍欠（勿用 Attribute 假装）。也可改为 BB Entity +
+                        表面解析显示名。
+                      </p>
+                    ) : null}
+                    {activeVar === 'curState' ? (
+                      <p className="upa-debt">
+                        作者意图：ReadGameplayTag → LookupTagDisplayText。L0 快捷 op 已在运行时线
+                        #868 落地；本编辑器仍是作者糖。仍欠表资产装载与表面 token→文案接线。
+                      </p>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+            </section>
 
-          <section className="upa-col" aria-labelledby="upa-lower-h">
-            <div className="upa-col-h">
-              <h3 id="upa-lower-h">落盘 / {SURFACE_META[surface].label}</h3>
-              <small>{SURFACE_META[surface].note}</small>
-            </div>
-            <div className="upa-col-b">
-              <pre className="upa-code upa-code-tight">{loweredOutputs(tpl)}</pre>
-              <SurfaceArtifact surface={surface} tpl={tpl} />
-            </div>
-          </section>
-        </aside>
-      </div>
+            <section className="upa-col" aria-labelledby="upa-lower-h">
+              <div className="upa-col-h">
+                <h3 id="upa-lower-h">落盘 / {SURFACE_META[surface].label}</h3>
+                <small>{SURFACE_META[surface].note}</small>
+              </div>
+              <div className="upa-col-b">
+                <pre className="upa-code upa-code-tight">{loweredOutputs(tpl)}</pre>
+                <SurfaceArtifact surface={surface} tpl={tpl} />
+              </div>
+            </section>
+          </aside>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/Tools/Ludots.Editor.React/src/pages/ui-panel-authoring/PlayerShowcase.tsx
+++ b/src/Tools/Ludots.Editor.React/src/pages/ui-panel-authoring/PlayerShowcase.tsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useState } from 'react';
+import type { PanelTemplate, SurfaceKind } from './model';
+import { SURFACE_META } from './model';
+
+type Beat = {
+  id: string;
+  label: string;
+  narrate: string;
+  values: Record<string, string>;
+};
+
+const ENTITY_BEATS: Beat[] = [
+  {
+    id: 'idle',
+    label: '点选斥候',
+    narrate: '你点中了斥候 Scout-7。信息卡按作者配好的引脚亮起来——不是界面自己编的数。',
+    values: { hp: '840', lastKill: '—', curState: '待命' },
+  },
+  {
+    id: 'kill',
+    label: '刚击杀敌军',
+    narrate: '黑板记下上一次击杀对象；状态仍是移动。文案来自变量表，不是硬编码 HTML。',
+    values: { hp: '720', lastKill: 'Raider-3', curState: '移动中' },
+  },
+  {
+    id: 'fight',
+    label: '交火',
+    narrate: '状态 tag 变成交战；查表后面板显示本地化状态。换表面语言，这三个引脚不用重算。',
+    values: { hp: '510', lastKill: 'Raider-3', curState: '交战中' },
+  },
+];
+
+const AGG_BEATS: Beat[] = [
+  {
+    id: 'full',
+    label: '三座矿站开工',
+    narrate: '顶栏资源是图算出来的合计。拆掉一座，数字会跟着变——不是 UI 自己加的。',
+    values: { oreTotal: '1200', crystalTotal: '450' },
+  },
+  {
+    id: 'cut',
+    label: '停工一座',
+    narrate: '一座产出归零后，合计立刻掉下来。同一套变量，Web UI / Reactive 只换画法。',
+    values: { oreTotal: '800', crystalTotal: '300' },
+  },
+];
+
+function beatsFor(tpl: PanelTemplate): Beat[] {
+  return tpl.id === 'panel.player_aggregate' ? AGG_BEATS : ENTITY_BEATS;
+}
+
+function fillCopy(template: string, values: Record<string, string>): string {
+  let text = template;
+  for (const [id, value] of Object.entries(values)) {
+    text = text.split(`{${id}}`).join(value);
+  }
+  return text;
+}
+
+export function PlayerShowcase({
+  tpl,
+  surface,
+}: {
+  tpl: PanelTemplate;
+  surface: SurfaceKind;
+}) {
+  const beats = beatsFor(tpl);
+  const [beatId, setBeatId] = useState(beats[0].id);
+  const beat = beats.find((b) => b.id === beatId) ?? beats[0];
+
+  useEffect(() => {
+    setBeatId(beatsFor(tpl)[0].id);
+  }, [tpl.id]);
+
+  return (
+    <div className="upa-play">
+      <div className="upa-play-story">
+        <p className="upa-play-kicker">试玩 · 玩家视角</p>
+        <h3>{tpl.name}</h3>
+        <p className="upa-play-narrate" key={beat.id}>
+          {beat.narrate}
+        </p>
+        <div className="upa-play-beats" role="group" aria-label="情景">
+          {beats.map((b) => (
+            <button
+              key={b.id}
+              type="button"
+              className={`upa-play-beat ${b.id === beat.id ? 'is-active' : ''}`}
+              onClick={() => setBeatId(b.id)}
+            >
+              {b.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="upa-play-stage">
+        <article className={`upa-play-card surface-${surface}`} key={`${tpl.id}-${beat.id}`}>
+          <header>
+            <span className="upa-play-card-title">
+              {tpl.id === 'panel.player_aggregate' ? '资源总览' : '实体信息'}
+            </span>
+            <span className="upa-play-card-surface">{SURFACE_META[surface].label}</span>
+          </header>
+          <pre className="upa-play-card-body">{fillCopy(tpl.copyTemplate, beat.values)}</pre>
+          <ul className="upa-play-pins">
+            {tpl.variables.map((v) => (
+              <li key={v.id}>
+                <span>{v.label}</span>
+                <strong>{beat.values[v.id] ?? '—'}</strong>
+              </li>
+            ))}
+          </ul>
+        </article>
+        <p className="upa-play-footnote">
+          引脚来自作者配置的同一张变量表；表面只决定怎么画，不算第二套数。
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/Tools/Ludots.Editor.React/src/pages/ui-panel-authoring/authoring.css
+++ b/src/Tools/Ludots.Editor.React/src/pages/ui-panel-authoring/authoring.css
@@ -682,3 +682,210 @@
   font-size: 0.74rem;
   line-height: 1.4;
 }
+
+.upa-mode-row {
+  display: flex;
+  gap: 8px;
+  max-width: 1280px;
+  margin: 0 auto 16px;
+}
+
+.upa-mode {
+  border: 1px solid var(--upa-line);
+  background: var(--upa-soft);
+  color: var(--upa-mute);
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-family: var(--upa-sans);
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.upa-mode.is-active {
+  color: var(--upa-ink);
+  background: var(--upa-mint);
+  border-color: transparent;
+  font-weight: 600;
+}
+
+.upa-play {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 28px;
+  max-width: 1280px;
+  margin: 0 auto;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .upa-play {
+    grid-template-columns: 1fr;
+  }
+}
+
+.upa-play-kicker {
+  margin: 0 0 6px;
+  font-family: var(--upa-mono);
+  font-size: 0.72rem;
+  color: var(--upa-sand);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.upa-play-story h3 {
+  margin: 0 0 10px;
+  font-family: var(--upa-display);
+  font-size: 1.8rem;
+}
+
+.upa-play-narrate {
+  margin: 0 0 16px;
+  max-width: 42ch;
+  color: var(--upa-mute);
+  line-height: 1.55;
+  animation: upa-fade-up 280ms ease-out;
+}
+
+.upa-play-beats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.upa-play-beat {
+  border: 1px solid var(--upa-line);
+  background: var(--upa-panel);
+  color: var(--upa-text);
+  border-radius: 10px;
+  padding: 10px 14px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.upa-play-beat.is-active {
+  border-color: var(--upa-sand);
+  box-shadow: inset 0 0 0 1px rgba(212, 180, 131, 0.35);
+}
+
+.upa-play-card {
+  border: 1px solid var(--upa-line);
+  border-radius: 16px;
+  background:
+    linear-gradient(160deg, rgba(111, 207, 151, 0.08), transparent 40%),
+    var(--upa-panel-2);
+  padding: 18px 18px 14px;
+  animation: upa-card-in 320ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.upa-play-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 12px;
+}
+
+.upa-play-card-title {
+  font-family: var(--upa-display);
+  font-size: 1.25rem;
+}
+
+.upa-play-card-surface {
+  font-family: var(--upa-mono);
+  font-size: 0.7rem;
+  color: var(--upa-sky);
+}
+
+.upa-play-card-body {
+  margin: 0 0 14px;
+  white-space: pre-wrap;
+  font-family: var(--upa-sans);
+  font-size: 1.05rem;
+  line-height: 1.5;
+  color: var(--upa-text);
+}
+
+.upa-play-pins {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.upa-play-pins li {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.22);
+  font-size: 0.88rem;
+}
+
+.upa-play-pins strong {
+  font-family: var(--upa-mono);
+  color: var(--upa-mint);
+}
+
+.upa-play-footnote {
+  margin: 12px 0 0;
+  color: var(--upa-mute);
+  font-size: 0.78rem;
+}
+
+.upa-config-panel {
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+.upa-config-actions {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.upa-config-actions button {
+  border: 1px solid var(--upa-line);
+  background: var(--upa-panel);
+  color: var(--upa-text);
+  border-radius: 10px;
+  padding: 8px 14px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.upa-config-json {
+  margin: 0;
+  max-height: 62vh;
+  overflow: auto;
+  padding: 14px;
+  border-radius: 12px;
+  border: 1px solid var(--upa-line);
+  background: #0a0f0c;
+  font-family: var(--upa-mono);
+  font-size: 0.72rem;
+  line-height: 1.45;
+  color: #c9d7cc;
+}
+
+@keyframes upa-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes upa-card-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/src/Tools/Ludots.Editor.React/src/pages/ui-panel-authoring/authoringConfig.ts
+++ b/src/Tools/Ludots.Editor.React/src/pages/ui-panel-authoring/authoringConfig.ts
@@ -1,0 +1,84 @@
+import type { PanelTemplate, SurfaceKind } from './model';
+
+/** Formal authoring config shape (runtime-facing contract sample). */
+export type PanelAuthoringConfig = {
+  schema: 'ludots.ui.panel_template/v1';
+  templates: PanelAuthoringTemplate[];
+};
+
+export type PanelAuthoringTemplate = {
+  templateId: string;
+  label: string;
+  blurb: string;
+  surfaceKind: SurfaceKind;
+  defaultGraphId: string;
+  variables: Array<{
+    variableId: string;
+    label: string;
+    valueKind: string;
+  }>;
+  bindings: Array<{
+    variableId: string;
+    sourceKind: string;
+    graphOutputKey?: string;
+    attributeId?: string;
+    /** presentationToken when valueKind is Text from tag/table lookup */
+    semantic?: string;
+  }>;
+  outputs: Array<{
+    id: string;
+    type: string;
+    key: string;
+    source: string;
+  }>;
+  copyTemplate: string;
+};
+
+export function toAuthoringTemplate(tpl: PanelTemplate): PanelAuthoringTemplate {
+  return {
+    templateId: tpl.id,
+    label: tpl.name,
+    blurb: tpl.blurb,
+    surfaceKind: tpl.surfaceKind,
+    defaultGraphId: `graph.${tpl.id.replace(/^panel\./, '')}`,
+    variables: tpl.variables.map((v) => ({
+      variableId: v.id,
+      label: v.label,
+      valueKind: v.valueKind,
+    })),
+    bindings: tpl.variables.map((v) => {
+      const b = tpl.bindings[v.id];
+      const binding: PanelAuthoringTemplate['bindings'][number] = {
+        variableId: v.id,
+        sourceKind: b?.sourceKind ?? 'graphOutput',
+      };
+      if (b?.graphOutputKey) binding.graphOutputKey = b.graphOutputKey;
+      if (b?.attributeId) binding.attributeId = b.attributeId;
+      if (v.valueKind === 'Text' && (v.id === 'curState' || v.id === 'lastKill')) {
+        binding.semantic = 'presentationToken';
+      }
+      return binding;
+    }),
+    outputs: tpl.variables.map((v) => {
+      const b = tpl.bindings[v.id];
+      return {
+        id: v.id,
+        type: v.valueKind === 'Text' ? 'TextToken' : v.valueKind,
+        key: b?.graphOutputKey ?? `panel.${v.id}`,
+        source: b?.fromNodeId ?? v.id,
+      };
+    }),
+    copyTemplate: tpl.copyTemplate,
+  };
+}
+
+export function toAuthoringConfig(templates: PanelTemplate[]): PanelAuthoringConfig {
+  return {
+    schema: 'ludots.ui.panel_template/v1',
+    templates: templates.map(toAuthoringTemplate),
+  };
+}
+
+export function authoringConfigJson(templates: PanelTemplate[], space = 2): string {
+  return JSON.stringify(toAuthoringConfig(templates), null, space);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

在作者形态编辑器上补齐**作者态配置**与**玩家试玩**，不掺通用查表实现。

叠在 [#864](https://github.com/MightyBubble/Ludots/pull/864) 上。

### 作者态配置
- schema `ludots.ui.panel_template/v1`：`variables` / `bindings` / `outputs` / `surfaceKind`
- 配置工作区：复制 / 下载当前模板或全部模板
- 样例：`Ludots.Editor.React/public/samples/panel_templates.json`

### Showcase（试玩）
- 玩家情景：点选斥候 / 击杀 / 交火；资源条开工 / 停工
- 换表面只换画法，引脚同一套
- 旁白说人话，不是技术流水账

### 相关拆出（不在本 PR）
- 通用查表节点：[#871](https://github.com/MightyBubble/Ludots/issues/871) / [#872](https://github.com/MightyBubble/Ludots/pull/872)
- Tag 快捷查表运行时：[#868](https://github.com/MightyBubble/Ludots/pull/868)
- 误开占位 [#870](https://github.com/MightyBubble/Ludots/issues/870) 请人工关闭

### Test plan
- [x] `npm run check` in `Ludots.Editor.React`
- [ ] 打开 `/ui-panel-authoring`：编排 / 试玩 / 配置 三态
- [ ] 下载 JSON 含 schema 与 bindings

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ae6b725-472c-4613-afa5-cff2488928e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ae6b725-472c-4613-afa5-cff2488928e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

