### PR TITLE
docs(audits): GAS + 图 VM 架构审查与修复任务分配（Epic + 15 子任务）

### DIFF
--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -19,6 +19,8 @@
 * [PR911 审计需求交接](pr911_funclib_actionlib_audit_handoff.md)
 * [PR911 FuncLib/ActionLib 架构审计（#914 SSOT）](pr911_funclib_actionlib_architecture_audit.md)
 * [PR911 审计修复清单（#913+#914 合并 / Epic #915）](pr911_audit_fix_checklist.md)
+* [GAS + Graph VM 架构审查（SSOT）](gas_graph_architecture_review.md)
+* [GAS + Graph VM 架构修复计划（Epic + 子任务）](gas_graph_architecture_fix_plan.md)
 
 ## 2 使用边界
 

--- a/docs/audits/gas_graph_architecture_fix_plan.md
+++ b/docs/audits/gas_graph_architecture_fix_plan.md
@@ -1,0 +1,1270 @@
+# GAS + Graph VM 架构修复计划（Epic + 子任务分配）
+
+**依据：** [GAS + Graph VM 架构审查](gas_graph_architecture_review.md)（SSOT）
+**被审 tip：** `origin/main` @ `82ddb3322a`
+**用途：** 本文件是开 GitHub Epic 与子 issue 的正文来源。每个子任务的「任务书」小节可以整段复制给一个修复 Agent，不需要再补上下文。
+**批量创建：** `scripts/create-gas-graph-fix-issues.sh`
+
+---
+
+## 1. 概述
+
+架构审查的结论是「骨架比收尾好得多」：图 VM 执行核心、编译器前端、组件布局、零分配纪律都是认真做的，不需要重做。因此本计划**不包含任何重写**，全部是收口。
+
+十四个子任务分四档。P0 三条是「今天就能出事」：一条会杀进程，一条让属性数值不可信，一条让技能结算能混进可挂起动作。P1 四条是「已经在骗人」：事务的回滚本身会失败、容量到顶不说话、退役的门没锁、血条名不副实。P2 六条是「地基没夯实」：分层前门没人走、表现层在决定玩法、假防线成片、寄存器索引无归属。P3 一条是唯一的大工程：把层拆成真程序集。
+
+**先修哪个**：S1 → S2 → S3 三条可以同时开三个 Agent，互不冲突。其余按 §2 的依赖图排。
+
+---
+
+## 2. 结构
+
+### 2.1 优先级与并行性
+
+| 档 | 子任务 | 可并行 | 依赖 | 预估触碰面 |
+|----|--------|--------|------|------------|
+| **P0** | S1 图调用无界递归 | 是 | — | VM 1 处 + 校验器 1 处 + 新测试 |
+| **P0** | S2 属性写入权威统一 | 是 | — | 属性核心 + 7 处 Core 调用方 + 守卫 |
+| **P0** | S3 查询方言的可挂起动作开口 | 是 | — | 编译器 1 个分支 + 测试参数 |
+| **P1** | S4 事务收尾：回滚不可失败 | 是 | — | 事务类 4 个循环 + 销毁语义 |
+| **P1** | S5 容量三禁：丢弃 / 扩容 / 死信号 | 是 | — | 4 个队列 + 3 处 Reserve |
+| **P1** | S6 退役展厅锁门 + 停止清表 | 是 | — | 登记表 + 启动器 + 5 个 mod bootstrap |
+| **P1** | S7 展厅血条名实相符 | 是 | — | 画廊 driver + 分镜数据 + 文案 |
+| **P2** | S8 假防线集中整治 | 是 | — | 纯测试改动 |
+| **P2** | S9 L2 走 L1 正式前门（引入 GraphFrame） | 否 | **S1** | VM 对外 API + 3 个 L2 宿主 |
+| **P2** | S10 表现层不得 gate 玩法选中 | 是 | — | 2 个输入系统 + 新守卫 |
+| **P2** | S11 覆盖表错误归因 + 守卫强度 | 是 | — | 生成器 + 覆盖表守卫 |
+| **P2** | S12 寄存器归属 + 指令 descriptor | 否 | **S9** | 编译器 + 前门矩阵 |
+| **P2** | S13 Script 方言拓宽 | 否 | **S9 + S12** | 能力矩阵 + 宿主 state 合同 |
+| **P3** | S14 分层物理化（拆程序集） | 否 | 建议在 S9/S12 后 | 全仓 csproj 结构 |
+| **chore** | S15 验收页 SSOT 合并（红灯部分已修） | 是 | — | 一份文档 |
+
+### 2.2 依赖图
+
+```text
+S1 ──────────────► S9 ──────► S12 ──────► S13
+                    │           │
+                    └───────────┴────────► S14（建议，非硬依赖）
+
+S2  S3  S4  S5  S6  S7  S8  S10  S11  S15   ← 全部可独立并行开工
+```
+
+**唯一的硬顺序**：S13（拓宽 Script 方言）必须在 S9（宿主拿到完整执行帧）之后。反了必崩——今天三个 L2 宿主只填了部分寄存器就能跑，正是因为 Script 方言窄到用不到那些寄存器。
+
+### 2.3 不在本计划内
+
+UI 面板债（#886 / #893）、表现层改名、#723 评分预算、以及「删掉八个家族 Mod」（那是 S6 关门之后的独立票）。
+
+---
+
+## 3. 详情（子任务任务书）
+
+> 每个子任务的「给 Agent 的任务书」可整段复制。共同纪律，不再逐条重复：
+> 先读 `gitbook/contributing/ai-assisted-development.md` 的任务执行决策规范；
+> NO FALLBACK / SSOT / DRY / SOLID / DDD；数据驱动、NO HARDCODE；
+> ECS：SoA、0 Alloc、chunk 迭代、inline query、span、command buffer；禁止热路径结构变更、禁止内存飞线；
+> 只改自己这一条的范围，不顺手改别的；不重开已裁决的产品争论；
+> 禁止发明不存在的类型或方法（每个引用先搜索确认）。
+
+---
+
+### S1 · 图调用无界递归会杀进程 【P0】
+
+**审查编号：** A1
+
+**任务书**
+
+```text
+目标：让一张自己调自己（或成环）的图在登记时就被拒绝，并让运行期的失控有硬上限。
+这是当前唯一「一行配置杀死进程」的问题，优先级最高，改动面小且独立。
+
+现状（已实测，不要再花时间复现）：
+  注册一张脚本图，程序体只有一条 InvokeScript 指向自己 →
+  GraphProgramRegistry.Register 接受，TryGetProgram 返回 True（无装载期环检测）；
+  执行时递归 1495 层后栈溢出，进程退出码 134，try/catch 无法进入
+  （.NET 的 StackOverflowException 不可捕获）。
+
+三道看起来相关的闸门都不管这件事，别误以为它们能兜住：
+  1) GraphVmLimits.MaxCallStackDepth = 16 只约束同一程序内的 Call，
+     子调用拿到的是全新 CallStack 且 CallStackCount = 0；
+  2) MaxInstructionsPerExecution = 4096 是 per-Execute 预算，
+     GasGraphOpHandlerTable.Execute 每次新建 cursor 且 Steps = 0 —— 预算不复合，
+     实际上限是 4096 的深度次方；
+  3) GraphYieldPurityValidator 是唯一遍历 InvokeScript 边的组件，
+     它遇到环时是 if (!activeGraphs.Add(graphId)) return false;
+     —— 把环当作「没找到 Yield」放行，而不是判错。
+
+要做三件事：
+  1) 装载期拒环。复用 GraphYieldPurityValidator 已有的 activeGraphs 栈，
+     把「命中环」从 clean 改成 error（新错误码，形如 GAS.GRAPH.ERR.InvokeCycle，
+     沿用该文件既有的诊断风格，不要发明新的错误体系）。
+     注意它今天只挂在 GraphFunctionCatalogLoader 与 LiveGasEditPipeline 两处；
+     环检测必须覆盖所有 InvokeScript 来源，最自然的挂载点是
+     GraphProgramRegistry.Register / ReplaceProgram，或 GraphProgramConfigLoader.PatchAndRegister。
+     选哪个都行，但要在 PR 里说明为什么，并确保热改路径也过这道检查。
+  2) 运行期深度上限 + 共享步数预算。把 invoke depth 与「整棵调用树共享一个步数预算」
+     放进 GraphExecutionCursor（或等价位置），超限抛，不要静默截断。
+     这条是纵深防御：即使装载期漏了，运行期也必须是抛错而不是杀进程。
+  3) 补测试。今天零覆盖：rg "Recursi|SelfInvoke|Depth" 在 src/Tests/GasTests/Graph
+     只命中 MaxCallStackDepth 的 stackalloc。至少三条：
+     自递归拒绝、A→B→A 环拒绝、深度超限时抛（而非崩）。
+     注意：如果你要写一条「验证今天会崩」的测试，它会杀掉整个 test host，
+     必须隔离或直接不写——写「修好之后应当抛」的正向测试即可。
+
+顺带（同一处，成本几乎为零）：
+  RequireNoYield 目前在每次 InvokeScript 运行时对子程序做 O(n) 线性扫描找 Yield，
+  这本该在装载期做一次。你已经在动装载期校验了，可以一并挪过去。
+
+禁止：
+  用「限制 Script 图不许 InvokeScript」来回避问题 —— 那会砍掉 FuncLib 复用；
+  只加运行期深度上限而不做装载期拒环（作者应该在登记时就知道）；
+  把栈溢出改成捕获（.NET 里做不到，别试）。
+
+验收：
+  Feature: 一张图不能把游戏弄没了
+    Scenario: 自己调自己的图必须被拒绝
+      Given 我写了一张脚本图，它唯一做的事就是调用自己
+      When 这张图被登记进图注册表
+      Then 登记必须失败并告诉我这里有一个调用环
+      And 游戏不应该能带着这张图启动
+
+    Scenario: 绕一圈回来也算环
+      Given 图 A 调用图 B，图 B 又调用回图 A
+      When 它们被登记
+      Then 登记必须失败并指出这条环上的图
+
+    Scenario: 万一漏到了运行期，也要报错而不是消失
+      Given 一条嵌套调用链深过了引擎允许的深度
+      When 它被执行
+      Then 必须抛出并说明深度上限
+      And 进程不得退出
+```
+
+**该跑：** `--filter "FullyQualifiedName~GraphFunctionCatalogLoaderTests|FullyQualifiedName~GraphActionCatalogLoaderTests|FullyQualifiedName~LiveGasEditPipelineTests|FullyQualifiedName~GraphExecuteSliceBudgetTests|FullyQualifiedName~GraphContractTests"`
+
+---
+
+### S2 · 属性写入的权威与强制手段 【P0】
+
+**审查编号：** A2、A3、B10、B11、B12、B13
+
+**任务书**
+
+```text
+目标：让「我写进属性的数字就是最终生效的数字」成立，并让「只有结算能改属性」有强制手段。
+这是 GAS 的地基。建立在「属性值可信」之上的一切（伤害结算、触发条件、存档、回放）
+都在这条裂缝之上。
+
+现状（已实测，三格对照）：
+  基础值 100 的属性 + 一个永久 +18 的聚合修正，然后用正式接口 SetCurrent(50)：
+    属性夹上限（血量这类）+ 重新标脏 → 重算后 50   （写入存活）
+    属性不夹上限（移速这类）+ 重新标脏 → 重算后 118 （写入被静默丢弃）
+    属性不夹上限 + 不重新标脏         → 重算后 50   （暂时存活）
+  代码依据：AttributeAggregatorSystem.RestorePersistentCurrentValues
+    if (!touchedByAggregation || clampsToEffectiveCap) SetCurrent(i, previousCurrentValues[i]);
+  而 AttributeMutationOps.SetCurrent 不排 AttributeAggregateDirty，
+  所以覆盖时机与写入完全脱钩：值可存活任意多帧，直到不相干事件把实体标脏才被抹掉。
+
+要做的事，按四块，可以拆成四个 PR 但建议同一个 Agent 连续做（它们互相牵连）：
+
+一、把 current 的权威定下来并写进文档
+  今天「谁是权威」取决于运行时状态（属性有没有配约束、那一刻有没有活跃聚合修正），
+  这是不可接受的。裁决权在维护者，但实现上必须做到「同一个 API 语义唯一」。
+  两条可选路径，选一条并在 PR 里写明理由：
+    (a) 直写永远存活：聚合器只负责算「有效上限」，不回写 current；
+        需要重算 current 的场景改为显式操作。
+    (b) 直写永远不存活：把「直接改当前值」从公开 API 收回，
+        只留「申请一次属性变更（走结算）」，聚合器是唯一 current 写者。
+  不管选哪条，SetCurrent 必须排 AttributeAggregateDirty ——
+  「写了之后要过多久才被覆盖」不能是不确定的。
+  然后补上那唯一缺失的守卫格：无约束属性 + 活跃聚合修正 + 直写 current。
+  现有 AttributeAggregatorTests 覆盖了四种组合里的三种，唯独缺会丢数据的这一格。
+
+二、给写入面装强制手段（现在是零）
+  AttributeBuffer 的 SetBase/SetCurrent/SetAggregatedCurrent 全是 public，
+  AttributeMutationOps 是 public static，无 internal 收口、无 analyzer 工程、无守卫测试。
+  Core 自己就有 7 处裸写（ExchangeRuntime、InputActionAttributeBindingSystem、
+  ForceInput2DSink、CameraBehaviorInputSink、ComponentRegistry、
+  TemplateEntityBatchSpawner、QuestDefinitions），mod 侧 10+ 处。
+  所以这不是使用者的错，是架构没给手段。
+  仓库里已有现成范式，不要发明新东西：
+    - 围栏范式：GasGraphRuntimeApi 的 BeginDerivedAttributeWrites /
+      EndDerivedAttributeWrites / RejectDerivedAttributeSideEffect
+      已经证明「scope 独占 + 暂存 buffer + commit-or-discard + 越权即抛」在本代码库可行。
+    - 守卫范式：ArchitectureGuardTests 已有 IL 级调用扫描基建
+      （EnumerateCalledMethods，GasAbilityExecHotPath_DoesNotCallWorldAddOrRemoveDirectly 在用）。
+      把它的黑名单从一个类型扩到「AttributeBuffer 的写方法调用方必须在白名单内」，
+      是既有工具的直接复用。
+  注意有一条守卫测试目前反过来把绕行钉成了契约：
+    ArchitectureGuardTests.Issue250_ExchangeAttributeCostInput_UsesGasAttributesAndShowcaseMod
+    里有 Assert.That(runtime, Does.Contain("attributes.SetCurrent"))。
+    动 ExchangeRuntime 必须同时改这条断言。
+
+三、非法与越界 id 必须失败关闭
+  实测：SetCurrent(-1)、GetCurrent(-1)、SetCurrent(64) 全部静默返回不抛。
+  而按名字取 id 找不到时返回的正是 -1 —— 于是「取一个没注册的属性名然后写它」
+  这条常规路径会静默吞掉整次写入，连脏标记都不打，零异常零日志。
+  参照同族的 GameplayTagContainer.ValidateTagId（对非法 id 抛 ArgumentOutOfRangeException）。
+  上限 64 在三处独立定义（AttributeBuffer / AttributeRegistry / DirtyFlags），
+  顺手收成一处引用。
+
+四、统一两个注册表的有效性约定，并把属性表 Freeze 起来
+  属性表：_nextId = 0，InvalidId = -1  → id 0 合法
+  标签表：_nextId = 1,  InvalidId = 0  → id 0 非法
+  有 6+ 处代码套用标签表的约定去判属性（if (attributeId > 0)），
+  于是第一个注册的属性在这些路径上静默不可用，而「第一个」取决于 mod 加载顺序。
+  已知调用点：BuiltinHandlers.HandleApplyForce（4 处）、NarrativeDirector、
+  AbilityExecLoader（3 处）、UtilityAiRuntimeEvaluator。
+  同时：AttributeRegistry.Freeze() 与 AttributeSinkRegistry.Freeze() 生产从不调用，
+  而 ProgressionIdRegistry / ContextGroupIdRegistry / GraphIdRegistry 都规规矩矩 Freeze 了。
+  id 分配依赖 mod 加载顺序会威胁存档与回放的确定性，
+  gas-layered-architecture.md 也明文要求「在一个注册点统一 Register 并最终 Freeze」。
+
+禁止：
+  用「给所有属性都配上夹上限约束」来绕过第一块 —— 那是把 bug 变成约定；
+  只改 mod 侧调用方而不动强制手段（约定已经失败过一次，失败者包括规则作者自己）；
+  为了让守卫测试变绿而放宽断言。
+
+验收：
+  Feature: 我写进属性的数字不会自己变回去
+    Scenario: 直接写入的当前值语义唯一
+      Given 一个基础值 100 的属性，挂着一个永久 +18 的修正
+      And 我通过正式接口把当前值写成 50
+      When 属性重算发生
+      Then 结果必须与该属性是否配了夹上限约束无关
+      And 这个语义必须写进正式文档
+
+  Feature: 写错属性名不应该悄无声息
+    Scenario: 非法属性编号必须失败关闭
+      Given 我引用了一个没有注册的属性名
+      When 系统按这个名字取编号，然后拿这个编号去写值
+      Then 写入必须失败并点名这个属性名
+
+  Feature: 属性的编号不该看 mod 装载顺序
+    Scenario: 第一个注册的属性也必须可用
+      Given 某个属性恰好是本次运行中第一个被注册的
+      When 内置的施加冲力之类的路径去读它
+      Then 它应当和其他属性一样正常工作
+
+  Feature: 绕过结算改属性必须被拦住
+    Scenario: 裸写属性缓冲要么编译不过，要么 CI 红
+      Given 一段代码直接调用属性缓冲的写方法，而它不在允许名单里
+      When CI 跑架构守卫
+      Then 守卫必须失败并点名这个调用方
+```
+
+**该跑：** `--filter "FullyQualifiedName~AttributeAggregatorTests|FullyQualifiedName~AttributeDerivedGraphTests|FullyQualifiedName~AttributeBindingTests|FullyQualifiedName~DeferredTriggerCollectionTests|FullyQualifiedName~DeferredTriggerTests|FullyQualifiedName~ExchangeRuntimeTests|FullyQualifiedName~AllocationTests|FullyQualifiedName~InstantEffectTransactionTests|FullyQualifiedName~SystemIntegrationTests"`
+另跑 `src/Tests/ArchitectureTests/ArchitectureTests.csproj --filter "FullyQualifiedName~ArchitectureGuardTests"`
+
+---
+
+### S3 · 查询方言可从纯管道调起可挂起动作 【P0】
+
+**审查编号：** A4（同 `pr932_graph_landed_architecture_audit.md` B1）
+
+**任务书**
+
+```text
+目标：关掉查询方言的可挂起动作开口，让「技能结算不得中途调可挂起动作」这条红线
+在所有方言上一致成立。这是作者今天就能写出来的，且零测试覆盖。
+
+现状：
+  线性方言（Effect/Score/Validation/Derived）在 GraphControlFlowCompiler.Linear.cs 里
+  对 InvokeScript 明确拒绝裸图号：缺 functionName 报 MissingNodeRef，
+  给了 graphId 报 TypeMismatch「cannot use graphId in linear FuncLib authoring」。
+  查询方言在 GraphControlFlowCompiler.Query.cs 里只拒绝「两个都给」和「两个都不给」，
+  只给 graphId 一路放行，CompileQueryNode 原样编译成 Imm = node.GraphId; Flags = 0。
+  下游拦不住：能力矩阵把 InvokeScript 静态标为 Pure（与 Jump/Call/Return 同组），
+  只看本图不跟进被调图；运行期只校验被调图 kind == Script 且不含 Yield，
+  而 action_lib.json 11 条里有 9 条不含 Yield，全部可被一张查询图调起。
+  违反 graph-funclib-actionlib-contract.md §3.4 明文禁令。
+
+要做：
+  1) 查询方言与线性方言对齐：InvokeScript 只允许 functionName，graphId 直绑拒绝。
+     诊断码与文案沿用线性侧，不要发明新错误体系。
+  2) 给 GraphEffectAuthoringExpressivenessTests.FrontDoor_LinearKindsInvokeScriptGraphId_FailClosed
+     的 [TestCase] 补上 "Effect" 与 "Query"。今天它只覆盖 Score / Validation / Derived。
+  3) 先搜 assets/ 与 mods/ 下所有 kind=Query 且用 graphId 的图。
+     如果有现存图因此编译失败，失败关闭并在 PR 里报告，
+     不要为了让测试变绿而放宽校验。
+
+背景（这条为什么是架构问题而不只是一个漏判分支，供你判断改法用）：
+  这套能力模型是「逐指令 + 只看本图」的。把 InvokeScript 标成 Pure，
+  等于把「调用」当成控制流而不是能力传递点 —— 而调用的实际能力取决于被调图。
+  全仓唯一的跨图分析是 GraphYieldPurityValidator，它只管 Yield 纯度，
+  且只挂在 FuncLib 登记与热改两条路上。所以「禁止裸图号、强制一切间接调用
+  都经过一本有跨图校验的清单」是这套模型下唯一自洽的收口方式，
+  而线性方言已经这么做了 —— 你只是把它推广到全部方言。
+  如果你想改成「调用的能力 = 被调图能力的并集」（真过程间分析），
+  那是更彻底但更大的改动，请先提方案再动手。
+
+禁止：改合同措辞来迁就实现；新增 opcode；碰线性方言。
+
+验收：
+  Feature: 纯查询里不能偷偷跑起会等一拍的动作
+    Scenario: 查询图直绑图号必须被拒绝
+      Given 我在一张查询图里写了一个调用，直接指向某个巡逻动作的图号
+      When 这张图通过作者前门编译
+      Then 编译必须失败，理由与线性方言一致
+    Scenario: 走清单名字仍然允许
+      Given 我在查询图里用纯算式清单里登记的函数名做调用
+      When 这张图通过作者前门编译
+      Then 编译应当成功
+```
+
+**该跑：** `--filter "FullyQualifiedName~GraphEffectAuthoringExpressivenessTests|FullyQualifiedName~GraphQueryControlFlowTests|FullyQualifiedName~GraphContractTests"`
+
+---
+
+### S4 · 事务收尾：回滚必须不可失败 【P1】
+
+**审查编号：** B1、B2、B3、B4、C3、C4、C5
+
+**任务书**
+
+```text
+目标：让效果阶段事务的回滚路径无条件成功，并把「事务边界」与「一次结算」对齐。
+事务骨架本身是专业的（暂存 + 校验 + 提交 + 回滚，六个外部队列都有检查点），
+不要重写它 —— 只补收尾。
+
+四个已定位的脏点：
+
+一、回滚自己会抛（最要紧）
+  EffectPhaseSideEffectTransaction.RollbackWorldWrites 里相邻循环风格不一致：
+    恢复 ActiveEffectContainer 的循环   → 有 _world.IsAlive && _world.Has 守卫
+    恢复 GameplayEffect 的循环          → 有守卫
+    恢复 BlackboardFloatBuffer 的循环   → 裸 _world.Get<T>()，无守卫
+    恢复 BlackboardIntBuffer 的循环     → 无守卫
+    恢复 BlackboardEntityBuffer 的循环  → 无守卫
+    恢复 cancelledEffect 的循环         → 无守卫
+  这是漏写而非设计选择。阶段执行期间若有实体被销毁，回滚会中途抛出，
+  其后的 listener buffer / relation / 结构性移除全部不执行 —— 回滚本身留下部分结果。
+  真事务的铁律是回滚路径必须无条件成功。补齐守卫，并补一条测试：
+  阶段执行中销毁一个持有黑板的实体，断言回滚完整走完。
+
+二、提交路径内的销毁不可逆
+  Commit() 在外部发布之后执行 _world.Destroy(effect) 循环，之后还有 _rootBudget.CommitWrites。
+  销毁一旦发生 Rollback 没有任何复活手段（RollbackWorldWrites 所有循环都以 IsAlive 为前提）。
+  所以 destroy 之后的任一异常会留下「实体没了、但它的属性/标签/关系被回滚」的混合态。
+  选一条：把销毁移到提交的最后一步（之后不允许有任何可失败操作），
+  或者把销毁降级成「打标记 + 由 Cleanup 相落地」。后者与引擎既有的
+  publish→finalize 两拍销毁协议一致，更推荐。
+
+三、事务边界小于结算边界
+  EffectApplicationSystem.UpdateSlice 的 ProcessPending 阶段已经把效果塞进目标的
+  ActiveEffectContainer（并可能 World.Add 该组件），这些都在事务之外；
+  ActivateEffects 阶段才开事务跑阶段图。两阶段之间可因 MaxWorkUnitsPerSlice 跨帧让步，
+  失败时靠 RollbackPersistentAttachment 手工补偿。
+  要么把 attach 纳入同一事务，要么明确「挂载是可见的中间态」并补测试固定这个语义。
+  不要留在「靠补偿函数拼接」的状态。补一条测试：在两阶段之间截断，断言中间态符合选定语义。
+
+四、标签授予绕过事务
+  EffectApplicationSystem 在事务作用域内调 EffectTagContributionHelper.PrepareGrantToEntity，
+  后者直接 world.Get<GameplayTagContainer> 改世界、不进暂存，
+  靠外层 tagsBefore / tagCountsBefore / dirtyFlagsBefore 三个快照在 catch 里手工还原。
+  顺序目前是对的，但这正是边界清单「禁止阶段执行直接绕过事务写入外部系统」所指的形态：
+  同一实体的标签有两套写入与两套回滚机制。把它纳入事务暂存。
+
+顺带（同一批，成本低）：
+  - StagePresentationEvent 在服务缺失时静默 no-op，而同类 StageEffectRequest /
+    StageSpawnRequest 抛异常 —— 同一个类里两种缺服务语义，统一成抛。
+  - 三个 fan-out builtin 在 SpatialQueries / FanOutBudget / ResolverBuffer 缺失时
+    静默 return 零结果，把「服务没接」降级成「零目标」。改成抛。
+  - PrepareCommitState() 在 try 之外调用，Commit 非自洽，全靠三个调用方各自 catch 兜底。
+  - Commit 是 AttributeMutationOps 的平行重实现（整 struct 赋值 + 手写 dirty 循环），
+    两套语义需人工同步 —— 如果 S2 已经动了属性写入面，这里要一并对齐。
+
+禁止：把回滚改成「尽量回滚，失败就记日志」；重写事务骨架。
+
+验收：
+  Feature: 一次结算要么全算，要么全不算
+    Scenario: 目标中途消失时回滚仍然完整
+      Given 一次命中打了多个目标
+      And 其中一个目标在结算过程中被别的效果销毁
+      When 这次结算失败并回滚
+      Then 所有已经发生的改动都必须被撤销
+      And 回滚过程本身不得抛出
+
+    Scenario: 服务没接好要报错，不要装作没有目标
+      Given 某个扇出内置需要的服务没有注册
+      When 它被执行
+      Then 必须抛出并点名缺失的服务
+      And 不得返回「命中零个目标」
+```
+
+**该跑：** `--filter "FullyQualifiedName~InstantEffectTransactionTests|FullyQualifiedName~EffectPhaseArchitectureTests|FullyQualifiedName~PhaseExecutionPathTests|FullyQualifiedName~PhaseListenerBatchHexTests|FullyQualifiedName~ResponseWindowRobustnessTests|FullyQualifiedName~RootBudgetTests|FullyQualifiedName~EffectCompositionSsotTests"`
+
+---
+
+### S5 · 容量三禁：静默丢弃 / 热路径扩容 / 死信号 【P1】
+
+**审查编号：** B5、B6、B7、B8、C6
+
+**任务书**
+
+```text
+目标：让 gas-layered-architecture.md 的「禁止固定容量溢出时静默丢弃、截断或在热路径扩容」
+在代码里真的成立，并把整条断线的容量遥测接上。
+
+三类违规，都已定位：
+
+一、静默丢弃
+  DeferredTriggerQueue：主缓冲与溢出缓冲皆满时直接 return 丢弃触发器，
+  唯一痕迹是 _attributeBudgetFused / _tagBudgetFused / _tagCountBudgetFused 三个标志，
+  而这三个标志有 public getter 但**全仓库没有任何读取点**。
+  后果：属性/标签变化触发器在高压帧被静默丢弃 —— 面板数字是对的，联动不响，极难定位。
+  改成抛，并点名容量与来源。
+
+  图 VM 的关系查询算子静默截断：出边超过 MaxTargets = 256 的实体，多出的目标无声消失
+  （RelationshipRuntime.CollectOutgoing 满即 break、只返回 count 不返回 dropped；
+  GraphTargetList.SetCount 再截一刀）。
+  对照组就在同一个文件里：空间查询算子做得完全正确 ——
+  默认 RequireComplete，dropped > 0 且未显式授权就抛 GAS.GRAPH.ERR.SpatialQueryIncomplete，
+  AllowTruncated 必须显式声明并把 dropped 写进输出寄存器。
+  照抄空间查询那套策略到关系查询算子上。注意 OwnershipResolver 的
+  CollectOutgoingOwned/CollectIncomingOwners 用 Array.Resize 重试，
+  恰好补上了 CollectOutgoing 缺失的 dropped 语义 —— 可以参考它的信息，但别照抄扩容做法。
+
+二、热路径扩容
+  RuntimeEntitySpawnSystem 三处 _effectRequests.Reserve(Count + OverflowCount + N)，
+  而 Reserve 是真扩容（换两条更大的数组 + 搬运溢出环，只增不减）。
+  这把本该抛的 CapacityExceededError 变成了静默堆增长。
+  注意相邻分支写得很对：队列服务缺失时直接抛 —— 说明作者是有意识要保证容量够的，
+  只是选的手段恰好是被禁的那个。改成容量断言（不够就抛，让调用方或配置去调容量）。
+
+三、死信号（这一类比缺功能更糟：它让人以为有防护，而测试还在盖章）
+  EffectRequestQueue._dropped 全文没有任何自增，DroppedCount 恒为 0，
+  而测试里有 Assert.That(q.DroppedCount, Is.EqualTo(0)) —— 恒真的空断言。
+  _budgetFused 置位后终身为真、无人读、Clear/ConsumePrefix 都不复位。
+  BuiltinHandlerExecutionContext.DroppedCount 的唯一写入者 AddDropped 的入参
+  来自 TargetResolverFanOutHelper.ValidateAndCollect 的 ref int dropped，
+  而该方法从不给它赋值（容量与预算超限都是直接抛）。
+  于是 GasBudget.EffectProposalFanOutDropped 与 EffectApplicationSystem._fanOutDropped 也恒为 0。
+  决策：要么真接线（有丢弃就计数并上报），要么整套删掉。
+  留着「有 getter 没有写入方」是最坏的选项。同时把那条恒真断言删掉或改成有意义的断言。
+
+顺带：
+  EffectRequestQueue.Clear() 是 _count = 0 之后 RefillFromOverflow() ——
+  如果主缓冲里还有未消费项会被无声丢弃，且回灌溢出环。
+  Core 生产系统不调它（用的是 ConsumePrefix），但 showcase mod 有 4 处在调：
+  GraphOpsHeadlessGameEngine（换展厅）、AttrNodeDriver、SandboxNodeDriver、EventNodeDriver
+  （后三个每拍都在调）。先确认没有调用方依赖「Clear 后 refill」这个行为，
+  再把 Clear 的语义改成真清空（含溢出环与熔断位）。
+
+禁止：用「把容量调大」代替失败关闭；保留任何「有 getter 无写入方」的遥测字段。
+
+验收：
+  Feature: 容量到顶时要说话
+    Scenario: 延迟触发器队列满时必须失败关闭
+      Given 一帧内产生的属性变化触发器超过了队列容量
+      When 主缓冲与溢出缓冲都已满
+      Then 系统必须抛出并点名容量与来源
+
+    Scenario: 关系查询捞不全时必须失败关闭
+      Given 一个实体的关系边数超过了单次查询的上限
+      When 一张图对它做关系查询而没有显式允许截断
+      Then 执行必须失败并说明被丢掉了多少
+      And 显式允许截断时，被丢掉的数量必须能被作者读到
+
+    Scenario: 生成实体时容量不够要报错，不要偷偷扩容
+      Given 一批生成请求需要的效果队列容量超过了当前容量
+      When 系统预检容量
+      Then 必须抛出并说明需要多少
+```
+
+**该跑：** `--filter "FullyQualifiedName~GraphFailFastAndCapacityTests|FullyQualifiedName~DeferredTriggerCollectionTests|FullyQualifiedName~DeferredTriggerTests|FullyQualifiedName~GasExecutionBudgetTests|FullyQualifiedName~RootBudgetTests|FullyQualifiedName~PhaseListenerBatchHexTests"`
+
+---
+
+### S6 · 退役展厅锁门 + 停止清空图编号表 【P1】
+
+**审查编号：** `pr932_graph_landed_architecture_audit.md` B2（本轮 B25 提供了根因）
+
+**任务书**
+
+```text
+目标：把八间已宣布退役的家族展厅的门真锁上，并停止在 mod 运行时清空引擎的图编号表。
+这两件事单独看都只是 Major，叠在一起才是阻断 —— 玩家点得进去，而进去就破坏核心注册表。
+
+现状：
+  登记表这边做干净了：八条 status=retired、preset=null。
+  但 binding 八条全留着，launcher.config.json 里八条 binding 全是活的；
+  启动器 launchHint() 先看 binding、完全不看 status，
+  于是每张退役卡照样吐出可复制的启动命令。
+  而 Rel / Query 两间在 GameStart 上对活引擎直呼 BindStandaloneFromModAssets()，
+  落到 bootstrap 的 GraphIdRegistry.Clear()；
+  Attr / Spatial / Event 三间的 bootstrap 里也有同一句。
+  GraphIdRegistry.Clear() 连 _frozen 一起复位、_nextId 归 1，
+  而引擎在 init 期已注册全部图编号，实例级 GraphProgramRegistry 仍按旧编号存程序
+  —— 同进程两套编号空间打架。
+
+第一步（锁门）：
+  1) showcase.registry.json 里八条 capability_standard_graph_ops_* 的 binding 置 null。
+     正确先例是 physics2d_playground（退役时 binding 与 preset 双 null + 豁免）。
+  2) launcher.config.json 删掉对应八条 binding。
+  3) scripts/validate-registry.py 强制 registry binding 与 launcher binding 双向一致，
+     所以要按它的 exemptions(kind=binding) 机制补豁免，
+     或改规则让 retired 条目允许 binding=null —— 二选一，写清理由，不要留静默特例。
+     注意这条规则目前形成了反向激励：退役条目一旦删掉 binding 就会校验失败，
+     机制上鼓励「留着门」。改规则是更根本的做法。
+  4) 启动器侧：src/Tools/Ludots.Launcher.React/src/lib/showcase.ts 的 launchHint
+     与 components/ShowcasePanel.tsx 必须让 status=retired 不再产出可复制的启动命令。
+
+第二步（停止清表）：
+  删掉这五处生产 mod 代码里的 GraphIdRegistry.Clear()：
+    GraphOpsRelShowcaseBootstrap / GraphOpsQueryCatalogBootstrap /
+    GraphOpsAttrGraphBootstrap / GraphOpsSpatialCatalogBootstrap / GraphOpsEventGraphBootstrap
+  Rel 与 Query 的 ModEntry 还在 GameEvents.GameStart 上对活引擎调
+  BindStandaloneFromModAssets() —— 这条也要断掉。
+  清表是测试夹具的需求，不是 mod 运行时的需求；测试侧需要就在测试里做。
+  并给那六个未标注的 fixture 补 [NonParallelizable]（今天只有 Rel/Query 标了，
+  而五个 bootstrap 都会清进程级静态注册表 —— 这是 CI 串扰风险）。
+
+顺带记录（不在本票范围，但请在 PR 里链出来）：
+  GraphIdRegistry.Clear() 是 public static 且连 _frozen 一起复位，这是设计缺陷本身；
+  静态注册表的 freeze 合同还不一致（属性表 Clear 在冻结时抛，
+  标签表/效果模板表/技能表/图表全部静默解冻）。根治属于 S14 的范围。
+
+禁止：删掉八家族 Mod 本身（那是本票关门之后的独立票）；改动逐节点展厅。
+
+验收：
+  Feature: 划掉的门要真的锁上
+    Scenario: 退役展厅不再给出可点的入口
+      Given 登记表里某个展厅已经标成退役
+      When 我在启动器里翻到它
+      Then 卡片上不得出现可复制的启动命令
+      And 顶栏的预设列表里也翻不到它
+
+  Feature: 进一间展厅不该弄坏别的展厅
+    Scenario: mod 启动不再清空引擎的图编号表
+      Given 我启动任意一个展厅
+      When 该展厅的 mod 完成初始化
+      Then 引擎在启动期注册的图编号必须全部仍然有效
+```
+
+**该跑：** `python3 scripts/validate-registry.py`；`--filter "FullyQualifiedName~GraphOpsRelShowcaseAcceptanceTests|FullyQualifiedName~GraphOpsQueryShowcaseAcceptanceTests|FullyQualifiedName~GraphOpsAttrShowcaseAcceptanceTests|FullyQualifiedName~GraphOpsSpatialShowcaseAcceptanceTests|FullyQualifiedName~GraphOpsEventShowcaseAcceptanceTests|FullyQualifiedName~GraphOpsNodeGallery"`
+
+---
+
+### S7 · 展厅血条名实相符 + 删掉静默回卷 【P1】
+
+**审查编号：** `pr932_graph_landed_architecture_audit.md` B3
+
+**任务书**
+
+```text
+目标：让玩家看到的血条代表它声称代表的东西，并删掉一条藏在代码里的暗规则。
+
+现状（数字来源是真的，落地方式不是）：
+  每间展厅先跑真 VM（真 BuiltinHandlerRegistry / EffectTemplateRegistry / EffectRequestQueue 根），
+  取出寄存器里的数 —— 这一半是对的，保留。
+  但把这个数变成血条那一步是 next -= 图返回值 之后
+  AttributeMutationOps.SetBase/SetCurrent 直接写属性，不走任何效果结算；
+  而且 LinearNodeDriver 里有 if (next <= 0f) next = opening;
+  —— 血要掉到 0 就静默回卷成开局值，而这条规则不在任何分镜数据里。
+  EventNodeDriver 也有同类回卷。
+  C# 影子数组 ctx.ActorHealth 每拍被 SyncHud 无条件刷回世界。
+
+  重要背景：这套写法之所以「看起来无害」，是因为血量恰好是配了夹上限约束的属性
+  （实测：同样写法换到不夹上限的属性上会被聚合器静默丢弃）。
+  也就是说现状能用是运气，不是设计。
+
+要做：
+  一、删掉静默回卷（这是 NO FALLBACK 红线）
+    本该「打死了」的时刻被静默改写成「满血重来」。两条路选一条：
+    删掉让它失败关闭，或者把「循环 / 复位」写成分镜里的显式字段（推荐后者，数据驱动）。
+    禁止留在 C# 里。
+
+  二、把「演戏」与「真结算」分开处理，不要一刀切
+    - 真有结算语义的 op（ApplyEffect* / FanOutApplyEffect* / ModifyAttributeAdd /
+      WriteSelfAttribute 等）：走正式效果管线，让血条反映真结算。
+      参照 AttrNodeDriver.Tick 那条已经干净的路
+      （ExecuteFeaturedGraph + SyncActorHealthFromWorld，C# 只读回来）。
+    - 纯算式 op（AddFloat / ClampFloat 之类，图本身不改世界）：血条不是它的正确表达。
+      要么改用非血量的指示物，要么在分镜与展厅简介里说清「这根条是示意」。
+      今天 showcase.registry.json 的 AddFloat 简介写「血条按总和往下掉」，
+      玩家会理解成真结算 —— 文案与实现必须对齐，改哪边都行但必须一致。
+
+  三、ScriptNodeDriver 把「茶水量」写进 ActorHealth，属于血条被当通用数值槽复用，同上处理。
+
+禁止：
+  动知识披露与头顶条那一侧（那一侧是对的，别改坏 —— 披露走真 KnowledgeProjectionStore
+  与 WorldHud 属性掩码，六角圈人那三间的语义完全干净并有测试逐档断言）；
+  改测试门槛来掩盖；把 ctx.ActorHealth 影子数组的读写方向搞反。
+
+验收：
+  Feature: 血条要么代表真被打掉的血，要么别装成那样
+    Scenario: 打到零不许偷偷回满
+      Given 一间展厅里这一刀足以把木桩的血打到零
+      When 这一刀结算
+      Then 结果必须由数据决定，而不是被代码悄悄改回满血
+
+    Scenario: 展厅简介不能承诺它没做的事
+      Given 某间展厅的图只是做纯算术，不改世界
+      When 我读它的简介
+      Then 简介不得让我以为血条是被真打掉的
+```
+
+**该跑：** `--filter "FullyQualifiedName~GraphOpsNodeGallery"`；`python3 scripts/validate-registry.py`
+
+---
+
+### S8 · 假防线集中整治 【P2】
+
+**审查编号：** B7、B26、B27、B28、以及 `pr932` M3/M4 的守卫强度部分
+
+**任务书**
+
+```text
+目标：让名字里写着「零分配 / 基准 / 五毫秒」的测试真的在守门。
+这一票纯改测试，不动生产代码，但它决定了其他所有修复以后守不守得住。
+投入最小，收益最高，建议早做。
+
+真有牙齿的零分配断言目前只有 6 条（AllocationTests 4 条 + MathOpsChain 1 条
++ EntityCollection 1 条）。以下是「测了不断言」或「断言恒真」的清单：
+
+一、测了不断言（只 Console.WriteLine）
+  - GraphPerfTests.cs 整个文件零断言。Benchmark_GraphExecutor_SmallProgram
+    跑 100 万次图 VM、算出分配字节数、打印、结束。
+    这是图 VM 唯一的零分配基准，它只能因为抛异常而失败。
+    另：它没有兄弟基准都有的 [Category("benchmark")]。
+  - GasBenchmarkTests.cs 8 个 benchmark、5 个测分配，
+    全文件只有 2 句关于触发器计数的断言，没有一句关于分配或耗时。
+    第 74 行还写着注释「Assert & Log」，实际只有 Log。
+  - EffectPhaseStressTests.PhaseExecutor_HighVolume_ReportsThroughputAndGc
+    算了 allocDelta、打印、不断言。
+  - GraphBehaviorPressureMatrixTests.WritePressureMatrices_M1_M2_M3_M6
+    全文件 3 句断言全是 File.Exists —— 只保证 CSV 被写出，不保证数字在任何范围内。
+    （附带证据：跑一次测试后 docs/benchmarks/graph-behavior-pressure/matrix-m*.csv
+    就会变成 modified，说明这些数字会漂移且无人把关。）
+  处理：先跑一遍读 stdout 里的分配数字。如果为零，直接补成断言；
+  如果非零，说明存在真实但无人看管的分配 —— 那就是一条新发现，单独开票。
+
+二、断言恒真（比不断言更糟，因为它在盖章）
+  - GraphFailFastAndCapacityTests 里 Assert.That(q.DroppedCount, Is.EqualTo(0))：
+    该计数器全文没有任何自增，恒为 0。删掉或改成有意义的断言（与 S5 联动）。
+
+三、注释/命名与断言不符
+  - EffectPhaseStressTests.PhaseExecutor_HighVolume_...：注释写「<10μs per phase」，
+    断言是 Is.LessThan(50.0) —— 差 5 倍。
+  - BlackboardOps_Stress_MassWriteRead_ZeroGc：名字带 ZeroGc，
+    唯一性能断言是 TotalSeconds < 30.0；更麻烦的是它测不了自己 ——
+    CallStack = new int[MaxCallStackDepth] 在被测循环体内，
+    每次迭代分配一个新数组，测量区间自己污染自己。先把分配移出循环，再补断言。
+  - BehaviorTreeRuntimeTests.ThinkWave_10k_AlwaysSuccess16_UnderFiveMilliseconds：
+    断言 Is.LessThan(15.0)，裸断言无消息。
+  - FsmRuntimeTests.ThinkWave_10k_SentryHfsmWithScripts_UnderFiveMilliseconds：
+    断言 15.0（消息如实写了 15）。
+  处理：让名字、注释、断言、失败消息四者一致。
+  门槛该放宽就放宽（CI 抖动是真的），但名字必须跟着改。
+  参考正面例子：GraphBehaviorArenaAcceptanceTests 的三重门槛
+  （over5ms == 0 + avg < 15 + p95 < 15）名实相符且三条都带消息。
+
+四、覆盖缺口
+  - 4 条真断言覆盖的是 proposal / 瞬时效果 / 关系事务 / listener 派发，
+    完全没覆盖持续效果的 tick 循环：EffectApplicationSystem、AttributeAggregatorSystem、
+    EffectLifetimeSystem、TimedTagExpirationSystem、DeferredTriggerCollectionSystem。
+    而「每帧两次 archetype 迁移」（见 S9 顺带项 / B9）恰好就发生在这些没被测的系统里。
+    至少给持续效果的 tick 补一条零分配断言。
+
+五、顺序守卫其实不守顺序
+  - ArchitectureGuardTests.SystemGroup_MustMatchDesignDocument 用
+    Assert.That(Enum.GetNames<SystemGroup>(), Is.EquivalentTo(expected)) ——
+    EquivalentTo 是集合相等，不比较顺序。把 Cleanup 挪到最前面它照样绿。
+    改成按序比较，并且交叉校验 enum 与
+    PhaseOrderedCooperativeSimulation.PhaseOrder 两份列表（今天一致但无守卫）。
+    另：正式顺序表缺 RuntimeEntityBinding，而它有 9 处生产用法 —— 一并补上。
+    还要补一条：某个组在 enum 里有、在 PhaseOrder 里漏了，必须失败
+    （今天是注册进去的系统每帧都不跑且无任何诊断）。
+
+六、守卫层自己的债（可以同票做，也可以拆出去）
+  - 两个 ArchitectureGuardTests 同名同 namespace、37 个方法逐字节相同的复制，
+    合计 144 次 ReadAllText + 6 次反射。
+  - 而 gas-order-input-runtime-contract.md 明文写着「不得用 ReadAllText + Contains
+    复述源码实现；需要静态门禁时使用编译后的 API、Roslyn/analyzer」——
+    守卫层违反了它守的合同。
+    至少先去重（留一份）；改成 IL/Roslyn 门禁可以单独开票。
+
+禁止：为了让测试变绿而放宽任何真实门槛；删掉测试而不替换等价覆盖。
+
+验收：
+  Feature: 零分配的承诺要有人守着
+    Scenario: 名字里写零分配的测试必须断言分配量
+      Given 一批名字包含 ZeroAlloc / Benchmark / ZeroGc 的测试
+      When 我检查它们的断言
+      Then 每一条都必须对分配量下断言
+      And 断言的数值必须与方法名和注释一致
+
+    Scenario: 顺序守卫必须真的守顺序
+      Given 我把系统阶段的顺序打乱
+      When CI 跑架构守卫
+      Then 守卫必须失败
+```
+
+**该跑：** `--filter "FullyQualifiedName~AllocationTests|FullyQualifiedName~GraphPerfTests|FullyQualifiedName~GasBenchmarkTests|FullyQualifiedName~EffectPhaseStressTests|FullyQualifiedName~EntityCollectionQueryBenchmarkTests|FullyQualifiedName~AiBenchmarkTests|FullyQualifiedName~BehaviorTreeRuntimeTests|FullyQualifiedName~FsmRuntimeTests|FullyQualifiedName~GraphBehaviorArenaAcceptanceTests" --logger "console;verbosity=detailed"`
+另跑 `src/Tests/ArchitectureTests/ArchitectureTests.csproj --filter "FullyQualifiedName~ArchitectureGuardTests"`
+
+---
+
+### S9 · L2 宿主走 L1 正式执行前门（引入执行帧） 【P2 · 依赖 S1】
+
+**审查编号：** A5、B15、B16、B17、C13
+
+**任务书**
+
+```text
+目标：让所有图执行都经过同一道有校验的门，并让「部分初始化的执行状态」在类型上不可能出现。
+
+现状：
+  L1 的正式执行前门 GraphExecutor 每个入口都先 RequireKind 再 RequireAllowed，
+  ExecuteScriptSlice 还额外检查六个寄存器 span 的尺寸。
+  它在生产代码里零调用者 —— 只有 3 个测试文件用。门造好了没人走。
+  四个生产切片宿主全部直接调 GasGraphOpHandlerTable.ExecuteSlice，三项检查全跳过：
+    BehaviorTreeWorld / GraphProgramHfsmHost（连 RequireKind 都没有，
+    Effect 图挂成状态机条件能跑到 NRE）/ LevelScriptPrograms
+  run-to-halt 侧另有 EffectPhaseExecutor / PerformerRuleSystem /
+  GraphReturnWriter / AbilityAimPresentationRuntime 也是直连。
+  （run-to-halt 的 ExecuteValidation/ExecuteScore/ExecuteDerived 确实有生产调用方，
+  那半边门是真的。）
+
+  根因：GraphExecutionState 是 15 字段的 ref struct，没有构造不变式，
+  部分初始化合法，全仓 11 个手工构造点完整度各不相同。
+  最刺眼的后果：Programs 字段除了测试专用入口与嵌套子帧之外没有任何宿主填写，
+  而 HandleInvokeScript 首行 if (s.Programs == null) throw ——
+  所有生产执行路径都写得出 InvokeScript，一个都执行不了。
+  范围包含 Effect 阶段、Query 输出、Performer 条件、Aim 预览，不止 L2 三个宿主。
+
+要做：
+  1) 引入执行帧类型（GraphFrame 或等价）：持有寄存器存储 + cursor + kind + api + programs，
+     由 VM 构造并一次性验证。宿主拿帧，不拿裸 ref struct。
+  2) 把 GasGraphOpHandlerTable.Execute / ExecuteSlice 收成 VM 内部，
+     对外只暴露经过校验的入口。
+  3) 七个直连点全部改走新入口。特别注意 GraphProgramHfsmHost 今天连 kind 都不查。
+  4) 图号是裸 int，没有 typed id 承载 kind ——
+     行为树节点、状态机转移条件、关卡脚本的 graphId 字段建议改成带 kind 的 typed id，
+     让「把 Effect 图塞进行为树叶子」在类型层面就不可能。
+     如果这一步太大，至少在绑定时校验并失败关闭。
+  5) 顺带收口 E[2] 的三种不同预置含义（Viewer / TargetContext / previewTarget）——
+     今天它是潜伏的（没有节点能读到预置值，Load* 全读 state 字段），
+     但新帧模型应该把它定义清楚。
+
+同票一并修两条相关的执行模型问题：
+  - 掉出程序尾部被当成「成功停机」：(uint)pc >= (uint)program.Length → Halted + 返回成功，
+    负 pc 也走这条。任何坏跳转都被报成正常完成。
+    注释把它写明为「既有 GAS 图掉出尾部算成功完成」—— 一条兼容性 fallback 焊进了 VM 内核。
+    改成要求显式终结指令 + 装载期校验跳转目标，pc 越界即错误。
+  - GraphExecutionStatus 把「未开始」与「预算耗尽挂起」压在同一个 Running 上，
+    而 BehaviorTreeWorld 的续跑判断只认 Yielded：
+      bool resumeYield = cursor.Status == GraphExecutionStatus.Yielded;
+      if (!resumeYield) { ints.Clear(); bools.Clear(); callStack.Clear(); cursor.Reset(); }
+    所以 action 叶子一旦因预算耗尽返回 Running，下一拍寄存器清空、cursor 归零、
+    脚本从 pc=0 静默重跑，已产生的副作用重放。这是个真 bug，不是瑕疵。
+    把状态区分开（未开始 / 挂起于 Yield / 挂起于预算），并补测试。
+
+顺带（可选，与 B17 相关）：
+  程序校验目前发生在每次执行而非登记时。RequireAllowed 是 O(程序长度) 全扫、
+  每次执行都跑（登记时已跑过一次）；EffectPhaseExecutor.AnalyzeScratchUsage 是第二遍全扫，
+  而它是全系统唯一的寄存器越界校验 —— 其余宿主一概没有，越界只表现为
+  span 的 IndexOutOfRangeException 而非失败关闭诊断。
+  建议在 GraphProgramRegistry.Register / ReplaceProgram 里跑一次统一的程序校验器
+  （kind 能力 + 寄存器边界 + 分支目标 + 终结指令），之后热循环零前置校验。
+  这一步会顺手把两遍 O(n) 全扫从热路径拿掉。
+
+禁止：在本票里拓宽 Script 方言（那是 S13，必须在本票之后）；
+      为了让 L2 跑通而放宽 kind 校验。
+
+验收：
+  Feature: 所有图执行走同一道门
+    Scenario: 图的种类不对必须被拒绝
+      Given 我把一张效果图绑到行为树的叶子上
+      When 代理执行到这个叶子
+      Then 必须失败并说明这个种类的图不能挂在这里
+
+    Scenario: 坏跳转不能被报成正常完成
+      Given 一张图里有一个跳到程序外面的跳转
+      When 这张图被登记
+      Then 登记必须失败并指出这个跳转
+
+  Feature: 跨拍的动作要接着跑，不要重头再来
+    Scenario: 预算耗尽后从断点继续
+      Given 一个行为树叶子里的动作因为当拍预算耗尽而挂起
+      When 下一拍继续
+      Then 它必须从断点继续，而不是从头重跑
+      And 已经产生的效果不得重复发生
+```
+
+**该跑：** `--filter "FullyQualifiedName~Ludots.Tests.Gas.AI|FullyQualifiedName~GraphExecuteSliceBudgetTests|FullyQualifiedName~GraphScriptControlFlowTests|FullyQualifiedName~GraphContractTests|FullyQualifiedName~EffectPhaseArchitectureTests|FullyQualifiedName~LifecycleArchitectureTests"`
+
+---
+
+### S10 · 表现层不得决定玩法选中 【P2】
+
+**审查编号：** A6、C22
+
+**任务书**
+
+```text
+目标：让「谁能被选中、谁能收指令」只由模拟状态决定，不由相机剔除结果决定。
+
+现状：
+  CommandSourcePointerHitResolver 与 CommandSourceAcquisitionSystem 的选中查询签名是
+  (Entity, ref VisualTransform, ref CullState, ref CommandSourceSelectableTag)，
+  两处都以 if (!cull.IsVisible) return; 开头。
+  CommandSourceAcquisitionSystem 由 CoreInputMod 经
+  InsertSystemBeforeRequired<AxisMoveOrderSystem>(..., SystemGroup.InputCollection)
+  装进模拟循环。
+  含义是：相机剔除结果（视觉）决定了哪个实体能被选中，从而决定谁能收到订单。
+  同时违反两份合同：
+    entity-simulation-layering.md：CullState 只负责视觉，不得作为剔除真相
+    gas-order-input-runtime-contract.md：Core 不读取表现层 VisualTransform 作为玩法真相
+  全仓的架构守卫里 VisualTransform 出现次数为 0 —— 这个方向零守卫。
+
+要做：
+  1) 选中判定改用模拟侧真相：位置用 WorldPositionCm，可选中性用玩法组件
+     （CommandSourceSelectableTag 本身是玩法组件，保留），
+     可见性若确实需要参与判定，必须用玩法侧的知识/视野投影
+     （KnowledgeProjectionStore 已经是正式通道），不是相机剔除。
+  2) 补守卫：模拟相（InputCollection / AbilityActivation / EffectProcessing /
+     AttributeCalculation 等）的系统不得读 VisualTransform / CullState。
+     ArchitectureGuardTests 已有 IL 级调用扫描基建可复用。
+  3) 顺带把跨层组件的所有权写清楚（今天没有任何机制表达）：
+     PresentationStableId 由模拟侧多处写、表现侧读；
+     PresentationDestroyPending 模拟侧多处读写、表现侧消费，连 L0 的
+     GasGraphRuntimeApi 都在读它；
+     CullState 由 RuntimeEntitySpawnSystem（模拟）创建、CameraCullingSystem（表现）写、
+     Input（模拟）读 —— 三方读写、无声明 owner。
+     entity-simulation-layering.md 的「单写真相规则」在代码里没有任何执行体。
+     本票至少给这三个组件写明 owner 并加守卫；partial-world 隔离属于 S14。
+
+禁止：把剔除标记改名了事；用「反正现在能用」保留视觉 gate。
+
+验收：
+  Feature: 镜头看不看得见，不该决定我能不能指挥
+    Scenario: 镜头外的单位仍然可以被指挥
+      Given 我的一个单位当前不在镜头范围内
+      When 我通过编队或框选对它下指令
+      Then 指令必须生效
+    Scenario: 模拟系统不得读表现层组件
+      Given 一个跑在模拟相里的系统
+      When CI 跑架构守卫
+      Then 若它读了视觉变换或剔除状态，守卫必须失败
+```
+
+**该跑：** `src/Tests/ArchitectureTests/ArchitectureTests.csproj --filter "FullyQualifiedName~ArchitectureGuardTests|FullyQualifiedName~Rfc0065InteractionCastingBoundaryContractTests|FullyQualifiedName~PerformContractsAndLegacyLaneTests"`；`--filter "FullyQualifiedName~OrderBufferSystem|FullyQualifiedName~CommandSource"`
+
+---
+
+### S11 · 覆盖表错误归因 + 守卫强度 【P2】
+
+**审查编号：** `pr932_graph_landed_architecture_audit.md` M3、M4
+
+**任务书**
+
+```text
+目标：让覆盖表的「已覆盖」是被度量出来的，而不是被结构保证的。
+
+现状：
+  覆盖表 120 条，unitTestFilter 有 21 条错误归因 —— 登记的画廊测试根本不执行那个 op。
+  最典型：事件族 15 个 op 全指向 SnapToNearestInCollection_SucceedsWithPlayerCaption
+  （一个单 op 测试），而 SendEvent_BroadcastsPlayerReadableHit、
+  ClampTargetToRange_PullsLandingPointInRange、LoadViewer_ReadsTheAudience、
+  KnowledgeHasProjection_ShowsVisible、SnapToNearestGraphEdge_SnapsOntoTheRoad
+  就在同一个类里却零引用；
+  ConstFloat / AddFloat 指向 FloatFamilyOp_RendersPlayerCaption，
+  而那个 TestCaseSource 数组里没有这两个 op。
+
+  守卫抓不到的原因（这是根因，比表面数字更重要）：
+    1) LoadGasTestMethodNames 只按方法名建集合、丢掉类名，
+       校验时只问「全 GasTests 里有没有这个方法名」。
+    2) hasGalleryTest 只检查前缀是否 GraphOpsNodeGallery，
+       而那两条 token 是生成器无条件注入的 —— 生成器写什么守卫就查什么，闭环自证，
+       这条断言永远不可能失败。
+    3) 生成器的 DRIVER_FAMILY_TEST 按 driver 字段盲配，
+       不校验该 op 是否在被配测试的 op 列表里 —— 这是 21 条错误归因的产生机制。
+    4) status 只剩 covered 一个合法值（生成器拒绝非 covered，守卫也把非 covered 记为 failure），
+       P2 计划里的 missing / runtime-only 已无法表达。
+
+要做：
+  1) 守卫改成 (类, 方法) 对，而不是方法名集合。
+  2) 更重要：守卫要能校验「被引用的测试真的执行该 op」——
+     需要能展开 [TestCaseSource] / [TestCase] / 方法内 op 数组字面量。
+  3) 生成器改成：只有该 op 真在目标测试的 op 列表里才写进 filter；
+     否则指向它的 op 专属测试（很多已经存在，只是没被引用）；
+     都没有就让生成器失败关闭。
+  4) hasGalleryTest 改成要求至少一条 op 专属画廊测试。
+  5) 把 ExistingVignettes_CompileWithFeaturedOp（唯一断言编译产物真的
+     emit 了那个 opcode 的测试）与 GeneratedMaps_SpawnEveryVignetteActor 纳入 filter，
+     今天它们引用次数是 0。
+  6) unitTestFilter 字段名与内容不符：它是分号拼接的裸 Class.Method，
+     不是可运行的 filter 表达式，生成器还主动剥掉 FullyQualifiedName~ 前缀。
+     要么改成真可运行的表达式，要么改字段名。
+  7) 补一条 CI 闸门：跑生成器并比对是否有漂移。
+     今天 120/120 对齐是人工正确，不是机制保证 ——
+     .github/workflows/ 全目录没有该脚本的引用。
+     （已实测：当前复跑零漂移，所以这条闸门加上去就是绿的。）
+  8) 生成器只 upsert 不删除：退役或删掉一个节点会留下全套孤儿门
+     （binding / preset / registry 条目 / 薄入口 Mod / 画廊地图），
+     而 validate-registry.py 仍判通过（孤儿两边都在、双向一致）。
+     这正是八条家族 binding 残留的机制（见 S6）。加删除或加孤儿检测。
+
+禁止：为了让守卫变绿而把那 21 条改成 status=missing 了事 ——
+      那 21 个 op 大多有真测试，问题是指针指错了；
+      先修指针，确认真的有 op 没有专属测试再谈降级。
+
+验收：
+  Feature: 说覆盖了就要真的覆盖
+    Scenario: 登记的测试必须真的跑那个节点
+      Given 覆盖表给某个图节点登记了一条测试
+      When 守卫检查这条登记
+      Then 那条测试必须真的执行这个节点
+    Scenario: 生成器的产物不能被手改而无人知
+      Given 有人手改了生成器产出的文件
+      When CI 复跑生成器并比对
+      Then 必须失败并指出漂移的文件
+```
+
+**该跑：** `--filter "FullyQualifiedName~GraphNodeOpCoverageRegistryTests|FullyQualifiedName~GraphOpsNodeGallery"`；`python3 scripts/generate-graph-op-node-galleries.py --strict` 后 `git diff --exit-code`
+
+---
+
+### S12 · 寄存器归属与指令 descriptor 【P2 · 依赖 S9】
+
+**审查编号：** B14、B18、C12
+
+**任务书**
+
+```text
+目标：让寄存器索引有单一归属，让 kind × opcode 能力矩阵有单一数据源。
+
+一、寄存器（B14）
+  今天有三套互不相认的占位机制：
+    1) bump 分配器：AllocateOutputs 里 intNext++ / boolNext++ / floatNext++，
+       无 liveness 复用（约束是「产值节点数 ≤ 32」而非「同时活跃值 ≤ 32」）。
+       溢出是 RegisterOutOfRange 编译错 —— 这点是对的，保留。
+    2) 作者手填 PinRegister：只对 int 生效，且只在 intNext <= pin 时抬高 intNext。
+       pin 小于当前 intNext 时没有任何诊断 —— 静默与已分配寄存器别名。
+    3) 硬编码常量 scratch：TargetListGet 与 SnapToNearestInCollection 的 validOutput
+       都写死 B[31]（MaxBoolRegisters - 1）。
+  而唯一做对的分配器 AllocateSugarScratches 是按 used-set 找空位的，
+  但它的 used-set 只包含 outputRegisters，不包含 B[31] ——
+  bool 用满 31 个时它会把糖的 scratch 分到 31，第三次相撞。
+  再叠上宿主侧的 ABI 槽：B[0] = Validation 判定、F[0] = Score 分数、
+  I[0] = 行为树 sensor、B[31] = scratch。这四个槽的 SSOT 不在代码里任何一处
+  （B[0] 写在 placement-validation-ssot.md，F[0] 写在 graph-funclib-actionlib-contract.md），
+  而 int/bool/float 分配器都从 0 开始。只有 entity 有真 ABI 并被分配器遵守
+  （E0 caster / E1 target / E2 viewer，entityNext = 3）。
+
+  要做：一个 GraphRegisterFile 类型，持有「按 kind 声明的保留槽 + used-set + 分配 + AllocScratch()」。
+  GraphVmLimits 只提供容量。任何 scratch 必须走 AllocScratch()，
+  常量索引在编译器里被禁止出现。PinRegister 别名必须报诊断。
+  liveness 复用可以后置 —— 它是容量问题，前面这些是正确性问题。
+  顺带：上限 32 不是瓶颈（32 个 float 才 128 字节），真正的天花板是
+  GraphInstruction 的 Dst/A/B/C 是 byte（最多 255），所以 32 → 64 几乎零成本，
+  但先别顺手改容量，先把归属收干净。
+
+二、能力矩阵（B18）
+  前门是三张手写 op 列表（线性 86 / 查询 41 / Script 11），
+  一张线性表被 4 个 kind 共用，而这 4 个 kind 有 3 套不同策略。
+  缝隙已量化：Score / Validation / Derived 各有 19–20 个「前门允许但策略拒」
+  （策略在装载期赢，所以是失败关闭，不是漏洞 ——
+  但作者拿到的诊断是「操作不被 kind 允许」而不是「这个节点在这个方言里不存在」）；
+  各 kind 另有 33–89 个「策略允许但前门写不出」。
+  GraphKindOperationPolicy 半数据驱动，外加 3 处硬编码例外
+  （Yield 只给 Script、Derived 额外放 WriteSelfAttribute、listener 的三个 LoadConfig*）。
+  没有任何测试断言「前门 ⊆ 策略」。
+
+  要做：一张 per-op descriptor 表（kinds × ports × operand roles）作为唯一数据源，
+  前门矩阵、GetLinearOutputType / GetQueryOutputType、端口白名单、
+  覆盖表的 authorableKinds 全部由它投影。
+  GraphKindOperationPolicy 的 3 处例外变成 descriptor 上的字段。
+  补一条「前门 ⊆ 策略」的一致性断言。
+
+三、指令编码（C12，同批做成本最低）
+  GraphInstruction 只有 Op/Dst/A/B/C/Flags/Imm/ImmF，
+  而 GraphInstructionFlags 只定义了 1 个 bit。实际 Flags 承担至少 7 种含义
+  （bool 寄存器索引、空间容量策略、relationship typeId、排序 descending、
+  teamId 来源选择、EffectArgs float 个数、FuncLib 标记），
+  Dst 承担 4 种（目标寄存器 / relationship typeId / reasonId / dispatch preset id）。
+  这套语义必须在三处一致：编译器 emit、符号 patch、handler。
+  descriptor 表落地后，operand role 应当由它声明。
+  同时修一个真问题：GraphProgramSymbolPatcher.Patch 不是幂等的 ——
+  它把符号索引原地覆写成解析后的 id，第二次跑会把 id 当符号索引再解析
+  （静默错绑或越界抛）。热改路径值得单独查一遍。
+
+禁止：在本票里改容量上限；发明新的 opcode。
+
+验收：
+  Feature: 两个节点不会抢同一个格子
+    Scenario: 所有临时格子都由分配器发放
+      Given 一张图同时用到了目标列表读取和吸附的有效位
+      When 它被编译
+      Then 这两个输出不得落在同一个格子上
+    Scenario: 作者钉的格子与已分配的冲突时要报错
+      Given 我把某个节点的输出钉到一个已经被分配出去的格子
+      When 这张图被编译
+      Then 编译必须失败并指出冲突
+
+  Feature: 文档说能写的节点，作者真写得出
+    Scenario: 前门与能力策略不得互相矛盾
+      Given 任意一个图种类
+      When 我列出前门允许写的节点，与能力策略允许执行的节点
+      Then 前者必须是后者的子集
+```
+
+**该跑：** `--filter "FullyQualifiedName~GraphControlFlowConfigCoverageTests|FullyQualifiedName~GraphContractTests|FullyQualifiedName~GraphEffectAuthoringExpressivenessTests|FullyQualifiedName~GraphQueryControlFlowTests|FullyQualifiedName~GraphNodeOpCoverageRegistryTests|FullyQualifiedName~LiveGasEditPipelineTests"`
+
+---
+
+### S13 · Script 方言拓宽 + L2 作者面 【P2 · 依赖 S9 + S12】
+
+**审查编号：** B19、B20
+
+**任务书**
+
+```text
+目标：让「一切皆 Mod」在 L2 上也成立。
+
+先读这条顺序依赖，它是硬的：
+  Script 方言今天只有 11 个可写 op（int 数学 + 控制流），
+  读不到属性、读不到黑板、做不了 float 运算、发不了查询。
+  于是行为树必须用 C# 的 IBehaviorTreeSensorFeed 把感知结果塞进 I[0]。
+  而三个 L2 宿主之所以能只填 I / B / CallStack 就跑，正是因为 Script 这么窄 ——
+  往 Script 矩阵里加任何一个 LoadAttribute / ReadBlackboard* / Query* 类的 op，
+  行为树 / 状态机 / 关卡立刻崩：F / E / Targets 是零长 span，Api 与 Programs 是 null。
+  所以必须先做 S9（宿主拿到完整执行帧），再做本票。反了必崩。
+
+要做：
+  1) 拓宽 Script 方言的能力矩阵（经 S12 的 descriptor 表），
+     让 L2 叶子能自己读属性、读黑板、做查询。
+  2) 给 L2 一个数据作者面。今天 AI 配置覆盖 Utility / GOAP / HTN / atoms /
+     projections / bindings，但没有行为树、没有状态机 ——
+     拓扑只能在 C# 里用 BehaviorTreeFactory / HfsmFactory 造。
+     需要 JSON schema + loader，让 mod 能定义自己的树与状态机。
+  3) 把住在 Core 的玩法语义搬出去：
+     HfsmFactory.CreateSentryHierarchy(WithScripts) 的完整状态机拓扑
+     （Idle → Alert → Combat → Retreat）、
+     BehaviorTreeFactory.CreatePatrolChaseAttackTree 的整棵巡逻-追击-攻击树、
+     以及 BehaviorTreeScriptKeys / HfsmScriptKeys / LevelScriptKeys 里的 11 个名字。
+     这 11 个名字同时又是 action_lib.json 的全部条目名 —— 同一份内容两个 SSOT，
+     搬出去的同时把 SSOT 收成一份。
+  4) L2 叶子调纯算式清单：三个宿主构造执行状态时都不填 Programs，
+     而 InvokeScript 首行就检查它 —— 所以 ActionLib 动作调 FuncLib 纯函数必抛。
+     合同 §3.3 把 FuncLib 的调用方明确列为「…Script、ActionLib」。
+     S9 的帧模型应该已经解决了这个，本票确认它真的能用并补测试。
+  5) 合同 §4.4 写「HFSM OnTick → ActionLib『警戒一步』（内含 Yield）」，
+     实现相反：GraphProgramHfsmHost.RunAction 非 Halted 即抛
+     「Yield is not allowed on lifecycle bindings」，Level RunScript 同样。
+     且 GraphActionCatalogLoader 不按宿主区分 Yield 策略 ——
+     含 Yield 的 hfsm.* 条目能加载通过、只在运行时炸，加载期没有失败关闭。
+     裁决「HFSM 到底能不能挂含 Yield 的动作」，然后让合同与实现一致，
+     并把宿主维度的 Yield 策略校验挪到加载期。
+
+禁止：在 S9 之前开工；用「给 Core 工厂加参数」代替数据作者面。
+
+验收：
+  Feature: 行为可以用数据写，不必改引擎
+    Scenario: Mod 定义自己的行为树
+      Given 我在 mod 里用配置写了一棵巡逻-追击-攻击的树
+      When 游戏加载这个 mod
+      Then 代理应当按我写的树行动
+      And 我不需要改 Core 的任何 C# 代码
+
+    Scenario: 叶子自己能感知
+      Given 一个行为树叶子需要读取目标的血量来决定是否撤退
+      When 它执行
+      Then 它应当能直接读到血量
+      And 不需要 C# 侧先把结果喂进来
+```
+
+**该跑：** `--filter "FullyQualifiedName~Ludots.Tests.Gas.AI|FullyQualifiedName~GraphContractTests|FullyQualifiedName~GraphActionCatalogLoaderTests|FullyQualifiedName~ScriptFlowSandboxShowcaseAcceptanceTests|FullyQualifiedName~GraphBehaviorSeparatedShowcaseAcceptanceTests"`
+
+---
+
+### S14 · 分层物理化（拆程序集） 【P3 · 需先出设计】
+
+**审查编号：** B21、B22、B23、B24、B25、C21、C22
+
+**任务书**
+
+```text
+目标：让层与层之间的墙在编译期存在，而不是靠运行期检查与文本扫描事后追认。
+这是唯一的大工程，也是其他所有边界问题的根因。**先出设计，评审通过再动手。**
+
+现状：
+  src/Core/Ludots.Core.csproj 一个程序集同时装下
+  L0 VM、L1 编译器、L2 调度器、Presentation、Input、Spatial、Navigation
+  （只有 Physics2D 三个项目被拆出去）。
+  所以：
+    - L0 的数据半边（src/Core/GraphRuntime/）有一条守卫说它不许引用 GAS，
+      但这条守卫已被 GraphControlFlowDocument.cs 的传递依赖穿透；
+      而 L0 的执行半边（GasGraphOpHandlerTable）根本不在守卫目录里，
+      它的 using 段直接写着 GAS / Placement / Relationships / Teams。
+      L1 编译器还依赖 Presentation.TagDisplay。
+    - Core/Mod 端口被一跳绕开：IModContext 设计干净，
+      但 ScriptContext.GetEngine() 交出具体 GameEngine，mods 里 205 处在用；
+      另有 100 处直接 RegisterSystem 进 6 个组，无白名单无能力声明。
+      Mod 还直写 Core 进程级静态：TeamManager(7 mod)、
+      TagRegistry / AttributeRegistry(4)、GraphIdRegistry.Clear(5)、
+      SetCoordinateConverter(3)。
+    - 静态注册表 + 实例级注册表并存：GraphIdRegistry（static，name→id）
+      与 GraphProgramRegistry（实例级，id→program）。
+      GraphIdRegistry.Clear() 连 _frozen 一起复位、且是 public static。
+      同进程二次装载时 id 错位是必然而非偶发。
+      同族的 freeze 合同还不一致：属性表 Clear 在冻结时抛，
+      标签表 / 效果模板表 / 技能表 / 图表全部静默解冻。
+    - 跨层组件所有权无机制表达（见 S10 第 3 条）。
+    - 守卫层自己违反它守的合同：两个 ArchitectureGuardTests 逐字节复制，
+      合计 144 次 ReadAllText，而合同明令要用编译后 API / Roslyn / analyzer。
+
+设计要回答的问题（这是本票第一阶段的交付物，不是代码）：
+  1) 切几个程序集、边界画在哪。至少要能表达：
+     L0（VM + 指令 + 注册表接口）、L1（编译器 + 前门）、L2（行为调度）、
+     GAS（效果 + 属性 + 标签）、Presentation、Input、Spatial。
+     哪些是 abstractions-only 的契约程序集？
+  2) 注册表怎么从进程级静态变成实例状态
+     （挂在引擎上，或一个交给各 loader 的 ModRegistrySet）。
+     Clear() 消失、换新实例；Freeze 是该实例上的单向转换。
+     这是「多地图 / 多引擎实例 / 热改」三件事共同的前置。
+  3) Mod 只能看见什么。IModContext 要不要成为唯一通路、GetEngine() 怎么退役、
+     205 个调用点怎么分批迁移。
+  4) 跨层组件（PresentationStableId / PresentationDestroyPending / CullState /
+     VisualTransform）的所有权怎么在类型或 world 层面表达。
+  5) SystemGroup 顺序的单一数据源（今天 enum 与 PhaseOrder 两份、无交叉校验、
+     漏组静默失效；顺序守卫用集合比较。S8 会先做临时守卫，本票做根治）。
+  6) 迁移路径：怎么分批、每批怎么保证不回退、CI 怎么守。
+
+禁止：不出设计直接开始搬文件；一次性大爆改。
+
+验收（第一阶段只验设计）：
+  Feature: 层与层之间的墙在编译期就在
+    Scenario: 设计能回答边界问题
+      Given 一份分层物理化设计
+      When 维护者评审
+      Then 它必须回答上面六个问题
+      And 给出可分批执行、每批可验证的迁移路径
+```
+
+---
+
+### S15 · 验收页 SSOT 合并（链接部分已在本计划 PR 修掉） 【chore】
+
+**审查编号：** `pr932_graph_landed_architecture_audit.md` M13（已关）、M12（仍开）
+
+**已完成部分**：`gitbook/acceptance/graph-funclib-actionlib-uat.md` 的相对链接少一级 `../`，
+导致 `missing-link-target` 规则在 `main` 上持续报红、挡住所有改文档的 PR。
+本计划所在的 PR 已修掉这一行，`scripts/validate-docs.ps1` 现在全仓通过。
+**剩余部分**是同一个文件的 SSOT 合并，见下。
+
+**任务书**
+
+```text
+目标：把验收页合成一份，消除自相矛盾的覆盖结论。
+
+背景：链接那一行已经修好了（docs-governance 现在是绿的），本票只剩文档合并。
+
+现状（见 pr932 报告 M12）：
+  这个文件里有两个 H1，是两份文档被拼接，对同一批合同 §6 场景给出互相矛盾的结论
+  （一处说已覆盖、一处标 Gap）。合成一份，逐条以实测为准：
+    - bt.patrol 的跨拍续跑已覆盖，下半那句「缺一条 bt.patrolStep 真 Yield」已不成立。
+    - 「技能阶段不能调用 ActionLib」：合同原文用 InvokeAction，该节点全仓不存在，
+      真正存在的守卫是 FrontDoor_EffectInvokeScriptFunctionNameActionLibName_PatchFailsClosed，
+      且同一红线在查询方言上还是开的（见 S3）。照实写，不要写成已覆盖。
+    - 合同 §6 写 bt.patrolStep，资产实际叫 bt.patrol，名字要对齐（一处为准）。
+  gitbook/SUMMARY.md 指向的是被删掉的下半标题，同步更新。
+
+验证：pwsh ./scripts/validate-docs.ps1 必须仍然零 finding（合并时别把链接改回去）。
+
+禁止：删场景来让映射表好看；把「等价守卫存在」写成「合同原文场景已覆盖」。
+```
+
+---
+
+## 4. 场景（这些修完之后，玩家与作者会看到什么变化）
+
+1. **技能作者写错图不再让所有人的游戏消失**，而是在加载时拿到一条「这里有个调用环」的报错。
+2. **策划写进属性的数字不再自己变回去**；写错属性名会立刻报错而不是"这个效果没反应"。
+3. **技能结算里不会混进会等一拍的动作**，不管作者从哪个方言写。
+4. **高压帧不再静默丢联动**：血量触发被动该响就响，容量到顶会明确报错让人去调容量。
+5. **一次命中要么全算要么全不算**，不会留下一半回滚的世界。
+6. **启动器里划掉的门是真锁上的**，点不进去，也不会因为点进去而弄坏别的展厅。
+7. **展厅的血条代表它声称代表的东西**，纯算式的展厅不再假装在打伤害。
+8. **镜头看不见的单位仍然可以指挥。**
+9. **行为树和状态机可以用数据写**（S13 之后），mod 作者不必改引擎 C#。
+
+---
+
+## 5. 边界
+
+**本计划包含**：上述十五个子任务的目标、现状定位、要求、禁止项、验收与该跑的测试。
+
+**不包含**：
+- UI 面板债（#886 / #893）、表现层改名、#723 评分预算
+- 删除八个家族 Mod（S6 关门之后的独立票）
+- 图 VM 执行核心、编译器前端、组件 SoA 布局的重写——审查结论是这些**是对的**
+- 把 opcode 数量当问题——120 个不是问题，分派表撑得住再加 100 个
+
+**修复时请勿顺手改坏的东西**（审查确认它们是对的）：
+- VM 的类型初始化完备性硬闸（缺 handler / 描述 / 分类就抛）
+- 执行状态的 `ref struct` + `Span` 寄存器设计
+- 编译器的值边类型检查、未定义寄存器读检查、不可达检测、编译期指令预算
+- `AddFixed<T>` 的「预分配 + 容量闸门 + 超限抛」模式
+- 派生属性写入的围栏（scope 独占 + 暂存 + commit-or-discard + 越权即抛）
+- 缺 `DirtyFlags` 的失败关闭设计（`.WithNone<DirtyFlags>()` 配只抛异常的 job）
+- 技能→效果→图 的单向性（由闭合枚举在类型层面兜住）
+- 知识披露与头顶条那一侧（六角圈人三间的语义完全干净且有逐档断言）
+
+---
+
+## 6. UAT（Epic 关单条件）
+
+```gherkin
+Feature: 引擎不会因为一份配置而崩掉或说谎
+  作为维护者
+  我希望这套战斗与图能力的地基是可信的
+  以便建立在它上面的玩法不需要反复怀疑引擎
+
+  Scenario: 三条 P0 全部关闭
+    Given 一份会自己调自己的图、一个不夹上限的属性、一张从查询里调动作的图
+    When 我把它们分别喂给引擎
+    Then 第一个必须在登记时被拒绝，且进程不得退出
+    And 第二个写进去的数值语义必须唯一且与属性约束无关
+    And 第三个必须在编译时被拒绝
+
+  Scenario: 失败路径本身可靠
+    Given 任意一次结算在中途失败
+    When 回滚发生
+    Then 回滚必须完整走完且自身不抛
+    And 不得留下一半生效的世界
+
+  Scenario: 容量与遥测不再说谎
+    Given 任意一个固定容量的队列被打满
+    When 溢出发生
+    Then 系统必须抛出并点名容量与来源
+    And 仓库里不得存在「有读取接口但从不被写入」的遥测字段
+
+  Scenario: 防线是真的
+    Given 所有名字里包含零分配、基准、耗时门槛的测试
+    When 我检查它们
+    Then 每一条都必须对它声称的指标下断言
+    And 断言数值必须与方法名和注释一致
+
+  Scenario: 玩家门名实相符
+    Given 启动器里的展厅列表
+    When 我逐一点开
+    Then 划掉的门必须点不进去
+    And 点得进去的门，字幕与血条必须与它的简介一致
+```
+
+---
+
+## 7. 相关文档
+
+- 审查结论（本计划的依据）：[GAS + Graph VM 架构审查](gas_graph_architecture_review.md)
+- 前序：[PR932 main 图能力收口架构审计](pr932_graph_landed_architecture_audit.md)
+- 前序：[PR911 审计修复清单](pr911_audit_fix_checklist.md)
+- 判据：[GAS 分层架构](../../gitbook/architecture/gas-layered-architecture.md)
+- 判据：[图分层、流程与行为](../../gitbook/architecture/graph-layering-flow-and-behavior.md)
+- 判据：[图复用库合同](../../gitbook/architecture/graph-funclib-actionlib-contract.md)
+- 判据：[实体模拟分层](../../gitbook/architecture/entity-simulation-layering.md)
+- 判据：[Mod 架构](../../gitbook/architecture/mod-architecture.md)
+- 判据：[GAS、订单与输入运行时合同](../../gitbook/architecture/gas-order-input-runtime-contract.md)

--- a/docs/audits/gas_graph_architecture_review.md
+++ b/docs/audits/gas_graph_architecture_review.md
@@ -1,0 +1,303 @@
+# GAS + Graph VM 架构审查（SSOT）
+
+**被审对象：** `origin/main` @ `82ddb3322a` 的 GAS 与图 VM 全栈
+**范围：** `src/Core/Gameplay/GAS/`（215 个文件）、`src/Core/NodeLibraries/`（28 个）、及其牵连的 `src/Core/GraphRuntime/`、`Spatial/`、`Association/`
+**判据：** `gitbook/architecture/gas-layered-architecture.md`、`gitbook/architecture/graph-layering-flow-and-behavior.md`、`gitbook/architecture/graph-funclib-actionlib-contract.md`、`gitbook/architecture/entity-simulation-layering.md`、`gitbook/architecture/mod-architecture.md`、`gitbook/architecture/gas-order-input-runtime-contract.md`
+**配套修复分配：** [GAS + Graph VM 架构修复计划](gas_graph_architecture_fix_plan.md)
+
+本文件是本轮架构审查的唯一结论。六个方向（VM 核心、效果管线事务性、属性系统、分层边界、ECS 纪律、以及主审的交叉实测）已在此合成。
+
+---
+
+## 1. 概述
+
+### 一句话结论
+
+**骨架比收尾好得多。** 执行核心、组件布局、零分配纪律都是认真做的，不需要重做；风险几乎全部集中在三类"收尾"上——跨图与跨层的传播分析缺失、失败路径本身不可靠、以及一批看起来在守门实际不断言的防线。
+
+### 分层评级
+
+| 层 | 评级 | 一句话 |
+|----|------|--------|
+| 图 VM 执行核心（L0） | **好** | 纪律写进了运行期契约，不是文档口号；能再承载 100 个 opcode |
+| 图编译器与作者前门（L1 编译期） | **良** | 有真前端（类型检查、未定义寄存器读检查、不可达检测），单一入口；寄存器索引归属未收口 |
+| 能力模型（kind × opcode） | **有结构缺陷** | 逐指令、只看本图；调用被当控制流而非能力传递 |
+| 效果管线事务性 | **设计到位、收尾有洞** | 骨架专业，但回滚不是不可失败的，边界比一次结算小一圈 |
+| 属性系统 | **地基有裂缝** | 数值权威随运行时状态翻转，且无任何强制手段 |
+| 分层与边界 | **一堵真墙 + 几堵纸墙** | 只有「技能不能直接跑图」由类型系统兜住 |
+| ECS 纪律（实现） | **良** | 零 LINQ、零热路径字符串、零组件引用字段；1 处闭包 |
+| ECS 纪律（防线） | **差** | 真有牙齿的零分配断言只有 6 条 |
+
+### 三条必须优先处理
+
+1. **图调用无界递归会杀进程**（唯一"今天就能炸"）
+2. **属性数值的权威会随运行时状态翻转**（地基）
+3. **查询方言可从纯管道调起可挂起动作**（合同红线，作者今天就能写）
+
+---
+
+## 2. 结构
+
+```text
+方向 A  图 VM 核心：寄存器模型 / 分派 / 执行模型 / 能力矩阵 / 静态注册表
+方向 B  效果管线：阶段序 / Pre-Main-Post / listener / 事务性 / 冻结 / 容量
+方向 C  属性系统：写入路径 / base-current-modifier / dirty / id 约定
+方向 D  分层边界：L0-L1-L2 / Core-Mod / SystemGroup / 平行体系 / 模拟-表现
+方向 E  ECS 纪律：分配 / 查询形态 / 结构变更 / SoA / 容量 / 性能防线
+方向 F  主审交叉实测：把 A–E 的推导性断言实跑证实或推翻
+```
+
+方向 F 推翻了零条、证实了四条关键推导（§6）。
+
+---
+
+## 3. 详情
+
+### 3.1 立得住的部分（不要动）
+
+| 结论 | 证据 |
+|------|------|
+| 只有一台 VM、一个解释循环。`Execute`（跑到停）与 `ExecuteSlice`（跨拍续跑）共用 `ExecuteSliceCore`，前者只是「固定预算 + 拒绝 Yield + 预算耗尽抛」的薄壳 | `src/Core/NodeLibraries/GASGraph/GasGraphOpHandlerTable.cs` |
+| 分派是类型初始化时预建的 512 槽委托数组，热路径一次索引一次间接调用，零分配零查表 | 同上；`GraphVmLimits.HandlerTableSize` |
+| **类型初始化期的完备性硬闸**：每个枚举值必须有 handler + 描述 + 操作分类，缺一样第一次碰到 `Instance` 就抛；`Register` 拒重复、拒空描述 | `GasGraphOpHandlerTable.cs`（`EnsureRegistrationComplete`、`CreateOperationMetadata`） |
+| 执行状态是 `ref struct`，寄存器全是 `Span`，由调用方 `stackalloc` 提供；调用栈不够深就抛，错误话术写明「这条路禁止堆分配」 | `GraphExecutionState.cs`；`GasGraphOpHandlerTable.Execute` |
+| 编译器有真前端：值边类型检查、未定义寄存器读检查、必需控制边、不可达检测、指令预算编译期检查 | `GraphControlFlowCompiler.cs` |
+| 寄存器由编译器分配而非作者手填；溢出是编译期 `RegisterOutOfRange` 失败关闭 | `GraphControlFlowCompiler.AllocateOutputs` / `Alloc` |
+| 组件全是定长 `unsafe struct` + `fixed` 数组，且组件内部再拆成并行数组（`ActiveEffectContainer` 把 Entity 拆成 Ids/WorldIds/Versions 三条）；`Components/` 目录搜引用类型字段零命中 | `src/Core/Gameplay/GAS/Components/` |
+| 零 LINQ（连 `using System.Linq` 都没有）、零 tick 内字符串拼接、热路径仅 1 处闭包；inline query 与 chunk 迭代 23 处 vs lambda 查询 1 处 | 全目录扫描 |
+| `AddFixed<T>` 模式：预分配 `List<T>` + 显式容量闸门，超限抛 `FixedListCapacityExceeded`，既零分配又失败关闭 | `EffectApplicationSystem.cs`、`EffectLifetimeSystem.cs` |
+| 效果管线的合同主体成立：阶段序、Pre→Main→Post、模板 Main 优先、`main` 与 `skipMain` 冲突拒绝、四执行窗口全成功才一次性冻结、listener 与阶段图同批认证、`OnPropose` 未写结果按拒绝、listener 禁 `InvokeBuiltin`/`LoadConfig*`、禁重复注册、禁保留 ID 0、未认证能力（`RevealArea`）拒作阶段图 | `EffectPhaseExecutor`、`EffectExecutionPlanCompiler`、`EffectTemplateRegistry`、`EffectPhaseListenerContract`、`BuiltinHandlers` |
+| 技能→效果→图 单向，且由**类型系统**强制：`ExecItemKind` 闭合枚举无 Graph 条目，`GraphNodeOp` 无技能激活 opcode；技能跑图只跑 Validation 且双重闸门 | `AbilityExecComponents.cs`、`AbilityActivationPreconditionEvaluator.cs` |
+| 派生属性写入是**真围栏**：scope 独占、只允许写自己、scope 内一切副作用 op 直接抛、暂存 buffer commit-or-discard | `GasGraphRuntimeApi`（`BeginDerivedAttributeWrites` / `EndDerivedAttributeWrites` / `RejectDerivedAttributeSideEffect`） |
+| 缺 `DirtyFlags` 是**结构上不可能漏**的失败关闭：aggregator 专门开一个 `.WithNone<DirtyFlags>()` 查询配一个只会抛异常的 job | `AttributeAggregatorSystem` |
+
+### 3.2 阻断
+
+| # | 问题 | 证据 | 实测 |
+|---|------|------|------|
+| **A1** | **`InvokeScript` 嵌套无深度上限、步数预算不复合、装载期不拒环 → 一行配置杀进程。** 深度上限 16 只约束程序内 `Call`；4096 步预算每层递归重新计数，实际上限是 4096^深度；唯一遍历跨图调用边的校验器遇到环时是 `return false`（当作「没找到 Yield」放行）而非判错 | `GasGraphOpHandlerTable.HandleInvokeScript`（递归调 `Execute`，每层 `stackalloc` 约 3.8KB）；`GraphYieldPurityValidator`（`activeGraphs.Add` 失败即 return false）；`GraphVmLimits` | **是**。注册自递归 Script 图，装载期全绿，运行期递归 1495 层栈溢出，进程退出码 134，`try/catch` 无法进入 |
+| **A2** | **属性数值的权威随运行时状态翻转。** 同一个正式 API 写入：受 `ClampCurrentToBase` 保护的属性上存活；无约束且有活跃聚合 modifier 的属性上被静默丢弃。且 `SetCurrent` 不排 `AttributeAggregateDirty`，覆盖时机与写入完全脱钩——值可存活任意多帧，直到不相干事件把实体标脏才被抹掉 | `AttributeAggregatorSystem.RestorePersistentCurrentValues`：`if (!touchedByAggregation \|\| clampsToEffectiveCap) SetCurrent(i, previous)` | **是**。三格对照见 §6 |
+| **A3** | **写属性的路是并行而非分层，且无任何强制手段。** `AttributeBuffer` 写入面全 `public`，`AttributeMutationOps` 是 `public static`，无 `internal` 收口、无 analyzer 工程、无守卫测试。真结算与直接摆数字在世界状态、dirty flag、presentation bits 上留下**逐字节相同**的痕迹，无 provenance 字段。Core 自己 7 处裸写，mod 10+ 处，且有一条守卫测试反过来把绕行钉成契约 | `AttributeBuffer.cs`；`AttributeMutationOps.cs`；`ArchitectureGuardTests.Issue250_...`（`Does.Contain("attributes.SetCurrent")`） | — |
+| **A4** | **查询方言允许 `InvokeScript.graphId`，作者可从 L1 纯管道调起可挂起动作。** 线性方言明确拒绝裸图号，查询方言只拒「两个都给」和「两个都不给」；`action_lib.json` 11 条里 9 条不含 Yield，全部可被一张查询图调起。违反合同 §3.4 明文禁令，零测试覆盖 | `GraphControlFlowCompiler.Query.cs` 对照 `.Linear.cs` | — |
+| **A5** | **L2 三个宿主全部绕过 L1 正式执行前门直连 VM**，不做 `RequireKind` / `RequireAllowed` / 寄存器尺寸检查。而写得很规矩的 `GraphExecutor.ExecuteScriptSlice` 在生产代码里**零调用者**（只有 3 个测试文件用）。图号是裸 `int`，没有 typed id 承载 kind，任何已注册图都能塞进行为树叶子 / 状态机转移条件 / 关卡脚本 | `BehaviorTreeWorld.cs`、`GraphProgramHfsmHost.cs`、`LevelScriptPrograms.cs` 对照 `GraphExecutor.cs` | — |
+| **A6** | **表现层可见性 gate 玩法选中。** 选中查询以 `if (!cull.IsVisible) return;` 开头，且读 `VisualTransform`——相机剔除结果决定谁能被选中、从而决定谁能收指令。同时违反 `entity-simulation-layering.md`「`CullState` 只负责视觉，不得作为剔除真相」与 `gas-order-input-runtime-contract.md`「Core 不读取表现层 `VisualTransform` 作为玩法真相」。全仓守卫里 `VisualTransform` 出现 0 次 | `CommandSourceAcquisitionSystem.cs`、`CommandSourcePointerHitResolver.cs` | — |
+
+### 3.3 Major
+
+| # | 问题 | 证据 |
+|---|------|------|
+| **B1** | **事务回滚自身可抛 → 半回滚。** 同一方法内相邻循环风格不一致：恢复效果容器与效果组件的循环有 `IsAlive && Has` 守卫，紧接着三个黑板循环与取消标记循环是裸取组件。阶段执行期间若有实体被销毁，回滚中途抛出，其后的 listener buffer / relation / 结构性移除全不执行。真事务的铁律是回滚路径必须无条件成功 | `EffectPhaseSideEffectTransaction.RollbackWorldWrites` |
+| **B2** | 提交路径内 `World.Destroy` 不可逆，其后任一异常留下「实体没了但属性/标签被回滚」的混合态 | `EffectPhaseSideEffectTransaction.Commit` |
+| **B3** | **事务边界小于结算边界。** 效果挂到目标身上在事务外（`ProcessPending`），跑阶段图才开事务（`ActivateEffects`），两者之间可因时间切片跨帧让步。「失败不留部分结果」在单窗口内成立，跨窗口不成立 | `EffectApplicationSystem.UpdateSlice` |
+| **B4** | 标签授予绕过事务直写世界，靠外层三个快照手工补偿。同一实体的标签有两套写入与两套回滚机制 | `EffectApplicationSystem` → `EffectTagContributionHelper.PrepareGrantToEntity` |
+| **B5** | **延迟触发器队列静默丢弃。** 主缓冲与溢出缓冲皆满时直接 `return`，唯一痕迹是三个 fuse 标志，而这三个标志**全仓无任何读取点**。直接违反「禁止固定容量溢出时静默丢弃」 | `DeferredTriggerQueue.cs` |
+| **B6** | **热路径扩容。** 生成实体路径三处 `Reserve(Count + OverflowCount + N)`，`Reserve` 是真扩容（换两条更大数组 + 搬运溢出环，只增不减），把本该抛的 `CapacityExceededError` 变成静默堆增长。相邻分支在服务缺失时是正确抛错的 | `RuntimeEntitySpawnSystem.cs`；`EffectRequestQueue.Reserve` |
+| **B7** | **死信号：容量遥测整条断线。** `EffectRequestQueue._dropped` 全文无自增，`DroppedCount` 恒为 0，而测试在断言它等于 0（恒真空断言）；`_budgetFused` 置位后终身为真、无人读、不复位；`BuiltinHandlerExecutionContext.DroppedCount` 的唯一写入者入参从不被赋值 | `EffectRequestQueue.cs`；`TargetResolverFanOutHelper.ValidateAndCollect` |
+| **B8** | **图 VM 关系查询算子静默截断。** 出边超 `MaxTargets = 256` 的实体，多出的目标无声消失（`CollectOutgoing` 满即 break、只返回 count 不返回 dropped；`SetCount` 再截一刀）。对照组就在同一文件里：空间查询算子完全合规（默认 RequireComplete、dropped > 0 即抛、AllowTruncated 必须显式授权）。同一份策略只落实了一半 | `GasGraphOpHandlerTable`（关系查询 handler）；`RelationshipRuntime.CollectOutgoing` |
+| **B9** | **变更通知建立在 tag component 加删上。** `AttributeAggregateDirty` / `GameplayAttributeChangedBits` 加走直接 `World.Add`、删走 CommandBuffer，每个当帧变化的实体每帧固定两次 archetype 迁移；角色 archetype 约 1.3KB/实体，每次迁移 memcpy 约 1.3KB。与红线「禁止热路径结构变更」正面冲突。`DirtyFlags` 那种常驻位掩码组件已证明替代路径可行 | `AttributeMutationOps.MarkPresentationChanged`、`EffectApplicationSystem`、`EffectProposalProcessingSystem`、`GasGraphRuntimeApi`、`ClearPresentationFlagsSystem` |
+| **B10** | **dirty 是双钥匙，只置一把静默失效。** 延迟触发器系统只从队列取实体、不做全表扫。旁路写既不置 mask 也不入队 → 属性变化触发器永不触发；且不刷 `AttributeLastSnapshot`，导致**下一次合法写入报出的 `OldValue` 把旁路那段 delta 一起吞进来**，污染 delta 归因 | `DeferredTriggerCollectionSystem` |
+| **B11** | **越界与非法属性 id 静默吞写。** `SetCurrent(-1)` / `GetCurrent(-1)` / `SetCurrent(64)` 全部静默返回不抛；而按名字取 id 失败时返回的正是 `-1`。喂 `-1` 进去的结果是读 0、写被吞、`before == after` 于是连 dirty 都不打，全程零异常零日志。同族的 `GameplayTagContainer.ValidateTagId` 对非法 id 是**抛异常**的 | `AttributeBuffer.cs` 对照 `GameplayTagContainer.cs` |
+| **B12** | **两个兄弟注册表的有效性约定相反。** 属性表 `_nextId = 0` / `InvalidId = -1`；标签表 `_nextId = 1` / `InvalidId = 0`。6+ 处代码套用标签表约定去判属性（`if (attributeId > 0)`），于是**第一个注册的属性**在这些路径上静默不可用，而「第一个」是谁取决于 mod 加载顺序 | `AttributeRegistry.cs` vs `TagRegistry.cs`；`BuiltinHandlers.HandleApplyForce` 等 |
+| **B13** | **属性与 sink 注册表生产从不 Freeze。** id 分配依赖 mod 加载顺序 → 换一组 mod 或换加载序，同一个属性名拿到不同 id，威胁存档/回放确定性。而 `ProgressionIdRegistry` / `ContextGroupIdRegistry` / `GraphIdRegistry` 都规规矩矩 Freeze 了——属性与 sink 是唯二例外，且违反 `gas-layered-architecture.md` 明文要求 | 无生产调用点 |
+| **B14** | **寄存器索引有三套互不相认的占位机制。** ① bump 分配器（无 liveness 复用）；② 作者 `PinRegister`（pin 小于当前游标时**无诊断**，静默与已分配寄存器别名）；③ 硬编码常量 scratch（`TargetListGet` 与 `validOutput` 都写死 B[31]）。而唯一做对的 `AllocateSugarScratches` 按 used-set 找空位，但它的 used-set **不含 B[31]**。再叠上宿主侧 ABI 槽（B[0] Validation 判定、F[0] Score 分数、I[0] BT sensor），这四个槽的 SSOT 不在代码里任何一处 | `GraphControlFlowCompiler.cs`、`.Linear.cs`；`GraphExecutor.cs`；`BehaviorTreeOps.cs` |
+| **B15** | **`Programs` 字段除测试专用入口与嵌套子帧外没有任何宿主填写**，而 `HandleInvokeScript` 首行 `if (s.Programs == null) throw`。即：所有生产执行路径都**写得出** `InvokeScript`，一个都**执行不了**。范围包含 Effect 阶段、Query 输出、Performer 条件、Aim 预览，不止 L2 三个宿主 | `GraphExecutionState`（15 字段 ref struct、无构造不变式、11 个手工构造点）；`GasGraphOpHandlerTable.HandleInvokeScript` |
+| **B16** | **掉出程序尾部被当成「成功停机」。** `(uint)pc >= (uint)program.Length` → `Halted` + 返回成功，负 pc 也走这条。任何坏跳转都被报成正常完成。注释把它写明为「既有 GAS 图掉出尾部算成功完成」——一条兼容性 fallback 焊进了 VM 内核。且跳转目标从不在装载期校验 | `GasGraphOpHandlerTable.ExecuteSliceCore` |
+| **B17** | **程序校验发生在每次执行而非登记时。** `RequireAllowed` 是 O(程序长度) 全扫、每次执行都跑（登记时已跑过一次）；`AnalyzeScratchUsage` 是第二遍 O(n) 全扫，且它是**全系统唯一的寄存器越界校验**——BT / HFSM / Level / Performer / Aim / ReturnWriter 一概没有，越界只表现为 span 的 `IndexOutOfRangeException` 而非失败关闭诊断 | `GraphKindOperationPolicy`；`EffectPhaseExecutor.AnalyzeScratchUsage` |
+| **B18** | **能力矩阵与前门是两份手工数据。** 前门是三张手写 op 列表（线性 86 / 查询 41 / Script 11），一张线性表被 4 个 kind 共用而这 4 个 kind 有 3 套策略。缝隙可量化：Score/Validation/Derived 有 19–20 个「前门允许但策略拒」（策略在装载期赢，所以是失败关闭，但作者拿到的诊断是「操作不被 kind 允许」而非「这个节点在这个方言里不存在」）；各 kind 另有 33–89 个「策略允许但前门写不出」。**没有任何测试断言「前门 ⊆ 策略」** | `GraphKindOperationPolicy`（含 3 处硬编码例外）；`GraphControlFlowCompiler.Linear.cs` / `.Query.cs` |
+| **B19** | **Script 方言窄到「感知」必须写在 C# 里。** 只有 11 个可写 op（int 数学 + 控制流），读不到属性、读不到黑板、做不了 float 运算、发不了查询，于是行为树必须用 C# sensor feed 把结果塞进 I[0]。而三个 L2 宿主之所以能只填 `I/B/CallStack` 就跑（B15），**正是因为 Script 这么窄**——往 Script 矩阵加任何一个读属性/黑板/查询的 op，三个宿主立刻崩（`F`/`E`/`Targets` 是零长 span，`Api` 与 `Programs` 是 null）。**这两件事必须同时改** | `GraphControlFlowCompiler.cs`（Script 内联列表）；`BehaviorTreeOps.cs`；`AiConfigModels.cs`（无 BT/HFSM 条目） |
+| **B20** | **L2 没有作者面。** AI 配置覆盖 Utility / GOAP / HTN / atoms / projections / bindings，**没有行为树、没有状态机**。拓扑只能在 C# 里用工厂造，而这些工厂连同玩法语义（哨兵状态机、巡逻-追击-攻击树、11 个 `bt.*`/`hfsm.*`/`level.*` 名字）都住在 Core。「一切皆 Mod」在 L2 上不成立。这 11 个名字同时又是 `action_lib.json` 的全部条目名——同一份内容两个 SSOT | `HfsmDefinition.cs`、`BehaviorTreeOps.cs`、`BehaviorTreeFactory.cs`、`LevelScriptPrograms.cs` |
+| **B21** | **一个程序集装下全部层。** `Ludots.Core.csproj` 同时是 L0 VM、L1 编译器、L2 调度器、Presentation、Input、Spatial、Navigation（只有 Physics2D 三个项目被拆出去）。所有「墙」在编译期都不存在，只能靠运行期检查与文本扫描事后追认。**这是其他所有结构性边界问题的根因** | `src/Core/Ludots.Core.csproj` |
+| **B22** | **Core/Mod 端口被一跳绕开。** `IModContext` 本身设计干净（VFS / FunctionRegistry / SystemFactoryRegistry / TriggerDecorators / OnEvent / Log），但 `ScriptContext.GetEngine()` 交出具体 `GameEngine`，mods 里 205 处在用；另有 100 处直接 `RegisterSystem` 进 6 个组。Mod 还直写 Core 进程级静态：`TeamManager`(7 mod)、`TagRegistry`/`AttributeRegistry`(4)、`GraphIdRegistry.Clear`(5)、`SetCoordinateConverter`(3) | `ScriptContextExtensions.cs`；`mod-architecture.md` |
+| **B23** | **`SystemGroup` 顺序有两份列表、零顺序守卫、漏组静默失效。** 真正决定执行顺序的是 `PhaseOrderedCooperativeSimulation.PhaseOrder` 数组，enum 声明顺序对执行无影响；两份今天一致但无交叉校验。守卫用 `Is.EquivalentTo`（集合相等，**不比较顺序**），把 `Cleanup` 挪到最前面它照样绿。某个组在 enum 里有、在 `PhaseOrder` 里漏了，注册进去的系统每帧都不跑且无诊断 | `PhaseOrderedCooperativeSimulation.cs`；`ArchitectureGuardTests.SystemGroup_MustMatchDesignDocument` |
+| **B24** | **守卫层自身违反它守的合同**，且违反 DRY：两个 `ArchitectureGuardTests` 同名同 namespace、37 个方法逐字节相同的复制，合计 144 次 `ReadAllText` + 6 次反射；而 `gas-order-input-runtime-contract.md` 白纸黑字写着「不得用 `ReadAllText + Contains` 复述源码实现；需要静态门禁时使用编译后的 API、Roslyn/analyzer」 | `src/Tests/ArchitectureTests/Governance/ArchitectureGuardTests.cs` vs `src/Tests/GasTests/Integration/ArchitectureGuardTests.cs` |
+| **B25** | **静态注册表的 freeze 合同不一致。** 属性表 `Clear()` 在冻结时抛；标签表 / 效果模板 id 表 / 技能 id 表 / 图 id 表全部**静默解冻**。`GraphIdRegistry.Clear()` 连 `_frozen` 一起复位，且是 `public static`、mod 可调。实例级 `GraphProgramRegistry` 与静态 id 表并存 → 同进程二次装载时 id 错位是**必然**而非偶发 | `GraphIdRegistry.cs`、`TagRegistry.cs`、`EffectTemplateIdRegistry.cs`、`AbilityIdRegistry.cs` 对照 `AttributeRegistry.cs` |
+| **B26** | **「测了不断言」的假防线成片存在。** `GraphPerfTests.cs` 整个文件零断言（跑 100 万次图 VM、算出分配字节数、`Console.WriteLine`、结束）——这是图 VM 唯一的零分配基准；`GasBenchmarkTests.cs` 8 个 benchmark、5 个测分配，全文件只有 2 句关于触发器计数的断言；`PhaseExecutor_HighVolume_ReportsThroughputAndGc` 注释写「<10μs」断言写 `< 50.0`；`BlackboardOps_Stress_MassWriteRead_ZeroGc` 名字带 ZeroGc 但唯一性能断言是 `TotalSeconds < 30.0`，且**测量区间内每次迭代 `new int[]` 自己污染自己**；`GraphBehaviorPressureMatrixTests` 全文件 3 句断言全是 `File.Exists`（只保证 CSV 被写出，不保证数字在任何范围内）。真有牙齿的零分配断言只有 6 条 | 上述文件 |
+| **B27** | 性能门槛命名与断言不符：行为树那条名叫「五毫秒」实际断言 `< 15.0` 且裸断言无消息；脚本版状态机同样名说 5 实测 15（消息如实写了 15）。另两条名实相符。#914 声称还原的思考波闸门（`over5ms == 0` + avg/p95 < 15）**确认是真还原** | `BehaviorTreeRuntimeTests.cs`、`FsmRuntimeTests.cs`、`GraphBehaviorArenaAcceptanceTests.cs` |
+| **B28** | **零分配覆盖有系统性缺口**：4 条真断言覆盖 proposal / 瞬时效果 / 关系事务 / listener 派发，**完全没覆盖持续效果的 tick 循环**——`EffectApplicationSystem`、`AttributeAggregatorSystem`、`EffectLifetimeSystem`、`TimedTagExpirationSystem`、`DeferredTriggerCollectionSystem` 一个都没进零分配测试。而 B9 那个「每帧两次迁移」恰好就发生在这些没被测的系统里 | `AllocationTests.cs` |
+
+### 3.4 Minor 与债务（择要）
+
+| # | 项 |
+|---|---|
+| C1 | `BuiltinHandlers` 的位移替换是全 GAS 唯一 lambda 查询，捕获 4 个可变局部 → 每次调用一个 display class + 一个委托；同函数还有直接同步 `world.Remove`，而同组件在另一系统走的是 CommandBuffer |
+| C2 | `MaterializeEffect` 建实体后最多连做 8 次 `World.Add`（8 次连续 archetype 迁移），而 factory 里已有预建原型 + CommandBuffer 的合规重载没被用 |
+| C3 | `EffectPhaseSideEffectTransaction.Commit` 是 `AttributeMutationOps` 的平行重实现（整 struct 赋值 + 手写 dirty 循环），两套语义需人工同步 |
+| C4 | `StagePresentationEvent` 缺服务时静默 no-op，而同类 `StageEffectRequest`/`StageSpawnRequest` 抛异常；三个 fan-out builtin 缺服务时静默返回零结果 |
+| C5 | `PrepareCommitState()` 在 `try` 之外调用，`Commit` 非自洽，全靠三个调用方各自 catch 兜底 |
+| C6 | `EffectRequestQueue.Clear()` 静默丢弃未消费项 + 回灌溢出环；Core 生产系统不调它，但 showcase mod 有 4 处在调（换展厅 1 处 + 3 个 driver 每拍） |
+| C7 | `AbilityExecInstance.SetItem` 定长溢出静默 `return`，丢弃时间线条目 |
+| C8 | `SystemFactoryRegistry` 重名后写覆盖只 Warn（与「禁止 registry 重复注册后采用最后一次写入」冲突）；找不到 factory 只 Warn |
+| C9 | `GraphControlFlowCompiler` 是 `public static partial class`，`Compile` 公开可绕前门直连（今天只有测试这么干，无 analyzer 阻止生产代码这么干）——「前门」是命名约定不是可见性约束 |
+| C10 | 图程序有四个来源：配置管线、mod 自扫资产、**C# 字符串常量内嵌**（Float mod 还用 `.Replace` 做 C# 侧文本模板，与「不支持编译期文本宏」冲突）、LSW 热改补丁 |
+| C11 | `GraphProgramSymbolPatcher.Patch` **不幂等**：把符号索引原地覆写成解析后 id，第二次跑会把 id 当符号索引再解析——热改路径值得单独查 |
+| C12 | 指令编码无 operand schema：`Flags` 承担至少 7 种含义，`Dst` 承担 4 种；语义必须在编译器 emit / 符号 patch / handler 三处手工对齐，这是 B14 那类 bug 的温床。relationship typeId 被 byte + 哨兵封在 254 以内 |
+| C13 | `GraphExecutionStatus` 把「未开始」与「预算耗尽挂起」压在同一个 `Running` 上，而行为树续跑判断只认 `Yielded` → action 叶子因预算耗尽返回 Running 时，下一拍寄存器清空、cursor 归零、**脚本从 pc=0 静默重跑，已产生的副作用重放** |
+| C14 | `LoadConfigInt` 与 `LoadConfigEffectId` 是同一个函数体，零语义差异；120 这个数字被这类别名和「静态/动态 × 单体/扇出」组合撑大，真实 kernel 家族约 30–40 |
+| C15 | `RequireNoYield` 每次 `InvokeScript` 运行时对子程序做 O(n) 线性扫描（本该在装载期）；同处 `RequireKind` + `TryGetProgram` 两次字典查找 |
+| C16 | 聚合循环不用 `DefinedMask` 剪枝，每脏实体每 pass 约 320 次定长迭代，无论它定义了 2 个还是 60 个属性 |
+| C17 | `GameplayAttributeChangedBits` 用 64 字节表达 64 bit（`Clear`/`IsAnyBitSet` 都是 O(64) 循环），与 `DirtyFlags.AttributeDirtyMask`（一个 `ulong`）语义重复且占 8 倍空间 |
+| C18 | `MAX_ATTRS = 64` 在三处独立定义互不引用；`"Health"`/`"MoveSpeed"` 等字面量 20+ 处（含 Core）无集中常量表；评估/投影层每次调用按字符串取 id |
+| C19 | `ExtensionAttributeRegistry` 是死代码：发 10001+ 的 id，而 `AttributeBuffer` 对 ≥64 的 id 一律静默 return，全仓无消费者。一整套挂在 Phase 0 上、每帧遍历空队列的平行 id 空间 |
+| C20 | `EntityLifecycleAtomicOps.CopyAttributeSlice` 在循环外取 `ref AttributeBuffer`，循环内首次写入触发 archetype 迁移 → 第 2 次及以后迭代读的是旧 chunk 失效内存（`AttributeSliceCount >= 2` 且目标尚无 `GameplayAttributeChangedBits` 时命中） |
+| C21 | `GraphRuntime` 不许引用 GAS 的唯一分层守卫已被 `GraphControlFlowDocument.cs` 的传递依赖穿透；L1 编译器还依赖 `Presentation.TagDisplay` |
+| C22 | 跨层组件所有权无机制表达：`PresentationStableId` / `PresentationDestroyPending` / `CullState` 三方读写、无声明 owner（`CullState` 由模拟创建、表现写、输入读）；`entity-simulation-layering.md` 的「单写真相规则」在代码里没有任何执行体 |
+| C23 | 测试树里有第二执行器（Roslyn 生成 C# → collectible ALC），带对拍测试、属受控 spike，但「禁止第二执行器」的合同没为它写豁免 |
+| C24 | `SystemGroup` 正式顺序表（文档与任务书）缺 `RuntimeEntityBinding`，而它有 9 处生产用法 |
+| C25 | `OwnershipResolver` 在热路径 `Array.Resize` 扩容重试（摊销、且恰好补上了 B8 缺失的 dropped 语义） |
+| C26 | `GasClockSystem.FireTurnAdvanced` 每次 `new ScriptContext()` 且装箱（只在手动/回合步进，不在固定 tick） |
+| C27 | `EffectTemplateRegistry.TryReplaceHotNumericField` 在冻结后改写模板数组（仅 duration/period，仅 LSW 调用） |
+| C28 | `ResetAbortedStructuralCommands` 在回滚路径 `new CommandBuffer`（错误路径分配） |
+
+---
+
+## 4. 场景（这些问题玩家/作者会怎么撞上）
+
+1. **技能作者写了一张会自己调自己的图**（或 A→B→A 的环）。加载全绿，一进战斗游戏直接消失——不是报错弹窗，是进程没了。日志里什么都没有，因为栈溢出不给你写日志的机会。
+
+2. **策划配了一个不夹上限的属性**（比如移速），给它挂一个永久 +18 的 buff，然后在某处直接写了一个移速值。当场看是对的，过了若干秒、玩家做了一件毫不相干的事之后，那个值自己变回去了。查不出来，因为写入的地方和变回去的时刻没有任何因果可见性。
+
+3. **策划把某个属性配成 mod 里第一个注册的**。于是几条内置路径（比如施加冲力）对这个属性静默失效——不报错，就是没效果。换个 mod 加载顺序，症状转移到另一个属性上。
+
+4. **作者在查询图里写了一条调用，指向一个巡逻动作**。查询本该是纯的，但这条能编译、能加载、能执行。技能结算里混进了一个会等一拍的动作。
+
+5. **高压帧**（大量属性变化）：延迟触发器队列满了，"血量低于 30% 触发被动"这类联动**静默不响**。面板上的数字是对的，所以第一反应会去查被动逻辑，而真正的原因是触发器被丢了。
+
+6. **一次命中打了很多目标，中途某个目标被别的效果销毁**。事务回滚在中途抛出，留下一半回滚的世界——属性回滚了、关系没回滚。
+
+7. **玩家在启动器列表里看到八张打了"已退役"灰标的旧展厅卡，卡底还是有可复制的启动命令**。复制粘贴进去，其中五间一进门就把引擎的图编号表清空。
+
+8. **玩家点进"两段伤害叠在一起"，字幕说血条按总和往下掉**。数字是真图算的，但把它落到世界上那一步是脚本直接改的；而且如果这一刀本该把血打到 0，代码会静默把它回卷成满血。
+
+---
+
+## 5. 边界
+
+**做了**
+
+- 以正式架构文档为判据，逐条证伪 GAS 与图 VM 的分层、事务性、属性链、能力模型、ECS 纪律
+- 把"结构性问题"与"实现瑕疵"分开定性（后者不该按前者的成本去修）
+- 对六条推导性断言做实测证实（§6），不以静态阅读替代运行证据
+
+**没做**
+
+- 不改任何生产代码（本轮零生产改动）
+- 不审 UI 面板债（#886 / #893）、表现层改名、#723 评分预算
+- 不重开已裁决的产品争论（Duration/Period 在效果壳上；FuncLib 纯 / ActionLib 可挂起；单节点展厅是玩家门）
+- 不对"拆程序集"给出具体切分方案——那需要单独设计，见修复计划 S12
+
+**刻意保留的判断**
+
+- 图 VM 执行核心、编译器前端、组件 SoA 布局、`AddFixed` 容量模式、派生属性围栏、`DirtyFlags` 失败关闭设计，**都是对的，修复时不要顺手改**
+- 120 个 opcode 这个规模**不是**问题；分派表撑得住再加 100 个。真正到临界点的是寄存器索引归属、装载期校验器缺位、以及调用的能力传播
+
+---
+
+## 6. UAT
+
+以下六条是本轮**实测**（非静态推导）的验收记录。探针源码见 PR 附件 `attribute_probe_Program.cs` 与 `recursion_probe.cs`，均为 `/tmp` 下独立项目直连 `src/Core/Ludots.Core.csproj`，未修改工作区任何源码。
+
+```gherkin
+Feature: 一张图不能把游戏弄没了
+  作为技能作者
+  我希望我写错的图被当场拒绝
+  以便我不会因为一个笔误让所有人的游戏直接退出
+
+  Scenario: 自己调自己的图必须被拒绝            # 未过（实测进程被杀）
+    Given 我写了一张脚本图，它唯一做的事就是调用自己
+    When 这张图被登记进图注册表
+    Then 登记必须失败并告诉我这里有一个调用环
+    And 游戏不应该能带着这张图启动
+
+    实测：注册表接受了它（TryGetProgram 返回 True，无任何装载期环检测）；
+          执行时递归 1495 层后栈溢出，进程退出码 134，try/catch 无法进入。
+
+Feature: 我写进属性的数字不会自己变回去
+  作为策划
+  我希望我通过正式接口写进去的数值就是最终生效的数值
+  以便我不用怀疑是不是引擎在背后改我的数
+
+  Scenario Outline: 直接写入的当前值应当保持   # 部分过（取决于属性配了什么约束）
+    Given 一个基础值 100 的属性，挂着一个永久 +18 的修正
+    And 我通过正式接口把当前值写成 50
+    When 属性重算发生
+    Then 当前值应当仍然是 50
+
+    实测：
+      | 属性是否夹上限 | 是否重新标脏 | 重算后 | 结果 |
+      | 是（血量这类） | 是           | 50     | 过   |
+      | 否（移速这类） | 是           | 118    | 未过 —— 写进去的 50 被静默丢弃 |
+      | 否             | 否           | 50     | 过，但只是暂时的：覆盖被推迟到别的事件把该实体标脏时才发生 |
+
+Feature: 写错属性名不应该悄无声息
+  作为策划
+  我希望我把属性名拼错时能立刻知道
+  以便我不用靠"为什么这个效果没反应"去反推
+
+  Scenario: 非法属性编号必须失败关闭          # 未过
+    Given 我引用了一个没有注册的属性名
+    When 系统按这个名字取编号，然后拿这个编号去写值
+    Then 写入必须失败并点名这个属性名
+
+    实测：取编号返回 -1；SetCurrent(-1) 静默返回、GetCurrent(-1) 返回 0、
+          SetCurrent(64) 静默返回（上限 64）。三者均不抛，且因为 before == after，
+          连脏标记都不打——全程零异常零日志。
+          对照：同族的标签容器对非法编号是抛异常的。
+
+Feature: 属性的编号不该看 mod 装载顺序
+  作为存档与回放的使用者
+  我希望同一个属性名在任何一次运行里拿到同一个编号
+  以便旧存档在新版本里读出来还是同一个意思
+
+  Scenario: 第一个注册的属性也必须可用      # 未过
+    Given 某个属性恰好是本次运行中第一个被注册的
+    When 内置的施加冲力之类的路径去读它
+    Then 它应当和其他属性一样正常工作
+
+    实测：清空注册表后第一次注册拿到编号 0，而"无效"标记是 -1；
+          若干路径用「编号大于 0」判有效，因此对编号 0 的属性静默跳过。
+          换一组 mod 或换加载顺序，受害者就换一个。
+
+Feature: 容量到顶时要说话
+  作为运维与开发
+  我希望系统在压力到顶时明确报错
+  以便我知道要调容量，而不是以为功能坏了
+
+  Scenario: 延迟触发器队列满时必须失败关闭    # 未过
+    Given 一帧内产生的属性变化触发器超过了队列容量
+    When 队列的主缓冲与溢出缓冲都已满
+    Then 系统必须抛出并点名容量与来源
+
+    实测：直接 return 丢弃，只置一个 fuse 标志；
+          该标志有 public getter 但全仓无任何读取点。
+          同型死信号还有效果请求队列的丢弃计数器（永不自增，而测试在断言它等于 0）。
+
+Feature: 零分配的承诺要有人守着
+  作为性能负责人
+  我希望名字里写着零分配的测试真的在断言零分配
+  以便防线退化时 CI 会红
+
+  Scenario: 零分配断言必须真实存在            # 部分过
+    Given 一批名字包含 ZeroAlloc / Benchmark / ZeroGc 的测试
+    When 我检查它们的断言
+    Then 每一条都应当对分配量下断言
+
+    实测：真有牙齿的零分配断言 6 条（AllocationTests 4 条 + MathOpsChain 1 条
+          + EntityCollection 1 条），全部通过。
+          而图 VM 唯一的零分配基准整个文件零断言（只 Console.WriteLine）；
+          另一批 benchmark 测了分配但全文件只有 2 句与分配无关的断言。
+          持续效果的 tick 循环（效果应用、属性聚合、生命周期、标签过期、
+          触发器收集）完全没有零分配覆盖。
+```
+
+**另有五路静态审查的完整逐条符合性判定**，因篇幅未全部展开于 UAT，见 §3 各表的证据列。
+
+---
+
+## 7. 相关文档
+
+- 修复任务分配：[GAS + Graph VM 架构修复计划](gas_graph_architecture_fix_plan.md)
+- 前序：[PR932 main 图能力收口架构审计](pr932_graph_landed_architecture_audit.md)
+- 前序：[PR911 FuncLib/ActionLib 架构审计](pr911_funclib_actionlib_architecture_audit.md)
+- 判据：[GAS 分层架构](../../gitbook/architecture/gas-layered-architecture.md)
+- 判据：[图分层、流程与行为](../../gitbook/architecture/graph-layering-flow-and-behavior.md)
+- 判据：[图复用库合同](../../gitbook/architecture/graph-funclib-actionlib-contract.md)

--- a/gitbook/acceptance/graph-funclib-actionlib-uat.md
+++ b/gitbook/acceptance/graph-funclib-actionlib-uat.md
@@ -4,7 +4,7 @@
 
 图复用库与可挂起动作的合同验收：FuncLib 纯函数无 Yield；ActionLib 供行为调度跨拍；Effect 可调 FuncLib 不可调 ActionLib；L1 Kind 前门与加载期失败关闭。
 
-对照：[图复用库合同](architecture/graph-funclib-actionlib-contract.md)。
+对照：[图复用库合同](../architecture/graph-funclib-actionlib-contract.md)。
 
 ## 2. 结构
 

--- a/scripts/create-gas-graph-fix-issues.sh
+++ b/scripts/create-gas-graph-fix-issues.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# 从 docs/audits/gas_graph_architecture_fix_plan.md 批量创建 Epic 与子 issue。
+#
+# 用法：
+#   scripts/create-gas-graph-fix-issues.sh --dry-run     # 只打印将要创建什么（默认）
+#   scripts/create-gas-graph-fix-issues.sh --apply       # 真的创建
+#
+# 前置：gh 已登录且有 issue 写权限（gh auth status 需显示 repo scope）。
+# 每个子 issue 的正文从修复计划文档里按小节切出，因此文档是唯一内容源；
+# 改任务书请改文档，不要改本脚本里的文案。
+
+set -euo pipefail
+
+REPO="${REPO:-MightyBubble/Ludots}"
+PLAN="docs/audits/gas_graph_architecture_fix_plan.md"
+REVIEW="docs/audits/gas_graph_architecture_review.md"
+MODE="dry-run"
+
+for arg in "$@"; do
+  case "$arg" in
+    --apply)    MODE="apply" ;;
+    --dry-run)  MODE="dry-run" ;;
+    *) echo "未知参数: $arg" >&2; exit 2 ;;
+  esac
+done
+
+cd "$(dirname "$0")/.."
+[[ -f "$PLAN" ]]   || { echo "找不到修复计划: $PLAN" >&2; exit 1; }
+[[ -f "$REVIEW" ]] || { echo "找不到审查结论: $REVIEW" >&2; exit 1; }
+
+# id|优先级|依赖|标题
+SUBTASKS=$(cat <<'EOF'
+S1|P0|-|图调用无界递归会杀进程：装载期拒环 + 深度上限 + 共享预算
+S2|P0|-|属性写入的权威与强制手段：语义唯一 + 围栏 + id 约定统一
+S3|P0|-|查询方言可从纯管道调起可挂起动作（合同 §3.4 红线）
+S4|P1|-|事务收尾：回滚必须不可失败 + 销毁语义 + 边界对齐结算
+S5|P1|-|容量三禁：静默丢弃 / 热路径扩容 / 死信号接线
+S6|P1|-|退役展厅锁门 + 停止在 mod 运行时清空图编号表
+S7|P1|-|展厅血条名实相符 + 删掉静默回卷
+S8|P2|-|假防线集中整治：测了不断言 / 恒真断言 / 命名与门槛不符
+S9|P2|S1|L2 宿主走 L1 正式执行前门（引入执行帧）
+S10|P2|-|表现层不得决定玩法选中
+S11|P2|-|覆盖表错误归因 + 守卫强度
+S12|P2|S9|寄存器归属与指令 descriptor
+S13|P2|S9,S12|Script 方言拓宽 + L2 数据作者面
+S14|P3|-|分层物理化（拆程序集）— 需先出设计
+S15|chore|-|验收页 SSOT 合并（docs-governance 红灯部分已随计划 PR 修掉）
+EOF
+)
+
+# 从计划文档里切出某个子任务小节的正文（### Sxx · ... 到下一个 ### 或 ---\n## 之前）
+extract_section() {
+  local id="$1"
+  awk -v id="$id" '
+    $0 ~ "^### " id " · " { capture = 1 }
+    capture && /^### / && $0 !~ "^### " id " · " { exit }
+    capture && /^## / { exit }
+    capture { print }
+  ' "$PLAN"
+}
+
+echo "仓库      : $REPO"
+echo "模式      : $MODE"
+echo "内容源    : $PLAN"
+echo "子任务数  : $(echo "$SUBTASKS" | wc -l | tr -d ' ')"
+echo
+
+if [[ "$MODE" == "apply" ]]; then
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "gh 未登录或凭据无效。先跑 gh auth login，确认有 repo scope。" >&2
+    exit 1
+  fi
+  if ! gh issue list --repo "$REPO" --limit 1 >/dev/null 2>&1; then
+    echo "gh 无法读取 $REPO 的 issue（凭据可能是只读的）。创建会失败，已中止。" >&2
+    exit 1
+  fi
+fi
+
+# ---------- Epic ----------
+EPIC_BODY=$(cat <<EOF
+GAS 与图 VM 全栈架构审查的修复收口。审查结论见 \`$REVIEW\`，任务分配见 \`$PLAN\`。
+
+## 结论摘要
+
+骨架比收尾好得多。图 VM 执行核心、编译器前端、组件布局、零分配纪律都是认真做的，
+**本 Epic 不包含任何重写**，全部是收口。
+
+三条 P0 是「今天就能出事」，且**已实测证实**：
+
+1. 一张自己调自己的图，登记全绿，执行时递归 1495 层栈溢出，**进程被杀**（退出码 134），
+   \`try/catch\` 无法拦截。
+2. 属性数值的权威随运行时状态翻转：同一个正式接口写入，在夹上限的属性上存活、
+   在不夹上限且有活跃修正的属性上**被静默丢弃**，且覆盖时机与写入完全脱钩。
+3. 查询方言允许直绑图号，作者可从 L1 纯管道调起可挂起动作，违反合同 §3.4，零测试覆盖。
+
+## 开工顺序
+
+S1 / S2 / S3 可以同时开三个 Agent，互不冲突。
+唯一的硬顺序是 S13 必须在 S9 之后（今天三个 L2 宿主只填部分寄存器就能跑，
+正是因为 Script 方言窄到用不到那些寄存器；反了必崩）。
+
+\`\`\`text
+S1 ──► S9 ──► S12 ──► S13
+        │      │
+        └──────┴────► S14（建议，非硬依赖）
+
+S2  S3  S4  S5  S6  S7  S8  S10  S11  S15   ← 全部可独立并行开工
+\`\`\`
+
+## 子任务
+
+<!-- SUBTASK_LIST -->
+
+## 关单条件
+
+见 \`$PLAN\` §6 的 Cucumber 验收：三条 P0 全部关闭、失败路径本身可靠、
+容量与遥测不再说谎、防线是真的、玩家门名实相符。
+
+## 修复时请勿顺手改坏
+
+审查确认以下是**对的**，不在修复范围内：VM 的类型初始化完备性硬闸、
+执行状态的 ref struct + Span 寄存器设计、编译器前端的四类检查、
+\`AddFixed<T>\` 容量模式、派生属性写入围栏、缺 DirtyFlags 的失败关闭设计、
+技能→效果→图 的类型级单向性、知识披露与头顶条那一侧。
+EOF
+)
+
+EPIC_TITLE="Epic: GAS + Graph VM 架构收口（审查后修复）"
+
+if [[ "$MODE" == "dry-run" ]]; then
+  echo "──────── 将创建 Epic ────────"
+  echo "标题: $EPIC_TITLE"
+  echo "正文: $(echo "$EPIC_BODY" | wc -l | tr -d ' ') 行"
+  echo
+  echo "──────── 将创建子 issue ────────"
+  while IFS='|' read -r id prio dep title; do
+    [[ -z "$id" ]] && continue
+    body_lines=$(extract_section "$id" | wc -l | tr -d ' ')
+    printf '  %-4s [%-5s] deps=%-8s %s  (正文 %s 行)\n' "$id" "$prio" "$dep" "$title" "$body_lines"
+    if [[ "$body_lines" -lt 10 ]]; then
+      echo "        !! 正文切取异常，检查 $PLAN 里 '### $id · ' 小节标题格式" >&2
+    fi
+  done <<< "$SUBTASKS"
+  echo
+  echo "以上为预演。加 --apply 真的创建。"
+  exit 0
+fi
+
+# ---------- 真的创建 ----------
+declare -a CREATED_URLS=()
+declare -a CREATED_IDS=()
+
+while IFS='|' read -r id prio dep title; do
+  [[ -z "$id" ]] && continue
+  section=$(extract_section "$id")
+  if [[ $(echo "$section" | wc -l) -lt 10 ]]; then
+    echo "跳过 $id：正文切取异常" >&2
+    continue
+  fi
+
+  dep_line=""
+  [[ "$dep" != "-" ]] && dep_line="**依赖：** ${dep}（必须在它们之后开工）"$'\n\n'
+
+  body="**优先级：** ${prio}"$'\n'"${dep_line}"$'\n'"审查依据：\`${REVIEW}\`　任务书出处：\`${PLAN}\` § ${id}"$'\n\n---\n\n'"${section}"
+
+  url=$(gh issue create --repo "$REPO" --title "[${prio}][${id}] ${title}" --body "$body")
+  echo "已创建 $id: $url"
+  CREATED_URLS+=("$url")
+  CREATED_IDS+=("$id")
+done <<< "$SUBTASKS"
+
+# Epic 正文里填入子任务清单（GitHub 的 task list 会自动渲染成进度条）
+subtask_md=""
+i=0
+while IFS='|' read -r id prio dep title; do
+  [[ -z "$id" ]] && continue
+  url="${CREATED_URLS[$i]:-}"
+  [[ -z "$url" ]] && { i=$((i+1)); continue; }
+  dep_note=""
+  [[ "$dep" != "-" ]] && dep_note=" _(依赖 ${dep})_"
+  subtask_md+="- [ ] ${url} \`${prio}\` ${title}${dep_note}"$'\n'
+  i=$((i+1))
+done <<< "$SUBTASKS"
+
+epic_body_final="${EPIC_BODY//<!-- SUBTASK_LIST -->/$subtask_md}"
+epic_url=$(gh issue create --repo "$REPO" --title "$EPIC_TITLE" --body "$epic_body_final")
+echo
+echo "已创建 Epic: $epic_url"
+
+# 尝试建立原生 sub-issue 层级（GitHub 的 addSubIssue）。
+# 失败不影响结果 —— Epic 正文里的 task list 已经把关系表达清楚了，这里只是额外加成。
+epic_num="${epic_url##*/}"
+epic_node=$(gh api "repos/$REPO/issues/$epic_num" --jq .node_id 2>/dev/null || echo "")
+if [[ -n "$epic_node" ]]; then
+  linked=0
+  for url in "${CREATED_URLS[@]}"; do
+    num="${url##*/}"
+    child_node=$(gh api "repos/$REPO/issues/$num" --jq .node_id 2>/dev/null || echo "")
+    [[ -z "$child_node" ]] && continue
+    if gh api graphql -f query='
+      mutation($parent:ID!, $child:ID!) {
+        addSubIssue(input:{issueId:$parent, subIssueId:$child}) { issue { number } }
+      }' -f parent="$epic_node" -f child="$child_node" >/dev/null 2>&1; then
+      linked=$((linked+1))
+    fi
+  done
+  echo "原生 sub-issue 关联成功 $linked / ${#CREATED_URLS[@]} 条（未成功的仍在 Epic 的清单里）"
+else
+  echo "未能取到 Epic 的 node id，跳过原生 sub-issue 关联（Epic 清单不受影响）"
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# 概要

- 变更目标：交付整套 GAS 与图 VM 的架构审查结论，并把修复拆成可直接派给 Agent 的 Epic + 15 个子任务。附一个一键批量建 issue 的脚本。
- 影响范围：两份新文档 + 目录一行 + 一个脚本 + **一行文档链接修复**（见下）。无生产代码改动。

## 结论：骨架比收尾好得多

图 VM 执行核心、编译器前端、组件布局、零分配纪律都是认真做的，**修复计划里没有任何重写**，全部是收口。风险集中在三类「收尾」：跨图与跨层的传播分析缺失、失败路径本身不可靠、以及一批看起来在守门实际不断言的防线。

三条 P0 **都是实跑证实的，不是读代码推断的**：

| # | 问题 | 实测结果 |
|---|------|---------|
| 1 | 一张自己调自己的图 | 注册表照收、装载期全绿；执行时递归 1495 层栈溢出，**进程被杀（退出码 134）**，`try/catch` 无法进入 |
| 2 | 属性数值的权威 | 同一个正式接口写 50：夹上限的属性上存活；不夹上限且有活跃修正的属性上**变回 118**；且覆盖时机与写入完全脱钩（可存活任意多帧，直到不相干事件把实体标脏） |
| 3 | 查询方言直绑图号 | 线性方言拒绝、查询方言放行；动作清单 11 条里 9 条不含 Yield，全部可被一张查询图调起。违反合同 §3.4，零测试覆盖 |

实测探针源码随 PR 附上（`/tmp` 下独立项目直连 `src/Core/Ludots.Core.csproj`，未改工作区任何源码）。

顺带修正了我在 [#940](https://github.com/MightyBubble/Ludots/pull/940) 里的一处定性：那个 `validOutput` 写死 31 号布尔格子的问题，**不是模型缺陷而是绕过分配器的硬编码特例**——编译器其实有寄存器分配器和类似 SSA 的检查，溢出是编译期失败关闭。

## SSOT 落点

- 正式规则：无
- 正式架构：无（审查判定合同 `gitbook/architecture/graph-funclib-actionlib-contract.md` 应继续「修复中」，本 PR 不改它）
- 正式查表或操作：无
- 仓库深度材料：无
- 审计或提案：`docs/audits/gas_graph_architecture_review.md`（审查 SSOT）、`docs/audits/gas_graph_architecture_fix_plan.md`（任务分配）

## 设计与挂靠点

- 挂靠点：`docs/audits/`，沿用既有的「审查结论 + 修复清单」两件套惯例（`pr911_audit_fix_checklist.md` 是先例）。两份文档都按 1 概述 / 2 结构 / 3 详情 / 4 场景 / 5 边界 / 6 UAT 组织，UAT 用 Cucumber 从玩家与作者视角写。
- 复用清单：六个方向的判据全部来自既有正式文档（GAS 分层、图分层、图复用库合同、实体模拟分层、Mod 架构、订单与输入运行时合同）；批量建 issue 复用 `gh issue create` + GraphQL `addSubIssue`。
- 新增清单：审查结论、修复计划、`scripts/create-gas-graph-fix-issues.sh`、目录两行。

## 任务分配

15 个子任务分四档。**S1 / S2 / S3 可以同时开三个 Agent，互不冲突。**

```text
S1 ──► S9 ──► S12 ──► S13
        │      │
        └──────┴────► S14（建议，非硬依赖）

S2  S3  S4  S5  S6  S7  S8  S10  S11  S15   ← 全部可独立并行开工
```

唯一的硬顺序是 **S13 必须在 S9 之后**：今天三个 L2 宿主只填了部分寄存器就能跑，正是因为脚本方言窄到用不到那些寄存器；反了必崩。

| 档 | 子任务 |
|----|--------|
| **P0** | S1 图调用无界递归 · S2 属性写入权威与强制手段 · S3 查询方言的可挂起动作开口 |
| **P1** | S4 事务回滚不可失败 · S5 容量三禁 · S6 退役展厅锁门+停止清表 · S7 展厅血条名实 |
| **P2** | S8 假防线整治 · S9 L2 走正式前门 · S10 表现层不决定玩法选中 · S11 覆盖表归因 · S12 寄存器归属+descriptor · S13 脚本方言拓宽+L2 作者面 |
| **P3** | S14 分层物理化（先出设计再动手） |
| chore | S15 验收页 SSOT 合并 |

每个子任务的「任务书」小节可以**整段复制**给一个 Agent：含目标、现状定位（带文件与方法名）、要做什么、明确的禁止项、Cucumber 验收、以及该跑的测试 filter。已经定位过的现状都写进去了，Agent 不需要重新查。

## 验证证据

| 动作 | 结果 |
|------|------|
| `pwsh ./scripts/validate-docs.ps1` | **全仓通过**（见下，本 PR 顺带修掉了 main 上的红灯） |
| `python3 scripts/validate-registry.py` | 通过（271 条 / 0 错误 / 23 条既有 T1 警告） |
| `bash scripts/create-gas-graph-fix-issues.sh --dry-run` | 15 个子任务正文全部正确切出（33–114 行），Epic 正文 44 行 |
| 零分配与性能防线实跑 | 58 条全绿，含跑 43 秒的一万智能体零分配基准 |
| 属性权威实测 | 三格对照见上表；探针 `attribute_probe_Program.cs` |
| 图递归实测 | 进程退出码 134；探针 `recursion_probe.cs` |
| `#914` 声称还原的思考波闸门 | **确认真还原**（不许任何一次超 5ms + 均值与 95 分位都在 15 内，三条断言都带消息） |

**关于 `docs-governance`：本 PR 让它变绿了。** `gitbook/acceptance/graph-funclib-actionlib-uat.md` 的相对链接少一级 `../`，触发 `missing-link-target`，自 #932 合入起一直红着并**挡住所有改文档的 PR**。我只改了那一行（一个字符级改动）来清路；同一文件的 SSOT 合并（两个 H1 给出互相矛盾的覆盖结论）工作量不小，仍作为 S15 分配出去。

## 如何创建 issue

我这边 `GH_TOKEN` 已失效（issue API 返回 401），无法直接建。合入后跑：

```bash
scripts/create-gas-graph-fix-issues.sh --dry-run   # 先看会创建什么
scripts/create-gas-graph-fix-issues.sh --apply     # 真的创建
```

脚本从计划文档按小节切正文，**文档是唯一内容源**——要改任务书请改文档，不要改脚本里的文案。它会先创建 15 个子 issue、再创建 Epic 并把清单填进去（GitHub 的 task list 会渲染成进度条），然后尝试建立原生 sub-issue 层级；层级失败不影响结果，因为 Epic 正文已经把关系表达清楚了。`--apply` 前会先校验 `gh` 凭据确实能读该仓库的 issue，读不到就中止而不是半路失败。

# 文档同步

- [x] 行为变更已同步更新 `gitbook/` 正式文档 —— 本 PR 无行为变更；唯一的 `gitbook/` 改动是修一行失效链接
- [x] 所属目录 `README.md` 或 `SUMMARY.md` 已同步 —— `docs/audits/README.md` 已加两行
- [x] 若影响入口或导航，`README.md` / `README_CN.md` / `AGENTS.md` / `CLAUDE.md` 已同步 —— 不影响入口

## 备注

审查明确列出了**修复时请勿顺手改坏**的东西（计划 §5）：VM 的类型初始化完备性硬闸、执行状态的 `ref struct` + `Span` 设计、编译器前端的四类检查、`AddFixed<T>` 容量模式、派生属性写入围栏、缺脏标记组件的失败关闭设计、技能→效果→图 的类型级单向性、以及知识披露与头顶条那一侧。另外 **120 个 opcode 这个规模不是问题**，分派表撑得住再加 100 个——真正到临界点的是寄存器索引归属、装载期校验器缺位、以及调用的能力传播。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-200699fb-fa95-43f5-8239-f1e7d03b0f85?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-200699fb-fa95-43f5-8239-f1e7d03b0f85&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

