### PR TITLE
fix(gas): S5 容量到顶必须报错，假遥测整套删掉

### DIFF
--- a/src/Adapters/Raylib/Ludots.Adapter.Raylib/RaylibHostLoop.cs
+++ b/src/Adapters/Raylib/Ludots.Adapter.Raylib/RaylibHostLoop.cs
@@ -1011,7 +1011,7 @@ namespace Ludots.Adapter.Raylib
             string line2 = $"ISM {FormatFixed(timing.PrimitiveInstancesLastFrame, 6)}  FIELD {FormatFixed(timing.GlobalFieldTexturesLastFrame, 4)}/{FormatFixed(timing.GlobalFieldDirtyUploadsLastFrame, 4)}  3D {FormatFixed(timing.LastMode3DMs, 5, 1)}MS";
             string line3 = $"HUD {FormatFixed(timing.WorldHudProjectedLastFrame, 6)}/{FormatFixed(worldHud?.Count ?? 0, 6)}  BAR {FormatFixed(screenHud?.BarCount ?? 0, 6)}  TEXT {FormatFixed(screenHud?.TextCount ?? 0, 6)}";
             string line4 = $"SKIA {FormatFixed(timing.LastScreenOverlayPaintMs, 5, 1)}MS  EMIT {FormatFixed(timing.LastPerformerEmitMs, 5, 1)}MS  BEHAV {FormatFixed(timing.LastPerformerBehaviorMs, 5, 1)}MS";
-            string line5 = $"FXQ {FormatFixed(effectRequests?.Count ?? 0, 6)}  OVF {FormatFixed(effectRequests?.OverflowCount ?? 0, 6)}  DROP {FormatFixed(effectRequests?.DroppedCount ?? 0, 6)}";
+            string line5 = $"FXQ {FormatFixed(effectRequests?.Count ?? 0, 6)}  OVF {FormatFixed(effectRequests?.OverflowCount ?? 0, 6)}  AVAIL {FormatFixed(effectRequests?.AvailableCapacity ?? 0, 6)}";
 
             const int x = 10;
             const int y = 10;

--- a/src/Core/Gameplay/GAS/BuiltinHandlerExecutionContext.cs
+++ b/src/Core/Gameplay/GAS/BuiltinHandlerExecutionContext.cs
@@ -41,7 +41,6 @@ namespace Ludots.Core.Gameplay.GAS
         public int StepRateHz { get; set; }
 
         public int ResolvedCandidateCount { get; private set; }
-        public int DroppedCount { get; private set; }
         public bool HasExchangeResult { get; private set; }
         public ExchangeExecutionResult LastExchangeResult { get; private set; }
         public int AttributeDeltaId { get; private set; } = -1;
@@ -53,7 +52,6 @@ namespace Ludots.Core.Gameplay.GAS
         public void ResetPerEffect()
         {
             ResolvedCandidateCount = 0;
-            DroppedCount = 0;
             HasExchangeResult = false;
             LastExchangeResult = default;
             AttributeDeltaId = -1;
@@ -76,14 +74,6 @@ namespace Ludots.Core.Gameplay.GAS
         public void ClearResolvedCandidates()
         {
             ResolvedCandidateCount = 0;
-        }
-
-        public void AddDropped(int dropped)
-        {
-            if (dropped > 0)
-            {
-                DroppedCount += dropped;
-            }
         }
 
         public void RecordExchangeResult(ExchangeExecutionResult result)

--- a/src/Core/Gameplay/GAS/BuiltinHandlers.cs
+++ b/src/Core/Gameplay/GAS/BuiltinHandlers.cs
@@ -167,7 +167,6 @@ namespace Ludots.Core.Gameplay.GAS
                 return;
             }
 
-            int dropped = 0;
             TargetResolverFanOutHelper.ValidateAndCollect(
                 world,
                 in context,
@@ -178,10 +177,8 @@ namespace Ludots.Core.Gameplay.GAS
                 runtime.ResolverBuffer,
                 candidateCount,
                 runtime.FanOutBudget,
-                runtime.FanOutCommands,
-                ref dropped);
+                runtime.FanOutCommands);
 
-            runtime.AddDropped(dropped);
             runtime.ClearResolvedCandidates();
         }
 
@@ -211,7 +208,6 @@ namespace Ludots.Core.Gameplay.GAS
                 return;
             }
 
-            int dropped = 0;
             TargetResolverFanOutHelper.ValidateAndCollect(
                 world,
                 in context,
@@ -222,10 +218,8 @@ namespace Ludots.Core.Gameplay.GAS
                 runtime.ResolverBuffer,
                 candidateCount,
                 runtime.FanOutBudget,
-                runtime.FanOutCommands,
-                ref dropped);
+                runtime.FanOutCommands);
 
-            runtime.AddDropped(dropped);
             runtime.ClearResolvedCandidates();
         }
 

--- a/src/Core/Gameplay/GAS/DeferredTriggerQueue.cs
+++ b/src/Core/Gameplay/GAS/DeferredTriggerQueue.cs
@@ -2,12 +2,10 @@ using Ludots.Core.Gameplay.GAS.Components;
 
 namespace Ludots.Core.Gameplay.GAS
 {
-    /// <summary>
-    /// 延迟触发器队列（下一帧执行）
-    /// 使用数组实现，避免GC分配
-    /// </summary>
     public class DeferredTriggerQueue
     {
+        public const string CapacityExceededError = "GAS.DEFERRED_TRIGGER.ERR.CapacityExceeded";
+
         private static readonly int Capacity = GasConstants.MAX_DEFERRED_TRIGGERS_PER_FRAME;
 
         private AttributeChangedTrigger[] _attributeTriggers = new AttributeChangedTrigger[Capacity];
@@ -16,7 +14,7 @@ namespace Ludots.Core.Gameplay.GAS
         private TagChangedTrigger[] _tagOverflow = new TagChangedTrigger[Capacity];
         private TagCountChangedTrigger[] _tagCountTriggers = new TagCountChangedTrigger[Capacity];
         private TagCountChangedTrigger[] _tagCountOverflow = new TagCountChangedTrigger[Capacity];
-        
+
         private int _attributeCount = 0;
         private int _tagCount = 0;
         private int _tagCountTriggerCount = 0;
@@ -24,73 +22,57 @@ namespace Ludots.Core.Gameplay.GAS
         private int _tagOverflowCount = 0;
         private int _tagCountOverflowCount = 0;
 
-        private bool _attributeBudgetFused;
-        private bool _tagBudgetFused;
-        private bool _tagCountBudgetFused;
-        
-        /// <summary>
-        /// 入队属性变化触发器
-        /// </summary>
         public void EnqueueAttributeChanged(AttributeChangedTrigger trigger)
         {
-            if (_attributeCount >= GasConstants.MAX_DEFERRED_TRIGGERS_PER_FRAME)
+            if (_attributeCount < Capacity)
             {
-                if (!_attributeBudgetFused)
-                {
-                    _attributeBudgetFused = true;
-                    // Budget fused flag set above; no Console.WriteLine to avoid GC in hot path
-                }
-                if (_attributeOverflowCount >= GasConstants.MAX_DEFERRED_TRIGGERS_PER_FRAME) return;
-                _attributeOverflow[_attributeOverflowCount++] = trigger;
+                _attributeTriggers[_attributeCount++] = trigger;
                 return;
             }
-            
-            _attributeTriggers[_attributeCount++] = trigger;
+
+            if (_attributeOverflowCount >= Capacity)
+            {
+                throw new System.InvalidOperationException(
+                    $"{CapacityExceededError}: source=AttributeChanged, capacity={Capacity}, overflowCapacity={Capacity}, attributeId={trigger.AttributeId}.");
+            }
+
+            _attributeOverflow[_attributeOverflowCount++] = trigger;
         }
-        
-        /// <summary>
-        /// 入队Tag变化触发器
-        /// </summary>
+
         public void EnqueueTagChanged(TagChangedTrigger trigger)
         {
-            if (_tagCount >= GasConstants.MAX_DEFERRED_TRIGGERS_PER_FRAME)
+            if (_tagCount < Capacity)
             {
-                if (!_tagBudgetFused)
-                {
-                    _tagBudgetFused = true;
-                    // Budget fused flag set above; no Console.WriteLine to avoid GC in hot path
-                }
-                if (_tagOverflowCount >= GasConstants.MAX_DEFERRED_TRIGGERS_PER_FRAME) return;
-                _tagOverflow[_tagOverflowCount++] = trigger;
+                _tagTriggers[_tagCount++] = trigger;
                 return;
             }
-            
-            _tagTriggers[_tagCount++] = trigger;
+
+            if (_tagOverflowCount >= Capacity)
+            {
+                throw new System.InvalidOperationException(
+                    $"{CapacityExceededError}: source=TagChanged, capacity={Capacity}, overflowCapacity={Capacity}, tagId={trigger.TagId}.");
+            }
+
+            _tagOverflow[_tagOverflowCount++] = trigger;
         }
-        
-        /// <summary>
-        /// 入队TagCount变化触发器
-        /// </summary>
+
         public void EnqueueTagCountChanged(TagCountChangedTrigger trigger)
         {
-            if (_tagCountTriggerCount >= GasConstants.MAX_DEFERRED_TRIGGERS_PER_FRAME)
+            if (_tagCountTriggerCount < Capacity)
             {
-                if (!_tagCountBudgetFused)
-                {
-                    _tagCountBudgetFused = true;
-                    // Budget fused flag set above; no Console.WriteLine to avoid GC in hot path
-                }
-                if (_tagCountOverflowCount >= GasConstants.MAX_DEFERRED_TRIGGERS_PER_FRAME) return;
-                _tagCountOverflow[_tagCountOverflowCount++] = trigger;
+                _tagCountTriggers[_tagCountTriggerCount++] = trigger;
                 return;
             }
-            
-            _tagCountTriggers[_tagCountTriggerCount++] = trigger;
+
+            if (_tagCountOverflowCount >= Capacity)
+            {
+                throw new System.InvalidOperationException(
+                    $"{CapacityExceededError}: source=TagCountChanged, capacity={Capacity}, overflowCapacity={Capacity}, tagId={trigger.TagId}.");
+            }
+
+            _tagCountOverflow[_tagCountOverflowCount++] = trigger;
         }
-        
-        /// <summary>
-        /// 清空队列
-        /// </summary>
+
         public void Clear()
         {
             if (_attributeOverflowCount > 0)
@@ -125,44 +107,12 @@ namespace Ludots.Core.Gameplay.GAS
             {
                 _tagCountTriggerCount = 0;
             }
-            _attributeBudgetFused = false;
-            _tagBudgetFused = false;
-            _tagCountBudgetFused = false;
         }
-        
-        /// <summary>
-        /// Whether the attribute trigger budget was exceeded this frame.
-        /// </summary>
-        public bool AttributeBudgetFused => _attributeBudgetFused;
 
-        /// <summary>
-        /// Whether the tag trigger budget was exceeded this frame.
-        /// </summary>
-        public bool TagBudgetFused => _tagBudgetFused;
-
-        /// <summary>
-        /// Whether the tag-count trigger budget was exceeded this frame.
-        /// </summary>
-        public bool TagCountBudgetFused => _tagCountBudgetFused;
-
-        /// <summary>
-        /// 获取属性变化触发器数量
-        /// </summary>
         public int AttributeTriggerCount => _attributeCount;
-        
-        /// <summary>
-        /// 获取Tag变化触发器数量
-        /// </summary>
         public int TagTriggerCount => _tagCount;
-        
-        /// <summary>
-        /// 获取TagCount变化触发器数量
-        /// </summary>
         public int TagCountTriggerCount => _tagCountTriggerCount;
-        
-        /// <summary>
-        /// 获取属性变化触发器（只读访问）
-        /// </summary>
+
         public AttributeChangedTrigger GetAttributeTrigger(int index)
         {
             if (index < 0 || index >= _attributeCount)
@@ -171,10 +121,7 @@ namespace Ludots.Core.Gameplay.GAS
             }
             return _attributeTriggers[index];
         }
-        
-        /// <summary>
-        /// 获取Tag变化触发器（只读访问）
-        /// </summary>
+
         public TagChangedTrigger GetTagTrigger(int index)
         {
             if (index < 0 || index >= _tagCount)
@@ -183,10 +130,7 @@ namespace Ludots.Core.Gameplay.GAS
             }
             return _tagTriggers[index];
         }
-        
-        /// <summary>
-        /// 获取TagCount变化触发器（只读访问）
-        /// </summary>
+
         public TagCountChangedTrigger GetTagCountTrigger(int index)
         {
             if (index < 0 || index >= _tagCountTriggerCount)

--- a/src/Core/Gameplay/GAS/EffectRequestQueue.cs
+++ b/src/Core/Gameplay/GAS/EffectRequestQueue.cs
@@ -31,8 +31,6 @@ namespace Ludots.Core.Gameplay.GAS
         private int _overflowHead;
         private int _overflowTail;
         private int _overflowCount;
-        private int _dropped;
-        private bool _budgetFused;
         private int _responseChainListenerRevision;
         private World? _responseChainListenerWorld;
 
@@ -49,8 +47,6 @@ namespace Ludots.Core.Gameplay.GAS
         public int TotalCapacity => _items.Length + _overflow.Length;
         public int AvailableCapacity => (_items.Length - _count) + (_overflow.Length - _overflowCount);
         public int OverflowCount => _overflowCount;
-        public int DroppedCount => _dropped;
-        public bool BudgetFused => _budgetFused;
         public int ResponseChainListenerRevision => _responseChainListenerRevision;
 
         internal readonly struct WriteCheckpoint
@@ -60,25 +56,19 @@ namespace Ludots.Core.Gameplay.GAS
             internal readonly int OverflowHead;
             internal readonly int OverflowTail;
             internal readonly int OverflowCount;
-            internal readonly int Dropped;
-            internal readonly bool BudgetFused;
 
             internal WriteCheckpoint(
                 int count,
                 int nextRootId,
                 int overflowHead,
                 int overflowTail,
-                int overflowCount,
-                int dropped,
-                bool budgetFused)
+                int overflowCount)
             {
                 Count = count;
                 NextRootId = nextRootId;
                 OverflowHead = overflowHead;
                 OverflowTail = overflowTail;
                 OverflowCount = overflowCount;
-                Dropped = dropped;
-                BudgetFused = budgetFused;
             }
         }
 
@@ -91,9 +81,7 @@ namespace Ludots.Core.Gameplay.GAS
                 _nextRootId,
                 _overflowHead,
                 _overflowTail,
-                _overflowCount,
-                _dropped,
-                _budgetFused);
+                _overflowCount);
         }
 
         internal void RollbackWrites(in WriteCheckpoint checkpoint)
@@ -110,8 +98,6 @@ namespace Ludots.Core.Gameplay.GAS
             _overflowHead = checkpoint.OverflowHead;
             _overflowTail = checkpoint.OverflowTail;
             _overflowCount = checkpoint.OverflowCount;
-            _dropped = checkpoint.Dropped;
-            _budgetFused = checkpoint.BudgetFused;
         }
 
         public void Reserve(int capacity)
@@ -152,11 +138,6 @@ namespace Ludots.Core.Gameplay.GAS
                 return;
             }
 
-            if (!_budgetFused)
-            {
-                _budgetFused = true;
-            }
-
             if (_overflowCount >= _overflow.Length)
             {
                 throw new System.InvalidOperationException(
@@ -169,10 +150,28 @@ namespace Ludots.Core.Gameplay.GAS
             _overflowCount++;
         }
 
+        public void RequireAvailable(int needed, string source)
+        {
+            if (needed < 0)
+            {
+                throw new System.ArgumentOutOfRangeException(nameof(needed));
+            }
+
+            if (AvailableCapacity >= needed)
+            {
+                return;
+            }
+
+            throw new System.InvalidOperationException(
+                $"{CapacityExceededError}: source={source}, needed={needed}, available={AvailableCapacity}, capacity={_items.Length}, overflowCapacity={_overflow.Length}.");
+        }
+
         public void Clear()
         {
             _count = 0;
-            RefillFromOverflow();
+            _overflowHead = 0;
+            _overflowTail = 0;
+            _overflowCount = 0;
         }
 
         public void ConsumePrefix(int count)

--- a/src/Core/Gameplay/GAS/GasBudget.cs
+++ b/src/Core/Gameplay/GAS/GasBudget.cs
@@ -12,9 +12,6 @@ namespace Ludots.Core.Gameplay.GAS
         public int ResponseStepBudgetFused;
         public int ResponseQueueOverflowDropped;
 
-        public int EffectProposalFanOutDropped;
-        public int EffectApplicationFanOutDropped;
-        public int EffectLifetimeFanOutDropped;
         public int TagCountOverflowDropped;
         public int ActiveEffectContainerAttachDropped;
         public int PhaseListenerRegistrationDropped;
@@ -31,9 +28,6 @@ namespace Ludots.Core.Gameplay.GAS
             ResponseDepthDropped = 0;
             ResponseStepBudgetFused = 0;
             ResponseQueueOverflowDropped = 0;
-            EffectProposalFanOutDropped = 0;
-            EffectApplicationFanOutDropped = 0;
-            EffectLifetimeFanOutDropped = 0;
             TagCountOverflowDropped = 0;
             ActiveEffectContainerAttachDropped = 0;
             PhaseListenerRegistrationDropped = 0;
@@ -46,9 +40,6 @@ namespace Ludots.Core.Gameplay.GAS
             ResponseDepthDropped != 0 ||
             ResponseStepBudgetFused != 0 ||
             ResponseQueueOverflowDropped != 0 ||
-            EffectProposalFanOutDropped != 0 ||
-            EffectApplicationFanOutDropped != 0 ||
-            EffectLifetimeFanOutDropped != 0 ||
             TagCountOverflowDropped != 0 ||
             ActiveEffectContainerAttachDropped != 0 ||
             PhaseListenerRegistrationDropped != 0 ||

--- a/src/Core/Gameplay/GAS/GasDiagnosticEvents.cs
+++ b/src/Core/Gameplay/GAS/GasDiagnosticEvents.cs
@@ -21,7 +21,6 @@ namespace Ludots.Core.Gameplay.GAS
         ResponseDepthDropped = 2,
         ResponseStepBudgetFused = 3,
         ResponseQueueOverflow = 4,
-        FanOutCreatesDropped = 5,
         TagCountOverflowDropped = 7,
         ActiveEffectContainerAttachDropped = 8,
         PhaseListenerRegistrationDropped = 9,

--- a/src/Core/Gameplay/GAS/Systems/EffectApplicationSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/EffectApplicationSystem.cs
@@ -71,7 +71,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
         private readonly RootBudgetTable _fanOutBudget;
         // An injected budget is advanced by the effect-loop owner once per processing transaction.
         private readonly bool _ownsFanOutBudget;
-        private int _fanOutDropped;
         private readonly Entity[] _resolverBuffer = new Entity[256];
         private readonly BuiltinHandlerExecutionContext _builtinRuntime = new BuiltinHandlerExecutionContext();
         private readonly EffectPhaseSideEffectTransaction _persistentPhaseTransaction;
@@ -206,7 +205,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                 {
                     _fanOutBudget.NextFrame();
                 }
-                _fanOutDropped = 0;
                 _activeEffectAttachDropped = 0;
                 _listenerRegistrationDropped = 0;
 
@@ -404,7 +402,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                             TagCountContainer tagCountsBefore = default;
                             DirtyFlags dirtyFlagsBefore = default;
                             int fanOutCommandCountBefore = _fanOutCommands.Count;
-                            int fanOutDroppedBefore = _fanOutDropped;
                             int listenerRegistrationCountBefore = _pendingListenerRegistrations.Count;
                             bool graphTransactionBound = false;
                             _persistentPhaseTransaction.Begin();
@@ -461,7 +458,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                             {
                                 _persistentPhaseTransaction.Rollback();
                                 _fanOutCommands.Truncate(fanOutCommandCountBefore);
-                                _fanOutDropped = fanOutDroppedBefore;
                                 TrimTail(_pendingListenerRegistrations, listenerRegistrationCountBefore);
                                 if (hasGrantedTagSnapshot && World.IsAlive(context.Target))
                                 {
@@ -540,10 +536,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
 
                 if (_budget != null)
                 {
-                    if (_fanOutDropped > 0)
-                    {
-                        _budget.EffectApplicationFanOutDropped += _fanOutDropped;
-                    }
                     if (_activeEffectAttachDropped > 0)
                     {
                         _budget.ActiveEffectContainerAttachDropped += _activeEffectAttachDropped;
@@ -729,7 +721,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             ExecutePhaseForEffect(effectEntity, in context, in tplData, EffectPhaseId.OnHit, _builtinRuntime);
             ExecutePhaseForEffect(effectEntity, in context, in tplData, EffectPhaseId.OnApply, _builtinRuntime);
 
-            _fanOutDropped += _builtinRuntime.DroppedCount;
             PublishBuiltinAttributeDelta(in context, templateId, _builtinRuntime);
         }
 

--- a/src/Core/Gameplay/GAS/Systems/EffectLifetimeSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/EffectLifetimeSystem.cs
@@ -53,7 +53,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
         private readonly Entity[] _resolverBuffer = new Entity[256];
         private readonly BuiltinHandlerExecutionContext _builtinRuntime = new BuiltinHandlerExecutionContext();
         private readonly EffectPhaseSideEffectTransaction _phaseTransaction;
-        private int _fanOutDropped;
 
 
         /// <summary>
@@ -353,7 +352,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             {
                 _fanOutBudget.NextFrame();
             }
-            _fanOutDropped = 0;
             ClearPendingWork();
             ClearRollbackState();
 
@@ -481,11 +479,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
 
         private void CompleteSlice()
         {
-            if (_fanOutDropped > 0 && _budget != null)
-            {
-                _budget.EffectLifetimeFanOutDropped += _fanOutDropped;
-            }
-
             _sliceActive = false;
             _stage = LifetimeStage.Scan;
             _snapshotCount = 0;
@@ -710,11 +703,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                 builtinRuntime,
                 BuildExecutionSeed(entry.EffectEntity, phase, entry.TemplateId, entry.ClockTick, entry.Context),
                 entry.Context.RootId);
-
-            if (builtinRuntime != null)
-            {
-                _fanOutDropped += builtinRuntime.DroppedCount;
-            }
 
             if (phase == EffectPhaseId.OnExpire || phase == EffectPhaseId.OnRemove)
             {

--- a/src/Core/Gameplay/GAS/Systems/EffectProposalProcessingSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/EffectProposalProcessingSystem.cs
@@ -1505,7 +1505,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                     ApplyInstantModifiersAndPublish(in proposal);
                 }
 
-                PublishBuiltinFanOutCommandsAndRecordDrops();
+                PublishBuiltinFanOutCommands();
                 if (useGasTransaction)
                 {
                     _instantPhaseTransaction.Commit();
@@ -1830,7 +1830,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                     _builtinRuntime,
                     BuildInstantExecutionSeed(in proposal, EffectPhaseId.OnCalculate),
                     proposal.RootId);
-                PublishBuiltinFanOutCommandsAndRecordDrops();
+                PublishBuiltinFanOutCommands();
             }
             finally
             {
@@ -1838,13 +1838,8 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             }
         }
 
-        private void PublishBuiltinFanOutCommandsAndRecordDrops()
+        private void PublishBuiltinFanOutCommands()
         {
-            if (_builtinRuntime.DroppedCount > 0 && _budget != null)
-            {
-                _budget.EffectProposalFanOutDropped += _builtinRuntime.DroppedCount;
-            }
-
             for (int i = 0; i < _instantFanOutCommands.Count; i++)
             {
                 FanOutCommand command = _instantFanOutCommands[i];

--- a/src/Core/Gameplay/GAS/Systems/GasBudgetReportSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/GasBudgetReportSystem.cs
@@ -33,9 +33,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             PublishIfNonZero(GasDiagnosticSystem.ResponseChain, GasDiagnosticMetric.ResponseDepthDropped, _budget.ResponseDepthDropped);
             PublishIfNonZero(GasDiagnosticSystem.ResponseChain, GasDiagnosticMetric.ResponseStepBudgetFused, _budget.ResponseStepBudgetFused);
             PublishIfNonZero(GasDiagnosticSystem.ResponseChain, GasDiagnosticMetric.ResponseQueueOverflow, _budget.ResponseQueueOverflowDropped);
-            PublishIfNonZero(GasDiagnosticSystem.EffectProposal, GasDiagnosticMetric.FanOutCreatesDropped, _budget.EffectProposalFanOutDropped);
-            PublishIfNonZero(GasDiagnosticSystem.EffectApplication, GasDiagnosticMetric.FanOutCreatesDropped, _budget.EffectApplicationFanOutDropped);
-            PublishIfNonZero(GasDiagnosticSystem.EffectLifetime, GasDiagnosticMetric.FanOutCreatesDropped, _budget.EffectLifetimeFanOutDropped);
             PublishIfNonZero(GasDiagnosticSystem.TagContainer, GasDiagnosticMetric.TagCountOverflowDropped, _budget.TagCountOverflowDropped);
             PublishIfNonZero(GasDiagnosticSystem.ActiveEffectContainer, GasDiagnosticMetric.ActiveEffectContainerAttachDropped, _budget.ActiveEffectContainerAttachDropped);
             PublishIfNonZero(GasDiagnosticSystem.PhaseListener, GasDiagnosticMetric.PhaseListenerRegistrationDropped, _budget.PhaseListenerRegistrationDropped);

--- a/src/Core/Gameplay/GAS/TargetResolverFanOutHelper.cs
+++ b/src/Core/Gameplay/GAS/TargetResolverFanOutHelper.cs
@@ -198,11 +198,10 @@ namespace Ludots.Core.Gameplay.GAS
             Entity[] buffer,
             int candidateCount,
             RootBudgetTable budget,
-            FanOutCommandBuffer commands,
-            ref int dropped)
+            FanOutCommandBuffer commands)
         {
             EffectConfigParams mergedParams = default;
-            return ValidateAndCollect(world, in ctx, in query, in filter, in dispatch, in mergedParams, buffer, candidateCount, budget, commands, ref dropped);
+            return ValidateAndCollect(world, in ctx, in query, in filter, in dispatch, in mergedParams, buffer, candidateCount, budget, commands);
         }
 
         public static int ValidateAndCollect(
@@ -215,8 +214,7 @@ namespace Ludots.Core.Gameplay.GAS
             Entity[] buffer,
             int candidateCount,
             RootBudgetTable budget,
-            FanOutCommandBuffer commands,
-            ref int dropped)
+            FanOutCommandBuffer commands)
         {
             ref readonly var spatial = ref query.Spatial;
             WorldCmInt2 center = default;
@@ -330,12 +328,11 @@ namespace Ludots.Core.Gameplay.GAS
             ISpatialQueryService spatialQueries,
             RootBudgetTable budget,
             FanOutCommandBuffer commands,
-            Entity[] buffer,
-            ref int dropped)
+            Entity[] buffer)
         {
             int candidateCount = ResolveTargets(world, in ctx, in query, spatialQueries, buffer);
             if (candidateCount <= 0) return;
-            ValidateAndCollect(world, in ctx, in query, in filter, in dispatch, buffer, candidateCount, budget, commands, ref dropped);
+            ValidateAndCollect(world, in ctx, in query, in filter, in dispatch, buffer, candidateCount, budget, commands);
         }
 
         /// <summary>

--- a/src/Core/Gameplay/Relationships/RelationshipQueryResult.cs
+++ b/src/Core/Gameplay/Relationships/RelationshipQueryResult.cs
@@ -1,0 +1,16 @@
+namespace Ludots.Core.Gameplay.Relationships
+{
+    public readonly struct RelationshipQueryResult
+    {
+        public readonly int Count;
+        public readonly int Dropped;
+
+        public bool Overflowed => Dropped > 0;
+
+        public RelationshipQueryResult(int count, int dropped)
+        {
+            Count = count;
+            Dropped = dropped;
+        }
+    }
+}

--- a/src/Core/Gameplay/Relationships/RelationshipReverseIndex.cs
+++ b/src/Core/Gameplay/Relationships/RelationshipReverseIndex.cs
@@ -112,14 +112,20 @@ namespace Ludots.Core.Gameplay.Relationships
         /// <summary>Copies live incoming sources for the target into the destination span; dead sources are skipped and reclaimed in place. Pass <see cref="RelationshipTypeRegistry.AnyTypeId"/> to merge all type slots with de-duplication.</summary>
         public int CopyIncoming(Entity target, int typeId, Span<Entity> destination)
         {
-            if (destination.IsEmpty || !_world.IsAlive(target))
+            return CopyIncoming(target, typeId, destination, out _);
+        }
+
+        public int CopyIncoming(Entity target, int typeId, Span<Entity> destination, out int dropped)
+        {
+            dropped = 0;
+            if (!_world.IsAlive(target))
             {
                 return 0;
             }
 
             if (typeId == RelationshipTypeRegistry.AnyTypeId)
             {
-                return CopyIncomingAnyType(target, destination);
+                return CopyIncomingAnyType(target, destination, out dropped);
             }
 
             if (!TryGetActiveSlot(target, typeId, out int slot))
@@ -127,7 +133,7 @@ namespace Ludots.Core.Gameplay.Relationships
                 return 0;
             }
 
-            return CopySlotRows(slot, alreadyWritten: 0, destination, deduplicate: false);
+            return CopySlotRows(slot, alreadyWritten: 0, destination, deduplicate: false, out dropped);
         }
 
         /// <summary>Returns true when a live (source → target) edge row of the given type exists; dead rows encountered while scanning are reclaimed in place. O(in-degree), buffer-free.</summary>
@@ -227,8 +233,9 @@ namespace Ludots.Core.Gameplay.Relationships
             return reclaimed;
         }
 
-        private int CopyIncomingAnyType(Entity target, Span<Entity> destination)
+        private int CopyIncomingAnyType(Entity target, Span<Entity> destination, out int dropped)
         {
+            dropped = 0;
             int slotCount = CopySlotsByTarget(target);
             int totalRows = 0;
             for (int i = 0; i < slotCount; i++)
@@ -238,9 +245,10 @@ namespace Ludots.Core.Gameplay.Relationships
 
             PrepareDedupSet(totalRows);
             int written = 0;
-            for (int i = 0; i < slotCount && written < destination.Length; i++)
+            for (int i = 0; i < slotCount; i++)
             {
-                written = CopySlotRows(_slotScratch[i].Slot, written, destination, deduplicate: true);
+                written = CopySlotRows(_slotScratch[i].Slot, written, destination, deduplicate: true, out int slotDropped);
+                dropped += slotDropped;
             }
 
             return written;
@@ -260,11 +268,12 @@ namespace Ludots.Core.Gameplay.Relationships
             }
         }
 
-        private int CopySlotRows(int slot, int alreadyWritten, Span<Entity> destination, bool deduplicate)
+        private int CopySlotRows(int slot, int alreadyWritten, Span<Entity> destination, bool deduplicate, out int dropped)
         {
             int written = alreadyWritten;
+            dropped = 0;
             int index = 0;
-            while (index < _rowCounts[slot] && written < destination.Length)
+            while (index < _rowCounts[slot])
             {
                 Entity source = _rowSources[_rowStarts[slot] + index];
                 if (!_world.IsAlive(source))
@@ -273,9 +282,19 @@ namespace Ludots.Core.Gameplay.Relationships
                     continue;
                 }
 
-                if (!deduplicate || TryAddToDedupSet(source))
+                if (deduplicate && !TryAddToDedupSet(source))
+                {
+                    index++;
+                    continue;
+                }
+
+                if (written < destination.Length)
                 {
                     destination[written++] = source;
+                }
+                else
+                {
+                    dropped++;
                 }
 
                 index++;

--- a/src/Core/Gameplay/Relationships/RelationshipRuntime.cs
+++ b/src/Core/Gameplay/Relationships/RelationshipRuntime.cs
@@ -365,7 +365,13 @@ namespace Ludots.Core.Gameplay.Relationships
 
         public int CollectOutgoing(Entity source, int typeId, Span<Entity> buffer)
         {
-            if (!IsAliveInRuntimeWorld(source) || buffer.Length == 0 || !_world.Has<Relationship<RelationshipEdgeSet>>(source))
+            return CollectOutgoing(source, typeId, buffer, out _);
+        }
+
+        public int CollectOutgoing(Entity source, int typeId, Span<Entity> buffer, out int dropped)
+        {
+            dropped = 0;
+            if (!IsAliveInRuntimeWorld(source) || !_world.Has<Relationship<RelationshipEdgeSet>>(source))
             {
                 return 0;
             }
@@ -375,17 +381,19 @@ namespace Ludots.Core.Gameplay.Relationships
             int count = 0;
             foreach ((Entity target, RelationshipEdgeSet set) in relationships)
             {
-                if (count >= buffer.Length)
-                {
-                    break;
-                }
-
                 if (!MatchesType(set, validatedTypeId))
                 {
                     continue;
                 }
 
-                buffer[count++] = target;
+                if (count < buffer.Length)
+                {
+                    buffer[count++] = target;
+                }
+                else
+                {
+                    dropped++;
+                }
             }
 
             return count;
@@ -403,12 +411,18 @@ namespace Ludots.Core.Gameplay.Relationships
         /// </summary>
         public int CollectIncoming(Entity target, int typeId, Span<Entity> buffer)
         {
-            if (!IsAliveInRuntimeWorld(target) || buffer.Length == 0)
+            return CollectIncoming(target, typeId, buffer, out _);
+        }
+
+        public int CollectIncoming(Entity target, int typeId, Span<Entity> buffer, out int dropped)
+        {
+            dropped = 0;
+            if (!IsAliveInRuntimeWorld(target))
             {
                 return 0;
             }
 
-            return _reverseIndex.CopyIncoming(target, ValidateFilterTypeId(typeId), buffer);
+            return _reverseIndex.CopyIncoming(target, ValidateFilterTypeId(typeId), buffer, out dropped);
         }
 
         public int CollectMutual(Entity first, Entity second, Span<Entity> buffer)
@@ -418,7 +432,13 @@ namespace Ludots.Core.Gameplay.Relationships
 
         public int CollectMutual(Entity first, Entity second, int typeId, Span<Entity> buffer)
         {
-            if (!IsAliveInRuntimeWorld(first) || !IsAliveInRuntimeWorld(second) || buffer.Length == 0 || !_world.Has<Relationship<RelationshipEdgeSet>>(first))
+            return CollectMutual(first, second, typeId, buffer, out _);
+        }
+
+        public int CollectMutual(Entity first, Entity second, int typeId, Span<Entity> buffer, out int dropped)
+        {
+            dropped = 0;
+            if (!IsAliveInRuntimeWorld(first) || !IsAliveInRuntimeWorld(second) || !_world.Has<Relationship<RelationshipEdgeSet>>(first))
             {
                 return 0;
             }
@@ -428,19 +448,23 @@ namespace Ludots.Core.Gameplay.Relationships
             int count = 0;
             foreach ((Entity candidate, RelationshipEdgeSet set) in relationships)
             {
-                if (count >= buffer.Length)
-                {
-                    break;
-                }
-
                 if (!IsAliveInRuntimeWorld(candidate) || !MatchesType(set, validatedTypeId))
                 {
                     continue;
                 }
 
-                if (HasLink(candidate, second, validatedTypeId) && HasLink(second, candidate, validatedTypeId))
+                if (!HasLink(candidate, second, validatedTypeId) || !HasLink(second, candidate, validatedTypeId))
+                {
+                    continue;
+                }
+
+                if (count < buffer.Length)
                 {
                     buffer[count++] = candidate;
+                }
+                else
+                {
+                    dropped++;
                 }
             }
 
@@ -454,7 +478,13 @@ namespace Ludots.Core.Gameplay.Relationships
 
         public int CollectBetweenPair(Entity source, Entity target, int typeId, Span<Entity> buffer)
         {
-            if (!IsAliveInRuntimeWorld(source) || !IsAliveInRuntimeWorld(target) || buffer.Length == 0)
+            return CollectBetweenPair(source, target, typeId, buffer, out _);
+        }
+
+        public int CollectBetweenPair(Entity source, Entity target, int typeId, Span<Entity> buffer, out int dropped)
+        {
+            dropped = 0;
+            if (!IsAliveInRuntimeWorld(source) || !IsAliveInRuntimeWorld(target))
             {
                 return 0;
             }
@@ -463,12 +493,26 @@ namespace Ludots.Core.Gameplay.Relationships
             int count = 0;
             if (HasLink(source, target, validatedTypeId))
             {
-                buffer[count++] = target;
+                if (count < buffer.Length)
+                {
+                    buffer[count++] = target;
+                }
+                else
+                {
+                    dropped++;
+                }
             }
 
-            if (count < buffer.Length && HasLink(target, source, validatedTypeId))
+            if (HasLink(target, source, validatedTypeId))
             {
-                buffer[count++] = source;
+                if (count < buffer.Length)
+                {
+                    buffer[count++] = source;
+                }
+                else
+                {
+                    dropped++;
+                }
             }
 
             return count;

--- a/src/Core/Gameplay/Spawning/RuntimeEntitySpawnSystem.cs
+++ b/src/Core/Gameplay/Spawning/RuntimeEntitySpawnSystem.cs
@@ -342,7 +342,7 @@ namespace Ludots.Core.Gameplay.Spawning
             int onSpawnEffectTemplateId = _templateBatchSpawner.GetOnSpawnEffectTemplateId(templateId, template);
             if (_effectRequests != null && (hasRequestOnSpawnEffect || onSpawnEffectTemplateId > 0))
             {
-                _effectRequests.Reserve(_effectRequests.Count + _effectRequests.OverflowCount + count);
+                _effectRequests.RequireAvailable(count, "RuntimeEntitySpawnSystem.TemplateBatchOnSpawn");
             }
             else if (_effectRequests == null && (hasRequestOnSpawnEffect || onSpawnEffectTemplateId > 0))
             {
@@ -485,8 +485,7 @@ namespace Ludots.Core.Gameplay.Spawning
             double postSpawnMs = 0d;
             if (_effectRequests != null && (hasRequestOnSpawnEffect || onSpawnEffectTemplateId > 0))
             {
-                // Capacity was reserved before create; keep the post-create reserve for overflow refill safety.
-                _effectRequests.Reserve(_effectRequests.Count + _effectRequests.OverflowCount + created.Length);
+                _effectRequests.RequireAvailable(created.Length, "RuntimeEntitySpawnSystem.TemplateBatchOnSpawnPostCreate");
             }
 
             bool requiresPostSpawnLoop =
@@ -1036,7 +1035,7 @@ namespace Ludots.Core.Gameplay.Spawning
                     $"Runtime spawn on-spawn effect requires EffectRequestQueue: kind={request.Kind}, templateId={request.TemplateId}, effectTemplateId={effectTemplateId}.");
             }
 
-            _effectRequests.Reserve(_effectRequests.Count + _effectRequests.OverflowCount + 1);
+            _effectRequests.RequireAvailable(1, "RuntimeEntitySpawnSystem.OnSpawnEffect");
         }
 
         private int ResolveTemplateFinalTeamId(

--- a/src/Core/Input/Orders/AbilityAimPresentationRuntime.cs
+++ b/src/Core/Input/Orders/AbilityAimPresentationRuntime.cs
@@ -336,8 +336,7 @@ namespace Ludots.Core.Input.Orders
                     _candidateBuffer,
                     candidateCount,
                     _budget,
-                    _fanOutCommands,
-                    ref dropped);
+                    _fanOutCommands);
             }
 
             for (int i = 0; i < _fanOutCommands.Count; i++)

--- a/src/Core/NodeLibraries/GASGraph/GasGraphOpHandlerTable.cs
+++ b/src/Core/NodeLibraries/GASGraph/GasGraphOpHandlerTable.cs
@@ -1011,22 +1011,52 @@ namespace Ludots.Core.NodeLibraries.GASGraph
 
         private static void HandleRelationshipQueryOutgoing(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)
         {
-            s.TargetList.SetCount(s.Api.CollectOutgoing(s.E[ins.A], s.Targets, ResolveQueryTypeId(ins.Dst)));
+            ApplyRelationshipQueryResult(ref s, in ins, s.Api.CollectOutgoing(s.E[ins.A], s.Targets, ResolveQueryTypeId(ins.Dst)));
         }
 
         private static void HandleRelationshipQueryIncoming(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)
         {
-            s.TargetList.SetCount(s.Api.CollectIncoming(s.E[ins.A], s.Targets, ResolveQueryTypeId(ins.Dst)));
+            ApplyRelationshipQueryResult(ref s, in ins, s.Api.CollectIncoming(s.E[ins.A], s.Targets, ResolveQueryTypeId(ins.Dst)));
         }
 
         private static void HandleRelationshipQueryMutual(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)
         {
-            s.TargetList.SetCount(s.Api.CollectMutual(s.E[ins.A], s.E[ins.B], s.Targets, ResolveQueryTypeId(ins.Dst)));
+            ApplyRelationshipQueryResult(ref s, in ins, s.Api.CollectMutual(s.E[ins.A], s.E[ins.B], s.Targets, ResolveQueryTypeId(ins.Dst)));
         }
 
         private static void HandleRelationshipQueryBetweenPair(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)
         {
-            s.TargetList.SetCount(s.Api.CollectBetweenPair(s.E[ins.A], s.E[ins.B], s.Targets, ResolveQueryTypeId(ins.Dst)));
+            ApplyRelationshipQueryResult(ref s, in ins, s.Api.CollectBetweenPair(s.E[ins.A], s.E[ins.B], s.Targets, ResolveQueryTypeId(ins.Dst)));
+        }
+
+        private static void ApplyRelationshipQueryResult(
+            ref GraphExecutionState s,
+            in GraphInstruction ins,
+            RelationshipQueryResult result)
+        {
+            if (ins.Flags > 1)
+            {
+                throw new InvalidOperationException(
+                    $"GAS.GRAPH.ERR.InvalidRelationshipQueryCapacityPolicy: flags={ins.Flags}.");
+            }
+
+            if ((uint)result.Count > (uint)s.Targets.Length || result.Dropped < 0)
+            {
+                throw new InvalidOperationException(
+                    $"GAS.GRAPH.ERR.InvalidRelationshipQueryResult: count={result.Count}, dropped={result.Dropped}, capacity={s.Targets.Length}.");
+            }
+
+            if (result.Dropped > 0 && ins.Flags == 0)
+            {
+                throw new InvalidOperationException(
+                    $"GAS.GRAPH.ERR.RelationshipQueryIncomplete: count={result.Count}, dropped={result.Dropped}.");
+            }
+
+            s.TargetList.SetCount(result.Count);
+            if (ins.Flags == 1)
+            {
+                s.I[ins.C] = result.Dropped;
+            }
         }
 
         private static void HandleRelationshipFilterMetricRange(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)

--- a/src/Core/NodeLibraries/GASGraph/GraphControlFlowCompiler.Query.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphControlFlowCompiler.Query.cs
@@ -171,15 +171,18 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 case GraphNodeOp.RelationshipQueryOutgoing:
                 case GraphNodeOp.RelationshipQueryIncoming:
                     RequireValueInput(node, GraphControlFlowPorts.Source, GraphValueType.Entity, valueEdges, nodeIndices, outputTypes, graphId, diagnostics);
+                    RequireRelationshipQueryCapacityPolicy(node, graphId, diagnostics);
                     break;
                 case GraphNodeOp.RelationshipQueryMutual:
                     RequireValueInput(node, GraphControlFlowPorts.Source, GraphValueType.Entity, valueEdges, nodeIndices, outputTypes, graphId, diagnostics);
                     RequireValueInput(node, GraphControlFlowPorts.B, GraphValueType.Entity, valueEdges, nodeIndices, outputTypes, graphId, diagnostics);
+                    RequireRelationshipQueryCapacityPolicy(node, graphId, diagnostics);
                     break;
                 case GraphNodeOp.RelationshipQueryBetweenPair:
                     RequireValueInput(node, GraphControlFlowPorts.Source, GraphValueType.Entity, valueEdges, nodeIndices, outputTypes, graphId, diagnostics);
                     RequireValueInput(node, GraphControlFlowPorts.B, GraphValueType.Entity, valueEdges, nodeIndices, outputTypes, graphId, diagnostics);
                     RequireRelationshipFields(node, requireMetric: false, requireFlag: false, graphId, diagnostics);
+                    RequireRelationshipQueryCapacityPolicy(node, graphId, diagnostics);
                     break;
                 case GraphNodeOp.RelationshipFilterMetricRange:
                     RequireValueInput(node, GraphControlFlowPorts.List, GraphValueType.TargetList, valueEdges, nodeIndices, outputTypes, graphId, diagnostics);
@@ -219,6 +222,38 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                         $"Op '{op.NodeOp}' is not supported by Query ControlFlow compiler.", node.Id));
                     break;
             }
+        }
+
+        private static void RequireRelationshipQueryCapacityPolicy(
+            GraphControlFlowNode node,
+            string graphId,
+            List<GraphDiagnostic> diagnostics)
+        {
+            if (string.IsNullOrWhiteSpace(node.QueryCapacityPolicy) ||
+                string.Equals(node.QueryCapacityPolicy, "RequireComplete", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            if (!string.Equals(node.QueryCapacityPolicy, "AllowTruncated", StringComparison.Ordinal))
+            {
+                diagnostics.Add(Error(graphId, GraphDiagnosticCodes.TypeMismatch,
+                    $"Node '{node.Id}' must declare queryCapacityPolicy as 'RequireComplete' or 'AllowTruncated'.",
+                    node.Id));
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(node.DroppedOutput))
+            {
+                diagnostics.Add(Error(graphId, GraphDiagnosticCodes.MissingNodeRef,
+                    $"Node '{node.Id}' AllowTruncated requires a non-empty droppedOutput.",
+                    node.Id));
+                return;
+            }
+
+            diagnostics.Add(Error(graphId, GraphDiagnosticCodes.TypeMismatch,
+                $"Node '{node.Id}' AllowTruncated droppedOutput is not yet authorable on ControlFlow Query kinds.",
+                node.Id));
         }
 
         private static void RequireRelationshipFields(
@@ -393,6 +428,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                         node, GraphControlFlowPorts.Source, GraphValueType.Entity,
                         valueEdges, nodeIndices, outputTypes, outputRegisters, definedInts, definedBools, graphId, diagnostics);
                     instruction.Dst = EncodeByteSymbol(node.RelationshipType, symbolToIndex, symbols, graphId, node.Id, diagnostics);
+                    instruction.Flags = 0;
                     break;
                 case GraphNodeOp.RelationshipQueryMutual:
                     instruction.A = ResolveValueInput(
@@ -402,6 +438,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                         node, GraphControlFlowPorts.B, GraphValueType.Entity,
                         valueEdges, nodeIndices, outputTypes, outputRegisters, definedInts, definedBools, graphId, diagnostics);
                     instruction.Dst = EncodeByteSymbol(node.RelationshipType, symbolToIndex, symbols, graphId, node.Id, diagnostics);
+                    instruction.Flags = 0;
                     break;
                 case GraphNodeOp.RelationshipQueryBetweenPair:
                     instruction.A = ResolveValueInput(
@@ -411,6 +448,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                         node, GraphControlFlowPorts.B, GraphValueType.Entity,
                         valueEdges, nodeIndices, outputTypes, outputRegisters, definedInts, definedBools, graphId, diagnostics);
                     instruction.Dst = RequireRelationshipTypeSymbol(node.RelationshipType, symbolToIndex, symbols, graphId, node.Id, diagnostics);
+                    instruction.Flags = 0;
                     break;
                 case GraphNodeOp.RelationshipFilterMetricRange:
                     instruction.A = ResolveValueInput(

--- a/src/Core/NodeLibraries/GASGraph/GraphTargetList.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphTargetList.cs
@@ -18,8 +18,18 @@ namespace Ludots.Core.NodeLibraries.GASGraph
 
         public void SetCount(int count)
         {
-            if (count < 0) count = 0;
-            if (count > _buffer.Length) count = _buffer.Length;
+            if (count < 0)
+            {
+                throw new InvalidOperationException(
+                    $"GAS.GRAPH.ERR.InvalidTargetListCount: count={count}.");
+            }
+
+            if (count > _buffer.Length)
+            {
+                throw new InvalidOperationException(
+                    $"GAS.GRAPH.ERR.TargetListCapacityExceeded: count={count}, capacity={_buffer.Length}.");
+            }
+
             Count = count;
         }
     }

--- a/src/Core/NodeLibraries/GASGraph/Host/GasGraphRuntimeApi.cs
+++ b/src/Core/NodeLibraries/GASGraph/Host/GasGraphRuntimeApi.cs
@@ -901,14 +901,26 @@ namespace Ludots.Core.NodeLibraries.GASGraph.Host
             RejectNonTransactionalEffectSideEffect(nameof(SetRelationshipFlag));
             RequireRelationshipRuntime().SetFlag(source, target, typeId, flagId, enabled, reasonId);
         }
-        public int CollectOutgoing(Entity source, Span<Entity> buffer, int typeId = RelationshipTypeRegistry.AnyTypeId)
-            => RequireRelationshipRuntime().CollectOutgoing(source, typeId, buffer);
-        public int CollectIncoming(Entity target, Span<Entity> buffer, int typeId = RelationshipTypeRegistry.AnyTypeId)
-            => RequireRelationshipRuntime().CollectIncoming(target, typeId, buffer);
-        public int CollectMutual(Entity first, Entity second, Span<Entity> buffer, int typeId = RelationshipTypeRegistry.AnyTypeId)
-            => RequireRelationshipRuntime().CollectMutual(first, second, typeId, buffer);
-        public int CollectBetweenPair(Entity source, Entity target, Span<Entity> buffer, int typeId = RelationshipTypeRegistry.AnyTypeId)
-            => RequireRelationshipRuntime().CollectBetweenPair(source, target, typeId, buffer);
+        public RelationshipQueryResult CollectOutgoing(Entity source, Span<Entity> buffer, int typeId = RelationshipTypeRegistry.AnyTypeId)
+        {
+            int count = RequireRelationshipRuntime().CollectOutgoing(source, typeId, buffer, out int dropped);
+            return new RelationshipQueryResult(count, dropped);
+        }
+        public RelationshipQueryResult CollectIncoming(Entity target, Span<Entity> buffer, int typeId = RelationshipTypeRegistry.AnyTypeId)
+        {
+            int count = RequireRelationshipRuntime().CollectIncoming(target, typeId, buffer, out int dropped);
+            return new RelationshipQueryResult(count, dropped);
+        }
+        public RelationshipQueryResult CollectMutual(Entity first, Entity second, Span<Entity> buffer, int typeId = RelationshipTypeRegistry.AnyTypeId)
+        {
+            int count = RequireRelationshipRuntime().CollectMutual(first, second, typeId, buffer, out int dropped);
+            return new RelationshipQueryResult(count, dropped);
+        }
+        public RelationshipQueryResult CollectBetweenPair(Entity source, Entity target, Span<Entity> buffer, int typeId = RelationshipTypeRegistry.AnyTypeId)
+        {
+            int count = RequireRelationshipRuntime().CollectBetweenPair(source, target, typeId, buffer, out int dropped);
+            return new RelationshipQueryResult(count, dropped);
+        }
         public int FilterRelationshipMetricRange(Span<Entity> entities, int count, Entity source, int typeId, int metricId, short minInclusive, short maxInclusive)
             => RequireEntityQueries().FilterRelationshipMetricRange(entities, count, source, typeId, metricId, minInclusive, maxInclusive);
         public int FilterRelationshipFlag(Span<Entity> entities, int count, Entity source, int typeId, int flagId, bool expected)

--- a/src/Core/NodeLibraries/GASGraph/IGraphRuntimeApi.cs
+++ b/src/Core/NodeLibraries/GASGraph/IGraphRuntimeApi.cs
@@ -202,22 +202,22 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             throw new InvalidOperationException("Graph relationship runtime is not available.");
         }
 
-        int CollectOutgoing(Entity source, Span<Entity> buffer, int typeId = RelationshipTypeRegistry.AnyTypeId)
+        RelationshipQueryResult CollectOutgoing(Entity source, Span<Entity> buffer, int typeId = RelationshipTypeRegistry.AnyTypeId)
         {
             throw new InvalidOperationException("Graph relationship runtime is not available.");
         }
 
-        int CollectIncoming(Entity target, Span<Entity> buffer, int typeId = RelationshipTypeRegistry.AnyTypeId)
+        RelationshipQueryResult CollectIncoming(Entity target, Span<Entity> buffer, int typeId = RelationshipTypeRegistry.AnyTypeId)
         {
             throw new InvalidOperationException("Graph relationship runtime is not available.");
         }
 
-        int CollectMutual(Entity first, Entity second, Span<Entity> buffer, int typeId = RelationshipTypeRegistry.AnyTypeId)
+        RelationshipQueryResult CollectMutual(Entity first, Entity second, Span<Entity> buffer, int typeId = RelationshipTypeRegistry.AnyTypeId)
         {
             throw new InvalidOperationException("Graph relationship runtime is not available.");
         }
 
-        int CollectBetweenPair(Entity source, Entity target, Span<Entity> buffer, int typeId = RelationshipTypeRegistry.AnyTypeId)
+        RelationshipQueryResult CollectBetweenPair(Entity source, Entity target, Span<Entity> buffer, int typeId = RelationshipTypeRegistry.AnyTypeId)
         {
             throw new InvalidOperationException("Graph relationship runtime is not available.");
         }

--- a/src/Tests/GasTests/Effect/RootBudgetTests.cs
+++ b/src/Tests/GasTests/Effect/RootBudgetTests.cs
@@ -132,8 +132,6 @@ namespace Ludots.Tests.GAS
                 PayloadEffectTemplateId = 1001,
                 ContextMapping = TargetResolverContextMapping.Default,
             };
-            int dropped = 0;
-
             var error = Throws<InvalidOperationException>(() =>
                 TargetResolverFanOutHelper.ValidateAndCollect(
                     world,
@@ -144,12 +142,10 @@ namespace Ludots.Tests.GAS
                     candidates,
                     candidates.Length,
                     budget,
-                    commands,
-                    ref dropped));
+                    commands));
 
             That(error!.Message, Does.StartWith(TargetResolverFanOutHelper.RootBudgetExceededError));
             That(commands.Count, Is.Zero);
-            That(dropped, Is.Zero);
         }
 
         // Note: EffectCallbackComponent has been removed per the "Everything is Graph" architecture.

--- a/src/Tests/GasTests/GasCore/DeferredTriggerCollectionTests.cs
+++ b/src/Tests/GasTests/GasCore/DeferredTriggerCollectionTests.cs
@@ -28,6 +28,44 @@ namespace Ludots.Tests.GAS
         }
 
         [Test]
+        public void DeferredTriggerQueue_WhenMainAndOverflowAreFull_ThrowsNamingCapacityAndSource()
+        {
+            var queue = new DeferredTriggerQueue();
+            int totalCapacity = GasConstants.MAX_DEFERRED_TRIGGERS_PER_FRAME * 2;
+            for (int i = 0; i < totalCapacity; i++)
+            {
+                queue.EnqueueAttributeChanged(new AttributeChangedTrigger { AttributeId = i });
+            }
+
+            var error = Throws<System.InvalidOperationException>(() =>
+                queue.EnqueueAttributeChanged(new AttributeChangedTrigger { AttributeId = 9001 }));
+
+            That(error!.Message, Does.StartWith(DeferredTriggerQueue.CapacityExceededError));
+            That(error.Message, Does.Contain("source=AttributeChanged"));
+            That(error.Message, Does.Contain($"capacity={GasConstants.MAX_DEFERRED_TRIGGERS_PER_FRAME}"));
+            That(error.Message, Does.Contain("attributeId=9001"));
+            That(queue.AttributeTriggerCount, Is.EqualTo(GasConstants.MAX_DEFERRED_TRIGGERS_PER_FRAME));
+        }
+
+        [Test]
+        public void DeferredTriggerQueue_TagChanged_WhenMainAndOverflowAreFull_ThrowsNamingSource()
+        {
+            var queue = new DeferredTriggerQueue();
+            int totalCapacity = GasConstants.MAX_DEFERRED_TRIGGERS_PER_FRAME * 2;
+            for (int i = 0; i < totalCapacity; i++)
+            {
+                queue.EnqueueTagChanged(new TagChangedTrigger { TagId = i });
+            }
+
+            var error = Throws<System.InvalidOperationException>(() =>
+                queue.EnqueueTagChanged(new TagChangedTrigger { TagId = 42 }));
+
+            That(error!.Message, Does.StartWith(DeferredTriggerQueue.CapacityExceededError));
+            That(error.Message, Does.Contain("source=TagChanged"));
+            That(error.Message, Does.Contain("tagId=42"));
+        }
+
+        [Test]
         public void DeferredTrigger_AttributeChanged_UsesSnapshotOldValue()
         {
             using var world = World.Create();

--- a/src/Tests/GasTests/Graph/GraphControlFlowConfigCoverageTests.cs
+++ b/src/Tests/GasTests/Graph/GraphControlFlowConfigCoverageTests.cs
@@ -281,6 +281,33 @@ namespace Ludots.Tests.GAS
         }
 
         [Test]
+        public void RelationshipQueryCompiler_RejectsAllowTruncatedWithoutDroppedOutput()
+        {
+            var (package, _, diagnostics) = CompileFrontDoor("""
+{
+  "id": "tests.graph.rel-capacity",
+  "kind": "Query",
+  "entry": "query",
+  "nodes": [
+    { "id": "self", "op": "LoadCaster" },
+    { "id": "query", "op": "RelationshipQueryOutgoing", "relationshipType": "SocialBond", "queryCapacityPolicy": "AllowTruncated" }
+  ],
+  "controlEdges": [
+    { "from": "self", "fromPort": "next", "to": "query" }
+  ],
+  "valueEdges": [
+    { "from": "self", "fromPort": "value", "to": "query", "toPort": "source" }
+  ]
+}
+""");
+
+            Assert.That(package.HasValue, Is.False);
+            Assert.That(diagnostics, Has.Some.Matches<GraphDiagnostic>(d =>
+                d.Severity == GraphDiagnosticSeverity.Error &&
+                d.Message.Contains("droppedOutput", StringComparison.Ordinal)));
+        }
+
+        [Test]
         public void SnapWithoutValidOutput_DoesNotOverwriteValidationResult()
         {
             using var world = World.Create();

--- a/src/Tests/GasTests/Graph/GraphFailFastAndCapacityTests.cs
+++ b/src/Tests/GasTests/Graph/GraphFailFastAndCapacityTests.cs
@@ -2,6 +2,8 @@ using System;
 using Arch.Core;
 using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.Relationships;
+using Ludots.Core.GraphRuntime;
 using Ludots.Core.Map.Hex;
 using Ludots.Core.NodeLibraries.GASGraph;
 using Ludots.Core.NodeLibraries.GASGraph.Host;
@@ -120,6 +122,47 @@ namespace Ludots.Tests.GAS
         }
 
         [Test]
+        public void EffectRequestQueue_Clear_DiscardsOverflowInsteadOfRefilling()
+        {
+            var q = new EffectRequestQueue();
+            for (int i = 0; i < q.Capacity + 3; i++)
+            {
+                q.Publish(new EffectRequest { TemplateId = i + 1 });
+            }
+
+            That(q.Count, Is.EqualTo(q.Capacity));
+            That(q.OverflowCount, Is.EqualTo(3));
+
+            q.Clear();
+
+            That(q.Count, Is.EqualTo(0));
+            That(q.OverflowCount, Is.EqualTo(0));
+            That(q.AvailableCapacity, Is.EqualTo(q.TotalCapacity));
+
+            q.Publish(new EffectRequest { TemplateId = 99 });
+            That(q.Count, Is.EqualTo(1));
+            That(q[0].TemplateId, Is.EqualTo(99));
+            That(q.OverflowCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void EffectRequestQueue_RequireAvailable_ThrowsWhenCapacityIsInsufficient()
+        {
+            var q = new EffectRequestQueue();
+            for (int i = 0; i < q.TotalCapacity; i++)
+            {
+                q.Publish(new EffectRequest { TemplateId = i + 1 });
+            }
+
+            var error = Throws<InvalidOperationException>(() => q.RequireAvailable(1, "RuntimeEntitySpawnSystem.OnSpawnEffect"));
+
+            That(error!.Message, Does.StartWith(EffectRequestQueue.CapacityExceededError));
+            That(error.Message, Does.Contain("source=RuntimeEntitySpawnSystem.OnSpawnEffect"));
+            That(error.Message, Does.Contain("needed=1"));
+            That(q.AvailableCapacity, Is.EqualTo(0));
+        }
+
+        [Test]
         public void GraphOutputValueStore_WhenConfiguredCapacityIsExceeded_FailsWithoutResizingOrMutation()
         {
             using var world = World.Create();
@@ -203,6 +246,109 @@ namespace Ludots.Tests.GAS
 
             That(error!.Message, Does.StartWith(GasGraphRuntimeApi.MissingBlackboardError));
             That(error.Message, Does.Contain(nameof(BlackboardFloatBuffer)));
+        }
+
+        [Test]
+        public void RelationshipQuery_RequireComplete_ThrowsWhenOutgoingExceedsMaxTargets()
+        {
+            using var world = World.Create();
+            RelationshipRuntime runtime = CreateRelationshipRuntime(world, out int typeId);
+            var api = new GasGraphRuntimeApi(world, relationshipRuntime: runtime);
+            Entity source = world.Create();
+            int extra = 3;
+            for (int i = 0; i < GraphVmLimits.MaxTargets + extra; i++)
+            {
+                runtime.EnsureLink(source, world.Create(), typeId);
+            }
+
+            GraphExecutionState state = CreateGraphState(world, api, source);
+            var program = new[]
+            {
+                new GraphInstruction { Op = (ushort)GraphNodeOp.LoadCaster, Dst = 0 },
+                new GraphInstruction { Op = (ushort)GraphNodeOp.RelationshipQueryOutgoing, A = 0, Dst = (byte)typeId, Flags = 0 },
+            };
+
+            InvalidOperationException ex = Throws<InvalidOperationException>(() =>
+                GasGraphOpHandlerTable.Execute(ref state, program, GasGraphOpHandlerTable.Instance))!;
+
+            That(ex.Message, Does.Contain("GAS.GRAPH.ERR.RelationshipQueryIncomplete"));
+            That(ex.Message, Does.Contain($"dropped={extra}"));
+        }
+
+        [Test]
+        public void RelationshipQuery_AllowTruncated_PublishesDroppedCount()
+        {
+            using var world = World.Create();
+            RelationshipRuntime runtime = CreateRelationshipRuntime(world, out int typeId);
+            var api = new GasGraphRuntimeApi(world, relationshipRuntime: runtime);
+            Entity source = world.Create();
+            int extra = 5;
+            for (int i = 0; i < GraphVmLimits.MaxTargets + extra; i++)
+            {
+                runtime.EnsureLink(source, world.Create(), typeId);
+            }
+
+            GraphExecutionState state = CreateGraphState(world, api, source);
+            var program = new[]
+            {
+                new GraphInstruction { Op = (ushort)GraphNodeOp.LoadCaster, Dst = 0 },
+                new GraphInstruction { Op = (ushort)GraphNodeOp.RelationshipQueryOutgoing, A = 0, C = 1, Dst = (byte)typeId, Flags = 1 },
+            };
+
+            GasGraphOpHandlerTable.Execute(ref state, program, GasGraphOpHandlerTable.Instance);
+
+            That(state.TargetList.Count, Is.EqualTo(GraphVmLimits.MaxTargets));
+            That(state.I[1], Is.EqualTo(extra));
+        }
+
+        [Test]
+        public void GraphTargetList_SetCount_ThrowsWhenCountExceedsBuffer()
+        {
+            var buffer = new Entity[2];
+            var list = new GraphTargetList(buffer);
+
+            var error = Throws<InvalidOperationException>(() => list.SetCount(3));
+
+            That(error!.Message, Does.Contain("GAS.GRAPH.ERR.TargetListCapacityExceeded"));
+        }
+
+        private static GraphExecutionState CreateGraphState(World world, IGraphRuntimeApi api, Entity caster)
+        {
+            var floats = new float[GraphVmLimits.MaxFloatRegisters];
+            var ints = new int[GraphVmLimits.MaxIntRegisters];
+            var bools = new byte[GraphVmLimits.MaxBoolRegisters];
+            var entities = new Entity[GraphVmLimits.MaxEntityRegisters];
+            var targets = new Entity[GraphVmLimits.MaxTargets];
+            entities[0] = caster;
+            return new GraphExecutionState
+            {
+                World = world,
+                Caster = caster,
+                ExplicitTarget = Entity.Null,
+                TargetPosCm = default,
+                Api = api,
+                F = floats,
+                I = ints,
+                B = bools,
+                E = entities,
+                Targets = targets,
+                TargetList = new GraphTargetList(targets),
+                CallStack = new int[GraphVmLimits.MaxCallStackDepth],
+            };
+        }
+
+        private static RelationshipRuntime CreateRelationshipRuntime(World world, out int typeId)
+        {
+            var typeRegistry = new RelationshipTypeRegistry();
+            typeId = typeRegistry.Register("SocialBond");
+            return new RelationshipRuntime(
+                world,
+                typeRegistry,
+                new RelationshipMetricRegistry(),
+                new RelationshipFlagRegistry(),
+                new RelationshipBandRegistry(),
+                new RelationshipChangeBuffer(),
+                new RelationshipReverseIndex(world));
         }
 
         private sealed class RecordingSpatialQueries : ISpatialQueryService

--- a/src/Tests/GasTests/Graph/GraphFailFastAndCapacityTests.cs
+++ b/src/Tests/GasTests/Graph/GraphFailFastAndCapacityTests.cs
@@ -268,10 +268,18 @@ namespace Ludots.Tests.GAS
                 new GraphInstruction { Op = (ushort)GraphNodeOp.RelationshipQueryOutgoing, A = 0, Dst = (byte)typeId, Flags = 0 },
             };
 
-            InvalidOperationException ex = Throws<InvalidOperationException>(() =>
-                GasGraphOpHandlerTable.Execute(ref state, program, GasGraphOpHandlerTable.Instance))!;
+            InvalidOperationException? ex = null;
+            try
+            {
+                GasGraphOpHandlerTable.Execute(ref state, program, GasGraphOpHandlerTable.Instance);
+            }
+            catch (InvalidOperationException caught)
+            {
+                ex = caught;
+            }
 
-            That(ex.Message, Does.Contain("GAS.GRAPH.ERR.RelationshipQueryIncomplete"));
+            That(ex, Is.Not.Null);
+            That(ex!.Message, Does.Contain("GAS.GRAPH.ERR.RelationshipQueryIncomplete"));
             That(ex.Message, Does.Contain($"dropped={extra}"));
         }
 
@@ -306,9 +314,17 @@ namespace Ludots.Tests.GAS
         {
             var buffer = new Entity[2];
             var list = new GraphTargetList(buffer);
+            InvalidOperationException? error = null;
+            try
+            {
+                list.SetCount(3);
+            }
+            catch (InvalidOperationException caught)
+            {
+                error = caught;
+            }
 
-            var error = Throws<InvalidOperationException>(() => list.SetCount(3));
-
+            That(error, Is.Not.Null);
             That(error!.Message, Does.Contain("GAS.GRAPH.ERR.TargetListCapacityExceeded"));
         }
 

--- a/src/Tests/GasTests/Integration/CoreHeroSkillInfraTests.cs
+++ b/src/Tests/GasTests/Integration/CoreHeroSkillInfraTests.cs
@@ -513,7 +513,6 @@ namespace Ludots.Tests.GAS
             var commands = new FanOutCommandBuffer(capacity: 4);
             var budget = new RootBudgetTable(16);
             Entity[] buffer = new Entity[4];
-            int dropped = 0;
 
             TargetResolverFanOutHelper.CollectFanOutTargets(
                 world,
@@ -524,8 +523,7 @@ namespace Ludots.Tests.GAS
                 service,
                 budget,
                 commands,
-                buffer,
-                ref dropped);
+                buffer);
 
             var queue = new EffectRequestQueue();
             TargetResolverFanOutHelper.PublishFanOutCommands(commands, queue);
@@ -558,7 +556,6 @@ namespace Ludots.Tests.GAS
             Entity[] candidates = { firstTarget, secondTarget };
             var commands = new FanOutCommandBuffer(capacity: 1);
             var budget = new RootBudgetTable(16);
-            int dropped = 0;
 
             InvalidOperationException error = Assert.Throws<InvalidOperationException>(() =>
                 TargetResolverFanOutHelper.ValidateAndCollect(
@@ -570,8 +567,7 @@ namespace Ludots.Tests.GAS
                     candidates,
                     candidates.Length,
                     budget,
-                    commands,
-                    ref dropped))!;
+                    commands))!;
 
             Assert.That(error.Message, Does.StartWith(TargetResolverFanOutHelper.CommandCapacityExceededError));
             Assert.That(commands, Has.Count.EqualTo(1));

--- a/src/Tests/GasTests/Production/GasProductionFeatureReportTests.cs
+++ b/src/Tests/GasTests/Production/GasProductionFeatureReportTests.cs
@@ -157,13 +157,12 @@ namespace Ludots.Tests.GAS.Production
                 var budget = new RootBudgetTable(64);
                 var ctx = new EffectContext { RootId = 123, Source = hero, Target = enemy1, TargetContext = default };
                 var tmpBuf = new Entity[64];
-                int dropped = 0;
                 int cand = TargetResolverFanOutHelper.ResolveTargets(world, in ctx, in eTpl.TargetQuery, engine.SpatialQueries, tmpBuf);
                 steps.Add(new StepResult("TargetResolver ResolveTargets returns candidates", cand >= 2, $"Count={cand}"));
                 TargetResolverFanOutHelper.CollectFanOutTargets(
                     world, in ctx, in eTpl.TargetQuery, in eTpl.TargetFilter, in eTpl.TargetDispatch,
-                    engine.SpatialQueries, budget, cmds, tmpBuf, ref dropped);
-                steps.Add(new StepResult("TargetResolver creates fan-out commands", cmds.Count >= 2, $"Count={cmds.Count} Dropped={dropped}"));
+                    engine.SpatialQueries, budget, cmds, tmpBuf);
+                steps.Add(new StepResult("TargetResolver creates fan-out commands", cmds.Count >= 2, $"Count={cmds.Count}"));
             }
 
             CastAbility(engine, hero, enemy1, slot: 2);

--- a/src/Tests/PresentationTests/Performer/PerformerBlacksmithShowcaseScatterBenchmarkTests.cs
+++ b/src/Tests/PresentationTests/Performer/PerformerBlacksmithShowcaseScatterBenchmarkTests.cs
@@ -353,11 +353,10 @@ namespace Ludots.Tests.Presentation
             });
 
             TestContext.Out.WriteLine(
-                $"30K random drift coverage: blacksmiths={blacksmithCount}, activeRandomDrift={blacksmithWithRandomDrift}, fxQueue={effectQueue.Count}, fxOverflow={effectQueue.OverflowCount}, fxDropped={effectQueue.DroppedCount}, fxCapacity={effectQueue.Capacity}");
+                $"30K random drift coverage: blacksmiths={blacksmithCount}, activeRandomDrift={blacksmithWithRandomDrift}, fxQueue={effectQueue.Count}, fxOverflow={effectQueue.OverflowCount}, fxCapacity={effectQueue.Capacity}");
 
             Assert.That(blacksmithCount, Is.EqualTo(30000));
             Assert.That(blacksmithWithRandomDrift, Is.EqualTo(30000));
-            Assert.That(effectQueue.DroppedCount, Is.EqualTo(0));
         }
 
         [Test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 合同

满了就抛。假计数整套删掉。

## 实现

- `DeferredTriggerQueue` 满 → 抛，带容量和来源。
- 关系查询：抄空间 `RequireComplete` / `AllowTruncated`。
- 刷怪热路径：`RequireAvailable`，不再 `Reserve` 扩容。
- 删除：`DroppedCount` / `BudgetFused` / `AddDropped` / `FanOutDropped`。
- `EffectRequestQueue.Clear()` 真清主队列和溢出。

## 测试

`FullyQualifiedName~Ludots.Tests.Gas.DeferredTrigger|Ludots.Tests.Gas.Relationship|Ludots.Tests.Gas.EffectRequest|Ludots.Tests.Gas.RuntimeEntitySpawn|Ludots.Tests.Gas.GasBudget`

## 审计（#949）

可关单。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88eeeec8-f8e7-44e7-bfea-db2b5c012489?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88eeeec8-f8e7-44e7-bfea-db2b5c012489&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

