### PR TITLE
Split PresentationRequestBuffer into typed channels

### DIFF
--- a/src/Core/Engine/GameEngine.cs
+++ b/src/Core/Engine/GameEngine.cs
@@ -1053,7 +1053,19 @@ namespace Ludots.Core.Engine
             var skinnedVisualBatchBuffer = new SkinnedVisualBatchBuffer(presentationConfig.SkinnedVisualBatchCapacity);
             var stableDrawCache = new StableDrawCache(presentationConfig.VisualSnapshotBufferCapacity);
             var presentationTargetGeneration = new PresentationTargetGeneration();
-            var presentationRequestBuffer = new PresentationRequestBuffer(presentationConfig.PresentationRequestCapacity);
+            var presentationRequestBuffer = new PresentationRequestBuffer(new PresentationRequestChannelCapacities(
+                visualProxy: presentationConfig.VisualProxyBufferCapacity,
+                prefab: presentationConfig.VisualProxyBufferCapacity,
+                groundOverlay: presentationConfig.GroundOverlayCapacity,
+                worldHud: presentationConfig.WorldHudCapacity,
+                splineRibbon: presentationConfig.SplineRibbonCapacity,
+                surfaceSource: presentationConfig.PresenterInstanceCapacity,
+                removal: checked(
+                    presentationConfig.GroundOverlayCapacity
+                    + presentationConfig.WorldHudCapacity
+                    + presentationConfig.SplineRibbonCapacity
+                    + presentationConfig.PresenterInstanceCapacity),
+                clearTransient: presentationConfig.PresenterInstanceCapacity));
             var globalFieldVisualBuffer = new GlobalFieldVisualBuffer(
                 presentationConfig.GlobalFieldVisualRecordCapacity,
                 presentationConfig.GlobalFieldVisualCellCapacity,

--- a/src/Core/Presentation/Requests/PresentationRequestBuffer.cs
+++ b/src/Core/Presentation/Requests/PresentationRequestBuffer.cs
@@ -1,55 +1,382 @@
 using System;
+using Arch.Core;
+using Ludots.Core.Presentation.Rendering;
 
 namespace Ludots.Core.Presentation.Requests
 {
     public sealed class PresentationRequestBuffer
     {
-        private PresentationRequest[] _buffer;
-        private int _count;
+        private readonly VisualProxyChannelItem[] _visualProxies;
+        private readonly PrefabRequest[] _prefabs;
+        private readonly GroundOverlayChannelItem[] _groundOverlays;
+        private readonly WorldHudChannelItem[] _worldHud;
+        private readonly SplineRibbonChannelItem[] _splineRibbons;
+        private readonly SurfaceSourceChannelItem[] _surfaceSources;
+        private readonly PresentationRemovalRequest[] _removals;
+        private readonly Entity[] _clearTransients;
+        // Mixed-kind enqueue order must be preserved; flushing by channel would invert same-frame remove-then-add.
+        private readonly PresentationRequestOp[] _ops;
+        private PresentationRequest[]? _spanScratch;
+        private int _visualProxyCount;
+        private int _prefabCount;
+        private int _groundOverlayCount;
+        private int _worldHudCount;
+        private int _splineRibbonCount;
+        private int _surfaceSourceCount;
+        private int _removalCount;
+        private int _clearTransientCount;
+        private int _opCount;
 
         public PresentationRequestBuffer(int capacity = 131072)
+            : this(PresentationRequestChannelCapacities.Uniform(capacity))
         {
-            if (capacity <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(capacity));
-            }
-
-            _buffer = new PresentationRequest[capacity];
         }
 
-        public int Count => _count;
+        public PresentationRequestBuffer(in PresentationRequestChannelCapacities capacities)
+        {
+            _visualProxies = new VisualProxyChannelItem[capacities.VisualProxy];
+            _prefabs = new PrefabRequest[capacities.Prefab];
+            _groundOverlays = new GroundOverlayChannelItem[capacities.GroundOverlay];
+            _worldHud = new WorldHudChannelItem[capacities.WorldHud];
+            _splineRibbons = new SplineRibbonChannelItem[capacities.SplineRibbon];
+            _surfaceSources = new SurfaceSourceChannelItem[capacities.SurfaceSource];
+            _removals = new PresentationRemovalRequest[capacities.Removal];
+            _clearTransients = new Entity[capacities.ClearTransient];
+            _ops = new PresentationRequestOp[capacities.TotalOperationCapacity];
+        }
 
-        public int Capacity => _buffer.Length;
+        public int Count => _opCount;
+
+        public int Capacity => _ops.Length;
+
+        internal ReadOnlySpan<PresentationRequestOp> Ops => _ops.AsSpan(0, _opCount);
+
+        internal int PrefabCount => _prefabCount;
+
+        internal int ClearTransientCount => _clearTransientCount;
+
+        internal ReadOnlySpan<VisualProxyChannelItem> VisualProxies => _visualProxies.AsSpan(0, _visualProxyCount);
 
         public void Add(in PresentationRequest request)
         {
-            if (_count >= _buffer.Length)
+            switch (request.Kind)
             {
-                throw new InvalidOperationException(
-                    $"PresentationRequestBuffer overflowed while adding kind={request.Kind}, stableId={request.StableId}.");
+                case PresentationRequestKind.VisualProxy:
+                    AddVisualProxy(in request);
+                    break;
+                case PresentationRequestKind.Prefab:
+                    AddPrefab(in request);
+                    break;
+                case PresentationRequestKind.GroundOverlay:
+                    AddGroundOverlay(in request);
+                    break;
+                case PresentationRequestKind.WorldHud:
+                    AddWorldHud(in request);
+                    break;
+                case PresentationRequestKind.SplineRibbon:
+                    AddSplineRibbon(in request);
+                    break;
+                case PresentationRequestKind.SurfaceSource:
+                    AddSurfaceSource(in request);
+                    break;
+                case PresentationRequestKind.RemoveGroundOverlay:
+                case PresentationRequestKind.RemoveWorldHud:
+                case PresentationRequestKind.RemoveSplineRibbon:
+                case PresentationRequestKind.RemoveSurfaceSource:
+                    AddRemoval(in request);
+                    break;
+                case PresentationRequestKind.ClearTransientVisualProjection:
+                    AddClearTransient(in request);
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unknown PresentationRequestKind '{request.Kind}'.");
             }
-
-            _buffer[_count++] = request;
         }
 
         public ReadOnlySpan<PresentationRequest> GetSpan()
         {
-            return _buffer.AsSpan(0, _count);
+            if (_opCount == 0)
+            {
+                return ReadOnlySpan<PresentationRequest>.Empty;
+            }
+
+            EnsureSpanScratch();
+            for (int i = 0; i < _opCount; i++)
+            {
+                _spanScratch![i] = Reconstruct(i);
+            }
+
+            return _spanScratch.AsSpan(0, _opCount);
         }
 
         public ref readonly PresentationRequest Get(int index)
         {
-            if ((uint)index >= (uint)_count)
+            if ((uint)index >= (uint)_opCount)
             {
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
 
-            return ref _buffer[index];
+            EnsureSpanScratch();
+            _spanScratch![index] = Reconstruct(index);
+            return ref _spanScratch[index];
         }
 
         public void Clear()
         {
-            _count = 0;
+            _visualProxyCount = 0;
+            _prefabCount = 0;
+            _groundOverlayCount = 0;
+            _worldHudCount = 0;
+            _splineRibbonCount = 0;
+            _surfaceSourceCount = 0;
+            _removalCount = 0;
+            _clearTransientCount = 0;
+            _opCount = 0;
+        }
+
+        internal ref readonly PrefabRequest PrefabAt(int slot) => ref _prefabs[slot];
+
+        internal ref readonly GroundOverlayChannelItem GroundOverlayAt(int slot) => ref _groundOverlays[slot];
+
+        internal ref readonly WorldHudChannelItem WorldHudAt(int slot) => ref _worldHud[slot];
+
+        internal ref readonly SplineRibbonChannelItem SplineRibbonAt(int slot) => ref _splineRibbons[slot];
+
+        internal ref readonly SurfaceSourceChannelItem SurfaceSourceAt(int slot) => ref _surfaceSources[slot];
+
+        internal ref readonly PresentationRemovalRequest RemovalAt(int slot) => ref _removals[slot];
+
+        internal ref readonly VisualProxyChannelItem VisualProxyAt(int slot) => ref _visualProxies[slot];
+
+        private void AddVisualProxy(in PresentationRequest request)
+        {
+            EnsureChannelRoom(_visualProxyCount, _visualProxies.Length, request.Kind, request.VisualProxy.StableId);
+            int slot = _visualProxyCount++;
+            _visualProxies[slot] = new VisualProxyChannelItem
+            {
+                Owner = request.Owner,
+                VisualProxy = request.VisualProxy,
+            };
+            RecordOp(PresentationRequestChannel.VisualProxy, slot, request.Kind, request.VisualProxy.StableId);
+        }
+
+        private void AddPrefab(in PresentationRequest request)
+        {
+            EnsureChannelRoom(_prefabCount, _prefabs.Length, request.Kind, request.StableId);
+            int slot = _prefabCount++;
+            _prefabs[slot] = new PrefabRequest
+            {
+                Owner = request.Owner,
+                PrefabId = request.PrefabId,
+                StableId = request.StableId,
+                Position = request.Position,
+                Rotation = request.Rotation,
+                Scale = request.Scale,
+                Color = request.Color,
+                LOD = request.LOD,
+            };
+            RecordOp(PresentationRequestChannel.Prefab, slot, request.Kind, request.StableId);
+        }
+
+        private void AddGroundOverlay(in PresentationRequest request)
+        {
+            EnsureChannelRoom(_groundOverlayCount, _groundOverlays.Length, request.Kind, request.GroundOverlay.StableId);
+            int slot = _groundOverlayCount++;
+            _groundOverlays[slot] = new GroundOverlayChannelItem
+            {
+                Owner = request.Owner,
+                LOD = request.LOD,
+                Item = request.GroundOverlay,
+            };
+            RecordOp(PresentationRequestChannel.GroundOverlay, slot, request.Kind, request.GroundOverlay.StableId);
+        }
+
+        private void AddWorldHud(in PresentationRequest request)
+        {
+            EnsureChannelRoom(_worldHudCount, _worldHud.Length, request.Kind, request.WorldHud.StableId);
+            int slot = _worldHudCount++;
+            _worldHud[slot] = new WorldHudChannelItem
+            {
+                Owner = request.Owner,
+                LOD = request.LOD,
+                Item = request.WorldHud,
+            };
+            RecordOp(PresentationRequestChannel.WorldHud, slot, request.Kind, request.WorldHud.StableId);
+        }
+
+        private void AddSplineRibbon(in PresentationRequest request)
+        {
+            EnsureChannelRoom(_splineRibbonCount, _splineRibbons.Length, request.Kind, request.SplineRibbon.StableId);
+            int slot = _splineRibbonCount++;
+            _splineRibbons[slot] = new SplineRibbonChannelItem
+            {
+                Owner = request.Owner,
+                LOD = request.LOD,
+                Item = request.SplineRibbon,
+            };
+            RecordOp(PresentationRequestChannel.SplineRibbon, slot, request.Kind, request.SplineRibbon.StableId);
+        }
+
+        private void AddSurfaceSource(in PresentationRequest request)
+        {
+            EnsureChannelRoom(_surfaceSourceCount, _surfaceSources.Length, request.Kind, request.SurfaceSource.StableId);
+            int slot = _surfaceSourceCount++;
+            _surfaceSources[slot] = new SurfaceSourceChannelItem
+            {
+                Owner = request.Owner,
+                LOD = request.LOD,
+                Item = request.SurfaceSource,
+            };
+            RecordOp(PresentationRequestChannel.SurfaceSource, slot, request.Kind, request.SurfaceSource.StableId);
+        }
+
+        private void AddRemoval(in PresentationRequest request)
+        {
+            EnsureChannelRoom(_removalCount, _removals.Length, request.Kind, request.StableId);
+            int slot = _removalCount++;
+            _removals[slot] = new PresentationRemovalRequest
+            {
+                Kind = request.Kind,
+                Owner = request.Owner,
+                StableId = request.StableId,
+            };
+            RecordOp(PresentationRequestChannel.Removal, slot, request.Kind, request.StableId);
+        }
+
+        private void AddClearTransient(in PresentationRequest request)
+        {
+            EnsureChannelRoom(_clearTransientCount, _clearTransients.Length, request.Kind, request.StableId);
+            int slot = _clearTransientCount++;
+            _clearTransients[slot] = request.Owner;
+            RecordOp(PresentationRequestChannel.ClearTransient, slot, request.Kind, request.StableId);
+        }
+
+        private void RecordOp(PresentationRequestChannel channel, int slot, PresentationRequestKind kind, int stableId)
+        {
+            if (_opCount >= _ops.Length)
+            {
+                throw new InvalidOperationException(
+                    $"PresentationRequestBuffer overflowed while adding kind={kind}, stableId={stableId}.");
+            }
+
+            _ops[_opCount++] = new PresentationRequestOp(channel, slot);
+        }
+
+        private static void EnsureChannelRoom(int count, int capacity, PresentationRequestKind kind, int stableId)
+        {
+            if (count >= capacity)
+            {
+                throw new InvalidOperationException(
+                    $"PresentationRequestBuffer overflowed while adding kind={kind}, stableId={stableId}.");
+            }
+        }
+
+        private void EnsureSpanScratch()
+        {
+            if (_spanScratch != null && _spanScratch.Length >= _opCount)
+            {
+                return;
+            }
+
+            _spanScratch = new PresentationRequest[_ops.Length];
+        }
+
+        private PresentationRequest Reconstruct(int opIndex)
+        {
+            PresentationRequestOp op = _ops[opIndex];
+            switch (op.Channel)
+            {
+                case PresentationRequestChannel.VisualProxy:
+                {
+                    ref readonly VisualProxyChannelItem item = ref _visualProxies[op.Slot];
+                    return new PresentationRequest
+                    {
+                        Kind = PresentationRequestKind.VisualProxy,
+                        Owner = item.Owner,
+                        LOD = item.VisualProxy.LOD,
+                        VisualProxy = item.VisualProxy,
+                    };
+                }
+                case PresentationRequestChannel.Prefab:
+                {
+                    ref readonly PrefabRequest item = ref _prefabs[op.Slot];
+                    return new PresentationRequest
+                    {
+                        Kind = PresentationRequestKind.Prefab,
+                        Owner = item.Owner,
+                        PrefabId = item.PrefabId,
+                        StableId = item.StableId,
+                        Position = item.Position,
+                        Rotation = item.Rotation,
+                        Scale = item.Scale,
+                        Color = item.Color,
+                        LOD = item.LOD,
+                    };
+                }
+                case PresentationRequestChannel.GroundOverlay:
+                {
+                    ref readonly GroundOverlayChannelItem item = ref _groundOverlays[op.Slot];
+                    return new PresentationRequest
+                    {
+                        Kind = PresentationRequestKind.GroundOverlay,
+                        Owner = item.Owner,
+                        LOD = item.LOD,
+                        GroundOverlay = item.Item,
+                    };
+                }
+                case PresentationRequestChannel.WorldHud:
+                {
+                    ref readonly WorldHudChannelItem item = ref _worldHud[op.Slot];
+                    return new PresentationRequest
+                    {
+                        Kind = PresentationRequestKind.WorldHud,
+                        Owner = item.Owner,
+                        LOD = item.LOD,
+                        WorldHud = item.Item,
+                    };
+                }
+                case PresentationRequestChannel.SplineRibbon:
+                {
+                    ref readonly SplineRibbonChannelItem item = ref _splineRibbons[op.Slot];
+                    return new PresentationRequest
+                    {
+                        Kind = PresentationRequestKind.SplineRibbon,
+                        Owner = item.Owner,
+                        LOD = item.LOD,
+                        SplineRibbon = item.Item,
+                    };
+                }
+                case PresentationRequestChannel.SurfaceSource:
+                {
+                    ref readonly SurfaceSourceChannelItem item = ref _surfaceSources[op.Slot];
+                    return new PresentationRequest
+                    {
+                        Kind = PresentationRequestKind.SurfaceSource,
+                        Owner = item.Owner,
+                        LOD = item.LOD,
+                        StableId = item.Item.StableId,
+                        SurfaceSource = item.Item,
+                    };
+                }
+                case PresentationRequestChannel.Removal:
+                {
+                    ref readonly PresentationRemovalRequest item = ref _removals[op.Slot];
+                    return new PresentationRequest
+                    {
+                        Kind = item.Kind,
+                        Owner = item.Owner,
+                        StableId = item.StableId,
+                    };
+                }
+                case PresentationRequestChannel.ClearTransient:
+                    return new PresentationRequest
+                    {
+                        Kind = PresentationRequestKind.ClearTransientVisualProjection,
+                        Owner = _clearTransients[op.Slot],
+                    };
+                default:
+                    throw new InvalidOperationException($"Unknown PresentationRequestChannel '{op.Channel}'.");
+            }
         }
     }
 }

--- a/src/Core/Presentation/Requests/PresentationRequestBuffer.cs
+++ b/src/Core/Presentation/Requests/PresentationRequestBuffer.cs
@@ -100,25 +100,27 @@ namespace Ludots.Core.Presentation.Requests
                 return ReadOnlySpan<PresentationRequest>.Empty;
             }
 
-            EnsureSpanScratch();
+            if (_spanScratch == null || _spanScratch.Length < _opCount)
+            {
+                _spanScratch = new PresentationRequest[_opCount];
+            }
+
             for (int i = 0; i < _opCount; i++)
             {
-                _spanScratch![i] = Reconstruct(i);
+                _spanScratch[i] = Reconstruct(i);
             }
 
             return _spanScratch.AsSpan(0, _opCount);
         }
 
-        public ref readonly PresentationRequest Get(int index)
+        public PresentationRequest Get(int index)
         {
             if ((uint)index >= (uint)_opCount)
             {
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
 
-            EnsureSpanScratch();
-            _spanScratch![index] = Reconstruct(index);
-            return ref _spanScratch[index];
+            return Reconstruct(index);
         }
 
         public void Clear()
@@ -269,16 +271,6 @@ namespace Ludots.Core.Presentation.Requests
                 throw new InvalidOperationException(
                     $"PresentationRequestBuffer overflowed while adding kind={kind}, stableId={stableId}.");
             }
-        }
-
-        private void EnsureSpanScratch()
-        {
-            if (_spanScratch != null && _spanScratch.Length >= _opCount)
-            {
-                return;
-            }
-
-            _spanScratch = new PresentationRequest[_ops.Length];
         }
 
         private PresentationRequest Reconstruct(int opIndex)

--- a/src/Core/Presentation/Requests/PresentationRequestChannelCapacities.cs
+++ b/src/Core/Presentation/Requests/PresentationRequestChannelCapacities.cs
@@ -1,0 +1,62 @@
+using System;
+
+namespace Ludots.Core.Presentation.Requests
+{
+    public readonly struct PresentationRequestChannelCapacities
+    {
+        public PresentationRequestChannelCapacities(
+            int visualProxy,
+            int prefab,
+            int groundOverlay,
+            int worldHud,
+            int splineRibbon,
+            int surfaceSource,
+            int removal,
+            int clearTransient)
+        {
+            VisualProxy = RequirePositive(visualProxy, nameof(visualProxy));
+            Prefab = RequirePositive(prefab, nameof(prefab));
+            GroundOverlay = RequirePositive(groundOverlay, nameof(groundOverlay));
+            WorldHud = RequirePositive(worldHud, nameof(worldHud));
+            SplineRibbon = RequirePositive(splineRibbon, nameof(splineRibbon));
+            SurfaceSource = RequirePositive(surfaceSource, nameof(surfaceSource));
+            Removal = RequirePositive(removal, nameof(removal));
+            ClearTransient = RequirePositive(clearTransient, nameof(clearTransient));
+        }
+
+        public int VisualProxy { get; }
+        public int Prefab { get; }
+        public int GroundOverlay { get; }
+        public int WorldHud { get; }
+        public int SplineRibbon { get; }
+        public int SurfaceSource { get; }
+        public int Removal { get; }
+        public int ClearTransient { get; }
+
+        public int TotalOperationCapacity =>
+            checked(VisualProxy + Prefab + GroundOverlay + WorldHud + SplineRibbon + SurfaceSource + Removal + ClearTransient);
+
+        public static PresentationRequestChannelCapacities Uniform(int capacityPerChannel)
+        {
+            return new PresentationRequestChannelCapacities(
+                visualProxy: capacityPerChannel,
+                prefab: capacityPerChannel,
+                groundOverlay: capacityPerChannel,
+                worldHud: capacityPerChannel,
+                splineRibbon: capacityPerChannel,
+                surfaceSource: capacityPerChannel,
+                removal: capacityPerChannel,
+                clearTransient: capacityPerChannel);
+        }
+
+        private static int RequirePositive(int value, string name)
+        {
+            if (value <= 0)
+            {
+                throw new ArgumentOutOfRangeException(name, value, "Channel capacity must be > 0.");
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/Core/Presentation/Requests/PresentationRequestChannelItems.cs
+++ b/src/Core/Presentation/Requests/PresentationRequestChannelItems.cs
@@ -1,0 +1,85 @@
+using System.Numerics;
+using Arch.Core;
+using Ludots.Core.Presentation.Components;
+using Ludots.Core.Presentation.Hud;
+using Ludots.Core.Presentation.Rendering;
+
+namespace Ludots.Core.Presentation.Requests
+{
+    public enum PresentationRequestChannel : byte
+    {
+        VisualProxy = 1,
+        Prefab = 2,
+        GroundOverlay = 3,
+        WorldHud = 4,
+        SplineRibbon = 5,
+        SurfaceSource = 6,
+        Removal = 7,
+        ClearTransient = 8,
+    }
+
+    public readonly struct PresentationRequestOp
+    {
+        public PresentationRequestOp(PresentationRequestChannel channel, int slot)
+        {
+            Channel = channel;
+            Slot = slot;
+        }
+
+        public PresentationRequestChannel Channel { get; }
+        public int Slot { get; }
+    }
+
+    public struct VisualProxyChannelItem
+    {
+        public Entity Owner;
+        public PresentationVisualProxy VisualProxy;
+    }
+
+    public struct PrefabRequest
+    {
+        public Entity Owner;
+        public int PrefabId;
+        public int StableId;
+        public Vector3 Position;
+        public Quaternion Rotation;
+        public Vector3 Scale;
+        public Vector4 Color;
+        public LODLevel LOD;
+    }
+
+    public struct GroundOverlayChannelItem
+    {
+        public Entity Owner;
+        public LODLevel LOD;
+        public GroundOverlayItem Item;
+    }
+
+    public struct WorldHudChannelItem
+    {
+        public Entity Owner;
+        public LODLevel LOD;
+        public WorldHudItem Item;
+    }
+
+    public struct SplineRibbonChannelItem
+    {
+        public Entity Owner;
+        public LODLevel LOD;
+        public SplineRibbonRequest Item;
+    }
+
+    public struct SurfaceSourceChannelItem
+    {
+        public Entity Owner;
+        public LODLevel LOD;
+        public SurfaceSourceRequest Item;
+    }
+
+    public struct PresentationRemovalRequest
+    {
+        public PresentationRequestKind Kind;
+        public Entity Owner;
+        public int StableId;
+    }
+}

--- a/src/Core/Presentation/Requests/PresentationRequestFlushSystem.cs
+++ b/src/Core/Presentation/Requests/PresentationRequestFlushSystem.cs
@@ -64,8 +64,7 @@ namespace Ludots.Core.Presentation.Requests
         {
             long start = _timingDiagnostics != null ? Stopwatch.GetTimestamp() : 0L;
             _stableDrawCache.BeginFrame();
-            ReadOnlySpan<PresentationRequest> span = _requests.GetSpan();
-            bool hasTransientVisualProxy = HasTransientVisualProxy(span);
+            bool hasTransientVisualProxy = HasTransientVisualProxy(_requests);
             bool projectionTargetsCleared = false;
             if (hasTransientVisualProxy || _hadTransientVisualProjection)
             {
@@ -74,67 +73,56 @@ namespace Ludots.Core.Presentation.Requests
             }
             _hadTransientVisualProjection = hasTransientVisualProxy;
 
-            for (int i = 0; i < span.Length; i++)
+            ReadOnlySpan<PresentationRequestOp> ops = _requests.Ops;
+            for (int i = 0; i < ops.Length; i++)
             {
-                ref readonly PresentationRequest request = ref span[i];
-                switch (request.Kind)
+                PresentationRequestOp op = ops[i];
+                switch (op.Channel)
                 {
-                    case PresentationRequestKind.VisualProxy:
-                        EmitVisualProxy(request.VisualProxy);
+                    case PresentationRequestChannel.VisualProxy:
+                        EmitVisualProxy(in _requests.VisualProxyAt(op.Slot).VisualProxy);
                         break;
 
-                    case PresentationRequestKind.Prefab:
-                        EmitPrefab(in request);
+                    case PresentationRequestChannel.Prefab:
+                        EmitPrefab(in _requests.PrefabAt(op.Slot));
                         break;
 
-                    case PresentationRequestKind.GroundOverlay:
-                        if (!_groundOverlays.Upsert(request.GroundOverlay))
+                    case PresentationRequestChannel.GroundOverlay:
+                        if (!_groundOverlays.Upsert(_requests.GroundOverlayAt(op.Slot).Item))
                         {
                             throw new InvalidOperationException("GroundOverlayBuffer overflowed while flushing PresentationRequest.");
                         }
 
                         break;
 
-                    case PresentationRequestKind.WorldHud:
-                        if (!_worldHud.TryAdd(request.WorldHud))
+                    case PresentationRequestChannel.WorldHud:
+                    {
+                        ref readonly WorldHudChannelItem hud = ref _requests.WorldHudAt(op.Slot);
+                        if (!_worldHud.TryAdd(hud.Item))
                         {
                             throw new InvalidOperationException(
-                                $"WorldHudBatchBuffer overflowed while flushing PresentationRequest stableId={request.WorldHud.StableId}.");
+                                $"WorldHudBatchBuffer overflowed while flushing PresentationRequest stableId={hud.Item.StableId}.");
                         }
 
                         break;
+                    }
 
-                    case PresentationRequestKind.SplineRibbon:
-                        EmitSplineRibbon(in request.SplineRibbon);
+                    case PresentationRequestChannel.SplineRibbon:
+                        EmitSplineRibbon(in _requests.SplineRibbonAt(op.Slot).Item);
                         break;
 
-                    case PresentationRequestKind.SurfaceSource:
-                        // SurfaceSource requests are consumed by the dedicated presenter-surface runtime
-                        // before request flush reaches adapter-facing buffers.
+                    case PresentationRequestChannel.SurfaceSource:
                         break;
 
-                    case PresentationRequestKind.RemoveSurfaceSource:
-                        // SurfaceSource removals are consumed by SurfaceSourceFlushSystem.
+                    case PresentationRequestChannel.ClearTransient:
                         break;
 
-                    case PresentationRequestKind.ClearTransientVisualProjection:
-                        // Projection targets are cleared once before request replay when this marker is present.
-                        break;
-
-                    case PresentationRequestKind.RemoveGroundOverlay:
-                        _groundOverlays.Remove(request.StableId);
-                        break;
-
-                    case PresentationRequestKind.RemoveWorldHud:
-                        _worldHud.Remove(request.StableId);
-                        break;
-
-                    case PresentationRequestKind.RemoveSplineRibbon:
-                        _splineRibbons.Remove(request.StableId);
+                    case PresentationRequestChannel.Removal:
+                        FlushRemoval(in _requests.RemovalAt(op.Slot));
                         break;
 
                     default:
-                        throw new InvalidOperationException($"Unknown PresentationRequestKind '{request.Kind}'.");
+                        throw new InvalidOperationException($"Unknown PresentationRequestChannel '{op.Channel}'.");
                 }
             }
 
@@ -184,7 +172,27 @@ namespace Ludots.Core.Presentation.Requests
             _stableDrawCache.ClearStaticMeshDeltas();
         }
 
-        private void EmitPrefab(in PresentationRequest request)
+        private void FlushRemoval(in PresentationRemovalRequest removal)
+        {
+            switch (removal.Kind)
+            {
+                case PresentationRequestKind.RemoveGroundOverlay:
+                    _groundOverlays.Remove(removal.StableId);
+                    break;
+                case PresentationRequestKind.RemoveWorldHud:
+                    _worldHud.Remove(removal.StableId);
+                    break;
+                case PresentationRequestKind.RemoveSplineRibbon:
+                    _splineRibbons.Remove(removal.StableId);
+                    break;
+                case PresentationRequestKind.RemoveSurfaceSource:
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unknown PresentationRequestKind '{removal.Kind}' on removal channel.");
+            }
+        }
+
+        private void EmitPrefab(in PrefabRequest request)
         {
             if (!_prefabs.TryGet(request.PrefabId, out PrefabDefinition prefab))
             {
@@ -219,29 +227,23 @@ namespace Ludots.Core.Presentation.Requests
             _stableDrawCache.Upsert(proxy);
         }
 
-        private static bool HasTransientVisualProxy(ReadOnlySpan<PresentationRequest> requests)
+        private static bool HasTransientVisualProxy(PresentationRequestBuffer requests)
         {
-            for (int i = 0; i < requests.Length; i++)
+            if (requests.PrefabCount > 0 || requests.ClearTransientCount > 0)
             {
-                ref readonly PresentationRequest request = ref requests[i];
-                if (IsTransientPresentationRequest(in request))
+                return true;
+            }
+
+            ReadOnlySpan<VisualProxyChannelItem> visualProxies = requests.VisualProxies;
+            for (int i = 0; i < visualProxies.Length; i++)
+            {
+                if (IsTransientVisualProxy(in visualProxies[i].VisualProxy))
                 {
                     return true;
                 }
             }
 
             return false;
-        }
-
-        private static bool IsTransientPresentationRequest(in PresentationRequest request)
-        {
-            return request.Kind switch
-            {
-                PresentationRequestKind.ClearTransientVisualProjection => true,
-                PresentationRequestKind.Prefab => true,
-                PresentationRequestKind.VisualProxy => IsTransientVisualProxy(in request.VisualProxy),
-                _ => false,
-            };
         }
 
         private static bool IsTransientVisualProxy(in PresentationVisualProxy proxy)

--- a/src/Core/Presentation/Systems/SurfaceSourceFlushSystem.cs
+++ b/src/Core/Presentation/Systems/SurfaceSourceFlushSystem.cs
@@ -27,33 +27,40 @@ namespace Ludots.Core.Presentation.Systems
         public override void Update(in float dt)
         {
             int frame = _runtime.BeginFrame();
-            ReadOnlySpan<PresentationRequest> span = _requests.GetSpan();
-            for (int i = 0; i < span.Length; i++)
+            ReadOnlySpan<PresentationRequestOp> ops = _requests.Ops;
+            for (int i = 0; i < ops.Length; i++)
             {
-                ref readonly PresentationRequest request = ref span[i];
-                if (request.Kind != PresentationRequestKind.SurfaceSource)
+                PresentationRequestOp op = ops[i];
+                if (op.Channel == PresentationRequestChannel.Removal)
                 {
-                    if (request.Kind == PresentationRequestKind.RemoveSurfaceSource)
+                    ref readonly PresentationRemovalRequest removal = ref _requests.RemovalAt(op.Slot);
+                    if (removal.Kind == PresentationRequestKind.RemoveSurfaceSource)
                     {
-                        _runtime.MarkPendingRemoval(request.StableId);
+                        _runtime.MarkPendingRemoval(removal.StableId);
                     }
 
                     continue;
                 }
 
-                if (!_payloads.TryGet(request.SurfaceSource.ScopeId, out SurfacePayloadSnapshot payload))
+                if (op.Channel != PresentationRequestChannel.SurfaceSource)
                 {
-                    throw new InvalidOperationException(
-                        $"SurfaceSource presenter scopeId={request.SurfaceSource.ScopeId} stableId={request.SurfaceSource.StableId} is missing runtime payload registration.");
+                    continue;
                 }
 
-                if (payload.Kind != request.SurfaceSource.SurfaceKind)
+                ref readonly SurfaceSourceRequest surfaceSource = ref _requests.SurfaceSourceAt(op.Slot).Item;
+                if (!_payloads.TryGet(surfaceSource.ScopeId, out SurfacePayloadSnapshot payload))
                 {
                     throw new InvalidOperationException(
-                        $"SurfaceSource presenter scopeId={request.SurfaceSource.ScopeId} stableId={request.SurfaceSource.StableId} has payload kind '{payload.Kind}' but authoring kind '{request.SurfaceSource.SurfaceKind}'.");
+                        $"SurfaceSource presenter scopeId={surfaceSource.ScopeId} stableId={surfaceSource.StableId} is missing runtime payload registration.");
                 }
 
-                _runtime.Upsert(in request.SurfaceSource, in payload, frame);
+                if (payload.Kind != surfaceSource.SurfaceKind)
+                {
+                    throw new InvalidOperationException(
+                        $"SurfaceSource presenter scopeId={surfaceSource.ScopeId} stableId={surfaceSource.StableId} has payload kind '{payload.Kind}' but authoring kind '{surfaceSource.SurfaceKind}'.");
+                }
+
+                _runtime.Upsert(in surfaceSource, in payload, frame);
             }
         }
     }

--- a/src/Tests/PresentationTests/Core/PresentationRequestChannelTests.cs
+++ b/src/Tests/PresentationTests/Core/PresentationRequestChannelTests.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Arch.Core;
+using Ludots.Core.Presentation.Assets;
+using Ludots.Core.Presentation.Components;
+using Ludots.Core.Presentation.Hud;
+using Ludots.Core.Presentation.Rendering;
+using Ludots.Core.Presentation.Requests;
+using NUnit.Framework;
+
+namespace Ludots.Tests.Presentation
+{
+    [TestFixture]
+    public sealed class PresentationRequestChannelTests
+    {
+        [Test]
+        public void ChannelElementSizes_AreEachNarrowerThanFatPresentationRequest()
+        {
+            int fat = Unsafe.SizeOf<PresentationRequest>();
+            Assert.That(Unsafe.SizeOf<VisualProxyChannelItem>(), Is.LessThan(fat));
+            Assert.That(Unsafe.SizeOf<PrefabRequest>(), Is.LessThan(fat));
+            Assert.That(Unsafe.SizeOf<GroundOverlayChannelItem>(), Is.LessThan(fat));
+            Assert.That(Unsafe.SizeOf<WorldHudChannelItem>(), Is.LessThan(fat));
+            Assert.That(Unsafe.SizeOf<SplineRibbonChannelItem>(), Is.LessThan(fat));
+            Assert.That(Unsafe.SizeOf<SurfaceSourceChannelItem>(), Is.LessThan(fat));
+            Assert.That(Unsafe.SizeOf<PresentationRemovalRequest>(), Is.LessThan(fat));
+            Assert.That(Unsafe.SizeOf<PresentationRequestOp>(), Is.LessThan(fat));
+            Assert.That(Unsafe.SizeOf<Entity>(), Is.LessThan(fat));
+        }
+
+        [Test]
+        public void BlacksmithScaleTypedChannels_UseLessResidentMemoryThanFatRequestArray()
+        {
+            var capacities = new PresentationRequestChannelCapacities(
+                visualProxy: 1_048_576,
+                prefab: 1_048_576,
+                groundOverlay: 65_536,
+                worldHud: 1_048_576,
+                splineRibbon: 65_536,
+                surfaceSource: 1_048_576,
+                removal: 1_048_576 + 65_536 + 65_536 + 1_048_576,
+                clearTransient: 1_048_576);
+
+            long typedBytes =
+                (long)Unsafe.SizeOf<VisualProxyChannelItem>() * capacities.VisualProxy
+                + (long)Unsafe.SizeOf<PrefabRequest>() * capacities.Prefab
+                + (long)Unsafe.SizeOf<GroundOverlayChannelItem>() * capacities.GroundOverlay
+                + (long)Unsafe.SizeOf<WorldHudChannelItem>() * capacities.WorldHud
+                + (long)Unsafe.SizeOf<SplineRibbonChannelItem>() * capacities.SplineRibbon
+                + (long)Unsafe.SizeOf<SurfaceSourceChannelItem>() * capacities.SurfaceSource
+                + (long)Unsafe.SizeOf<PresentationRemovalRequest>() * capacities.Removal
+                + (long)Unsafe.SizeOf<Entity>() * capacities.ClearTransient
+                + (long)Unsafe.SizeOf<PresentationRequestOp>() * capacities.TotalOperationCapacity;
+
+            long fatBytes = (long)Unsafe.SizeOf<PresentationRequest>() * 2_097_152;
+            Assert.That(typedBytes, Is.LessThan(fatBytes));
+        }
+
+        [Test]
+        public void GetSpan_ReconstructsMixedKindsInEnqueueOrder()
+        {
+            var requests = new PresentationRequestBuffer(8);
+            requests.Add(PresentationRequest.RemoveGroundOverlay(Entity.Null, 7));
+            requests.Add(PresentationRequest.FromGroundOverlay(
+                Entity.Null,
+                new GroundOverlayItem { StableId = 7, Radius = 1.5f },
+                LODLevel.High));
+            requests.Add(PresentationRequest.FromVisualProxy(
+                Entity.Null,
+                new PresentationVisualProxy
+                {
+                    MeshAssetId = 11,
+                    StableId = 90,
+                    LOD = LODLevel.Medium,
+                }));
+
+            Assert.That(requests.Count, Is.EqualTo(3));
+            ReadOnlySpan<PresentationRequest> span = requests.GetSpan();
+            Assert.That(span[0].Kind, Is.EqualTo(PresentationRequestKind.RemoveGroundOverlay));
+            Assert.That(span[0].StableId, Is.EqualTo(7));
+            Assert.That(span[1].Kind, Is.EqualTo(PresentationRequestKind.GroundOverlay));
+            Assert.That(span[1].GroundOverlay.Radius, Is.EqualTo(1.5f).Within(0.001f));
+            Assert.That(span[2].Kind, Is.EqualTo(PresentationRequestKind.VisualProxy));
+            Assert.That(span[2].VisualProxy.MeshAssetId, Is.EqualTo(11));
+            Assert.That(requests.Get(2).VisualProxy.StableId, Is.EqualTo(90));
+        }
+
+        [Test]
+        public void Add_OverflowsTheFilledChannel_WithoutBlockingOtherChannels()
+        {
+            var requests = new PresentationRequestBuffer(new PresentationRequestChannelCapacities(
+                visualProxy: 1,
+                prefab: 1,
+                groundOverlay: 1,
+                worldHud: 1,
+                splineRibbon: 1,
+                surfaceSource: 1,
+                removal: 1,
+                clearTransient: 1));
+
+            requests.Add(PresentationRequest.FromVisualProxy(
+                Entity.Null,
+                new PresentationVisualProxy { StableId = 1, MeshAssetId = 4 }));
+
+            InvalidOperationException overflow = Assert.Throws<InvalidOperationException>(() =>
+                requests.Add(PresentationRequest.FromVisualProxy(
+                    Entity.Null,
+                    new PresentationVisualProxy { StableId = 2, MeshAssetId = 5 })));
+            Assert.That(overflow.Message, Does.Contain("kind=VisualProxy"));
+
+            requests.Add(PresentationRequest.FromGroundOverlay(
+                Entity.Null,
+                new GroundOverlayItem { StableId = 8 },
+                LODLevel.High));
+            Assert.That(requests.Count, Is.EqualTo(2));
+            Assert.That(requests.GetSpan()[1].Kind, Is.EqualTo(PresentationRequestKind.GroundOverlay));
+        }
+
+        [Test]
+        public void Flush_RemoveThenUpsertSameStableId_KeepsTheNewOverlay()
+        {
+            World world = World.Create();
+            try
+            {
+                var requests = new PresentationRequestBuffer(8);
+                var overlays = new GroundOverlayBuffer(8);
+                using var flush = CreateFlush(world, requests, overlays);
+
+                requests.Add(PresentationRequest.FromGroundOverlay(
+                    Entity.Null,
+                    new GroundOverlayItem { StableId = 7, Radius = 2f },
+                    LODLevel.High));
+                flush.Update(0.016f);
+                Assert.That(overlays.Count, Is.EqualTo(1));
+
+                requests.Add(PresentationRequest.RemoveGroundOverlay(Entity.Null, 7));
+                requests.Add(PresentationRequest.FromGroundOverlay(
+                    Entity.Null,
+                    new GroundOverlayItem { StableId = 7, Radius = 9f },
+                    LODLevel.High));
+                flush.Update(0.016f);
+
+                Assert.That(overlays.Count, Is.EqualTo(1),
+                    "Same-frame remove-then-add must keep the new overlay; flushing by channel would delete it.");
+                Assert.That(overlays.GetSpan()[0].Radius, Is.EqualTo(9f).Within(0.001f));
+            }
+            finally
+            {
+                World.Destroy(world);
+            }
+        }
+
+        [Test]
+        public void Flush_UpsertThenRemoveSameStableId_DeletesTheOverlay()
+        {
+            World world = World.Create();
+            try
+            {
+                var requests = new PresentationRequestBuffer(8);
+                var overlays = new GroundOverlayBuffer(8);
+                using var flush = CreateFlush(world, requests, overlays);
+
+                requests.Add(PresentationRequest.FromGroundOverlay(
+                    Entity.Null,
+                    new GroundOverlayItem { StableId = 7, Radius = 2f },
+                    LODLevel.High));
+                requests.Add(PresentationRequest.RemoveGroundOverlay(Entity.Null, 7));
+                flush.Update(0.016f);
+
+                Assert.That(overlays.Count, Is.EqualTo(0));
+            }
+            finally
+            {
+                World.Destroy(world);
+            }
+        }
+
+        private static PresentationRequestFlushSystem CreateFlush(
+            World world,
+            PresentationRequestBuffer requests,
+            GroundOverlayBuffer overlays)
+        {
+            return new PresentationRequestFlushSystem(
+                world,
+                requests,
+                new PrefabRegistry(),
+                new MeshAssetRegistry(),
+                new StableDrawCache(),
+                new PrimitiveDrawBuffer(),
+                overlays,
+                new WorldHudBatchBuffer(8),
+                new SplineRibbonBuffer(8),
+                new PrimitiveDrawBuffer(),
+                new PresentationVisualProxyBuffer(8),
+                new SkinnedVisualBatchBuffer(8));
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #747.

`PresentationRequest` used to be one fat struct stored in a single preallocated array. 30k/blacksmith set `presentationRequestCapacity` to 2,097,152, so the engine reserved about 1.4GB before anyone queued a request. Downstream flush already branches by kind; the extra fields on every slot were unused.

This PR keeps the producer API (`Add(in PresentationRequest)`) and the snapshot/flush timing contract. Internally the buffer stores each kind on its own channel and records mixed-kind enqueue order in an 8-byte sequencer, so same-frame remove-then-add still wins.

Production `GameEngine` sizes channels from existing knobs (`visualProxyBufferCapacity`, `groundOverlayCapacity`, `worldHudCapacity`, `splineRibbonCapacity`, `presenterInstanceCapacity`) instead of allocating every channel at 2M. `InstancedBatchRequestBuffer` still uses `presentationRequestCapacity`; that coupling is unchanged.

`Get` now returns a reconstructed value. `GetSpan` allocates scratch to the live enqueue count, not the summed channel capacity. Flush iterates the sequencer and typed channels directly.

Prefab stays a shrinking ticket on the old path. This is not a new Prefab product channel, and it does not delete Prefab (that remains #934).

Verified: 51 PresentationTests covering channel sizes, mixed-kind order, per-channel overflow, incremental static flush, prefab flush, and Presenter asset-kind GetSpan. `PresenterEmitSystem_AssetBinding_EmitsVisualSoundSplineHudAndText` already fails on atmosphere (`HasViewer` gates HUD); not changed here.

Not in scope: epic #924 P5 compiled lanes, Prefab delete, projected decal.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b445251-c269-4fcd-bdb5-dde3090fef14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b445251-c269-4fcd-bdb5-dde3090fef14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

