### PR TITLE
fix(editor): panel_templates 样品与 PanelVariableBinding 合同对齐（#884）

### DIFF
--- a/src/Tools/Ludots.Editor.React/package.json
+++ b/src/Tools/Ludots.Editor.React/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "check": "tsc -b --noEmit"
+    "check": "tsc -b --noEmit && node scripts/validate-panel-templates.mjs",
+    "validate:panel-templates": "node scripts/validate-panel-templates.mjs"
   },
   "dependencies": {
     "@types/three": "^0.182.0",

--- a/src/Tools/Ludots.Editor.React/public/samples/panel_templates.json
+++ b/src/Tools/Ludots.Editor.React/public/samples/panel_templates.json
@@ -16,8 +16,7 @@
         {
           "variableId": "hp",
           "sourceKind": "graphOutput",
-          "graphOutputKey": "panel.entity_info.hp",
-          "attributeId": "attribute.health.current"
+          "graphOutputKey": "panel.entity_info.hp"
         },
         {
           "variableId": "lastKill",

--- a/src/Tools/Ludots.Editor.React/scripts/validate-panel-templates.mjs
+++ b/src/Tools/Ludots.Editor.React/scripts/validate-panel-templates.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Fail-closed check for public/samples/panel_templates.json
+ * (mirrors Core PanelVariableBinding sourceKind ↔ ref exclusivity).
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ATTRIBUTE_KINDS = new Set(['singleAttribute', 'derivedAttribute']);
+const GRAPH_KINDS = new Set(['aggregateProjection', 'graphOutput']);
+
+function nonEmpty(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function assertBinding(binding, path) {
+  const variableId = binding?.variableId?.trim();
+  if (!variableId) {
+    throw new Error(`${path}: variableId is required.`);
+  }
+  const sourceKind = binding?.sourceKind?.trim();
+  if (!sourceKind) {
+    throw new Error(`${path}: sourceKind is required.`);
+  }
+  const hasAttribute = nonEmpty(binding.attributeId);
+  const hasGraphKey = nonEmpty(binding.graphOutputKey);
+
+  if (ATTRIBUTE_KINDS.has(sourceKind)) {
+    if (!hasAttribute) {
+      throw new Error(`${path}: sourceKind '${sourceKind}' requires attributeId.`);
+    }
+    if (hasGraphKey) {
+      throw new Error(`${path}: sourceKind '${sourceKind}' must not declare graphOutputKey.`);
+    }
+    return;
+  }
+
+  if (GRAPH_KINDS.has(sourceKind)) {
+    if (!hasGraphKey) {
+      throw new Error(`${path}: sourceKind '${sourceKind}' requires graphOutputKey.`);
+    }
+    if (hasAttribute) {
+      throw new Error(`${path}: sourceKind '${sourceKind}' must not declare attributeId.`);
+    }
+    return;
+  }
+
+  throw new Error(`${path}: unknown sourceKind '${sourceKind}'.`);
+}
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const samplePath = join(root, 'public/samples/panel_templates.json');
+const config = JSON.parse(readFileSync(samplePath, 'utf8'));
+
+if (config.schema !== 'ludots.ui.panel_template/v1') {
+  throw new Error(`Unsupported schema '${config.schema}'.`);
+}
+
+for (const [ti, template] of (config.templates ?? []).entries()) {
+  for (const [bi, binding] of (template.bindings ?? []).entries()) {
+    assertBinding(binding, `templates[${ti}].bindings[${bi}] (${binding?.variableId ?? '?'})`);
+  }
+}
+
+console.log(`OK: ${samplePath} bindings match PanelVariableBinding contract.`);

--- a/src/Tools/Ludots.Editor.React/src/pages/UiPanelAuthoringPage.tsx
+++ b/src/Tools/Ludots.Editor.React/src/pages/UiPanelAuthoringPage.tsx
@@ -11,7 +11,11 @@ import {
 } from './ui-panel-authoring/model';
 import { ShaderGraphCanvas } from './ui-panel-authoring/ShaderGraphCanvas';
 import { PlayerShowcase } from './ui-panel-authoring/PlayerShowcase';
-import { authoringConfigJson, toAuthoringTemplate } from './ui-panel-authoring/authoringConfig';
+import {
+  assertPanelBindingContract,
+  authoringConfigJson,
+  toAuthoringTemplate,
+} from './ui-panel-authoring/authoringConfig';
 import './ui-panel-authoring/authoring.css';
 
 type WorkspaceMode = 'author' | 'play' | 'config';
@@ -96,13 +100,23 @@ function SurfaceArtifact({
   const fields = tpl.variables
     .map((v) => {
       const b = tpl.bindings[v.id];
+      const sourceKind = b?.sourceKind ?? 'graphOutput';
+      assertPanelBindingContract({
+        variableId: v.id,
+        sourceKind,
+        attributeId: b?.attributeId,
+        graphOutputKey: b?.graphOutputKey,
+      });
       const lines = [
         `    {`,
         `      "fieldId": "${v.id}",`,
-        `      "sourceKind": "${b?.sourceKind ?? 'graphOutput'}",`,
+        `      "sourceKind": "${sourceKind}",`,
       ];
-      if (b?.attributeId) lines.push(`      "attributeId": "${b.attributeId}",`);
-      if (b?.graphOutputKey) lines.push(`      "graphOutputKey": "${b.graphOutputKey}",`);
+      if (sourceKind === 'singleAttribute' || sourceKind === 'derivedAttribute') {
+        lines.push(`      "attributeId": "${b?.attributeId}",`);
+      } else if (b?.graphOutputKey) {
+        lines.push(`      "graphOutputKey": "${b.graphOutputKey}",`);
+      }
       lines.push(`    }`);
       return lines.join('\n');
     })
@@ -131,6 +145,21 @@ function downloadJson(filename: string, text: string) {
   a.download = filename;
   a.click();
   URL.revokeObjectURL(url);
+}
+
+function exportOrAlert(action: () => void | Promise<void>): void {
+  try {
+    const result = action();
+    if (result && typeof (result as Promise<void>).then === 'function') {
+      void (result as Promise<void>).catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        window.alert(`导出失败（fail-closed）：${message}`);
+      });
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    window.alert(`导出失败（fail-closed）：${message}`);
+  }
 }
 
 export function UiPanelAuthoringPage() {
@@ -253,18 +282,30 @@ export function UiPanelAuthoringPage() {
           <div className="upa-config-actions">
             <button
               type="button"
-              onClick={async () => {
-                await copyText(activeConfigJson);
-                setCopied(true);
-                window.setTimeout(() => setCopied(false), 1200);
-              }}
+              onClick={() =>
+                exportOrAlert(async () => {
+                  await copyText(activeConfigJson);
+                  setCopied(true);
+                  window.setTimeout(() => setCopied(false), 1200);
+                })
+              }
             >
               {copied ? '已复制当前模板' : '复制当前模板 JSON'}
             </button>
-            <button type="button" onClick={() => downloadJson(`${tpl.id}.json`, activeConfigJson)}>
+            <button
+              type="button"
+              onClick={() =>
+                exportOrAlert(() => downloadJson(`${tpl.id}.json`, activeConfigJson))
+              }
+            >
               下载当前模板
             </button>
-            <button type="button" onClick={() => downloadJson('panel_templates.json', configJson)}>
+            <button
+              type="button"
+              onClick={() =>
+                exportOrAlert(() => downloadJson('panel_templates.json', configJson))
+              }
+            >
               下载全部模板
             </button>
           </div>

--- a/src/Tools/Ludots.Editor.React/src/pages/ui-panel-authoring/authoringConfig.ts
+++ b/src/Tools/Ludots.Editor.React/src/pages/ui-panel-authoring/authoringConfig.ts
@@ -1,9 +1,18 @@
-import type { PanelTemplate, SurfaceKind } from './model';
+import type { PanelTemplate, SourceKind, SurfaceKind } from './model';
 
 /** Formal authoring config shape (runtime-facing contract sample). */
 export type PanelAuthoringConfig = {
   schema: 'ludots.ui.panel_template/v1';
   templates: PanelAuthoringTemplate[];
+};
+
+export type PanelAuthoringBinding = {
+  variableId: string;
+  sourceKind: string;
+  graphOutputKey?: string;
+  attributeId?: string;
+  /** presentationToken when valueKind is Text from tag/table lookup */
+  semantic?: string;
 };
 
 export type PanelAuthoringTemplate = {
@@ -17,14 +26,7 @@ export type PanelAuthoringTemplate = {
     label: string;
     valueKind: string;
   }>;
-  bindings: Array<{
-    variableId: string;
-    sourceKind: string;
-    graphOutputKey?: string;
-    attributeId?: string;
-    /** presentationToken when valueKind is Text from tag/table lookup */
-    semantic?: string;
-  }>;
+  bindings: PanelAuthoringBinding[];
   outputs: Array<{
     id: string;
     type: string;
@@ -33,6 +35,89 @@ export type PanelAuthoringTemplate = {
   }>;
   copyTemplate: string;
 };
+
+const ATTRIBUTE_SOURCE_KINDS = new Set<SourceKind>(['singleAttribute', 'derivedAttribute']);
+const GRAPH_SOURCE_KINDS = new Set<SourceKind>(['aggregateProjection', 'graphOutput']);
+
+function nonEmpty(value: string | undefined | null): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/**
+ * Fail-closed mirror of Core PanelVariableBinding: sourceKind selects exactly one ref.
+ * attributeId ↔ graphOutputKey are mutually exclusive.
+ */
+export function assertPanelBindingContract(binding: {
+  variableId: string;
+  sourceKind: string;
+  attributeId?: string | null;
+  graphOutputKey?: string | null;
+}): void {
+  const variableId = binding.variableId?.trim();
+  if (!variableId) {
+    throw new Error('Panel binding requires variableId.');
+  }
+
+  const sourceKind = binding.sourceKind?.trim() as SourceKind;
+  if (!sourceKind) {
+    throw new Error(`Binding '${variableId}' requires sourceKind.`);
+  }
+
+  const hasAttribute = nonEmpty(binding.attributeId);
+  const hasGraphKey = nonEmpty(binding.graphOutputKey);
+
+  if (ATTRIBUTE_SOURCE_KINDS.has(sourceKind)) {
+    if (!hasAttribute) {
+      throw new Error(
+        `Binding '${variableId}' with sourceKind '${sourceKind}' requires attributeId.`,
+      );
+    }
+    if (hasGraphKey) {
+      throw new Error(
+        `Binding '${variableId}' with sourceKind '${sourceKind}' must not declare graphOutputKey.`,
+      );
+    }
+    return;
+  }
+
+  if (GRAPH_SOURCE_KINDS.has(sourceKind)) {
+    if (!hasGraphKey) {
+      throw new Error(
+        `Binding '${variableId}' with sourceKind '${sourceKind}' requires graphOutputKey.`,
+      );
+    }
+    if (hasAttribute) {
+      throw new Error(
+        `Binding '${variableId}' with sourceKind '${sourceKind}' must not declare attributeId.`,
+      );
+    }
+    return;
+  }
+
+  throw new Error(`Binding '${variableId}' has unknown sourceKind '${sourceKind}'.`);
+}
+
+function toAuthoringBinding(
+  variableId: string,
+  sourceKind: SourceKind,
+  attributeId: string | undefined,
+  graphOutputKey: string | undefined,
+  semantic: string | undefined,
+): PanelAuthoringBinding {
+  assertPanelBindingContract({ variableId, sourceKind, attributeId, graphOutputKey });
+
+  const binding: PanelAuthoringBinding = { variableId, sourceKind };
+  if (ATTRIBUTE_SOURCE_KINDS.has(sourceKind) && attributeId) {
+    binding.attributeId = attributeId.trim();
+  }
+  if (GRAPH_SOURCE_KINDS.has(sourceKind) && graphOutputKey) {
+    binding.graphOutputKey = graphOutputKey.trim();
+  }
+  if (semantic) {
+    binding.semantic = semantic;
+  }
+  return binding;
+}
 
 export function toAuthoringTemplate(tpl: PanelTemplate): PanelAuthoringTemplate {
   return {
@@ -48,16 +133,12 @@ export function toAuthoringTemplate(tpl: PanelTemplate): PanelAuthoringTemplate 
     })),
     bindings: tpl.variables.map((v) => {
       const b = tpl.bindings[v.id];
-      const binding: PanelAuthoringTemplate['bindings'][number] = {
-        variableId: v.id,
-        sourceKind: b?.sourceKind ?? 'graphOutput',
-      };
-      if (b?.graphOutputKey) binding.graphOutputKey = b.graphOutputKey;
-      if (b?.attributeId) binding.attributeId = b.attributeId;
-      if (v.valueKind === 'Text' && (v.id === 'curState' || v.id === 'lastKill')) {
-        binding.semantic = 'presentationToken';
-      }
-      return binding;
+      const sourceKind = b?.sourceKind ?? 'graphOutput';
+      const semantic =
+        v.valueKind === 'Text' && (v.id === 'curState' || v.id === 'lastKill')
+          ? 'presentationToken'
+          : undefined;
+      return toAuthoringBinding(v.id, sourceKind, b?.attributeId, b?.graphOutputKey, semantic);
     }),
     outputs: tpl.variables.map((v) => {
       const b = tpl.bindings[v.id];
@@ -81,4 +162,16 @@ export function toAuthoringConfig(templates: PanelTemplate[]): PanelAuthoringCon
 
 export function authoringConfigJson(templates: PanelTemplate[], space = 2): string {
   return JSON.stringify(toAuthoringConfig(templates), null, space);
+}
+
+/** Validate a already-shaped ludots.ui.panel_template/v1 document (samples / pasted JSON). */
+export function assertPanelAuthoringConfig(config: PanelAuthoringConfig): void {
+  if (config.schema !== 'ludots.ui.panel_template/v1') {
+    throw new Error(`Unsupported panel template schema '${String(config.schema)}'.`);
+  }
+  for (const template of config.templates ?? []) {
+    for (const binding of template.bindings ?? []) {
+      assertPanelBindingContract(binding);
+    }
+  }
 }

--- a/src/Tools/Ludots.Editor.React/src/pages/ui-panel-authoring/model.ts
+++ b/src/Tools/Ludots.Editor.React/src/pages/ui-panel-authoring/model.ts
@@ -80,7 +80,7 @@ export const SURFACE_META: Record<
   webui: {
     label: 'Web UI',
     native: 'WPK descriptor fields[]',
-    note: 'sourceKind + attributeId / graphOutputKey',
+    note: 'sourceKind 互斥：attributeId 或 graphOutputKey',
   },
 };
 
@@ -228,7 +228,6 @@ export const TEMPLATES: PanelTemplate[] = [
         sourceKind: 'graphOutput',
         graphOutputKey: 'panel.entity_info.hp',
         fromNodeId: 'hpAttr',
-        attributeId: 'attribute.health.current',
       },
       lastKill: {
         sourceKind: 'graphOutput',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

对齐编辑器样品 / 导出与运行时 `PanelVariableBinding`：`sourceKind` 对应引用互斥，fail-closed。

## 详情

- `panel.entity_info` 的 `hp`：去掉 `graphOutput` 下多余的 `attributeId`
- `assertPanelBindingContract`（`authoringConfig.ts`）镜像 Core 合同
- `scripts/validate-panel-templates.mjs` + `npm run check`
- `panel.player_aggregate` keys 已与 showcase 一致，未改动语义

## 相关

#884 · #886

未动 Core 图 VM / TagDisplay / showcase 玩法。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ae6b725-472c-4613-afa5-cff2488928e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ae6b725-472c-4613-afa5-cff2488928e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

