### PR TITLE
fix(graph): 自己调自己的图登记时拒绝，运行期超深抛错

### DIFF
--- a/artifacts/gas-composition-gate.md
+++ b/artifacts/gas-composition-gate.md
@@ -1,7 +1,7 @@
 ﻿## GAS Composition Gate — Self Review
 
-- **Task / Issue**: Close leftover GraphOps gallery tails (headless host must use GameEngine, symbol resolve fail-closed, overlay reads authored graph, family runtimes must not `World.Create`)
-- **Date**: 2026-08-13
+- **Task / Issue**: S1 · 图调用无界递归会杀进程（PR #942 修复计划 A1）
+- **Date**: 2026-08-14
 - **Agent / Author**: Cursor Grok 4.6
 
 ### 1. Core judgment
@@ -10,23 +10,24 @@
 
 结论: PASS
 
-一句话理由: 不新增 graph op / profile enum；把无头画廊和家族演示接到已有 GameEngine、MapLoader、GasGraphSymbolResolver 合同上。
+一句话理由: 不新增 graph 节点、profile enum 或平行管线；只把已有 `InvokeScript` 边的环从「当没找到 Yield」改成装载期错误，并给已有执行游标补上调用深度与整棵调用树共享的步数预算。
 
 ### 2. Layer assignment
 
 | 步骤/能力 | Layer (0/1/2/3) | 实现载体 |
 |-----------|-----------------|----------|
-| 无头画廊开图 | 2 | GameEngine.LoadMap + MapLoader.LoadEntitiesAndIndex |
-| 符号解析 | 0 | 已有 Tag/Attribute/Effect/Relationship registries GetId |
-| 空间圈人描边 | 2 | 已编译 graph 的 Imm / ConstInt |
-| 家族演示世界 | 2 | 可玩路径 GameEngine.World + BindMapEntity；无头验收用一次性 World，禁止再启第二台 GameEngine |
+| 装载期拒环 | 0 | `GraphYieldPurityValidator` + `GraphProgramRegistry.Register` / `ReplaceProgram` |
+| 热改过闸 | 2 | `LiveGasEditPipeline.Classify`（候选体）+ `ReplaceProgram`（硬闸） |
+| FuncLib 纯闭包 | 2 | 已有 `GraphFunctionCatalogLoader`（环从 clean 改 error） |
+| 运行期深度 / 共享步数 | 0 | `GraphVmLimits` + `GraphExecutionState` / `GraphExecutionCursor` + `GasGraphOpHandlerTable` |
+| Yield 进 Invoke 目标 | 0 | 登记期 `ContainsYield` 标记；运行期 O(1) 读标记 |
 
 ### 3. Reuse list
 
-- Handlers: 无新 BuiltinHandler
-- Queues / Systems: GameEngine 已注册 SpatialPartitionUpdateSystem、EffectRequestQueue
-- Resolvers / Registries: GasGraphSymbolResolver 合同（GetId 失败即抛）
-- Existing presets / graphs: `assets/GAS/graphs/*.json`、`tag_rules.json`、`effects.json`
+- Handlers: 已有 `HandleInvokeScript`；不新增 opcode
+- Queues / Systems: 无
+- Resolvers / Registries: `GraphProgramRegistry`、`GraphIdRegistry`、`GraphFunctionCatalog`（热改 / FuncLib 解析）
+- Existing presets / graphs: 不改资产；装载期只拒绝成环的 `InvokeScript` 图
 
 ### 4. New Layer 0 ops (if any)
 
@@ -34,13 +35,15 @@ N/A
 
 ### 5. Transaction boundary
 
-无 lifecycle spawn/morph 事务；画廊无头开图失败必须抛。家族无头验收用一次性 World，禁止再启第二台 GameEngine 去清 GraphIdRegistry。
+热改 `ReplaceProgram` 失败必须回滚到替换前的程序体（已有 `CommitNextCastSafeFrame` rollback 列表）。装载期 `Register` 失败不得留下半登记的 id。
 
 ### 6. Config SSOT
 
-行为配置落在: gallery `assets/GAS/graphs/`、`tag_rules.json`、`effects.json`、sandbox/catalog.json
+行为配置落在: 已有 graph / FuncLib / ActionLib catalog；闸门是登记与执行合同，不是新 JSON schema。
 
 是否新增 JSON schema: NO
+
+文档更新路径: `gitbook/architecture/graph-layering-flow-and-behavior.md`（步数硬顶旁补上调用环与 invoke 深度）。
 
 ### 7. Red flag scan
 
@@ -48,7 +51,38 @@ N/A
 - [x] 未新建与 spawn 平行的物化管线
 - [x] 未把 placement 校验塞进 lifecycle op
 - [x] 未添加「说不清的」默认 fallback
+- [x] 未用「Script 不许 InvokeScript」回避问题
+- [x] 未只加运行期深度而不做装载期拒环
+- [x] 未尝试捕获 `StackOverflowException`
 
 ### 8. Next variant test
 
 「下一个 Mod 变体」将修改: graph 连线 / effect 步骤
+
+---
+
+## 任务摘要
+
+一张图 `InvokeScript` 指向自己或成环时，当前会在运行期递归到栈溢出并杀掉进程。三道旧闸门都不覆盖跨图调用。本票只修这一条。
+
+## 判断标准结论
+
+通过。交付物是已有 op 边上的装载/运行闸门，不是新 enum 或新管线。
+
+## 复用 / 新增表
+
+| 类型 | 项 |
+|------|-----|
+| 复用 | `GraphYieldPurityValidator.activeGraphs`、`GraphProgramRegistry`、`LiveGasEditPipeline`、`GraphFunctionCatalogLoader`、`GraphExecutionCursor`、`GraphVmLimits.MaxInstructionsPerExecution` |
+| 新增 Layer 0 op | 无 |
+| 新增常量 | `GraphVmLimits.MaxInvokeDepth`（与同文件 `MaxCallStackDepth` 并列） |
+| 新增错误码 | `GAS.GRAPH.ERR.InvokeCycle`、`GAS.GRAPH.ERR.InvokeDepthExceeded`（沿用 `GAS.GRAPH.ERR.*` 诊断风格） |
+| 禁止 | 新 profile DSL、平行加载器、重写 VM 核心 |
+
+## 挂载点选择
+
+选 `GraphProgramRegistry.Register` / `ReplaceProgram`，不是只挂 `GraphProgramConfigLoader.PatchAndRegister`。
+
+理由：所有 `InvokeScript` 来源（配置装载、测试直登、画廊 Mod 直登、热改 `ReplaceProgram`）都经过这两处。`GraphYieldPurityValidator` 今天只挂在 FuncLib 装载与热改纯闭包检查上，挡不住直登脚本图。`GraphRuntime` 的架构守卫只禁止引用 `Gameplay.GAS`，同一程序集内复用 Host 校验器不破那道墙。
+
+增量登记时尚未登记的调用目标视为「还没到」，不报错，避免 `PatchAndRegister` 的前向引用被误杀；环在第二个参与者登记时闭合并失败。热改路径：`Classify` 用候选程序体预检，`ReplaceProgram` 再硬拒。

--- a/gitbook/acceptance/graph-funclib-actionlib-uat.md
+++ b/gitbook/acceptance/graph-funclib-actionlib-uat.md
@@ -4,7 +4,7 @@
 
 图复用库与可挂起动作的合同验收：FuncLib 纯函数无 Yield；ActionLib 供行为调度跨拍；Effect 可调 FuncLib 不可调 ActionLib；L1 Kind 前门与加载期失败关闭。
 
-对照：[图复用库合同](architecture/graph-funclib-actionlib-contract.md)。
+对照：[图复用库合同](../architecture/graph-funclib-actionlib-contract.md)。
 
 ## 2. 结构
 

--- a/gitbook/architecture/graph-layering-flow-and-behavior.md
+++ b/gitbook/architecture/graph-layering-flow-and-behavior.md
@@ -41,7 +41,7 @@ L0 GraphInstruction + handler table + Execute / ExecuteSlice
 | Score | 效用打分 | 禁止 |
 | Validation / Query / Derived | 既有专项 | 禁止 |
 
-跨图复用：`InvokeScript`（本切片只允许目标 Script **不含 Yield**）。
+跨图复用：`InvokeScript`（本切片只允许目标 Script **不含 Yield**）。`InvokeScript` 图在 `GraphProgramRegistry.Register` / `ReplaceProgram` 时必须是有向无环的；自调用或 A→B→A 以 `GAS.GRAPH.ERR.InvokeCycle` 失败关闭。运行期另有 `GraphVmLimits.MaxInvokeDepth`，且整棵调用树共享 `MaxInstructionsPerExecution`；超限抛错，禁止静默截断，也禁止把栈溢出当成可捕获错误。
 
 ### 作者糖（编译期降级）
 

--- a/src/Core/Gameplay/GAS/LiveSkillWorkbench/LiveGasEditPipeline.cs
+++ b/src/Core/Gameplay/GAS/LiveSkillWorkbench/LiveGasEditPipeline.cs
@@ -653,6 +653,31 @@ namespace Ludots.Core.Gameplay.GAS.LiveSkillWorkbench
                 return;
             }
 
+            if (!GraphYieldPurityValidator.TryValidateNoInvokeCycle(
+                    _graphs,
+                    graphId,
+                    $"graph '{graphKey}'",
+                    out string cycleDiagnostic,
+                    package.Program,
+                    package.Symbols,
+                    TryResolveFuncLibTarget,
+                    allowMissingTargets: true))
+            {
+                mapReload = true;
+                diags.Add(new LiveEditDiagnostic(
+                    LiveEditDiagnosticSeverity.Error,
+                    LiveEditDiagnosticCodes.GraphCompileFailed,
+                    $"{GraphYieldPurityValidator.InvokeCycleError}: {cycleDiagnostic}",
+                    graphKey));
+                items.Add(new LiveApplyClassificationItem(
+                    op.Kind,
+                    graphKey,
+                    LiveApplyMode.MapReloadRequired,
+                    "Graph candidate introduces an InvokeScript cycle.",
+                    diags));
+                return;
+            }
+
             _stagedGraphs.Add(new StagedGraphCandidate
             {
                 GraphKey = graphKey,

--- a/src/Core/GraphRuntime/GraphExecutionCursor.cs
+++ b/src/Core/GraphRuntime/GraphExecutionCursor.cs
@@ -13,6 +13,7 @@ namespace Ludots.Core.GraphRuntime
         public int Steps;
         public int CallStackCount;
         public int ReturnInt;
+        public int InvokeDepth;
         public GraphExecutionStatus Status;
 
         public void Reset()
@@ -21,6 +22,7 @@ namespace Ludots.Core.GraphRuntime
             Steps = 0;
             CallStackCount = 0;
             ReturnInt = 0;
+            InvokeDepth = 0;
             Status = GraphExecutionStatus.Running;
         }
     }

--- a/src/Core/GraphRuntime/GraphProgramRegistry.cs
+++ b/src/Core/GraphRuntime/GraphProgramRegistry.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using Ludots.Core.NodeLibraries.GASGraph;
+using Ludots.Core.NodeLibraries.GASGraph.Host;
 
 namespace Ludots.Core.GraphRuntime
 {
@@ -15,11 +17,26 @@ namespace Ludots.Core.GraphRuntime
             Program = program ?? Array.Empty<GraphInstruction>();
             Kind = kind;
             Symbols = symbols ?? Array.Empty<string>();
+            ContainsYield = ProgramContainsYield(Program);
         }
 
         public GraphInstruction[] Program { get; }
         public GraphKind Kind { get; }
         public string[] Symbols { get; }
+        public bool ContainsYield { get; }
+
+        private static bool ProgramContainsYield(GraphInstruction[] program)
+        {
+            for (int i = 0; i < program.Length; i++)
+            {
+                if (program[i].Op == (ushort)GraphNodeOp.Yield)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 
     public sealed class GraphProgramRegistry
@@ -58,6 +75,17 @@ namespace Ludots.Core.GraphRuntime
             {
                 _sourceMaps[graphId] = sourceMap;
             }
+
+            try
+            {
+                EnsureNoInvokeCycle(graphId);
+            }
+            catch
+            {
+                _programs.Remove(graphId);
+                _sourceMaps.Remove(graphId);
+                throw;
+            }
         }
 
         /// <summary>
@@ -88,6 +116,8 @@ namespace Ludots.Core.GraphRuntime
                     $"Graph program id {graphId} kind is '{existing.Kind}'; cannot replace with '{kind}' (identity change requires EngineRestart).");
             }
 
+            GraphProgramRegistration previous = existing;
+            _sourceMaps.TryGetValue(graphId, out GraphInstructionSourceMap previousSourceMap);
             _programs[graphId] = new GraphProgramRegistration(program, kind, symbols);
             if (sourceMap.HasSources)
             {
@@ -96,6 +126,38 @@ namespace Ludots.Core.GraphRuntime
             else
             {
                 _sourceMaps.Remove(graphId);
+            }
+
+            try
+            {
+                EnsureNoInvokeCycle(graphId);
+            }
+            catch
+            {
+                _programs[graphId] = previous;
+                if (previousSourceMap.HasSources)
+                {
+                    _sourceMaps[graphId] = previousSourceMap;
+                }
+                else
+                {
+                    _sourceMaps.Remove(graphId);
+                }
+
+                throw;
+            }
+        }
+
+        private void EnsureNoInvokeCycle(int graphId)
+        {
+            if (!GraphYieldPurityValidator.TryValidateNoInvokeCycle(
+                    this,
+                    graphId,
+                    GraphYieldPurityTarget.DescribeGraph(graphId),
+                    out string diagnostic,
+                    allowMissingTargets: true))
+            {
+                throw new InvalidOperationException($"{GraphYieldPurityValidator.InvokeCycleError}: {diagnostic}");
             }
         }
 

--- a/src/Core/GraphRuntime/GraphProgramRegistry.cs
+++ b/src/Core/GraphRuntime/GraphProgramRegistry.cs
@@ -117,7 +117,7 @@ namespace Ludots.Core.GraphRuntime
             }
 
             GraphProgramRegistration previous = existing;
-            _sourceMaps.TryGetValue(graphId, out GraphInstructionSourceMap previousSourceMap);
+            bool hadPreviousSourceMap = _sourceMaps.TryGetValue(graphId, out GraphInstructionSourceMap previousSourceMap);
             _programs[graphId] = new GraphProgramRegistration(program, kind, symbols);
             if (sourceMap.HasSources)
             {
@@ -135,7 +135,7 @@ namespace Ludots.Core.GraphRuntime
             catch
             {
                 _programs[graphId] = previous;
-                if (previousSourceMap.HasSources)
+                if (hadPreviousSourceMap)
                 {
                     _sourceMaps[graphId] = previousSourceMap;
                 }

--- a/src/Core/NodeLibraries/GASGraph/GasGraphOpHandlerTable.cs
+++ b/src/Core/NodeLibraries/GASGraph/GasGraphOpHandlerTable.cs
@@ -278,12 +278,19 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                     $"Execute requires a call stack span of at least {GraphVmLimits.MaxCallStackDepth} (caller-owned; heap allocation is forbidden on this path).");
             }
 
+            if (state.TreeSteps >= GraphVmLimits.MaxInstructionsPerExecution)
+            {
+                throw new InvalidOperationException(
+                    $"Graph VM exceeded MaxInstructionsPerExecution ({GraphVmLimits.MaxInstructionsPerExecution}). Possible infinite loop.");
+            }
+
             var cursor = new GraphExecutionCursor
             {
                 Pc = 0,
-                Steps = 0,
+                Steps = state.TreeSteps,
                 CallStackCount = state.CallStackCount,
                 ReturnInt = state.ReturnInt,
+                InvokeDepth = state.InvokeDepth,
                 Status = GraphExecutionStatus.Running
             };
 
@@ -292,10 +299,11 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 program,
                 handlers,
                 ref cursor,
-                GraphVmLimits.MaxInstructionsPerExecution);
+                GraphVmLimits.MaxInstructionsPerExecution - state.TreeSteps);
 
             state.CallStackCount = cursor.CallStackCount;
             state.ReturnInt = cursor.ReturnInt;
+            state.TreeSteps = cursor.Steps;
             state.Status = result.Status;
 
             if (result.Status == GraphExecutionStatus.Running)
@@ -359,6 +367,12 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             state.ReturnInt = cursor.ReturnInt;
             state.Status = GraphExecutionStatus.Running;
             state.ProgramLength = program.Length;
+            state.InvokeDepth = cursor.InvokeDepth;
+            if (state.TreeSteps < cursor.Steps)
+            {
+                state.TreeSteps = cursor.Steps;
+            }
+
             cursor.Status = GraphExecutionStatus.Running;
 
             var table = handlers.Handlers;
@@ -367,6 +381,17 @@ namespace Ludots.Core.NodeLibraries.GASGraph
 
             while (stepsThisSlice < budgetSteps)
             {
+                if (state.TreeSteps >= GraphVmLimits.MaxInstructionsPerExecution)
+                {
+                    cursor.Pc = pc;
+                    cursor.CallStackCount = state.CallStackCount;
+                    cursor.ReturnInt = state.ReturnInt;
+                    cursor.Steps = state.TreeSteps;
+                    cursor.Status = GraphExecutionStatus.Running;
+                    state.Status = GraphExecutionStatus.Running;
+                    return new GraphSliceResult(GraphExecutionStatus.Running, cursor.ReturnInt, cursor.Steps);
+                }
+
                 if ((uint)pc >= (uint)program.Length)
                 {
                     cursor.Pc = pc;
@@ -382,6 +407,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 pc++;
                 cursor.Steps++;
                 stepsThisSlice++;
+                state.TreeSteps = cursor.Steps;
 
                 if (ins.Op == 0)
                 {
@@ -402,6 +428,10 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 }
 
                 handler(ref state, in ins, ref pc);
+                if (state.TreeSteps > cursor.Steps)
+                {
+                    cursor.Steps = state.TreeSteps;
+                }
 
                 if (state.Status == GraphExecutionStatus.Yielded)
                 {
@@ -644,6 +674,12 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 throw new InvalidOperationException("InvokeScript requires GraphExecutionState.Programs.");
             }
 
+            if (s.InvokeDepth >= GraphVmLimits.MaxInvokeDepth)
+            {
+                throw new InvalidOperationException(
+                    $"GAS.GRAPH.ERR.InvokeDepthExceeded: invoke depth {s.InvokeDepth + 1} exceeds MaxInvokeDepth ({GraphVmLimits.MaxInvokeDepth}).");
+            }
+
             int graphId = ins.Imm;
             if (graphId <= 0)
             {
@@ -651,12 +687,18 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             }
 
             s.Programs.RequireKind(graphId, GraphKind.Script);
-            if (!s.Programs.TryGetProgram(graphId, out ReadOnlySpan<GraphInstruction> childProgram))
+            if (!s.Programs.TryGetRegistration(graphId, out GraphProgramRegistration childRegistration))
             {
                 throw new InvalidOperationException($"InvokeScript target graph id {graphId} is not registered.");
             }
 
-            RequireNoYield(childProgram, graphId);
+            if (childRegistration.ContainsYield)
+            {
+                throw new InvalidOperationException(
+                    $"InvokeScript target graph id {graphId} contains Yield; nested Yield is not supported in this slice.");
+            }
+
+            ReadOnlySpan<GraphInstruction> childProgram = childRegistration.Program;
 
             Span<float> f = stackalloc float[GraphVmLimits.MaxFloatRegisters];
             Span<int> i = stackalloc int[GraphVmLimits.MaxIntRegisters];
@@ -687,23 +729,14 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 Targets = targets,
                 TargetList = targetList,
                 CallStack = callStack,
-                Status = GraphExecutionStatus.Running
+                Status = GraphExecutionStatus.Running,
+                InvokeDepth = s.InvokeDepth + 1,
+                TreeSteps = s.TreeSteps
             };
 
             Execute(ref child, childProgram, Instance);
+            s.TreeSteps = child.TreeSteps;
             s.I[ins.Dst] = child.ReturnInt;
-        }
-
-        private static void RequireNoYield(ReadOnlySpan<GraphInstruction> program, int graphId)
-        {
-            for (int idx = 0; idx < program.Length; idx++)
-            {
-                if (program[idx].Op == (ushort)GraphNodeOp.Yield)
-                {
-                    throw new InvalidOperationException(
-                        $"InvokeScript target graph id {graphId} contains Yield; nested Yield is not supported in this slice.");
-                }
-            }
         }
 
         private static void HandleMoveInt(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)

--- a/src/Core/NodeLibraries/GASGraph/GraphExecutionState.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphExecutionState.cs
@@ -58,5 +58,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
         public GraphExecutionStatus Status;
         /// <summary>Set by the executor for the active program; used by Call absolute-target checks.</summary>
         public int ProgramLength;
+        public int InvokeDepth;
+        public int TreeSteps;
     }
 }

--- a/src/Core/NodeLibraries/GASGraph/GraphExecutor.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphExecutor.cs
@@ -333,6 +333,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 CallStack = callStack,
                 CallStackCount = cursor.CallStackCount,
                 ReturnInt = cursor.ReturnInt,
+                InvokeDepth = cursor.InvokeDepth,
                 Status = GraphExecutionStatus.Running
             };
 

--- a/src/Core/NodeLibraries/GASGraph/GraphVmLimits.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphVmLimits.cs
@@ -10,8 +10,15 @@ namespace Ludots.Core.NodeLibraries.GASGraph
         public const int MaxCallStackDepth = 16;
 
         /// <summary>
+        /// Hard limit on nested InvokeScript frames across one run-to-halt tree.
+        /// Distinct from MaxCallStackDepth, which only bounds Call inside one program.
+        /// </summary>
+        public const int MaxInvokeDepth = 16;
+
+        /// <summary>
         /// Hard limit on instructions executed per single Execute call.
         /// Prevents runaway programs (infinite jump loops, etc.) from hanging the frame.
+        /// Shared by the whole InvokeScript tree; nested Execute does not reset it.
         /// </summary>
         public const int MaxInstructionsPerExecution = 4096;
 

--- a/src/Core/NodeLibraries/GASGraph/Host/GraphFunctionCatalogLoader.cs
+++ b/src/Core/NodeLibraries/GASGraph/Host/GraphFunctionCatalogLoader.cs
@@ -140,7 +140,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
                             out string diagnostic))
                     {
                         errors.Add(
-                            $"FuncLib '{definition.Name}' in '{relativePath}': {rootLabel} reaches Yield or an invalid pure closure and belongs in ActionLib. Path: {diagnostic}");
+                            $"FuncLib '{definition.Name}' in '{relativePath}': {rootLabel} reaches Yield, an invoke cycle, or an invalid pure closure and belongs in ActionLib. Path: {diagnostic}");
                     }
                 }
             }

--- a/src/Core/NodeLibraries/GASGraph/Host/GraphYieldPurityValidator.cs
+++ b/src/Core/NodeLibraries/GASGraph/Host/GraphYieldPurityValidator.cs
@@ -28,6 +28,8 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
 
     internal static class GraphYieldPurityValidator
     {
+        public const string InvokeCycleError = "GAS.GRAPH.ERR.InvokeCycle";
+
         public static bool TryValidateNoReachableYield(
             GraphProgramRegistry programs,
             int rootGraphId,
@@ -40,103 +42,140 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
             if (programs == null) throw new ArgumentNullException(nameof(programs));
             if (resolveFunction == null) throw new ArgumentNullException(nameof(resolveFunction));
 
-            diagnostic = string.Empty;
-            var activeGraphs = new HashSet<int>();
-            var path = new List<string>(8);
             return !FindInGraph(
-                programs,
+                new WalkState(
+                    programs,
+                    rootGraphId,
+                    rootProgramOverride,
+                    rootSymbolsOverride,
+                    resolveFunction,
+                    findYield: true,
+                    allowMissingTargets: false),
                 rootGraphId,
                 string.IsNullOrWhiteSpace(rootLabel) ? GraphYieldPurityTarget.DescribeGraph(rootGraphId) : rootLabel,
-                rootGraphId,
-                rootProgramOverride,
-                rootSymbolsOverride,
-                resolveFunction,
-                activeGraphs,
-                path,
                 out diagnostic);
         }
 
-        private static bool FindInGraph(
+        public static bool TryValidateNoInvokeCycle(
             GraphProgramRegistry programs,
+            int rootGraphId,
+            string rootLabel,
+            out string diagnostic,
+            GraphInstruction[]? rootProgramOverride = null,
+            string[]? rootSymbolsOverride = null,
+            TryResolveFuncLibTarget? resolveFunction = null,
+            bool allowMissingTargets = true)
+        {
+            if (programs == null) throw new ArgumentNullException(nameof(programs));
+
+            return !FindInGraph(
+                new WalkState(
+                    programs,
+                    rootGraphId,
+                    rootProgramOverride,
+                    rootSymbolsOverride,
+                    resolveFunction,
+                    findYield: false,
+                    allowMissingTargets),
+                rootGraphId,
+                string.IsNullOrWhiteSpace(rootLabel) ? GraphYieldPurityTarget.DescribeGraph(rootGraphId) : rootLabel,
+                out diagnostic);
+        }
+
+        private sealed class WalkState
+        {
+            public WalkState(
+                GraphProgramRegistry programs,
+                int rootGraphId,
+                GraphInstruction[]? rootProgramOverride,
+                string[]? rootSymbolsOverride,
+                TryResolveFuncLibTarget? resolveFunction,
+                bool findYield,
+                bool allowMissingTargets)
+            {
+                Programs = programs;
+                RootGraphId = rootGraphId;
+                RootProgramOverride = rootProgramOverride;
+                RootSymbolsOverride = rootSymbolsOverride;
+                ResolveFunction = resolveFunction;
+                FindYield = findYield;
+                AllowMissingTargets = allowMissingTargets;
+                ActiveGraphs = new HashSet<int>();
+                Path = new List<string>(8);
+            }
+
+            public GraphProgramRegistry Programs { get; }
+            public int RootGraphId { get; }
+            public GraphInstruction[]? RootProgramOverride { get; }
+            public string[]? RootSymbolsOverride { get; }
+            public TryResolveFuncLibTarget? ResolveFunction { get; }
+            public bool FindYield { get; }
+            public bool AllowMissingTargets { get; }
+            public HashSet<int> ActiveGraphs { get; }
+            public List<string> Path { get; }
+        }
+
+        private static bool FindInGraph(
+            WalkState walk,
             int graphId,
             string label,
-            int rootGraphId,
-            GraphInstruction[]? rootProgramOverride,
-            string[]? rootSymbolsOverride,
-            TryResolveFuncLibTarget resolveFunction,
-            HashSet<int> activeGraphs,
-            List<string> path,
             out string diagnostic)
         {
             diagnostic = string.Empty;
             if (graphId <= 0)
             {
-                return Fail(path, $"invalid graph id {graphId}", out diagnostic);
+                return Fail(walk.Path, $"invalid graph id {graphId}", out diagnostic);
             }
 
-            if (!activeGraphs.Add(graphId))
+            if (!walk.ActiveGraphs.Add(graphId))
             {
-                return false;
+                return Fail(walk.Path, InvokeCycleError, out diagnostic);
             }
 
             try
             {
                 GraphInstruction[] program;
                 string[] symbols;
-                if (graphId == rootGraphId && rootProgramOverride != null)
+                if (graphId == walk.RootGraphId && walk.RootProgramOverride != null)
                 {
-                    program = rootProgramOverride;
-                    symbols = rootSymbolsOverride ?? Array.Empty<string>();
+                    program = walk.RootProgramOverride;
+                    symbols = walk.RootSymbolsOverride ?? Array.Empty<string>();
                 }
                 else
                 {
-                    if (!programs.TryGetRegistration(graphId, out GraphProgramRegistration registration))
+                    if (!walk.Programs.TryGetRegistration(graphId, out GraphProgramRegistration registration))
                     {
-                        return Fail(path, $"{GraphYieldPurityTarget.DescribeGraph(graphId)} has no registered program", out diagnostic);
+                        if (walk.AllowMissingTargets)
+                        {
+                            return false;
+                        }
+
+                        return Fail(walk.Path, $"{GraphYieldPurityTarget.DescribeGraph(graphId)} has no registered program", out diagnostic);
                     }
 
                     program = registration.Program;
                     symbols = registration.Symbols;
                 }
 
-                path.Add(label);
+                walk.Path.Add(label);
                 var visited = new bool[program.Length];
-                bool found = FindInProgram(
-                    programs,
-                    graphId,
-                    program,
-                    symbols,
-                    0,
-                    rootGraphId,
-                    rootProgramOverride,
-                    rootSymbolsOverride,
-                    resolveFunction,
-                    activeGraphs,
-                    visited,
-                    path,
-                    out diagnostic);
-                path.RemoveAt(path.Count - 1);
+                bool found = FindInProgram(walk, graphId, program, symbols, 0, visited, out diagnostic);
+                walk.Path.RemoveAt(walk.Path.Count - 1);
                 return found;
             }
             finally
             {
-                activeGraphs.Remove(graphId);
+                walk.ActiveGraphs.Remove(graphId);
             }
         }
 
         private static bool FindInProgram(
-            GraphProgramRegistry programs,
+            WalkState walk,
             int graphId,
             GraphInstruction[] program,
             string[] symbols,
             int pc,
-            int rootGraphId,
-            GraphInstruction[]? rootProgramOverride,
-            string[]? rootSymbolsOverride,
-            TryResolveFuncLibTarget resolveFunction,
-            HashSet<int> activeGraphs,
             bool[] visited,
-            List<string> path,
             out string diagnostic)
         {
             diagnostic = string.Empty;
@@ -157,36 +196,41 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
             switch (op)
             {
                 case GraphNodeOp.None:
-                    return FindInProgram(programs, graphId, program, symbols, pc + 1, rootGraphId, rootProgramOverride, rootSymbolsOverride, resolveFunction, activeGraphs, visited, path, out diagnostic);
+                    return FindInProgram(walk, graphId, program, symbols, pc + 1, visited, out diagnostic);
 
                 case GraphNodeOp.Yield:
-                    return Fail(path, $"Yield@pc={pc}", out diagnostic);
+                    if (walk.FindYield)
+                    {
+                        return Fail(walk.Path, $"Yield@pc={pc}", out diagnostic);
+                    }
+
+                    return FindInProgram(walk, graphId, program, symbols, pc + 1, visited, out diagnostic);
 
                 case GraphNodeOp.InvokeScript:
-                    if (FindInvokeTarget(programs, graphId, symbols, ins, pc, rootGraphId, rootProgramOverride, rootSymbolsOverride, resolveFunction, activeGraphs, path, out diagnostic))
+                    if (FindInvokeTarget(walk, symbols, ins, pc, out diagnostic))
                     {
                         return true;
                     }
 
-                    return FindInProgram(programs, graphId, program, symbols, pc + 1, rootGraphId, rootProgramOverride, rootSymbolsOverride, resolveFunction, activeGraphs, visited, path, out diagnostic);
+                    return FindInProgram(walk, graphId, program, symbols, pc + 1, visited, out diagnostic);
 
                 case GraphNodeOp.Call:
                 {
                     int target = ins.Imm;
                     if ((uint)target >= (uint)program.Length)
                     {
-                        return Fail(path, $"Call@pc={pc} target {target} is outside {GraphYieldPurityTarget.DescribeGraph(graphId)}", out diagnostic);
+                        return Fail(walk.Path, $"Call@pc={pc} target {target} is outside {GraphYieldPurityTarget.DescribeGraph(graphId)}", out diagnostic);
                     }
 
-                    path.Add($"Call@pc={pc}->pc={target}");
-                    bool found = FindInProgram(programs, graphId, program, symbols, target, rootGraphId, rootProgramOverride, rootSymbolsOverride, resolveFunction, activeGraphs, visited, path, out diagnostic);
-                    path.RemoveAt(path.Count - 1);
+                    walk.Path.Add($"Call@pc={pc}->pc={target}");
+                    bool found = FindInProgram(walk, graphId, program, symbols, target, visited, out diagnostic);
+                    walk.Path.RemoveAt(walk.Path.Count - 1);
                     if (found)
                     {
                         return true;
                     }
 
-                    return FindInProgram(programs, graphId, program, symbols, pc + 1, rootGraphId, rootProgramOverride, rootSymbolsOverride, resolveFunction, activeGraphs, visited, path, out diagnostic);
+                    return FindInProgram(walk, graphId, program, symbols, pc + 1, visited, out diagnostic);
                 }
 
                 case GraphNodeOp.Jump:
@@ -194,12 +238,12 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
                     int target = pc + 1 + ins.Imm;
                     if ((uint)target >= (uint)program.Length)
                     {
-                        return Fail(path, $"Jump@pc={pc} target {target} is outside {GraphYieldPurityTarget.DescribeGraph(graphId)}", out diagnostic);
+                        return Fail(walk.Path, $"Jump@pc={pc} target {target} is outside {GraphYieldPurityTarget.DescribeGraph(graphId)}", out diagnostic);
                     }
 
-                    path.Add($"Jump@pc={pc}->pc={target}");
-                    bool found = FindInProgram(programs, graphId, program, symbols, target, rootGraphId, rootProgramOverride, rootSymbolsOverride, resolveFunction, activeGraphs, visited, path, out diagnostic);
-                    path.RemoveAt(path.Count - 1);
+                    walk.Path.Add($"Jump@pc={pc}->pc={target}");
+                    bool found = FindInProgram(walk, graphId, program, symbols, target, visited, out diagnostic);
+                    walk.Path.RemoveAt(walk.Path.Count - 1);
                     return found;
                 }
 
@@ -208,18 +252,18 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
                     int target = pc + 1 + ins.Imm;
                     if ((uint)target >= (uint)program.Length)
                     {
-                        return Fail(path, $"JumpIfFalse@pc={pc} target {target} is outside {GraphYieldPurityTarget.DescribeGraph(graphId)}", out diagnostic);
+                        return Fail(walk.Path, $"JumpIfFalse@pc={pc} target {target} is outside {GraphYieldPurityTarget.DescribeGraph(graphId)}", out diagnostic);
                     }
 
-                    path.Add($"JumpIfFalse.false@pc={pc}->pc={target}");
-                    bool found = FindInProgram(programs, graphId, program, symbols, target, rootGraphId, rootProgramOverride, rootSymbolsOverride, resolveFunction, activeGraphs, visited, path, out diagnostic);
-                    path.RemoveAt(path.Count - 1);
+                    walk.Path.Add($"JumpIfFalse.false@pc={pc}->pc={target}");
+                    bool found = FindInProgram(walk, graphId, program, symbols, target, visited, out diagnostic);
+                    walk.Path.RemoveAt(walk.Path.Count - 1);
                     if (found)
                     {
                         return true;
                     }
 
-                    return FindInProgram(programs, graphId, program, symbols, pc + 1, rootGraphId, rootProgramOverride, rootSymbolsOverride, resolveFunction, activeGraphs, visited, path, out diagnostic);
+                    return FindInProgram(walk, graphId, program, symbols, pc + 1, visited, out diagnostic);
                 }
 
                 case GraphNodeOp.Return:
@@ -229,25 +273,18 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
                 default:
                     if (!Enum.IsDefined(typeof(GraphNodeOp), op))
                     {
-                        return Fail(path, $"unknown graph op {ins.Op}@pc={pc}", out diagnostic);
+                        return Fail(walk.Path, $"unknown graph op {ins.Op}@pc={pc}", out diagnostic);
                     }
 
-                    return FindInProgram(programs, graphId, program, symbols, pc + 1, rootGraphId, rootProgramOverride, rootSymbolsOverride, resolveFunction, activeGraphs, visited, path, out diagnostic);
+                    return FindInProgram(walk, graphId, program, symbols, pc + 1, visited, out diagnostic);
             }
         }
 
         private static bool FindInvokeTarget(
-            GraphProgramRegistry programs,
-            int graphId,
+            WalkState walk,
             string[] symbols,
             in GraphInstruction ins,
             int pc,
-            int rootGraphId,
-            GraphInstruction[]? rootProgramOverride,
-            string[]? rootSymbolsOverride,
-            TryResolveFuncLibTarget resolveFunction,
-            HashSet<int> activeGraphs,
-            List<string> path,
             out string diagnostic)
         {
             diagnostic = string.Empty;
@@ -255,39 +292,38 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
             {
                 if (!TryResolveSymbol(symbols, ins.Imm, out string functionName))
                 {
-                    return Fail(path, $"InvokeScript.functionName@pc={pc} cannot resolve symbol index {ins.Imm}", out diagnostic);
+                    return Fail(walk.Path, $"InvokeScript.functionName@pc={pc} cannot resolve symbol index {ins.Imm}", out diagnostic);
                 }
 
-                if (!resolveFunction(functionName, out GraphYieldPurityTarget target))
+                if (walk.ResolveFunction == null || !walk.ResolveFunction(functionName, out GraphYieldPurityTarget target))
                 {
-                    return Fail(path, $"InvokeScript.functionName '{functionName}'@pc={pc} is not registered in FuncLib", out diagnostic);
+                    if (walk.AllowMissingTargets)
+                    {
+                        return false;
+                    }
+
+                    return Fail(walk.Path, $"InvokeScript.functionName '{functionName}'@pc={pc} is not registered in FuncLib", out diagnostic);
                 }
 
-                path.Add($"InvokeScript.functionName '{functionName}'@pc={pc}");
-                bool found = FindInGraph(programs, target.GraphId, target.Label, rootGraphId, rootProgramOverride, rootSymbolsOverride, resolveFunction, activeGraphs, path, out diagnostic);
-                path.RemoveAt(path.Count - 1);
+                walk.Path.Add($"InvokeScript.functionName '{functionName}'@pc={pc}");
+                bool found = FindInGraph(walk, target.GraphId, target.Label, out diagnostic);
+                walk.Path.RemoveAt(walk.Path.Count - 1);
                 return found;
             }
 
             int childGraphId = ins.Imm;
             if (childGraphId <= 0)
             {
-                return Fail(path, $"InvokeScript.graphId@pc={pc} requires a positive graph id", out diagnostic);
+                return Fail(walk.Path, $"InvokeScript.graphId@pc={pc} requires a positive graph id", out diagnostic);
             }
 
-            path.Add($"InvokeScript.graphId={childGraphId}@pc={pc}");
+            walk.Path.Add($"InvokeScript.graphId={childGraphId}@pc={pc}");
             bool childFound = FindInGraph(
-                programs,
+                walk,
                 childGraphId,
                 GraphYieldPurityTarget.DescribeGraph(childGraphId),
-                rootGraphId,
-                rootProgramOverride,
-                rootSymbolsOverride,
-                resolveFunction,
-                activeGraphs,
-                path,
                 out diagnostic);
-            path.RemoveAt(path.Count - 1);
+            walk.Path.RemoveAt(walk.Path.Count - 1);
             return childFound;
         }
 

--- a/src/Tests/GasTests/Graph/GraphFunctionCatalogLoaderTests.cs
+++ b/src/Tests/GasTests/Graph/GraphFunctionCatalogLoaderTests.cs
@@ -317,6 +317,76 @@ namespace Ludots.Tests.Gas.Graph
         }
 
         [Test]
+        public void FuncCatalogLoader_RejectsInvokeCycleThroughFunctionNames()
+        {
+            GraphIdRegistry.Clear();
+            string root = string.Empty;
+            try
+            {
+                const string graphA = "Graph.Script.CycleA";
+                const string graphB = "Graph.Script.CycleB";
+                int idA = GraphIdRegistry.Register(graphA);
+                int idB = GraphIdRegistry.Register(graphB);
+                var programs = new GraphProgramRegistry();
+                programs.Register(
+                    idA,
+                    new[]
+                    {
+                        new GraphInstruction
+                        {
+                            Op = (ushort)GraphNodeOp.InvokeScript,
+                            Dst = 0,
+                            Imm = 0,
+                            Flags = GraphInstructionFlags.FuncLibName
+                        },
+                        new GraphInstruction { Op = (ushort)GraphNodeOp.HaltReturnInt, A = 0 }
+                    },
+                    GraphKind.Script,
+                    GraphInstructionSourceMap.Empty,
+                    new[] { "script.cycleB" });
+                programs.Register(
+                    idB,
+                    new[]
+                    {
+                        new GraphInstruction
+                        {
+                            Op = (ushort)GraphNodeOp.InvokeScript,
+                            Dst = 0,
+                            Imm = 0,
+                            Flags = GraphInstructionFlags.FuncLibName
+                        },
+                        new GraphInstruction { Op = (ushort)GraphNodeOp.HaltReturnInt, A = 0 }
+                    },
+                    GraphKind.Script,
+                    GraphInstructionSourceMap.Empty,
+                    new[] { "script.cycleA" });
+
+                var (pipeline, configCatalog, tempRoot) = CreateCatalogPipeline(
+                    "GAS/func_lib.json",
+                    """
+                    [
+                      { "name": "script.cycleA", "graph": "Graph.Script.CycleA", "kind": "Script", "purity": "pure" },
+                      { "name": "script.cycleB", "graph": "Graph.Script.CycleB", "kind": "Script", "purity": "pure" }
+                    ]
+                    """);
+                root = tempRoot;
+
+                var functionCatalog = new GraphFunctionCatalog();
+                var ex = Assert.Throws<AggregateException>(() =>
+                    new GraphFunctionCatalogLoader(pipeline, functionCatalog, programs).Load(configCatalog));
+
+                Assert.That(functionCatalog.Count, Is.EqualTo(0));
+                Assert.That(ex!.InnerExceptions[0].Message, Does.Contain("GAS.GRAPH.ERR.InvokeCycle"));
+                Assert.That(ex.InnerExceptions[0].Message, Does.Contain("invoke cycle"));
+            }
+            finally
+            {
+                GraphIdRegistry.Clear();
+                DeleteTempRoot(root);
+            }
+        }
+
+        [Test]
         public void FuncCatalogLoader_RejectsScoreKind()
         {
             GraphIdRegistry.Clear();

--- a/src/Tests/GasTests/Graph/GraphInvokeCycleTests.cs
+++ b/src/Tests/GasTests/Graph/GraphInvokeCycleTests.cs
@@ -2,6 +2,7 @@ using System;
 using Arch.Core;
 using Ludots.Core.GraphRuntime;
 using Ludots.Core.NodeLibraries.GASGraph;
+using Ludots.Core.NodeLibraries.GASGraph.Host;
 using NUnit.Framework;
 
 namespace Ludots.Tests.Gas.Graph
@@ -128,11 +129,19 @@ namespace Ludots.Tests.Gas.Graph
                 CallStack = callStack
             };
 
-            var ex = Assert.Throws<InvalidOperationException>(() =>
-                GasGraphOpHandlerTable.Execute(ref state, root, GasGraphOpHandlerTable.Instance));
+            string? message = null;
+            try
+            {
+                GasGraphOpHandlerTable.Execute(ref state, root, GasGraphOpHandlerTable.Instance);
+            }
+            catch (InvalidOperationException ex)
+            {
+                message = ex.Message;
+            }
 
-            Assert.That(ex!.Message, Does.Contain("GAS.GRAPH.ERR.InvokeDepthExceeded"));
-            Assert.That(ex.Message, Does.Contain("MaxInvokeDepth"));
+            Assert.That(message, Is.Not.Null);
+            Assert.That(message, Does.Contain("GAS.GRAPH.ERR.InvokeDepthExceeded"));
+            Assert.That(message, Does.Contain("MaxInvokeDepth"));
         }
 
         [Test]
@@ -183,10 +192,18 @@ namespace Ludots.Tests.Gas.Graph
                 TreeSteps = GraphVmLimits.MaxInstructionsPerExecution - 2
             };
 
-            var ex = Assert.Throws<InvalidOperationException>(() =>
-                GasGraphOpHandlerTable.Execute(ref state, root, GasGraphOpHandlerTable.Instance));
+            string? message = null;
+            try
+            {
+                GasGraphOpHandlerTable.Execute(ref state, root, GasGraphOpHandlerTable.Instance);
+            }
+            catch (InvalidOperationException ex)
+            {
+                message = ex.Message;
+            }
 
-            Assert.That(ex!.Message, Does.Contain("MaxInstructionsPerExecution"));
+            Assert.That(message, Is.Not.Null);
+            Assert.That(message, Does.Contain("MaxInstructionsPerExecution"));
             Assert.That(state.TreeSteps, Is.LessThanOrEqualTo(GraphVmLimits.MaxInstructionsPerExecution));
         }
 

--- a/src/Tests/GasTests/Graph/GraphInvokeCycleTests.cs
+++ b/src/Tests/GasTests/Graph/GraphInvokeCycleTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 namespace Ludots.Tests.Gas.Graph
 {
     [TestFixture]
+    [NonParallelizable]
     [Category("ci-gate")]
     public sealed class GraphInvokeCycleTests
     {

--- a/src/Tests/GasTests/Graph/GraphInvokeCycleTests.cs
+++ b/src/Tests/GasTests/Graph/GraphInvokeCycleTests.cs
@@ -1,0 +1,222 @@
+using System;
+using Arch.Core;
+using Ludots.Core.GraphRuntime;
+using Ludots.Core.NodeLibraries.GASGraph;
+using NUnit.Framework;
+
+namespace Ludots.Tests.Gas.Graph
+{
+    [TestFixture]
+    [Category("ci-gate")]
+    public sealed class GraphInvokeCycleTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            GraphIdRegistry.Clear();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            GraphIdRegistry.Clear();
+        }
+
+        [Test]
+        public void 自己调自己的图必须被拒绝()
+        {
+            const string graphKey = "Graph.Cycle.Self";
+            int graphId = GraphIdRegistry.Register(graphKey);
+            var programs = new GraphProgramRegistry();
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                programs.Register(
+                    graphId,
+                    new[]
+                    {
+                        new GraphInstruction { Op = (ushort)GraphNodeOp.InvokeScript, Dst = 0, Imm = graphId },
+                        new GraphInstruction { Op = (ushort)GraphNodeOp.HaltReturnInt, A = 0 }
+                    },
+                    GraphKind.Script));
+
+            Assert.That(ex!.Message, Does.Contain("GAS.GRAPH.ERR.InvokeCycle"));
+            Assert.That(ex.Message, Does.Contain(graphKey));
+            Assert.That(programs.TryGetProgram(graphId, out _), Is.False);
+        }
+
+        [Test]
+        public void 绕一圈回来也算环()
+        {
+            int graphA = GraphIdRegistry.Register("Graph.Cycle.A");
+            int graphB = GraphIdRegistry.Register("Graph.Cycle.B");
+            var programs = new GraphProgramRegistry();
+
+            programs.Register(
+                graphA,
+                new[]
+                {
+                    new GraphInstruction { Op = (ushort)GraphNodeOp.InvokeScript, Dst = 0, Imm = graphB },
+                    new GraphInstruction { Op = (ushort)GraphNodeOp.HaltReturnInt, A = 0 }
+                },
+                GraphKind.Script);
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                programs.Register(
+                    graphB,
+                    new[]
+                    {
+                        new GraphInstruction { Op = (ushort)GraphNodeOp.InvokeScript, Dst = 0, Imm = graphA },
+                        new GraphInstruction { Op = (ushort)GraphNodeOp.HaltReturnInt, A = 0 }
+                    },
+                    GraphKind.Script));
+
+            Assert.That(ex!.Message, Does.Contain("GAS.GRAPH.ERR.InvokeCycle"));
+            Assert.That(ex.Message, Does.Contain("Graph.Cycle.A").Or.Contain("Graph.Cycle.B"));
+            Assert.That(programs.TryGetProgram(graphA, out _), Is.True);
+            Assert.That(programs.TryGetProgram(graphB, out _), Is.False);
+        }
+
+        [Test]
+        public void 万一漏到了运行期也要报错而不是消失()
+        {
+            var programs = new GraphProgramRegistry();
+            int graphCount = GraphVmLimits.MaxInvokeDepth + 2;
+            int[] ids = new int[graphCount];
+            for (int i = 0; i < graphCount; i++)
+            {
+                ids[i] = GraphIdRegistry.Register($"Graph.Depth.{i}");
+            }
+
+            for (int i = 0; i < graphCount; i++)
+            {
+                GraphInstruction[] program = i == graphCount - 1
+                    ? new[]
+                    {
+                        new GraphInstruction { Op = (ushort)GraphNodeOp.ConstInt, Dst = 0, Imm = 1 },
+                        new GraphInstruction { Op = (ushort)GraphNodeOp.HaltReturnInt, A = 0 }
+                    }
+                    : new[]
+                    {
+                        new GraphInstruction { Op = (ushort)GraphNodeOp.InvokeScript, Dst = 0, Imm = ids[i + 1] },
+                        new GraphInstruction { Op = (ushort)GraphNodeOp.HaltReturnInt, A = 0 }
+                    };
+                programs.Register(ids[i], program, GraphKind.Script);
+            }
+
+            using var world = World.Create();
+            Entity caster = world.Create();
+            Span<float> f = stackalloc float[GraphVmLimits.MaxFloatRegisters];
+            Span<int> iRegs = stackalloc int[GraphVmLimits.MaxIntRegisters];
+            Span<byte> b = stackalloc byte[GraphVmLimits.MaxBoolRegisters];
+            Span<Entity> e = stackalloc Entity[GraphVmLimits.MaxEntityRegisters];
+            Span<Entity> targets = stackalloc Entity[GraphVmLimits.MaxTargets];
+            Span<int> callStack = stackalloc int[GraphVmLimits.MaxCallStackDepth];
+            e[0] = caster;
+
+            Assert.That(programs.TryGetProgram(ids[0], out ReadOnlySpan<GraphInstruction> root), Is.True);
+            var state = new GraphExecutionState
+            {
+                World = world,
+                Caster = caster,
+                Programs = programs,
+                F = f,
+                I = iRegs,
+                B = b,
+                E = e,
+                Targets = targets,
+                TargetList = new GraphTargetList(targets),
+                CallStack = callStack
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                GasGraphOpHandlerTable.Execute(ref state, root, GasGraphOpHandlerTable.Instance));
+
+            Assert.That(ex!.Message, Does.Contain("GAS.GRAPH.ERR.InvokeDepthExceeded"));
+            Assert.That(ex.Message, Does.Contain("MaxInvokeDepth"));
+        }
+
+        [Test]
+        public void Execute_SharedTreeBudget_ThrowsWhenNestedInvokeWouldResetSteps()
+        {
+            int leafId = GraphIdRegistry.Register("Graph.Budget.Leaf");
+            int rootId = GraphIdRegistry.Register("Graph.Budget.Root");
+            var programs = new GraphProgramRegistry();
+            programs.Register(
+                leafId,
+                new[]
+                {
+                    new GraphInstruction { Op = (ushort)GraphNodeOp.Jump, Imm = -1 }
+                },
+                GraphKind.Script);
+            programs.Register(
+                rootId,
+                new[]
+                {
+                    new GraphInstruction { Op = (ushort)GraphNodeOp.InvokeScript, Dst = 0, Imm = leafId },
+                    new GraphInstruction { Op = (ushort)GraphNodeOp.HaltReturnInt, A = 0 }
+                },
+                GraphKind.Script);
+
+            using var world = World.Create();
+            Entity caster = world.Create();
+            Span<float> f = stackalloc float[GraphVmLimits.MaxFloatRegisters];
+            Span<int> iRegs = stackalloc int[GraphVmLimits.MaxIntRegisters];
+            Span<byte> b = stackalloc byte[GraphVmLimits.MaxBoolRegisters];
+            Span<Entity> e = stackalloc Entity[GraphVmLimits.MaxEntityRegisters];
+            Span<Entity> targets = stackalloc Entity[GraphVmLimits.MaxTargets];
+            Span<int> callStack = stackalloc int[GraphVmLimits.MaxCallStackDepth];
+            e[0] = caster;
+
+            Assert.That(programs.TryGetProgram(rootId, out ReadOnlySpan<GraphInstruction> root), Is.True);
+            var state = new GraphExecutionState
+            {
+                World = world,
+                Caster = caster,
+                Programs = programs,
+                F = f,
+                I = iRegs,
+                B = b,
+                E = e,
+                Targets = targets,
+                TargetList = new GraphTargetList(targets),
+                CallStack = callStack,
+                TreeSteps = GraphVmLimits.MaxInstructionsPerExecution - 2
+            };
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                GasGraphOpHandlerTable.Execute(ref state, root, GasGraphOpHandlerTable.Instance));
+
+            Assert.That(ex!.Message, Does.Contain("MaxInstructionsPerExecution"));
+            Assert.That(state.TreeSteps, Is.LessThanOrEqualTo(GraphVmLimits.MaxInstructionsPerExecution));
+        }
+
+        [Test]
+        public void ReplaceProgram_SelfInvoke_IsRejectedAndRolledBack()
+        {
+            const string graphKey = "Graph.Cycle.Hot";
+            int graphId = GraphIdRegistry.Register(graphKey);
+            var programs = new GraphProgramRegistry();
+            GraphInstruction[] original =
+            {
+                new() { Op = (ushort)GraphNodeOp.ConstInt, Dst = 0, Imm = 3 },
+                new() { Op = (ushort)GraphNodeOp.HaltReturnInt, A = 0 }
+            };
+            programs.Register(graphId, original, GraphKind.Script);
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                programs.ReplaceProgram(
+                    graphId,
+                    new[]
+                    {
+                        new GraphInstruction { Op = (ushort)GraphNodeOp.InvokeScript, Dst = 0, Imm = graphId },
+                        new GraphInstruction { Op = (ushort)GraphNodeOp.HaltReturnInt, A = 0 }
+                    },
+                    GraphKind.Script,
+                    GraphInstructionSourceMap.Empty));
+
+            Assert.That(ex!.Message, Does.Contain("GAS.GRAPH.ERR.InvokeCycle"));
+            Assert.That(programs.TryGetProgram(graphId, out ReadOnlySpan<GraphInstruction> live), Is.True);
+            Assert.That(live[0].Op, Is.EqualTo((ushort)GraphNodeOp.ConstInt));
+        }
+    }
+}

--- a/src/Tests/GasTests/LiveGasEditPipelineTests.cs
+++ b/src/Tests/GasTests/LiveGasEditPipelineTests.cs
@@ -184,6 +184,55 @@ namespace Ludots.Tests.GAS
 
         [Test]
         [Category("ci-gate")]
+        public void Classify_GraphBodyReplaceThatCreatesInvokeCycle_MapReloadRequired()
+        {
+            const string graphKey = "Graph.Live.CycleHot";
+            int graphId = GraphIdRegistry.Register(graphKey);
+            var graphs = new GraphProgramRegistry();
+            graphs.Register(graphId, new[]
+            {
+                new GraphInstruction { Op = (ushort)GraphNodeOp.ConstInt, Dst = 0, Imm = 1 },
+                new GraphInstruction { Op = (ushort)GraphNodeOp.HaltReturnInt, A = 0 },
+            }, GraphKind.Script);
+
+            var pipeline = new LiveGasEditPipeline(graphs, new GraphFunctionCatalog());
+            LiveEditSession session = LiveEditSession.Start(LiveEditSource.ManualWorkbench);
+            string documentJson = $$"""
+                {
+                  "id": "{{graphKey}}",
+                  "kind": "Script",
+                  "entry": "invoke",
+                  "nodes": [
+                    { "id": "invoke", "op": "InvokeScript", "graphId": {{graphId}} },
+                    { "id": "h", "op": "HaltReturnInt" }
+                  ],
+                  "controlEdges": [
+                    { "from": "invoke", "fromPort": "next", "to": "h" }
+                  ],
+                  "valueEdges": [
+                    { "from": "invoke", "fromPort": "value", "to": "h", "toPort": "value" }
+                  ]
+                }
+                """;
+
+            That(session.TryStage(LiveDebugPatchOperation.GraphBodyReplace(
+                graphKey,
+                documentJson,
+                new LiveEditProvenance(LiveEditSource.ManualWorkbench, "workbench://graph/" + graphKey))).Succeeded,
+                Is.True);
+
+            LiveApplyClassificationReport report = pipeline.Classify(session);
+
+            That(report.CanCommitNextCast, Is.False);
+            That(report.RequiresMapReload, Is.True);
+            That(report.Items[0].Mode, Is.EqualTo(LiveApplyMode.MapReloadRequired));
+            That(report.Items[0].Diagnostics[0].Message, Does.Contain("GAS.GRAPH.ERR.InvokeCycle"));
+            That(graphs.TryGetProgram(graphId, out ReadOnlySpan<GraphInstruction> live), Is.True);
+            That(live[0].Op, Is.EqualTo((ushort)GraphNodeOp.ConstInt));
+        }
+
+        [Test]
+        [Category("ci-gate")]
         public void ClassifyAndCommit_EffectDurationTicks_NextCast()
         {
             string effectName = "Effect.Live.HotDuration";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 合同

- 登记期：调用边成环 → `GAS.GRAPH.ERR.InvokeCycle`，整图回滚、不入册。
- 运行期：`Invoke` 深度上限 16；超限 → `GAS.GRAPH.ERR.InvokeDepthExceeded`，进程不崩。
- 登记期解析不到的函数名边：`allowMissingTargets: true`，漏到运行期由深度上限兜住。

## 实现

- `GraphYieldPurityValidator`：栈上再遇同一图 = 环，不再当「无 Yield、通过」。
- `GraphProgramRegistry.Register` / `ReplaceProgram`：写入后立刻验环；失败回滚。
- `GraphExecutionCursor`：共享 `TreeSteps` 计数；`ContainsYield` 登记时算好。
- 文档：`gitbook/architecture/graph-layering-flow-and-behavior.md`。

## CI

- 文档治理：`graph-funclib-actionlib-uat.md` 相对链接补 `../`（主线预存红，本分支顺手修）。
- `GraphInvokeCycleTests` 标 `[NonParallelizable]`：会 `GraphIdRegistry.Clear()`，不能跟其他 `ci-gate` 并行。

## 测试

`FullyQualifiedName~Ludots.Tests.Gas.GraphInvokeCycleTests`

## 审计（#949）

可关单。S9 不再等本票。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88eeeec8-f8e7-44e7-bfea-db2b5c012489?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88eeeec8-f8e7-44e7-bfea-db2b5c012489&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

