### PR TITLE
fix(moba): Graph.Shield.Absorb LoadAttribute 入参改为 source（#916）

### DIFF
--- a/mods/showcases/moba_demo/MobaDemoMod/assets/Configs/GAS/graphs.json
+++ b/mods/showcases/moba_demo/MobaDemoMod/assets/Configs/GAS/graphs.json
@@ -26,7 +26,7 @@
         "from": "target",
         "fromPort": "value",
         "to": "shield",
-        "toPort": "target"
+        "toPort": "source"
       }
     ]
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

关闭 [#916](https://github.com/MightyBubble/Ludots/issues/916)：`Graph.Shield.Absorb` 的 `LoadAttribute` 入参从线性方言不认识的 `target` 改为 `source`。

## Test
- `MobaDemo*` / `ProdModSmoke_MobaDemoMod` → 4 passed

## Stack
Base = #919 / #911 修复分支（仅改 moba graphs 资产）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88eeeec8-f8e7-44e7-bfea-db2b5c012489?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88eeeec8-f8e7-44e7-bfea-db2b5c012489&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

