### PR TITLE
fix(gas): S4 结算回滚必须走完，缺服务不能装成零目标

### DIFF
--- a/artifacts/gas-composition-gate.md
+++ b/artifacts/gas-composition-gate.md
@@ -1,7 +1,7 @@
 ﻿## GAS Composition Gate — Self Review
 
-- **Task / Issue**: Close leftover GraphOps gallery tails (headless host must use GameEngine, symbol resolve fail-closed, overlay reads authored graph, family runtimes must not `World.Create`)
-- **Date**: 2026-08-13
+- **Task / Issue**: S4 · 事务收尾：回滚必须不可失败（PR #942 修复计划）
+- **Date**: 2026-08-14
 - **Agent / Author**: Cursor Grok 4.6
 
 ### 1. Core judgment
@@ -10,23 +10,24 @@
 
 结论: PASS
 
-一句话理由: 不新增 graph op / profile enum；把无头画廊和家族演示接到已有 GameEngine、MapLoader、GasGraphSymbolResolver 合同上。
+一句话理由: 不新增 graph 节点 / profile enum / 平行管线；只补齐已有 `EffectPhaseSideEffectTransaction` 的回滚守卫、提交收尾、标签暂存，以及缺服务失败关闭。
 
 ### 2. Layer assignment
 
 | 步骤/能力 | Layer (0/1/2/3) | 实现载体 |
 |-----------|-----------------|----------|
-| 无头画廊开图 | 2 | GameEngine.LoadMap + MapLoader.LoadEntitiesAndIndex |
-| 符号解析 | 0 | 已有 Tag/Attribute/Effect/Relationship registries GetId |
-| 空间圈人描边 | 2 | 已编译 graph 的 Imm / ConstInt |
-| 家族演示世界 | 2 | 可玩路径 GameEngine.World + BindMapEntity；无头验收用一次性 World，禁止再启第二台 GameEngine |
+| 回滚路径 IsAlive/Has 守卫 | 1 | `EffectPhaseSideEffectTransaction.RollbackWorldWrites` |
+| 提交内销毁后移 | 1 | 同一事务 `Commit` 成功后再落地销毁 |
+| 标签授予进暂存 | 1 | `StageGrantedTagGrant`（对称 `StageGrantedTagRevoke`） |
+| 挂载可见中间态 | 1 | `EffectApplicationSystem` 切片语义，不再用补偿函数拼接 |
+| 缺服务失败关闭 | 0 | `StagePresentationEvent` / fan-out builtins 抛缺失服务名 |
 
 ### 3. Reuse list
 
-- Handlers: 无新 BuiltinHandler
-- Queues / Systems: GameEngine 已注册 SpatialPartitionUpdateSystem、EffectRequestQueue
-- Resolvers / Registries: GasGraphSymbolResolver 合同（GetId 失败即抛）
-- Existing presets / graphs: `assets/GAS/graphs/*.json`、`tag_rules.json`、`effects.json`
+- Handlers: 已有 `BuiltinHandlers.HandleSpatialQuery` / `HandleDispatchPayload` / `HandleReResolveAndDispatch`
+- Queues / Systems: `EffectPhaseSideEffectTransaction`、`EffectApplicationSystem`、`EffectLifetimeSystem`、`TagOps`、`DirtyEntityQueue`
+- Resolvers / Registries: 已有 `GetOrAddTagEntity` 暂存面；不新增 Registry
+- Existing presets / graphs: 无新 preset / graph
 
 ### 4. New Layer 0 ops (if any)
 
@@ -34,11 +35,11 @@ N/A
 
 ### 5. Transaction boundary
 
-无 lifecycle spawn/morph 事务；画廊无头开图失败必须抛。家族无头验收用一次性 World，禁止再启第二台 GameEngine 去清 GraphIdRegistry。
+必须原子 rollback 的步骤: 属性 / 标签 / 黑板 / 取消标记 / listener / relation / 外部队列检查点。回滚自身不得抛。`World.Destroy` 不在可失败提交窗口内执行。挂载（`ActiveEffectContainer`）是切片可见中间态，不属于一次阶段结算事务；切片中止仍由 `ResetSlice` 收回未 Committed 挂载。
 
 ### 6. Config SSOT
 
-行为配置落在: gallery `assets/GAS/graphs/`、`tag_rules.json`、`effects.json`、sandbox/catalog.json
+行为配置落在: 无新配置；沿用现有 effect template + 事务 API
 
 是否新增 JSON schema: NO
 

--- a/src/Core/Gameplay/GAS/BuiltinHandlers.cs
+++ b/src/Core/Gameplay/GAS/BuiltinHandlers.cs
@@ -27,6 +27,12 @@ namespace Ludots.Core.Gameplay.GAS
     /// </summary>
     public static class BuiltinHandlers
     {
+        public const string MissingHandlerRuntimeError = "GAS.BUILTIN.ERR.MissingHandlerRuntime";
+        public const string MissingSpatialQueriesError = "GAS.BUILTIN.ERR.MissingSpatialQueries";
+        public const string MissingFanOutBudgetError = "GAS.BUILTIN.ERR.MissingFanOutBudget";
+        public const string MissingFanOutCommandsError = "GAS.BUILTIN.ERR.MissingFanOutCommands";
+        public const string MissingResolverBufferError = "GAS.BUILTIN.ERR.MissingResolverBuffer";
+
         private static void RejectNonTransactionalPersistentSideEffect(string operation)
         {
             if (BuiltinHandlerRuntimeScope.Current?.EffectSideEffects?.IsActive == true)
@@ -34,6 +40,17 @@ namespace Ludots.Core.Gameplay.GAS
                 throw new InvalidOperationException(
                     $"{EffectPhaseSideEffectTransaction.UnsupportedSideEffectError}: operation={operation}.");
             }
+        }
+
+        private static BuiltinHandlerExecutionContext RequireHandlerRuntime()
+        {
+            BuiltinHandlerExecutionContext? runtime = BuiltinHandlerRuntimeScope.Current;
+            if (runtime == null)
+            {
+                throw new InvalidOperationException(MissingHandlerRuntimeError);
+            }
+
+            return runtime;
         }
 
         public static void RegisterAll(BuiltinHandlerRegistry registry)
@@ -131,10 +148,14 @@ namespace Ludots.Core.Gameplay.GAS
             in EffectConfigParams mergedParams,
             in EffectTemplateData templateData)
         {
-            var runtime = BuiltinHandlerRuntimeScope.Current;
-            if (runtime?.SpatialQueries == null || runtime.ResolverBuffer == null)
+            var runtime = RequireHandlerRuntime();
+            if (runtime.SpatialQueries == null)
             {
-                return;
+                throw new InvalidOperationException(MissingSpatialQueriesError);
+            }
+            if (runtime.ResolverBuffer == null)
+            {
+                throw new InvalidOperationException(MissingResolverBufferError);
             }
 
             int candidateCount = TargetResolverFanOutHelper.ResolveTargets(
@@ -155,10 +176,18 @@ namespace Ludots.Core.Gameplay.GAS
             in EffectConfigParams mergedParams,
             in EffectTemplateData templateData)
         {
-            var runtime = BuiltinHandlerRuntimeScope.Current;
-            if (runtime?.FanOutBudget == null || runtime.FanOutCommands == null || runtime.ResolverBuffer == null)
+            var runtime = RequireHandlerRuntime();
+            if (runtime.FanOutBudget == null)
             {
-                return;
+                throw new InvalidOperationException(MissingFanOutBudgetError);
+            }
+            if (runtime.FanOutCommands == null)
+            {
+                throw new InvalidOperationException(MissingFanOutCommandsError);
+            }
+            if (runtime.ResolverBuffer == null)
+            {
+                throw new InvalidOperationException(MissingResolverBufferError);
             }
 
             int candidateCount = runtime.ResolvedCandidateCount;
@@ -192,10 +221,22 @@ namespace Ludots.Core.Gameplay.GAS
             in EffectConfigParams mergedParams,
             in EffectTemplateData templateData)
         {
-            var runtime = BuiltinHandlerRuntimeScope.Current;
-            if (runtime?.SpatialQueries == null || runtime.FanOutBudget == null || runtime.FanOutCommands == null || runtime.ResolverBuffer == null)
+            var runtime = RequireHandlerRuntime();
+            if (runtime.SpatialQueries == null)
             {
-                return;
+                throw new InvalidOperationException(MissingSpatialQueriesError);
+            }
+            if (runtime.FanOutBudget == null)
+            {
+                throw new InvalidOperationException(MissingFanOutBudgetError);
+            }
+            if (runtime.FanOutCommands == null)
+            {
+                throw new InvalidOperationException(MissingFanOutCommandsError);
+            }
+            if (runtime.ResolverBuffer == null)
+            {
+                throw new InvalidOperationException(MissingResolverBufferError);
             }
 
             int candidateCount = TargetResolverFanOutHelper.ResolveTargets(

--- a/src/Core/Gameplay/GAS/EffectPhaseSideEffectTransaction.cs
+++ b/src/Core/Gameplay/GAS/EffectPhaseSideEffectTransaction.cs
@@ -21,6 +21,7 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
     public const string UnsupportedSideEffectError = "GAS.EFFECT_TRANSACTION.ERR.UnsupportedSideEffect";
     public const string AttributeTargetInvalidError = "GAS.EFFECT_TRANSACTION.ERR.AttributeTargetInvalid";
     public const string RelationTargetInvalidError = "GAS.EFFECT_TRANSACTION.ERR.RelationTargetInvalid";
+    public const string MissingPresentationEventBufferError = "GAS.GRAPH.ERR.MissingGasPresentationEventBuffer";
 
     private readonly World _world;
     private readonly TagOps? _tagOps;
@@ -428,7 +429,7 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
         RequireActive();
         if (_presentationEvents == null)
         {
-            return;
+            throw new InvalidOperationException(MissingPresentationEventBufferError);
         }
         if (_presentationEventCount >= _stagedPresentationEvents.Length ||
             _presentationEventCount >= _presentationEvents.AvailableCapacity)
@@ -497,6 +498,45 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
 
         hasTag = _tagOps.HasTag(ref _tagValues[index], tagId, TagSense.Effective);
         return true;
+    }
+
+    public void StageGrantedTagGrant(Entity target, in EffectGrantedTags grantedTags, int stackCount)
+    {
+        RequireActive();
+        if (!_world.IsAlive(target) || grantedTags.Count <= 0)
+        {
+            return;
+        }
+        if (_tagOps == null)
+        {
+            throw new InvalidOperationException(TagOps.MissingTagOpsError);
+        }
+
+        int index = GetOrAddTagEntity(target);
+        bool changed = false;
+        for (int grantIndex = 0; grantIndex < grantedTags.Count; grantIndex++)
+        {
+            TagContribution contribution = grantedTags.Get(grantIndex);
+            int amount = contribution.Compute(stackCount);
+            for (int repeat = 0; repeat < amount; repeat++)
+            {
+                if (!_tagOps.AddTag(
+                    ref _tagValues[index],
+                    ref _tagCountValues[index],
+                    contribution.TagId,
+                    ref _tagDirtyValues[index]))
+                {
+                    throw new InvalidOperationException(TagOps.RuleRejectedError);
+                }
+
+                changed = true;
+            }
+        }
+
+        if (changed)
+        {
+            StageDirtyEntity(target);
+        }
     }
 
     public void StageGrantedTagRevoke(Entity target, in EffectGrantedTags grantedTags, int stackCount)
@@ -799,10 +839,11 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
     {
         RequireActive();
         ValidateCommit();
-        PrepareCommitState();
 
+        int pendingDestroyCount = _destroyedEffectCount;
         try
         {
+            PrepareCommitState();
             _worldCommitStarted = true;
             if (_structuralCommands.Size > 0)
             {
@@ -907,25 +948,21 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
             {
                 _gameplayEventBus!.Publish(_stagedGameplayEvents[i]);
             }
-            for (int i = 0; i < _destroyedEffectCount; i++)
-            {
-                Entity effect = _destroyedEffects[i];
-                if (_world.IsAlive(effect))
-                {
-                    _world.Destroy(effect);
-                }
-            }
-
             if (_rootBudget != null)
             {
                 _rootBudget.CommitWrites(in _rootBudgetCheckpoint);
             }
 
             End();
+            LandStagedDestroys(pendingDestroyCount);
         }
         catch
         {
-            Rollback();
+            if (IsActive)
+            {
+                Rollback();
+            }
+
             throw;
         }
     }
@@ -1711,25 +1748,32 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
         }
         for (int i = 0; i < _blackboardFloatCount; i++)
         {
-            _world.Get<BlackboardFloatBuffer>(_blackboardFloatEntities[i]) = _blackboardFloatOriginalValues[i];
+            RestoreComponent(_blackboardFloatEntities[i], in _blackboardFloatOriginalValues[i]);
         }
         for (int i = 0; i < _blackboardIntCount; i++)
         {
-            _world.Get<BlackboardIntBuffer>(_blackboardIntEntities[i]) = _blackboardIntOriginalValues[i];
+            RestoreComponent(_blackboardIntEntities[i], in _blackboardIntOriginalValues[i]);
         }
         for (int i = 0; i < _blackboardEntityCount; i++)
         {
-            _world.Get<BlackboardEntityBuffer>(_blackboardEntityEntities[i]) = _blackboardEntityOriginalValues[i];
+            RestoreComponent(_blackboardEntityEntities[i], in _blackboardEntityOriginalValues[i]);
         }
         for (int i = 0; i < _cancelledEffectCount; i++)
         {
-            _world.Get<GameplayEffect>(_cancelledEffects[i]).CancelRequested = _cancelledEffectOriginalValues[i];
+            Entity entity = _cancelledEffects[i];
+            if (_world.IsAlive(entity) && _world.Has<GameplayEffect>(entity))
+            {
+                _world.Get<GameplayEffect>(entity).CancelRequested = _cancelledEffectOriginalValues[i];
+            }
         }
         for (int i = 0; i < _listenerEntityCount; i++)
         {
-            if (_listenerExisted[i] && _world.Has<EffectPhaseListenerBuffer>(_listenerEntities[i]))
+            Entity entity = _listenerEntities[i];
+            if (_listenerExisted[i] &&
+                _world.IsAlive(entity) &&
+                _world.Has<EffectPhaseListenerBuffer>(entity))
             {
-                _world.Get<EffectPhaseListenerBuffer>(_listenerEntities[i]) = _listenerOriginalValues[i];
+                _world.Get<EffectPhaseListenerBuffer>(entity) = _listenerOriginalValues[i];
             }
         }
         for (int i = 0; i < _relationParentCount; i++)
@@ -1980,6 +2024,28 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
 
         position = default;
         return false;
+    }
+
+    private void RestoreComponent<T>(Entity entity, in T original)
+        where T : struct
+    {
+        if (_world.IsAlive(entity) && _world.Has<T>(entity))
+        {
+            _world.Get<T>(entity) = original;
+        }
+    }
+
+    private void LandStagedDestroys(int pendingDestroyCount)
+    {
+        // Destroy only after End(): the transaction can no longer fail or roll back.
+        for (int i = 0; i < pendingDestroyCount; i++)
+        {
+            Entity effect = _destroyedEffects[i];
+            if (_world.IsAlive(effect))
+            {
+                _world.Destroy(effect);
+            }
+        }
     }
 
     private void RequireActive()

--- a/src/Core/Gameplay/GAS/EffectTagContributionHelper.cs
+++ b/src/Core/Gameplay/GAS/EffectTagContributionHelper.cs
@@ -12,23 +12,6 @@ namespace Ludots.Core.Gameplay.GAS
     {
         public static void GrantToEntity(World world, Entity target, in EffectGrantedTags grantedTags, int stackCount, TagOps tagOps, GasBudget budget = null)
         {
-            GrantToEntityCore(world, target, in grantedTags, stackCount, tagOps, budget, trackDirtyEntity: true);
-        }
-
-        internal static void PrepareGrantToEntity(World world, Entity target, in EffectGrantedTags grantedTags, int stackCount, TagOps tagOps, GasBudget budget = null)
-        {
-            GrantToEntityCore(world, target, in grantedTags, stackCount, tagOps, budget, trackDirtyEntity: false);
-        }
-
-        private static void GrantToEntityCore(
-            World world,
-            Entity target,
-            in EffectGrantedTags grantedTags,
-            int stackCount,
-            TagOps tagOps,
-            GasBudget budget,
-            bool trackDirtyEntity)
-        {
             if (!world.IsAlive(target) || grantedTags.Count <= 0)
             {
                 return;
@@ -53,7 +36,7 @@ namespace Ludots.Core.Gameplay.GAS
                             throw new System.InvalidOperationException(TagOps.RuleRejectedError);
                     }
                 }
-                if (trackDirtyEntity && dirtyFlags.IsAnyTagDirty()) tagOps.MarkDirtyEntity(world, target);
+                if (dirtyFlags.IsAnyTagDirty()) tagOps.MarkDirtyEntity(world, target);
             }
             catch
             {

--- a/src/Core/Gameplay/GAS/Systems/EffectApplicationSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/EffectApplicationSystem.cs
@@ -82,7 +82,8 @@ namespace Ludots.Core.Gameplay.GAS.Systems
         public int LastSliceProcessed { get; private set; }
 
         /// <summary>
-        /// Time-sliced application stages for EffectApplicationSystem.
+        /// Time-sliced application stages. ProcessPending through AttachEffects
+        /// commit a visible attachment; ActivateEffects is the settlement transaction.
         /// </summary>
         private enum ApplicationStage : byte
         {
@@ -390,19 +391,14 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                             EffectContext context = World.Get<EffectContext>(e);
                             if (!IsEffectAttached(context.Target, e))
                             {
-                                RollbackPersistentAttachment(context.Target, e);
-                                ConsumeWork(ref workUnits);
-                                continue;
+                                throw new InvalidOperationException(
+                                    $"GAS.ACTIVE_EFFECT_CONTAINER.ERR.MissingAttachment: target={context.Target.Id}, effect={e.Id}.");
                             }
 
                             int templateId = World.Has<EffectTemplateRef>(e)
                                 ? World.Get<EffectTemplateRef>(e).TemplateId
                                 : 0;
 
-                            bool hasGrantedTagSnapshot = false;
-                            GameplayTagContainer tagsBefore = default;
-                            TagCountContainer tagCountsBefore = default;
-                            DirtyFlags dirtyFlagsBefore = default;
                             int fanOutCommandCountBefore = _fanOutCommands.Count;
                             int fanOutDroppedBefore = _fanOutDropped;
                             int listenerRegistrationCountBefore = _pendingListenerRegistrations.Count;
@@ -421,16 +417,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                                 {
                                     EffectGrantedTags grantedTags = World.Get<EffectGrantedTags>(e);
                                     int stackCount = World.Has<EffectStack>(e) ? World.Get<EffectStack>(e).Count : 1;
-                                    TagOps.RequireTagState(World, context.Target);
-                                    tagsBefore = World.Get<GameplayTagContainer>(context.Target);
-                                    tagCountsBefore = World.Get<TagCountContainer>(context.Target);
-                                    dirtyFlagsBefore = World.Get<DirtyFlags>(context.Target);
-                                    hasGrantedTagSnapshot = true;
-                                    EffectTagContributionHelper.PrepareGrantToEntity(World, context.Target, in grantedTags, stackCount, _tagOps, _budget);
-                                    if (World.Get<DirtyFlags>(context.Target).IsAnyTagDirty())
-                                    {
-                                        _persistentPhaseTransaction.StageDirtyEntity(context.Target);
-                                    }
+                                    _persistentPhaseTransaction.StageGrantedTagGrant(context.Target, in grantedTags, stackCount);
                                 }
 
                                 ExecutePersistentPhases(e, in context, templateId);
@@ -463,13 +450,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                                 _fanOutCommands.Truncate(fanOutCommandCountBefore);
                                 _fanOutDropped = fanOutDroppedBefore;
                                 TrimTail(_pendingListenerRegistrations, listenerRegistrationCountBefore);
-                                if (hasGrantedTagSnapshot && World.IsAlive(context.Target))
-                                {
-                                    World.Get<GameplayTagContainer>(context.Target) = tagsBefore;
-                                    World.Get<TagCountContainer>(context.Target) = tagCountsBefore;
-                                    World.Get<DirtyFlags>(context.Target) = dirtyFlagsBefore;
-                                }
-                                RollbackPersistentAttachment(context.Target, e);
                                 throw;
                             }
                             finally
@@ -744,38 +724,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             for (int i = 0; i < container.Count; i++)
             {
                 if (container.GetEntity(i) == effect)
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private void RollbackPersistentAttachment(Entity target, Entity effect)
-        {
-            bool removeCreatedContainer = false;
-            if (World.IsAlive(target) && World.Has<ActiveEffectContainer>(target))
-            {
-                ref ActiveEffectContainer container = ref World.Get<ActiveEffectContainer>(target);
-                container.Remove(effect);
-                removeCreatedContainer = container.Count == 0 && WasContainerCreatedThisPass(target);
-            }
-
-            if (removeCreatedContainer && World.IsAlive(target) && World.Has<ActiveEffectContainer>(target))
-            {
-                World.Remove<ActiveEffectContainer>(target);
-            }
-            if (World.IsAlive(effect))
-            {
-                World.Destroy(effect);
-            }
-        }
-
-        private bool WasContainerCreatedThisPass(Entity target)
-        {
-            for (int i = 0; i < _createdContainers.Count; i++)
-            {
-                if (_createdContainers[i] == target)
                 {
                     return true;
                 }

--- a/src/Tests/GasTests/Effect/InstantEffectTransactionTests.cs
+++ b/src/Tests/GasTests/Effect/InstantEffectTransactionTests.cs
@@ -397,6 +397,294 @@ public sealed class InstantEffectTransactionTests
         });
     }
 
+    [Test]
+    public unsafe void RollbackWorldWrites_WhenBlackboardHolderIsDestroyed_CompletesRemainingRestores()
+    {
+        using World world = World.Create();
+        int healthId = AttributeRegistry.Register("Test.S4.Rollback.Health");
+        var tagOps = new TagOps(new DirtyEntityQueue(8), new TagRuleRegistry());
+        Entity victim = world.Create(new BlackboardFloatBuffer());
+        Entity survivor = world.Create(new AttributeBuffer(), new DirtyFlags());
+        world.Get<AttributeBuffer>(survivor).SetBase(healthId, 100f);
+        Entity source = world.Create();
+        using var transaction = new EffectPhaseSideEffectTransaction(
+            world,
+            tagOps,
+            effectRequests: null,
+            spawnRequests: null,
+            presentationEvents: null,
+            attributeEntityCapacity: 8);
+        transaction.Begin();
+        transaction.StageBlackboardFloat(victim, keyId: 7, value: 3.5f);
+        transaction.StageAttributeAdd(survivor, healthId, -25f);
+        EffectPhaseListenerBuffer setup = default;
+        setup.Count = 1;
+        setup.Phases[0] = (byte)EffectPhaseId.OnApply;
+        setup.Scopes[0] = (byte)PhaseListenerScope.Target;
+        setup.ActionFlags[0] = (byte)PhaseListenerActionFlags.ExecuteGraph;
+        setup.GraphProgramIds[0] = 1;
+        var context = new EffectContext { Source = source, Target = survivor };
+        transaction.StageListenerRegistration(in context, in setup, ownerEffectId: 11);
+
+        Type transactionType = typeof(EffectPhaseSideEffectTransaction);
+        MethodInfo prepareCommitState = transactionType.GetMethod(
+            "PrepareCommitState",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        FieldInfo structuralCommandsField = transactionType.GetField(
+            "_structuralCommands",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        FieldInfo worldCommitStartedField = transactionType.GetField(
+            "_worldCommitStarted",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        FieldInfo attributeValuesField = transactionType.GetField(
+            "_attributeValues",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        prepareCommitState.Invoke(transaction, null);
+        worldCommitStartedField.SetValue(transaction, true);
+        ((CommandBuffer)structuralCommandsField.GetValue(transaction)!).Playback(world);
+        world.Get<AttributeBuffer>(survivor) = ((AttributeBuffer[])attributeValuesField.GetValue(transaction)!)[0];
+        world.Destroy(victim);
+
+        Assert.DoesNotThrow(() => transaction.Rollback());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(world.IsAlive(victim), Is.False);
+            Assert.That(world.Get<AttributeBuffer>(survivor).GetCurrent(healthId), Is.EqualTo(100f));
+            Assert.That(world.Has<EffectPhaseListenerBuffer>(survivor), Is.False);
+        });
+    }
+
+    [Test]
+    public void StagePresentationEvent_WhenBufferIsMissing_ThrowsNamedError()
+    {
+        using World world = World.Create();
+        using var transaction = new EffectPhaseSideEffectTransaction(
+            world,
+            tagOps: null,
+            effectRequests: null,
+            spawnRequests: null,
+            presentationEvents: null,
+            attributeEntityCapacity: 2);
+        transaction.Begin();
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() =>
+            transaction.StagePresentationEvent(new GasPresentationEvent
+            {
+                Kind = GasPresentationEventKind.EffectActivated,
+            }))!;
+
+        Assert.That(error.Message, Does.StartWith(EffectPhaseSideEffectTransaction.MissingPresentationEventBufferError));
+        transaction.Rollback();
+    }
+
+    [Test]
+    public void StageGrantedTagGrant_CommitsThroughTransactionAndRollsBackOnAbort()
+    {
+        using World world = World.Create();
+        const int tagId = 91;
+        var dirtyQueue = new DirtyEntityQueue(8);
+        var tagOps = new TagOps(dirtyQueue, new TagRuleRegistry());
+        Entity target = world.Create(new GameplayTagContainer(), new TagCountContainer(), new DirtyFlags());
+        var grantedTags = new EffectGrantedTags();
+        Assert.That(grantedTags.Add(new TagContribution
+        {
+            TagId = tagId,
+            Formula = TagContributionFormula.Fixed,
+            Amount = 1,
+        }), Is.True);
+        using var transaction = new EffectPhaseSideEffectTransaction(
+            world,
+            tagOps,
+            effectRequests: null,
+            spawnRequests: null,
+            presentationEvents: null,
+            attributeEntityCapacity: 4);
+
+        transaction.Begin();
+        transaction.StageGrantedTagGrant(target, in grantedTags, stackCount: 1);
+        Assert.That(world.Get<GameplayTagContainer>(target).HasTag(tagId), Is.False);
+        transaction.Rollback();
+        Assert.That(world.Get<GameplayTagContainer>(target).HasTag(tagId), Is.False);
+        Assert.That(dirtyQueue.Count, Is.Zero);
+
+        transaction.Begin();
+        transaction.StageGrantedTagGrant(target, in grantedTags, stackCount: 1);
+        transaction.Commit();
+
+        Assert.That(world.Get<GameplayTagContainer>(target).HasTag(tagId), Is.True);
+        Assert.That(world.Get<TagCountContainer>(target).GetCount(tagId), Is.EqualTo(1));
+        Assert.That(dirtyQueue.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void FanOutBuiltins_WhenRequiredServicesAreMissing_ThrowNamedErrors()
+    {
+        using World world = World.Create();
+        Entity source = world.Create();
+        Entity target = world.Create();
+        var context = new EffectContext { Source = source, Target = target };
+        EffectConfigParams mergedParams = default;
+        EffectTemplateData template = default;
+
+        using (BuiltinHandlerRuntimeScope.Push(new BuiltinHandlerExecutionContext()))
+        {
+            InvalidOperationException spatial = Assert.Throws<InvalidOperationException>(() =>
+                BuiltinHandlers.HandleSpatialQuery(world, default, ref context, in mergedParams, in template))!;
+            Assert.That(spatial.Message, Does.StartWith(BuiltinHandlers.MissingSpatialQueriesError));
+
+            InvalidOperationException dispatch = Assert.Throws<InvalidOperationException>(() =>
+                BuiltinHandlers.HandleDispatchPayload(world, default, ref context, in mergedParams, in template))!;
+            Assert.That(dispatch.Message, Does.StartWith(BuiltinHandlers.MissingFanOutBudgetError));
+
+            InvalidOperationException reresolve = Assert.Throws<InvalidOperationException>(() =>
+                BuiltinHandlers.HandleReResolveAndDispatch(world, default, ref context, in mergedParams, in template))!;
+            Assert.That(reresolve.Message, Does.StartWith(BuiltinHandlers.MissingSpatialQueriesError));
+        }
+
+        InvalidOperationException missingRuntime = Assert.Throws<InvalidOperationException>(() =>
+            BuiltinHandlers.HandleSpatialQuery(world, default, ref context, in mergedParams, in template))!;
+        Assert.That(missingRuntime.Message, Does.StartWith(BuiltinHandlers.MissingHandlerRuntimeError));
+    }
+
+    [Test]
+    public void EffectApplication_AttachIsVisibleIntermediateState_BeforeActivateSettlement()
+    {
+        using World world = World.Create();
+        Entity source = world.Create();
+        Entity target = world.Create(new ActiveEffectContainer());
+        Entity effect = GameplayEffectFactory.CreateEffect(
+            world,
+            rootId: 1,
+            source,
+            target,
+            durationTicks: 30,
+            lifetimeKind: EffectLifetimeKind.After);
+        var system = new EffectApplicationSystem(
+            world,
+            GasConstants.MAX_EFFECT_REQUESTS_PER_FRAME,
+            new DiscreteClock())
+        {
+            MaxWorkUnitsPerSlice = 1,
+        };
+
+        Assert.That(system.UpdateSlice(0f, int.MaxValue), Is.False);
+        Assert.That(world.IsAlive(effect), Is.True);
+        Assert.That(world.Get<ActiveEffectContainer>(target).Count, Is.EqualTo(1));
+        Assert.That(world.Get<GameplayEffect>(effect).State, Is.EqualTo(EffectState.Apply));
+
+        system.MaxWorkUnitsPerSlice = int.MaxValue;
+        int slices = 0;
+        while (!system.UpdateSlice(0f, int.MaxValue))
+        {
+            slices++;
+            Assert.That(slices, Is.LessThan(16));
+        }
+
+        Assert.That(world.Get<GameplayEffect>(effect).State, Is.EqualTo(EffectState.Committed));
+        Assert.That(world.Get<ActiveEffectContainer>(target).Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void EffectApplication_ActivateFailure_LeavesVisibleAttachment_AndResetSliceReclaimsIt()
+    {
+        using World world = World.Create();
+        const int templateId = 1942;
+        const int graphId = 1943;
+        var programs = new GraphProgramRegistry();
+        programs.Register(graphId,
+        [
+            new GraphInstruction { Op = (ushort)GraphNodeOp.WriteBlackboardFloat, A = 0, B = 0, Imm = 1 },
+        ], GraphKind.Effect);
+        EffectPhaseGraphBindings bindings = default;
+        Assert.That(bindings.TryAddStep(EffectPhaseId.OnApply, PhaseSlot.Main, graphId), Is.True);
+        var templates = new EffectTemplateRegistry();
+        templates.Register(templateId, new EffectTemplateData
+        {
+            LifetimeKind = EffectLifetimeKind.After,
+            DurationTicks = 30,
+            PhaseGraphBindings = bindings,
+        });
+        var presets = new PresetTypeRegistry();
+        var builtins = new BuiltinHandlerRegistry();
+        BuiltinHandlers.RegisterAll(builtins);
+        EffectExecutionPlanCompiler.FinalizeAll(
+            templates,
+            presets,
+            builtins,
+            programs,
+            GasGraphOpHandlerTable.Instance,
+            "Test/s4-attach-intermediate-effects.json");
+        var phaseExecutor = new EffectPhaseExecutor(
+            programs,
+            presets,
+            builtins,
+            GasGraphOpHandlerTable.Instance,
+            templates);
+        var graphApi = new GasGraphRuntimeApi(world);
+        Entity source = world.Create();
+        Entity target = world.Create(new ActiveEffectContainer());
+        Entity effect = GameplayEffectFactory.CreateEffect(
+            world,
+            rootId: 2,
+            source,
+            target,
+            durationTicks: 30,
+            lifetimeKind: EffectLifetimeKind.After);
+        world.Add(effect, new EffectTemplateRef { TemplateId = templateId });
+        var system = new EffectApplicationSystem(
+            world,
+            GasConstants.MAX_EFFECT_REQUESTS_PER_FRAME,
+            new DiscreteClock(),
+            templates: templates,
+            phaseExecutor: phaseExecutor,
+            graphApi: graphApi)
+        {
+            MaxWorkUnitsPerSlice = 1,
+        };
+
+        Assert.That(system.UpdateSlice(0f, int.MaxValue), Is.False);
+        Assert.That(world.Get<ActiveEffectContainer>(target).Count, Is.EqualTo(1));
+
+        system.MaxWorkUnitsPerSlice = int.MaxValue;
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() =>
+        {
+            while (!system.UpdateSlice(0f, int.MaxValue))
+            {
+            }
+        })!;
+
+        Assert.That(error.Message, Does.StartWith("GAS.EFFECT_TRANSACTION.ERR.MissingBlackboard"));
+        Assert.That(world.IsAlive(effect), Is.True);
+        Assert.That(world.Get<ActiveEffectContainer>(target).Count, Is.EqualTo(1));
+        Assert.That(world.Get<GameplayEffect>(effect).State, Is.EqualTo(EffectState.Apply));
+
+        system.ResetSlice();
+
+        Assert.That(world.IsAlive(effect), Is.False);
+        Assert.That(world.Get<ActiveEffectContainer>(target).Count, Is.Zero);
+    }
+
+    [Test]
+    public void StageEffectDestroy_LandsOnlyAfterSuccessfulCommit()
+    {
+        using World world = World.Create();
+        Entity effect = world.Create(new GameplayEffect());
+        using var transaction = new EffectPhaseSideEffectTransaction(
+            world,
+            tagOps: null,
+            effectRequests: null,
+            spawnRequests: null,
+            presentationEvents: null,
+            attributeEntityCapacity: 2);
+        transaction.Begin();
+        transaction.StageEffectDestroy(effect);
+        Assert.That(world.IsAlive(effect), Is.True);
+        transaction.Commit();
+        Assert.That(world.IsAlive(effect), Is.False);
+    }
+
     private static EffectProposalProcessingSystem CreateSetParentRuntime(
         World world,
         int templateId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 合同

回滚必须走完。缺服务报错，不静默跳过。

## 实现

- 回滚：黑板 / 已取消 / 监听循环加 `IsAlive && Has`。
- 销毁：成功 `Commit` 之后，不在 Commit 可失败窗口里。
- 标签：`StageGrantedTagGrant` 进事务缓冲。
- 缺服务：`StagePresentationEvent` 与三个扇出内建抛错。

## 已知缺口（#949）

Commit 仍整块赋值 `AttributeBuffer`，不走 S2 `AttributeMutationOps`。事务类在 S2 白名单里，两边合在一起也不会红。

## 测试

`FullyQualifiedName~Ludots.Tests.Gas.EffectPhaseArchitectureTests|Ludots.Tests.Gas.EffectPhaseTests`

## 审计（#949）

合入，**不关单**。收口：Commit 走 S2 正式写入面。附录 B.2。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88eeeec8-f8e7-44e7-bfea-db2b5c012489?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88eeeec8-f8e7-44e7-bfea-db2b5c012489&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

