### PR TITLE
chore(showcase): ui_player_aggregate 配置卫生与硬编码收敛（#882）

### DIFF
--- a/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/Runtime/UiPlayerAggregateGraphMvpConfig.cs
+++ b/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/Runtime/UiPlayerAggregateGraphMvpConfig.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Ludots.Core.Config;
@@ -7,15 +8,28 @@ namespace UiPlayerAggregateGraphMvpShowcaseMod.Runtime;
 
 public sealed class UiPlayerAggregateGraphMvpConfig
 {
+    public const string OreBindingVariableId = "oreTotal";
+    public const string CrystalBindingVariableId = "crystalTotal";
+
     public string MapId { get; set; } = UiPlayerAggregateGraphMvpIds.MapId;
     public string GraphId { get; set; } = string.Empty;
     public int PlayerTeamId { get; set; }
     public string FactionOwnerName { get; set; } = string.Empty;
     public string ShutDownBuildingName { get; set; } = string.Empty;
     public UiPlayerAggregateAttributeNames Attributes { get; set; } = new();
-    public UiPlayerAggregateSummaryKeys SummaryKeys { get; set; } = new();
+    public UiPlayerAggregatePanelBinding[] PanelBindings { get; set; } = Array.Empty<UiPlayerAggregatePanelBinding>();
     public UiPlayerAggregateBuildingSeed[] Buildings { get; set; } = Array.Empty<UiPlayerAggregateBuildingSeed>();
     public UiPlayerAggregatePresentation Presentation { get; set; } = new();
+
+    public UiPlayerAggregateSummaryKeys SummaryKeys => new()
+    {
+        OreTotal = RequireBinding(OreBindingVariableId).GraphOutputKey,
+        CrystalTotal = RequireBinding(CrystalBindingVariableId).GraphOutputKey,
+    };
+
+    public UiPlayerAggregatePanelBinding OreBinding => RequireBinding(OreBindingVariableId);
+
+    public UiPlayerAggregatePanelBinding CrystalBinding => RequireBinding(CrystalBindingVariableId);
 
     public static UiPlayerAggregateGraphMvpConfig Load(JsonObject configObject)
     {
@@ -32,6 +46,35 @@ public sealed class UiPlayerAggregateGraphMvpConfig
         return config;
     }
 
+    public static UiPlayerAggregateGraphMvpConfig Load(Stream stream)
+    {
+        using var document = JsonDocument.Parse(stream);
+        ValidateRequiredProperties(document.RootElement);
+        UiPlayerAggregateGraphMvpConfig? config = document.RootElement.Deserialize<UiPlayerAggregateGraphMvpConfig>(
+            StrictJsonOptions.CreateCamelCase());
+        if (config == null)
+        {
+            throw new InvalidOperationException("Failed to deserialize player aggregate graph MVP showcase config.");
+        }
+
+        config.Validate();
+        return config;
+    }
+
+    public UiPlayerAggregatePanelBinding RequireBinding(string variableId)
+    {
+        for (int i = 0; i < PanelBindings.Length; i++)
+        {
+            if (string.Equals(PanelBindings[i].VariableId, variableId, StringComparison.Ordinal))
+            {
+                return PanelBindings[i];
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Player aggregate graph MVP config is missing panelBindings entry '{variableId}'.");
+    }
+
     private static void ValidateRequiredProperties(JsonElement root)
     {
         RequireProperty(root, "mapId");
@@ -42,9 +85,20 @@ public sealed class UiPlayerAggregateGraphMvpConfig
         JsonElement attributes = RequireProperty(root, "attributes");
         RequireProperty(attributes, "ore");
         RequireProperty(attributes, "crystal");
-        JsonElement summaryKeys = RequireProperty(root, "summaryKeys");
-        RequireProperty(summaryKeys, "oreTotal");
-        RequireProperty(summaryKeys, "crystalTotal");
+        JsonElement panelBindings = RequireProperty(root, "panelBindings");
+        if (panelBindings.ValueKind != JsonValueKind.Array || panelBindings.GetArrayLength() < 2)
+        {
+            throw new InvalidOperationException("Player aggregate graph MVP config requires at least two panelBindings.");
+        }
+
+        foreach (JsonElement binding in panelBindings.EnumerateArray())
+        {
+            RequireProperty(binding, "variableId");
+            RequireProperty(binding, "label");
+            RequireProperty(binding, "graphOutputKey");
+            RequireProperty(binding, "accent");
+        }
+
         JsonElement buildings = RequireProperty(root, "buildings");
         if (buildings.ValueKind != JsonValueKind.Array || buildings.GetArrayLength() < 2)
         {
@@ -62,6 +116,39 @@ public sealed class UiPlayerAggregateGraphMvpConfig
         RequireProperty(presentation, "title");
         RequireProperty(presentation, "copy");
         RequireProperty(presentation, "controls");
+        JsonElement panel = RequireProperty(presentation, "panel");
+        RequireProperty(panel, "width");
+        RequireProperty(panel, "padding");
+        RequireProperty(panel, "gap");
+        RequireProperty(panel, "radius");
+        RequireProperty(panel, "background");
+        RequireProperty(panel, "borderColor");
+        RequireProperty(panel, "borderThickness");
+        RequireProperty(panel, "titleColor");
+        RequireProperty(panel, "copyColor");
+        RequireProperty(panel, "graphMetaColor");
+        RequireProperty(panel, "statusColor");
+        RequireProperty(panel, "controlsColor");
+        RequireProperty(panel, "chipValueColor");
+        RequireProperty(panel, "chipGap");
+        RequireProperty(panel, "buttonPaddingX");
+        RequireProperty(panel, "buttonPaddingY");
+        RequireProperty(panel, "buttonRadius");
+        RequireProperty(panel, "buttonBackground");
+        RequireProperty(panel, "buttonOfflineBackground");
+        RequireProperty(panel, "buttonColor");
+        JsonElement markers = RequireProperty(presentation, "markers");
+        RequireColor(RequireProperty(markers, "onlineColor"));
+        RequireColor(RequireProperty(markers, "offlineColor"));
+        RequireColor(RequireProperty(markers, "onlineDotColor"));
+        RequireColor(RequireProperty(markers, "offlineDotColor"));
+        RequireProperty(markers, "halfSizeMeters");
+        RequireProperty(markers, "innerScale");
+        RequireProperty(markers, "outerThickness");
+        RequireProperty(markers, "innerThickness");
+        RequireProperty(markers, "onlineDotRadius");
+        RequireProperty(markers, "offlineDotRadius");
+        RequireProperty(markers, "dotThickness");
     }
 
     private void Validate()
@@ -76,8 +163,6 @@ public sealed class UiPlayerAggregateGraphMvpConfig
             string.IsNullOrWhiteSpace(ShutDownBuildingName) ||
             string.IsNullOrWhiteSpace(Attributes.Ore) ||
             string.IsNullOrWhiteSpace(Attributes.Crystal) ||
-            string.IsNullOrWhiteSpace(SummaryKeys.OreTotal) ||
-            string.IsNullOrWhiteSpace(SummaryKeys.CrystalTotal) ||
             string.IsNullOrWhiteSpace(Presentation.Title) ||
             string.IsNullOrWhiteSpace(Presentation.Copy))
         {
@@ -88,6 +173,28 @@ public sealed class UiPlayerAggregateGraphMvpConfig
         {
             throw new InvalidOperationException("Player aggregate graph MVP config requires a positive playerTeamId.");
         }
+
+        if (PanelBindings.Length < 2)
+        {
+            throw new InvalidOperationException("Player aggregate graph MVP config requires at least two panelBindings.");
+        }
+
+        RequireBinding(OreBindingVariableId);
+        RequireBinding(CrystalBindingVariableId);
+        for (int i = 0; i < PanelBindings.Length; i++)
+        {
+            UiPlayerAggregatePanelBinding binding = PanelBindings[i];
+            if (string.IsNullOrWhiteSpace(binding.VariableId) ||
+                string.IsNullOrWhiteSpace(binding.Label) ||
+                string.IsNullOrWhiteSpace(binding.GraphOutputKey) ||
+                string.IsNullOrWhiteSpace(binding.Accent))
+            {
+                throw new InvalidOperationException("Player aggregate graph MVP panelBindings require variableId, label, graphOutputKey, and accent.");
+            }
+        }
+
+        Presentation.Panel.Validate();
+        Presentation.Markers.Validate();
 
         if (Buildings.Length < 2)
         {
@@ -115,6 +222,14 @@ public sealed class UiPlayerAggregateGraphMvpConfig
         }
     }
 
+    private static void RequireColor(JsonElement color)
+    {
+        RequireProperty(color, "r");
+        RequireProperty(color, "g");
+        RequireProperty(color, "b");
+        RequireProperty(color, "a");
+    }
+
     private static JsonElement RequireProperty(JsonElement root, string propertyName)
     {
         if (!root.TryGetProperty(propertyName, out JsonElement value))
@@ -138,6 +253,14 @@ public sealed class UiPlayerAggregateSummaryKeys
     public string CrystalTotal { get; set; } = string.Empty;
 }
 
+public sealed class UiPlayerAggregatePanelBinding
+{
+    public string VariableId { get; set; } = string.Empty;
+    public string Label { get; set; } = string.Empty;
+    public string GraphOutputKey { get; set; } = string.Empty;
+    public string Accent { get; set; } = string.Empty;
+}
+
 public sealed class UiPlayerAggregateBuildingSeed
 {
     public string Name { get; set; } = string.Empty;
@@ -150,6 +273,109 @@ public sealed class UiPlayerAggregatePresentation
     public string Title { get; set; } = string.Empty;
     public string Copy { get; set; } = string.Empty;
     public string Controls { get; set; } = string.Empty;
+    public UiPlayerAggregatePanelStyle Panel { get; set; } = new();
+    public UiPlayerAggregateMarkerStyle Markers { get; set; } = new();
+}
+
+public sealed class UiPlayerAggregatePanelStyle
+{
+    public float Width { get; set; }
+    public float Padding { get; set; }
+    public float Gap { get; set; }
+    public float Radius { get; set; }
+    public string Background { get; set; } = string.Empty;
+    public string BorderColor { get; set; } = string.Empty;
+    public float BorderThickness { get; set; }
+    public string TitleColor { get; set; } = string.Empty;
+    public string CopyColor { get; set; } = string.Empty;
+    public string GraphMetaColor { get; set; } = string.Empty;
+    public string StatusColor { get; set; } = string.Empty;
+    public string ControlsColor { get; set; } = string.Empty;
+    public string ChipValueColor { get; set; } = string.Empty;
+    public float ChipGap { get; set; }
+    public float ButtonPaddingX { get; set; }
+    public float ButtonPaddingY { get; set; }
+    public float ButtonRadius { get; set; }
+    public string ButtonBackground { get; set; } = string.Empty;
+    public string ButtonOfflineBackground { get; set; } = string.Empty;
+    public string ButtonColor { get; set; } = string.Empty;
+
+    public void Validate()
+    {
+        if (Width <= 0f ||
+            Padding < 0f ||
+            Gap < 0f ||
+            Radius < 0f ||
+            BorderThickness < 0f ||
+            ChipGap < 0f ||
+            ButtonPaddingX < 0f ||
+            ButtonPaddingY < 0f ||
+            ButtonRadius < 0f ||
+            string.IsNullOrWhiteSpace(Background) ||
+            string.IsNullOrWhiteSpace(BorderColor) ||
+            string.IsNullOrWhiteSpace(TitleColor) ||
+            string.IsNullOrWhiteSpace(CopyColor) ||
+            string.IsNullOrWhiteSpace(GraphMetaColor) ||
+            string.IsNullOrWhiteSpace(StatusColor) ||
+            string.IsNullOrWhiteSpace(ControlsColor) ||
+            string.IsNullOrWhiteSpace(ChipValueColor) ||
+            string.IsNullOrWhiteSpace(ButtonBackground) ||
+            string.IsNullOrWhiteSpace(ButtonOfflineBackground) ||
+            string.IsNullOrWhiteSpace(ButtonColor))
+        {
+            throw new InvalidOperationException("Player aggregate graph MVP presentation.panel requires positive layout values and explicit colors.");
+        }
+    }
+}
+
+public sealed class UiPlayerAggregateMarkerStyle
+{
+    public UiPlayerAggregateRgbaColor OnlineColor { get; set; } = new();
+    public UiPlayerAggregateRgbaColor OfflineColor { get; set; } = new();
+    public UiPlayerAggregateRgbaColor OnlineDotColor { get; set; } = new();
+    public UiPlayerAggregateRgbaColor OfflineDotColor { get; set; } = new();
+    public float HalfSizeMeters { get; set; }
+    public float InnerScale { get; set; }
+    public float OuterThickness { get; set; }
+    public float InnerThickness { get; set; }
+    public float OnlineDotRadius { get; set; }
+    public float OfflineDotRadius { get; set; }
+    public float DotThickness { get; set; }
+
+    public void Validate()
+    {
+        if (HalfSizeMeters <= 0f ||
+            InnerScale <= 0f ||
+            OuterThickness <= 0f ||
+            InnerThickness <= 0f ||
+            OnlineDotRadius <= 0f ||
+            OfflineDotRadius <= 0f ||
+            DotThickness <= 0f)
+        {
+            throw new InvalidOperationException("Player aggregate graph MVP presentation.markers requires positive sizes.");
+        }
+
+        OnlineColor.Validate("onlineColor");
+        OfflineColor.Validate("offlineColor");
+        OnlineDotColor.Validate("onlineDotColor");
+        OfflineDotColor.Validate("offlineDotColor");
+    }
+}
+
+public sealed class UiPlayerAggregateRgbaColor
+{
+    public byte R { get; set; }
+    public byte G { get; set; }
+    public byte B { get; set; }
+    public byte A { get; set; } = 255;
+
+    public void Validate(string name)
+    {
+        if (A == 0)
+        {
+            throw new InvalidOperationException($"Player aggregate graph MVP presentation.markers.{name} requires non-zero alpha.");
+        }
+    }
 }
 
 internal sealed class UiPlayerAggregateGraphMvpConfigLoader

--- a/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/Runtime/UiPlayerAggregateGraphMvpRuntime.cs
+++ b/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/Runtime/UiPlayerAggregateGraphMvpRuntime.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Arch.Core;
 using Ludots.Core.Components;
 using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.Components;
 using Ludots.Core.Gameplay.GAS.Components;
 using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.GraphRuntime;
 using Ludots.Core.Input.Runtime;
 using Ludots.Core.Mathematics;
 using Ludots.Core.Modding;
@@ -59,6 +62,16 @@ public sealed class UiPlayerAggregateGraphMvpRuntime
     public UiPlayerAggregateGraphMvpSnapshot Snapshot => BuildSnapshot();
 
     public ReadOnlySpan<UiPlayerAggregateProducerMarker> ProducerMarkers => _producerMarkers;
+
+    public UiPlayerAggregateMarkerStyle RequireMarkerStyle()
+    {
+        if (_config == null)
+        {
+            throw new InvalidOperationException("Player aggregate graph MVP marker style requires loaded showcase config.");
+        }
+
+        return _config.Presentation.Markers;
+    }
 
     public UiPlayerAggregateGraphMvpConfig RequireConfig(GameEngine engine) => EnsureConfig(engine);
 
@@ -170,25 +183,28 @@ public sealed class UiPlayerAggregateGraphMvpRuntime
     internal UiPlayerAggregateGraphMvpPanelState BuildPanelState()
     {
         UiPlayerAggregateGraphMvpSnapshot snapshot = BuildSnapshot();
+        UiPlayerAggregateGraphMvpConfig config = _config
+            ?? throw new InvalidOperationException("Player aggregate graph MVP panel requires loaded showcase config.");
         return new UiPlayerAggregateGraphMvpPanelState(
             Title: snapshot.Title,
             Copy: snapshot.Copy,
             Controls: snapshot.Controls,
             Status: snapshot.Status,
             GraphId: snapshot.GraphId,
-            OreSummaryKey: snapshot.OreSummaryKey,
-            CrystalSummaryKey: snapshot.CrystalSummaryKey,
+            OreBinding: config.OreBinding,
+            CrystalBinding: config.CrystalBinding,
             OreTotal: snapshot.OreTotal,
             CrystalTotal: snapshot.CrystalTotal,
             BuildingShutDown: snapshot.BuildingShutDown,
-            ShutDownBuildingName: snapshot.ShutDownBuildingName);
+            ShutDownBuildingName: snapshot.ShutDownBuildingName,
+            PanelStyle: config.Presentation.Panel);
     }
 
     private UiPlayerAggregateGraphMvpSnapshot BuildSnapshot()
     {
         UiPlayerAggregateGraphMvpConfig? config = _config;
         return new UiPlayerAggregateGraphMvpSnapshot(
-            Title: config?.Presentation.Title ?? "Player Resource Overview",
+            Title: config?.Presentation.Title ?? string.Empty,
             Copy: config?.Presentation.Copy ?? string.Empty,
             Controls: config?.Presentation.Controls ?? string.Empty,
             Status: _status,
@@ -222,20 +238,22 @@ public sealed class UiPlayerAggregateGraphMvpRuntime
         GraphOutputValueStore values = engine.GetService(CoreServiceKeys.GraphOutputValueStore)
             ?? throw new InvalidOperationException("GraphOutputValueStore is missing.");
         var reader = new PanelProjectionReader(engine.World, values);
+        UiPlayerAggregatePanelBinding oreBinding = _config.OreBinding;
+        UiPlayerAggregatePanelBinding crystalBinding = _config.CrystalBinding;
         _oreTotal = reader.ResolveFloat(
             _owner,
             new PanelVariableBinding(
-                "oreTotal",
+                oreBinding.VariableId,
                 PanelBindingSourceKind.AggregateProjection,
                 attributeId: null,
-                graphOutputKey: _config.SummaryKeys.OreTotal));
+                graphOutputKey: oreBinding.GraphOutputKey));
         _crystalTotal = reader.ResolveFloat(
             _owner,
             new PanelVariableBinding(
-                "crystalTotal",
+                crystalBinding.VariableId,
                 PanelBindingSourceKind.AggregateProjection,
                 attributeId: null,
-                graphOutputKey: _config.SummaryKeys.CrystalTotal));
+                graphOutputKey: crystalBinding.GraphOutputKey));
         if (!_buildingShutDown)
         {
             _status = "Tally graph projections are live on the resource strip.";
@@ -283,6 +301,9 @@ public sealed class UiPlayerAggregateGraphMvpRuntime
                 $"Resource attributes '{config.Attributes.Ore}' / '{config.Attributes.Crystal}' are not registered.");
         }
 
+        InjectPlayerTeamIdIntoAggregateGraph(engine, _graphId, config.PlayerTeamId);
+        RequireGraphOutputKeysMatchPanelBindings(engine, _graphId, config);
+
         _owner = FindEntityByName(engine.World, config.FactionOwnerName);
         _shutDownBuilding = FindEntityByName(engine.World, config.ShutDownBuildingName);
         _producerEntities = new Entity[config.Buildings.Length];
@@ -290,6 +311,14 @@ public sealed class UiPlayerAggregateGraphMvpRuntime
         for (int i = 0; i < config.Buildings.Length; i++)
         {
             _producerEntities[i] = FindEntityByName(engine.World, config.Buildings[i].Name);
+        }
+
+        ApplyPlayerTeam(engine.World, _owner, config.PlayerTeamId, config.FactionOwnerName);
+        for (int i = 0; i < _producerEntities.Length; i++)
+        {
+            UiPlayerAggregateBuildingSeed seed = config.Buildings[i];
+            ApplyPlayerTeam(engine.World, _producerEntities[i], config.PlayerTeamId, seed.Name);
+            ApplyBuildingSeed(engine.World, _producerEntities[i], seed, _oreAttributeId, _crystalAttributeId);
         }
 
         _scenarioReady = true;
@@ -373,6 +402,124 @@ public sealed class UiPlayerAggregateGraphMvpRuntime
     {
         return engine.GetService(CoreServiceKeys.GasGraphRuntimeApi)
             ?? throw new InvalidOperationException("Engine-owned production GasGraphRuntimeApi is missing.");
+    }
+
+    private static void InjectPlayerTeamIdIntoAggregateGraph(GameEngine engine, int graphId, int playerTeamId)
+    {
+        GraphProgramRegistry registry = engine.GetService(CoreServiceKeys.GraphProgramRegistry)
+            ?? throw new InvalidOperationException("GraphProgramRegistry is missing.");
+        if (!registry.TryGetProgram(graphId, out ReadOnlySpan<GraphInstruction> program) || program.IsEmpty)
+        {
+            throw new InvalidOperationException($"Aggregate graph id {graphId} has no compiled program.");
+        }
+
+        Span<GraphInstruction> instructions = MemoryMarshal.CreateSpan(
+            ref MemoryMarshal.GetReference(program),
+            program.Length);
+        int patched = 0;
+        for (int i = 0; i < instructions.Length; i++)
+        {
+            if ((GraphNodeOp)instructions[i].Op != GraphNodeOp.QueryFilterTeam)
+            {
+                continue;
+            }
+
+            if (instructions[i].Flags != 0)
+            {
+                throw new InvalidOperationException(
+                    "Player aggregate graph MVP requires QueryFilterTeam to use the Imm teamId field so showcase config can inject playerTeamId.");
+            }
+
+            instructions[i].Imm = playerTeamId;
+            patched++;
+        }
+
+        if (patched != 1)
+        {
+            throw new InvalidOperationException(
+                $"Player aggregate graph MVP expected exactly one QueryFilterTeam Imm injection site, found {patched}.");
+        }
+
+        if (!registry.TryGetProgram(graphId, out ReadOnlySpan<GraphInstruction> verify) ||
+            !TryReadInjectedTeamId(verify, out int injected) ||
+            injected != playerTeamId)
+        {
+            throw new InvalidOperationException(
+                $"Failed to inject playerTeamId {playerTeamId} into aggregate QueryFilterTeam Imm.");
+        }
+    }
+
+    private static bool TryReadInjectedTeamId(ReadOnlySpan<GraphInstruction> program, out int teamId)
+    {
+        teamId = 0;
+        int found = 0;
+        for (int i = 0; i < program.Length; i++)
+        {
+            if ((GraphNodeOp)program[i].Op != GraphNodeOp.QueryFilterTeam || program[i].Flags != 0)
+            {
+                continue;
+            }
+
+            teamId = program[i].Imm;
+            found++;
+        }
+
+        return found == 1;
+    }
+
+    private static void RequireGraphOutputKeysMatchPanelBindings(
+        GameEngine engine,
+        int graphId,
+        UiPlayerAggregateGraphMvpConfig config)
+    {
+        GraphOutputSchemaRegistry schemas = engine.GetService(CoreServiceKeys.GraphOutputSchemaRegistry)
+            ?? throw new InvalidOperationException("GraphOutputSchemaRegistry is missing.");
+        GraphOutputSchema schema = schemas.Get(graphId);
+        RequireSchemaContainsKey(schema, config.OreBinding.GraphOutputKey);
+        RequireSchemaContainsKey(schema, config.CrystalBinding.GraphOutputKey);
+    }
+
+    private static void RequireSchemaContainsKey(GraphOutputSchema schema, string key)
+    {
+        ReadOnlySpan<GraphOutputBinding> bindings = schema.Bindings;
+        for (int i = 0; i < bindings.Length; i++)
+        {
+            if (string.Equals(bindings[i].Key, key, StringComparison.Ordinal))
+            {
+                return;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Aggregate graph output schema is missing panel binding key '{key}'.");
+    }
+
+    private static void ApplyPlayerTeam(World world, Entity entity, int playerTeamId, string entityName)
+    {
+        if (!world.Has<Team>(entity))
+        {
+            throw new InvalidOperationException($"Showcase entity '{entityName}' requires a Team component.");
+        }
+
+        ref Team team = ref world.Get<Team>(entity);
+        team.Id = playerTeamId;
+    }
+
+    private static void ApplyBuildingSeed(
+        World world,
+        Entity entity,
+        UiPlayerAggregateBuildingSeed seed,
+        int oreAttributeId,
+        int crystalAttributeId)
+    {
+        if (!world.Has<AttributeBuffer>(entity))
+        {
+            throw new InvalidOperationException($"Producer building '{seed.Name}' has no AttributeBuffer.");
+        }
+
+        ref AttributeBuffer attributes = ref world.Get<AttributeBuffer>(entity);
+        attributes.SetBase(oreAttributeId, seed.Ore);
+        attributes.SetBase(crystalAttributeId, seed.Crystal);
     }
 
     private uint NextSeed()

--- a/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/Systems/UiPlayerAggregateGraphMvpPresentationSystem.cs
+++ b/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/Systems/UiPlayerAggregateGraphMvpPresentationSystem.cs
@@ -52,38 +52,46 @@ internal sealed class UiPlayerAggregateGraphMvpPresentationSystem : ISystem<floa
         }
 
         _debugDraw.Clear();
+        UiPlayerAggregateMarkerStyle style = _runtime.RequireMarkerStyle();
         ReadOnlySpan<UiPlayerAggregateProducerMarker> markers = _runtime.ProducerMarkers;
         for (int i = 0; i < markers.Length; i++)
         {
             UiPlayerAggregateProducerMarker marker = markers[i];
             DebugDrawColor color = marker.Offline
-                ? new DebugDrawColor(180, 70, 70)
-                : new DebugDrawColor(80, 200, 140);
+                ? ToDebugColor(style.OfflineColor)
+                : ToDebugColor(style.OnlineColor);
 
-            float half = 0.85f;
+            float half = style.HalfSizeMeters;
             _debugDraw.Boxes.Add(new DebugDrawBox2D
             {
                 Center = new Vector2(marker.XMeters, marker.ZMeters),
                 HalfWidth = half,
                 HalfHeight = half,
-                Thickness = 0.1f,
+                Thickness = style.OuterThickness,
                 Color = color
             });
             _debugDraw.Boxes.Add(new DebugDrawBox2D
             {
                 Center = new Vector2(marker.XMeters, marker.ZMeters),
-                HalfWidth = half * 0.55f,
-                HalfHeight = half * 0.55f,
-                Thickness = 0.08f,
+                HalfWidth = half * style.InnerScale,
+                HalfHeight = half * style.InnerScale,
+                Thickness = style.InnerThickness,
                 Color = color
             });
             _debugDraw.Circles.Add(new DebugDrawCircle2D
             {
                 Center = new Vector2(marker.XMeters, marker.ZMeters),
-                Radius = marker.Offline ? 0.28f : 0.42f,
-                Thickness = 0.08f,
-                Color = marker.Offline ? DebugDrawColor.Red : DebugDrawColor.Yellow
+                Radius = marker.Offline ? style.OfflineDotRadius : style.OnlineDotRadius,
+                Thickness = style.DotThickness,
+                Color = marker.Offline
+                    ? ToDebugColor(style.OfflineDotColor)
+                    : ToDebugColor(style.OnlineDotColor)
             });
         }
+    }
+
+    private static DebugDrawColor ToDebugColor(UiPlayerAggregateRgbaColor color)
+    {
+        return new DebugDrawColor(color.R, color.G, color.B, color.A);
     }
 }

--- a/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/UI/UiPlayerAggregateGraphMvpPanelController.cs
+++ b/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/UI/UiPlayerAggregateGraphMvpPanelController.cs
@@ -62,23 +62,24 @@ internal sealed class UiPlayerAggregateGraphMvpPanelController
     private UiElementBuilder BuildRoot(ReactiveContext<UiPlayerAggregateGraphMvpPanelState> context)
     {
         UiPlayerAggregateGraphMvpPanelState state = context.State;
+        UiPlayerAggregatePanelStyle style = state.PanelStyle;
         return Ui.Column(
                 Ui.Panel(
-                        Ui.Text(state.Title).FontSize(20f).Bold().Color("#F4F7FB"),
+                        Ui.Text(state.Title).FontSize(20f).Bold().Color(style.TitleColor),
                         Ui.Row(
-                                ResourceChip("Ore", state.OreTotal, "#F0C36B"),
-                                ResourceChip("Crystal", state.CrystalTotal, "#7CC4FF"))
-                            .Gap(18f),
+                                ResourceChip(state.OreBinding.Label, state.OreTotal, state.OreBinding.Accent, style.ChipValueColor),
+                                ResourceChip(state.CrystalBinding.Label, state.CrystalTotal, state.CrystalBinding.Accent, style.ChipValueColor))
+                            .Gap(style.ChipGap),
                         Ui.Text(state.Copy)
                             .FontSize(11.5f)
-                            .Color("#B7C9DA")
+                            .Color(style.CopyColor)
                             .WhiteSpace(UiWhiteSpace.Normal),
-                        Ui.Text($"Graph `{state.GraphId}` → `{state.OreSummaryKey}` / `{state.CrystalSummaryKey}`")
+                        Ui.Text($"Graph `{state.GraphId}` → `{state.OreBinding.GraphOutputKey}` / `{state.CrystalBinding.GraphOutputKey}`")
                             .FontSize(10.5f)
-                            .Color("#8096AA")
+                            .Color(style.GraphMetaColor)
                             .WhiteSpace(UiWhiteSpace.Normal),
-                        Ui.Text(state.Status).FontSize(12f).Color("#F5C66E").WhiteSpace(UiWhiteSpace.Normal),
-                        Ui.Text(state.Controls).FontSize(11f).Color("#94D2FF"),
+                        Ui.Text(state.Status).FontSize(12f).Color(style.StatusColor).WhiteSpace(UiWhiteSpace.Normal),
+                        Ui.Text(state.Controls).FontSize(11f).Color(style.ControlsColor),
                         Ui.Button(
                                 state.BuildingShutDown
                                     ? $"{state.ShutDownBuildingName} offline"
@@ -97,28 +98,28 @@ internal sealed class UiPlayerAggregateGraphMvpPanelController
                                     }
                                 })
                             .Id(UiPlayerAggregateGraphMvpIds.ShutDownButtonElementId)
-                            .Padding(12f, 8f)
-                            .Radius(8f)
-                            .Background(state.BuildingShutDown ? "#243140" : "#3B5F7A")
-                            .Color("#F5F7FA"))
+                            .Padding(style.ButtonPaddingX, style.ButtonPaddingY)
+                            .Radius(style.ButtonRadius)
+                            .Background(state.BuildingShutDown ? style.ButtonOfflineBackground : style.ButtonBackground)
+                            .Color(style.ButtonColor))
                     .Id(UiPlayerAggregateGraphMvpIds.PanelRootElementId)
-                    .Width(560f)
-                    .Padding(16f)
-                    .Gap(10f)
-                    .Radius(10f)
-                    .Background("#0A1320")
-                    .Border(1f, ParseColor("#2F475E"))
+                    .Width(style.Width)
+                    .Padding(style.Padding)
+                    .Gap(style.Gap)
+                    .Radius(style.Radius)
+                    .Background(style.Background)
+                    .Border(style.BorderThickness, ParseColor(style.BorderColor))
                     .Absolute(16f, 16f))
             .WidthPercent(100f)
             .HeightPercent(100f)
             .ZIndex(42);
     }
 
-    private static UiElementBuilder ResourceChip(string label, float total, string accent)
+    private static UiElementBuilder ResourceChip(string label, float total, string accent, string valueColor)
     {
         return Ui.Column(
                 Ui.Text(label).FontSize(11f).Bold().Color(accent),
-                Ui.Text(FormatNumber(total)).FontSize(28f).Bold().Color("#F7FBFF"))
+                Ui.Text(FormatNumber(total)).FontSize(28f).Bold().Color(valueColor))
             .Gap(2f);
     }
 

--- a/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/UI/UiPlayerAggregateGraphMvpPanelState.cs
+++ b/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/UI/UiPlayerAggregateGraphMvpPanelState.cs
@@ -1,3 +1,5 @@
+using UiPlayerAggregateGraphMvpShowcaseMod.Runtime;
+
 namespace UiPlayerAggregateGraphMvpShowcaseMod.UI;
 
 internal readonly record struct UiPlayerAggregateGraphMvpPanelState(
@@ -6,9 +8,10 @@ internal readonly record struct UiPlayerAggregateGraphMvpPanelState(
     string Controls,
     string Status,
     string GraphId,
-    string OreSummaryKey,
-    string CrystalSummaryKey,
+    UiPlayerAggregatePanelBinding OreBinding,
+    UiPlayerAggregatePanelBinding CrystalBinding,
     float OreTotal,
     float CrystalTotal,
     bool BuildingShutDown,
-    string ShutDownBuildingName);
+    string ShutDownBuildingName,
+    UiPlayerAggregatePanelStyle PanelStyle);

--- a/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/UiPlayerAggregateGraphMvpShowcaseModEntry.cs
+++ b/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/UiPlayerAggregateGraphMvpShowcaseModEntry.cs
@@ -13,8 +13,9 @@ public sealed class UiPlayerAggregateGraphMvpShowcaseModEntry : IMod
 {
     public void OnLoad(IModContext context)
     {
-        AttributeRegistry.Register("Showcase.Resource.Ore");
-        AttributeRegistry.Register("Showcase.Resource.Crystal");
+        UiPlayerAggregateGraphMvpConfig bootstrapConfig = LoadBootstrapConfig(context);
+        AttributeRegistry.Register(bootstrapConfig.Attributes.Ore);
+        AttributeRegistry.Register(bootstrapConfig.Attributes.Crystal);
 
         var runtime = new UiPlayerAggregateGraphMvpRuntime();
 
@@ -50,5 +51,12 @@ public sealed class UiPlayerAggregateGraphMvpShowcaseModEntry : IMod
 
     public void OnUnload()
     {
+    }
+
+    private static UiPlayerAggregateGraphMvpConfig LoadBootstrapConfig(IModContext context)
+    {
+        using var stream = context.GetResource(
+            $"{context.ModId}:assets/{UiPlayerAggregateGraphMvpConfigLoader.RelativePath}");
+        return UiPlayerAggregateGraphMvpConfig.Load(stream);
     }
 }

--- a/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/assets/GAS/graphs.json
+++ b/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/assets/GAS/graphs.json
@@ -6,7 +6,7 @@
     "nodes": [
       { "id": "owner", "op": "LoadCaster" },
       { "id": "allMap", "op": "QueryAllMapEntities" },
-      { "id": "team", "op": "QueryFilterTeam", "teamId": 1 },
+      { "id": "team", "op": "QueryFilterTeam", "teamId": 2147483646 },
       { "id": "oreSum", "op": "AggSumAttribute", "attribute": "Showcase.Resource.Ore" },
       { "id": "crystalSum", "op": "AggSumAttribute", "attribute": "Showcase.Resource.Crystal" }
     ],

--- a/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/assets/Maps/ui_player_aggregate_graph_mvp.json
+++ b/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/assets/Maps/ui_player_aggregate_graph_mvp.json
@@ -23,13 +23,7 @@
       "InstanceId": "ui-player-aggregate-ore-depot",
       "Overrides": {
         "Name": { "Value": "Ore Depot Alpha" },
-        "WorldPositionCm": { "Value": { "X": 1320, "Y": 760 } },
-        "AttributeBuffer": {
-          "base": {
-            "Showcase.Resource.Ore": 120,
-            "Showcase.Resource.Crystal": 30
-          }
-        }
+        "WorldPositionCm": { "Value": { "X": 1320, "Y": 760 } }
       }
     },
     {
@@ -37,13 +31,7 @@
       "InstanceId": "ui-player-aggregate-crystal-hub",
       "Overrides": {
         "Name": { "Value": "Crystal Hub Beta" },
-        "WorldPositionCm": { "Value": { "X": 1680, "Y": 1040 } },
-        "AttributeBuffer": {
-          "base": {
-            "Showcase.Resource.Ore": 60,
-            "Showcase.Resource.Crystal": 90
-          }
-        }
+        "WorldPositionCm": { "Value": { "X": 1680, "Y": 1040 } }
       }
     }
   ]

--- a/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/assets/UiPlayerAggregateGraphMvpShowcaseConfig.json
+++ b/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/assets/UiPlayerAggregateGraphMvpShowcaseConfig.json
@@ -8,10 +8,20 @@
     "ore": "Showcase.Resource.Ore",
     "crystal": "Showcase.Resource.Crystal"
   },
-  "summaryKeys": {
-    "oreTotal": "ui.panel.player.ore.total",
-    "crystalTotal": "ui.panel.player.crystal.total"
-  },
+  "panelBindings": [
+    {
+      "variableId": "oreTotal",
+      "label": "Ore",
+      "graphOutputKey": "ui.panel.player.ore.total",
+      "accent": "#F0C36B"
+    },
+    {
+      "variableId": "crystalTotal",
+      "label": "Crystal",
+      "graphOutputKey": "ui.panel.player.crystal.total",
+      "accent": "#7CC4FF"
+    }
+  ],
   "buildings": [
     {
       "name": "Ore Depot Alpha",
@@ -27,6 +37,41 @@
   "presentation": {
     "title": "Player Resource Overview",
     "copy": "Ore and Crystal totals come from the tally Query graph projection written into GraphOutputValueStore — the panel never hand-sums buildings.",
-    "controls": "Click Shut down Crystal Hub, or press Space."
+    "controls": "Click Shut down Crystal Hub, or press Space.",
+    "panel": {
+      "width": 560,
+      "padding": 16,
+      "gap": 10,
+      "radius": 10,
+      "background": "#0A1320",
+      "borderColor": "#2F475E",
+      "borderThickness": 1,
+      "titleColor": "#F4F7FB",
+      "copyColor": "#B7C9DA",
+      "graphMetaColor": "#8096AA",
+      "statusColor": "#F5C66E",
+      "controlsColor": "#94D2FF",
+      "chipValueColor": "#F7FBFF",
+      "chipGap": 18,
+      "buttonPaddingX": 12,
+      "buttonPaddingY": 8,
+      "buttonRadius": 8,
+      "buttonBackground": "#3B5F7A",
+      "buttonOfflineBackground": "#243140",
+      "buttonColor": "#F5F7FA"
+    },
+    "markers": {
+      "onlineColor": { "r": 80, "g": 200, "b": 140, "a": 255 },
+      "offlineColor": { "r": 180, "g": 70, "b": 70, "a": 255 },
+      "onlineDotColor": { "r": 255, "g": 255, "b": 0, "a": 255 },
+      "offlineDotColor": { "r": 255, "g": 0, "b": 0, "a": 255 },
+      "halfSizeMeters": 0.85,
+      "innerScale": 0.55,
+      "outerThickness": 0.1,
+      "innerThickness": 0.08,
+      "onlineDotRadius": 0.42,
+      "offlineDotRadius": 0.28,
+      "dotThickness": 0.08
+    }
   }
 }

--- a/src/Tests/GasTests/Production/UiPlayerAggregateGraphMvpShowcaseAcceptanceTests.cs
+++ b/src/Tests/GasTests/Production/UiPlayerAggregateGraphMvpShowcaseAcceptanceTests.cs
@@ -6,6 +6,10 @@ using System.Numerics;
 using System.Text.Json;
 using Arch.Core;
 using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.Components;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.GraphRuntime;
 using Ludots.Core.Input.Config;
 using Ludots.Core.Input.Runtime;
 using Ludots.Core.NodeLibraries.GASGraph;
@@ -46,6 +50,7 @@ public sealed class UiPlayerAggregateGraphMvpShowcaseAcceptanceTests
         AssertLauncherBinding(repoRoot);
         AssertLauncherPreset(repoRoot);
         AssertNoPresentationEntitySum(repoRoot);
+        AssertConfigHygieneArtifacts(repoRoot);
 
         string artifactDir = Path.Combine(repoRoot, "artifacts", "acceptance", "ui-player-aggregate-graph-mvp");
         string screensDir = Path.Combine(artifactDir, "screens");
@@ -66,6 +71,8 @@ public sealed class UiPlayerAggregateGraphMvpShowcaseAcceptanceTests
         float expectedOre = SumSeed(config.Buildings, static building => building.Ore);
         float expectedCrystal = SumSeed(config.Buildings, static building => building.Crystal);
 
+        AssertConfigIsRuntimeAuthority(engine, config);
+
         UiPlayerAggregateGraphMvpSnapshot initial = runtime.Snapshot;
         Assert.Multiple(() =>
         {
@@ -73,10 +80,14 @@ public sealed class UiPlayerAggregateGraphMvpShowcaseAcceptanceTests
             Assert.That(initial.OreTotal, Is.EqualTo(expectedOre).Within(0.001f));
             Assert.That(initial.CrystalTotal, Is.EqualTo(expectedCrystal).Within(0.001f));
             Assert.That(initial.BuildingShutDown, Is.False);
+            Assert.That(initial.OreSummaryKey, Is.EqualTo(config.OreBinding.GraphOutputKey));
+            Assert.That(initial.CrystalSummaryKey, Is.EqualTo(config.CrystalBinding.GraphOutputKey));
             IReadOnlyList<string> uiText = AcceptanceUiEvidenceWriter.ExtractUiText(uiRoot);
             Assert.That(uiText, Does.Contain(config.Presentation.Title));
             Assert.That(string.Join('\n', uiText), Does.Contain("GraphOutputValueStore"));
             Assert.That(string.Join('\n', uiText), Does.Contain(config.GraphId));
+            Assert.That(string.Join('\n', uiText), Does.Contain(config.OreBinding.Label));
+            Assert.That(string.Join('\n', uiText), Does.Contain(config.CrystalBinding.Label));
             Assert.That(
                 uiRoot.Scene!.FindByElementId(UiPlayerAggregateGraphMvpIds.PanelRootElementId),
                 Is.Not.Null);
@@ -206,6 +217,117 @@ public sealed class UiPlayerAggregateGraphMvpShowcaseAcceptanceTests
             Assert.That(text, Does.Not.Contain("AttributeBuffer"));
             Assert.That(text, Does.Not.Contain("world.Query"));
         }
+    }
+
+    private static void AssertConfigHygieneArtifacts(string repoRoot)
+    {
+        string modDir = Path.Combine(
+            repoRoot,
+            "mods",
+            "showcases",
+            "ui_player_aggregate_graph_mvp",
+            ShowcaseModId);
+        string mapPath = Path.Combine(modDir, "assets", "Maps", "ui_player_aggregate_graph_mvp.json");
+        string graphsPath = Path.Combine(modDir, "assets", "GAS", "graphs.json");
+        string configPath = Path.Combine(modDir, "assets", "UiPlayerAggregateGraphMvpShowcaseConfig.json");
+        string modEntryPath = Path.Combine(modDir, "UiPlayerAggregateGraphMvpShowcaseModEntry.cs");
+
+        using JsonDocument mapDocument = JsonDocument.Parse(File.ReadAllText(mapPath));
+        foreach (JsonElement entity in mapDocument.RootElement.GetProperty("Entities").EnumerateArray())
+        {
+            if (!entity.TryGetProperty("Overrides", out JsonElement overrides))
+            {
+                continue;
+            }
+
+            Assert.That(
+                overrides.TryGetProperty("AttributeBuffer", out _),
+                Is.False,
+                "Map Overrides must not author AttributeBuffer stock; buildings[] in showcase config is the SSOT.");
+        }
+
+        using JsonDocument configDocument = JsonDocument.Parse(File.ReadAllText(configPath));
+        int playerTeamId = configDocument.RootElement.GetProperty("playerTeamId").GetInt32();
+        using JsonDocument graphsDocument = JsonDocument.Parse(File.ReadAllText(graphsPath));
+        int authoredGraphTeamId = RequireGraphTeamId(graphsDocument.RootElement);
+        Assert.That(
+            authoredGraphTeamId,
+            Is.Not.EqualTo(playerTeamId),
+            "graphs.json QueryFilterTeam.teamId must stay a non-authoritative compile placeholder; runtime Imm is injected from playerTeamId.");
+
+        string modEntry = File.ReadAllText(modEntryPath);
+        Assert.That(modEntry, Does.Not.Contain("AttributeRegistry.Register(\"Showcase.Resource."));
+        Assert.That(modEntry, Does.Contain("bootstrapConfig.Attributes"));
+    }
+
+    private static void AssertConfigIsRuntimeAuthority(GameEngine engine, UiPlayerAggregateGraphMvpConfig config)
+    {
+        int graphId = GraphIdRegistry.GetId(config.GraphId);
+        Assert.That(graphId, Is.GreaterThan(0));
+        GraphProgramRegistry programs = engine.GetService(CoreServiceKeys.GraphProgramRegistry)
+            ?? throw new InvalidOperationException("GraphProgramRegistry missing.");
+        Assert.That(programs.TryGetProgram(graphId, out ReadOnlySpan<GraphInstruction> program), Is.True);
+        Assert.That(TryReadInjectedTeamId(program, out int injectedTeamId), Is.True);
+        Assert.That(injectedTeamId, Is.EqualTo(config.PlayerTeamId));
+
+        int oreAttributeId = AttributeRegistry.GetId(config.Attributes.Ore);
+        int crystalAttributeId = AttributeRegistry.GetId(config.Attributes.Crystal);
+        Assert.That(oreAttributeId, Is.Not.EqualTo(AttributeRegistry.InvalidId));
+        Assert.That(crystalAttributeId, Is.Not.EqualTo(AttributeRegistry.InvalidId));
+
+        for (int i = 0; i < config.Buildings.Length; i++)
+        {
+            UiPlayerAggregateBuildingSeed seed = config.Buildings[i];
+            Entity entity = FindEntityByName(engine.World, seed.Name);
+            Assert.That(engine.World.Get<Team>(entity).Id, Is.EqualTo(config.PlayerTeamId), seed.Name);
+            ref AttributeBuffer attributes = ref engine.World.Get<AttributeBuffer>(entity);
+            Assert.That(attributes.GetCurrent(oreAttributeId), Is.EqualTo(seed.Ore).Within(0.001f), seed.Name);
+            Assert.That(attributes.GetCurrent(crystalAttributeId), Is.EqualTo(seed.Crystal).Within(0.001f), seed.Name);
+        }
+
+        Entity owner = FindEntityByName(engine.World, config.FactionOwnerName);
+        Assert.That(engine.World.Get<Team>(owner).Id, Is.EqualTo(config.PlayerTeamId));
+    }
+
+    private static int RequireGraphTeamId(JsonElement graphsRoot)
+    {
+        foreach (JsonElement graph in graphsRoot.EnumerateArray())
+        {
+            if (!string.Equals(graph.GetProperty("id").GetString(), "ui.panel.player.resource.aggregate", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (JsonElement node in graph.GetProperty("nodes").EnumerateArray())
+            {
+                if (!string.Equals(node.GetProperty("op").GetString(), "QueryFilterTeam", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                return node.GetProperty("teamId").GetInt32();
+            }
+        }
+
+        throw new InvalidOperationException("Aggregate graph QueryFilterTeam teamId is missing.");
+    }
+
+    private static bool TryReadInjectedTeamId(ReadOnlySpan<GraphInstruction> program, out int teamId)
+    {
+        teamId = 0;
+        int found = 0;
+        for (int i = 0; i < program.Length; i++)
+        {
+            if ((GraphNodeOp)program[i].Op != GraphNodeOp.QueryFilterTeam || program[i].Flags != 0)
+            {
+                continue;
+            }
+
+            teamId = program[i].Imm;
+            found++;
+        }
+
+        return found == 1;
     }
 
     private static void AssertLauncherBinding(string repoRoot)

--- a/src/Tests/GasTests/Production/UiPlayerAggregateGraphMvpShowcaseAcceptanceTests.cs
+++ b/src/Tests/GasTests/Production/UiPlayerAggregateGraphMvpShowcaseAcceptanceTests.cs
@@ -13,6 +13,7 @@ using Ludots.Core.GraphRuntime;
 using Ludots.Core.Input.Config;
 using Ludots.Core.Input.Runtime;
 using Ludots.Core.NodeLibraries.GASGraph;
+using Ludots.Core.NodeLibraries.GASGraph.Host;
 using Ludots.Core.Scripting;
 using Ludots.Tests;
 using Ludots.UI;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

收干净 `ui_player_aggregate_graph_mvp` 的配置双真相与表现硬编码；既有停工合计验收不回退。

## 双真相收敛

| 项 | 之后 |
|----|------|
| playerTeamId | 配置权威；scenario 注入 `QueryFilterTeam` Imm |
| 建筑矿/晶 | 仅 `buildings[]`；ensure 时 `SetBase`；地图只留 Name/坐标 |
| 面板绑定 | `panelBindings` + `presentation.panel` |
| 标记样式 | `presentation.markers` |
| AttributeRegistry | 从同一份 config `attributes.*` Register |

## 测试

`UiPlayerAggregateGraphMvpShowcaseAcceptanceTests` 通过（含地图无 AttributeBuffer 存量、Imm==playerTeamId 等新断言）。

相关：#882 · #886

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ae6b725-472c-4613-afa5-cff2488928e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ae6b725-472c-4613-afa5-cff2488928e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

