### PR TITLE
fix(gas): S2 写进属性的数不再自己变回去

### DIFF
--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -16,6 +16,7 @@
   - [Browser Runtime Provider Adapter Guide](architecture/browser-runtime-provider-adapter-guide.md)
   - [Mod 架构](architecture/mod-architecture.md)
   - [GAS 分层架构](architecture/gas-layered-architecture.md)
+  - [属性写入权威](architecture/attribute-write-authority.md)
   - [图分层：Flow / Script 与行为调度](architecture/graph-layering-flow-and-behavior.md)
   - [图复用库合同：FuncLib / ActionLib](architecture/graph-funclib-actionlib-contract.md)
   - [Graph FuncLib / ActionLib UAT 映射](acceptance/graph-funclib-actionlib-uat.md)

--- a/gitbook/architecture/README.md
+++ b/gitbook/architecture/README.md
@@ -9,6 +9,7 @@
 - [UI 面板作者形态（四种表面）](ui-panel-authoring-form.md)
 - [Mod 架构](mod-architecture.md)
 - [GAS 分层架构](gas-layered-architecture.md)
+- [属性写入权威](attribute-write-authority.md) — **current 直写存活；聚合器只算有效上限；裸写由 IL 守卫收口**
 - [图分层：Flow / Script 与行为调度](graph-layering-flow-and-behavior.md)
 - [图复用库合同：FuncLib / ActionLib](graph-funclib-actionlib-contract.md) — **纯函数库 vs 可挂起动作库；Effect 时间轴与阶段表达力补丁**
 - [Tag → 展示 Token 查表（面板 curState）](tag-display-lookup.md)

--- a/gitbook/architecture/attribute-write-authority.md
+++ b/gitbook/architecture/attribute-write-authority.md
@@ -30,7 +30,7 @@
 
 ## 强制手段
 
-`AttributeBuffer.SetBase` / `SetCurrent` / `SetAggregatedCurrent` 不是玩法写入面。Core 里只有白名单类型可以调用它们：
+`AttributeBuffer.SetBase` / `SetCurrent` / `SetAggregatedCurrent` 不是玩法写入面。Core 与展厅程序集里只有白名单类型可以调用它们：
 
 - 结算：`AttributeMutationOps`、`EffectModifierOps`、`EffectPhaseSideEffectTransaction`
 - 聚合与派生：`AttributeAggregatorSystem`、`GasGraphRuntimeApi`（仅派生暂存 buffer）
@@ -38,7 +38,7 @@
 - 每帧脉冲消费：`ForceInput2DSink`、`CameraBehaviorInputSink`
 - 基准装配：`GasBenchmark`
 
-新的运行时写入必须走 `AttributeMutationOps`。`ArchitectureGuardTests` 用 IL 扫描强制这条名单；不在名单里的调用方必须让 CI 失败并点名。
+展厅运行时（含运行期补金、种子属性、基准装配）必须走 `AttributeMutationOps`，禁止裸写缓冲。`ArchitectureGuardTests.AttributeBufferWrites_MustComeFromWhitelistedCallers` 用 IL 扫描 Core 与展厅程序集强制这条名单；不在名单里的调用方必须让 CI 失败并点名。
 
 ## 非法编号失败关闭
 

--- a/gitbook/architecture/attribute-write-authority.md
+++ b/gitbook/architecture/attribute-write-authority.md
@@ -1,0 +1,102 @@
+# 属性写入权威
+
+本页是 Attribute current / cap 写入合同的正式入口。实现必须服从本页；运行时状态（有没有夹上限、此刻有没有聚合修正）不能改变同一个 API 的语义。
+
+## 权威路径
+
+选择 **(a) 直写永远存活**。
+
+- 正式写入面是 `AttributeMutationOps.SetCurrent` / `SetBase` / `AddCurrent`。写入的 current 就是之后 `GetCurrent` 读到的值。
+- `AttributeAggregatorSystem` 只重算有效上限，写入 `CapValues`，由 `AttributeBuffer.GetCap` 读取。聚合器不把 current 改回「基础值 + 修正」。
+- 需要把 current 对齐到有效上限时，调用显式操作 `AttributeMutationOps.ReplaceCurrentFromCap`。禁止依赖「无约束属性被聚合器悄悄覆盖」。
+- `SetCurrent` / `SetBase` 必须排队 `AttributeAggregateDirty`（实体已有 `ActiveEffectContainer` 时），因此「写完之后要过多久才重算上限」是确定的。
+
+不选择 (b) 的理由：把「直接改当前值」从公开 API 收回、只让聚合器写 current，会让正式写入在重算后消失。那正好是本页要消灭的裂缝。
+
+夹上限约束只约束「current 不得超过有效上限」，不决定「这次写入能不能活下来」。禁止给所有属性都配上夹上限来假装语义统一。
+
+## 读写合同
+
+| API | 语义 |
+|-----|------|
+| `AttributeMutationOps.SetCurrent` | 结算写入 current；值存活；标脏并排队聚合 |
+| `AttributeMutationOps.SetBase` | 结算写入基础值，并把 current 重置到新基础值后走同一套约束 |
+| `AttributeMutationOps.ReplaceCurrentFromCap` | 显式把 current 设成当前有效上限 |
+| `AttributeBuffer.GetCurrent` | 读取权威 current |
+| `AttributeBuffer.GetCap` | 读取聚合后的有效上限 |
+| `AttributeBuffer.GetBase` | 夹上限属性返回有效上限；其余返回基础值 |
+
+派生属性仍走已有围栏：`BeginDerivedAttributeWrites` / `EndDerivedAttributeWrites` / `RejectDerivedAttributeSideEffect`。该围栏是对的，本页不改它的语义。派生图对 current 的显式写入会保留；聚合修正本身不会覆盖 current。
+
+## 强制手段
+
+`AttributeBuffer.SetBase` / `SetCurrent` / `SetAggregatedCurrent` 不是玩法写入面。Core 里只有白名单类型可以调用它们：
+
+- 结算：`AttributeMutationOps`、`EffectModifierOps`、`EffectPhaseSideEffectTransaction`
+- 聚合与派生：`AttributeAggregatorSystem`、`GasGraphRuntimeApi`（仅派生暂存 buffer）
+- 装载物化：`ComponentRegistry`、`TemplateEntityBatchSpawner`、`QuestDefinitions`
+- 每帧脉冲消费：`ForceInput2DSink`、`CameraBehaviorInputSink`
+- 基准装配：`GasBenchmark`
+
+新的运行时写入必须走 `AttributeMutationOps`。`ArchitectureGuardTests` 用 IL 扫描强制这条名单；不在名单里的调用方必须让 CI 失败并点名。
+
+## 非法编号失败关闭
+
+属性编号的合法区间是 `[0, AttributeRegistry.MaxAttributes)`。`InvalidId` 是 `-1`。
+
+- `GetId(name)` 找不到时返回 `InvalidId`。
+- `RequireId(name)` 找不到时抛异常并点名该属性名。
+- `GetCurrent` / `SetCurrent` / `SetBase` / `GetCap` 遇到非法或越界 id 抛 `ArgumentOutOfRangeException`。禁止静默返回 `0` 或丢掉写入。
+
+容量常量只在 `AttributeRegistry.MaxAttributes` 定义一处；`AttributeBuffer` 与 `DirtyFlags` 引用它。
+
+## 注册表约定与 Freeze
+
+属性表与标签表的哨兵不同，调用方必须用各自的 `InvalidId` / `IsValidId`，禁止套用 `id > 0`：
+
+| 表 | 首个合法 id | `InvalidId` |
+|----|-------------|-------------|
+| `AttributeRegistry` | `0` | `-1` |
+| `TagRegistry` | `1` | `0` |
+
+生产装载在统一注册点 `Register`，并在 GameEngine 装载结束后 `AttributeRegistry.Freeze()` / `AttributeSinkRegistry.Freeze()`。冻结后禁止新增属性身份；已登记名称可以继续解析。`Clear()` 只用于测试隔离，会解除冻结。
+
+## UAT
+
+```gherkin
+Feature: 我写进属性的数字不会自己变回去
+
+  Scenario: 直接写入的当前值语义唯一
+    Given 一个基础值 100 的属性，挂着一个永久 +18 的修正
+    And 我通过正式接口把当前值写成 50
+    When 属性重算发生
+    Then 当前值仍是 50
+    And 这个结果与该属性是否配了夹上限约束无关
+    And 有效上限是 118
+
+Feature: 写错属性名不应该悄无声息
+
+  Scenario: 非法属性编号必须失败关闭
+    Given 我引用了一个没有注册的属性名
+    When 系统按这个名字取编号，然后拿这个编号去写值
+    Then 写入必须失败并点名这个属性名
+
+Feature: 属性的编号不该看 mod 装载顺序
+
+  Scenario: 第一个注册的属性也必须可用
+    Given 某个属性恰好是本次运行中第一个被注册的
+    When 内置的施加冲力之类的路径去读它
+    Then 它应当和其他属性一样正常工作
+
+Feature: 绕过结算改属性必须被拦住
+
+  Scenario: 裸写属性缓冲要么编译不过，要么 CI 红
+    Given 一段代码直接调用属性缓冲的写方法，而它不在允许名单里
+    When CI 跑架构守卫
+    Then 守卫必须失败并点名这个调用方
+```
+
+相关入口：
+
+- [GAS 分层架构](gas-layered-architecture.md)
+- [GAS、订单与输入运行时合同](gas-order-input-runtime-contract.md)

--- a/gitbook/architecture/gas-layered-architecture.md
+++ b/gitbook/architecture/gas-layered-architecture.md
@@ -136,8 +136,11 @@ Feature: 用数据组合新的技能效果
     And 玩家不会进入使用了该无效规则的对局
 ```
 
+属性 current 的权威、有效上限、非法 id 失败关闭与注册表 Freeze 见 [属性写入权威](attribute-write-authority.md)。属性表必须在一个注册点统一 `Register` 并在装载结束时 `Freeze`。
+
 相关入口：
 
+- [属性写入权威](attribute-write-authority.md)
 - [GAS、订单与输入运行时合同](gas-order-input-runtime-contract.md)
 - [实体生命周期原子操作](entity-lifecycle-atomic-ops.md)
 - [Graph Query Services](../reference/graph-query-services.md)

--- a/mods/GasBenchmarkMod/GasBenchmarkModEntry.cs
+++ b/mods/GasBenchmarkMod/GasBenchmarkModEntry.cs
@@ -127,11 +127,10 @@ namespace GasBenchmarkMod
                 var e = world.Create(archetype);
                 entities[i] = e;
 
-                ref var attr = ref world.Get<AttributeBuffer>(e);
-                attr.SetBase(healthId, 100f);
-                attr.SetBase(manaId, 100f);
-                attr.SetCurrent(healthId, 100f);
-                attr.SetCurrent(manaId, 100f);
+                AttributeMutationOps.SetBase(world, e, healthId, 100f, tagOps);
+                AttributeMutationOps.SetBase(world, e, manaId, 100f, tagOps);
+                AttributeMutationOps.SetCurrent(world, e, healthId, 100f, tagOps);
+                AttributeMutationOps.SetCurrent(world, e, manaId, 100f, tagOps);
 
                 ref var abilities = ref world.Get<AbilityStateBuffer>(e);
                 abilities.AddAbility(abilityTemplateEntity);

--- a/mods/PerformanceVisualizationMod/Runtime/VisualBenchmarkRuntime.cs
+++ b/mods/PerformanceVisualizationMod/Runtime/VisualBenchmarkRuntime.cs
@@ -6,6 +6,7 @@ using Ludots.Core.Components;
 using Ludots.Core.Engine;
 using Ludots.Core.Gameplay.Camera;
 using Ludots.Core.Gameplay.Components;
+using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Components;
 using Ludots.Core.Gameplay.GAS.Registry;
 using Ludots.Core.Knowledge;
@@ -456,9 +457,10 @@ namespace PerformanceVisualizationMod.Runtime
                 {
                     world.Add(entity, new AttributeBuffer());
                     world.Add(entity, new DirtyFlags());
-                    ref var attributes = ref world.Get<AttributeBuffer>(entity);
-                    attributes.SetBase(_healthAttributeId, 100f);
-                    attributes.SetCurrent(_healthAttributeId, 40f + (i % 60));
+                    TagOps tagOps = engine.GetService(CoreServiceKeys.TagOps)
+                        ?? throw new InvalidOperationException("PerformanceVisualizationMod requires TagOps.");
+                    AttributeMutationOps.SetBase(world, entity, _healthAttributeId, 100f, tagOps);
+                    AttributeMutationOps.SetCurrent(world, entity, _healthAttributeId, 40f + (i % 60), tagOps);
 
                     knowledge!.Upsert(
                         audienceViewer,

--- a/mods/showcases/capability_standard/CapabilityStandardGraphOpsAttrMod/Runtime/GraphOpsAttrRuntime.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardGraphOpsAttrMod/Runtime/GraphOpsAttrRuntime.cs
@@ -45,6 +45,7 @@ public sealed class GraphOpsAttrRuntime : IDisposable
     private bool _visualsSpawned;
     private World? _world;
     private GasGraphRuntimeApi? _api;
+    private TagOps? _tagOps;
     private EffectRequestQueue? _requests;
     private Entity _caster;
     private Entity _target;
@@ -124,8 +125,8 @@ public sealed class GraphOpsAttrRuntime : IDisposable
         _session = GraphOpsEngineWorld.AttachOrCreate(_engine, AppContext.BaseDirectory);
         _world = _session.World;
         _requests = new EffectRequestQueue();
-        var tagOps = new TagOps(new DirtyEntityQueue(GasConstants.MAX_EFFECT_REQUESTS_PER_FRAME), new TagRuleRegistry());
-        _api = new GasGraphRuntimeApi(_world, spatialQueries: null, coords: null, eventBus: null, effectRequests: _requests, tagOps: tagOps);
+        _tagOps = new TagOps(new DirtyEntityQueue(GasConstants.MAX_EFFECT_REQUESTS_PER_FRAME), new TagRuleRegistry());
+        _api = new GasGraphRuntimeApi(_world, spatialQueries: null, coords: null, eventBus: null, effectRequests: _requests, tagOps: _tagOps);
 
         _caster = _world.Create(new AttributeBuffer(), new DirtyFlags());
         _target = _world.Create(new AttributeBuffer(), new DirtyFlags(), new ActiveEffectContainer());
@@ -364,18 +365,18 @@ public sealed class GraphOpsAttrRuntime : IDisposable
 
     private void ResetCombatants()
     {
-        ref var casterAttrs = ref _world!.Get<AttributeBuffer>(_caster);
-        ref var targetAttrs = ref _world.Get<AttributeBuffer>(_target);
-        casterAttrs.SetBase(_healthAttrId, 100f);
-        casterAttrs.SetCurrent(_healthAttrId, 100f);
-        casterAttrs.SetBase(_bonusAttrId, 5f);
-        casterAttrs.SetCurrent(_bonusAttrId, 5f);
-        casterAttrs.SetBase(_tallyAttrId, 0f);
-        casterAttrs.SetCurrent(_tallyAttrId, 0f);
-        casterAttrs.SetBase(_lastHitAttrId, 0f);
-        casterAttrs.SetCurrent(_lastHitAttrId, 0f);
-        targetAttrs.SetBase(_healthAttrId, OpeningHealth);
-        targetAttrs.SetCurrent(_healthAttrId, OpeningHealth);
+        TagOps tagOps = _tagOps
+            ?? throw new InvalidOperationException("GraphOpsAttr requires TagOps.");
+        AttributeMutationOps.SetBase(_world!, _caster, _healthAttrId, 100f, tagOps);
+        AttributeMutationOps.SetCurrent(_world, _caster, _healthAttrId, 100f, tagOps);
+        AttributeMutationOps.SetBase(_world, _caster, _bonusAttrId, 5f, tagOps);
+        AttributeMutationOps.SetCurrent(_world, _caster, _bonusAttrId, 5f, tagOps);
+        AttributeMutationOps.SetBase(_world, _caster, _tallyAttrId, 0f, tagOps);
+        AttributeMutationOps.SetCurrent(_world, _caster, _tallyAttrId, 0f, tagOps);
+        AttributeMutationOps.SetBase(_world, _caster, _lastHitAttrId, 0f, tagOps);
+        AttributeMutationOps.SetCurrent(_world, _caster, _lastHitAttrId, 0f, tagOps);
+        AttributeMutationOps.SetBase(_world, _target, _healthAttrId, OpeningHealth, tagOps);
+        AttributeMutationOps.SetCurrent(_world, _target, _healthAttrId, OpeningHealth, tagOps);
         TargetHealth = OpeningHealth;
         CasterHealth = 100f;
         DamageBonus = 5f;

--- a/mods/showcases/capability_standard/CapabilityStandardGraphOpsQueryMod/Runtime/GraphOpsQueryRuntime.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardGraphOpsQueryMod/Runtime/GraphOpsQueryRuntime.cs
@@ -35,6 +35,7 @@ public sealed class GraphOpsQueryRuntime : IDisposable
     private GasGraphRuntimeApi? _api;
     private EntitySetQueryRuntime? _entityQueries;
     private EntityCollectionStore? _collections;
+    private TagOps? _tagOps;
     private Entity _caster;
     private Entity[] _units = Array.Empty<Entity>();
     private readonly float[] _floats = new float[GraphVmLimits.MaxFloatRegisters];
@@ -108,7 +109,7 @@ public sealed class GraphOpsQueryRuntime : IDisposable
 
         _session = GraphOpsEngineWorld.AttachOrCreate(_engine, AppContext.BaseDirectory);
         _world = _session.World;
-        var tagOps = new TagOps(new DirtyEntityQueue(GasConstants.MAX_EFFECT_REQUESTS_PER_FRAME), new TagRuleRegistry(), new GasBudget());
+        _tagOps = new TagOps(new DirtyEntityQueue(GasConstants.MAX_EFFECT_REQUESTS_PER_FRAME), new TagRuleRegistry(), new GasBudget());
         var relationships = new RelationshipRuntime(
             _world,
             new RelationshipTypeRegistry(),
@@ -117,10 +118,10 @@ public sealed class GraphOpsQueryRuntime : IDisposable
             new RelationshipBandRegistry(),
             new RelationshipChangeBuffer(),
             new RelationshipReverseIndex(_world));
-        _entityQueries = new EntitySetQueryRuntime(_world, tagOps, relationships);
+        _entityQueries = new EntitySetQueryRuntime(_world, _tagOps, relationships);
         _api = new GasGraphRuntimeApi(
             _world,
-            tagOps: tagOps,
+            tagOps: _tagOps,
             relationshipRuntime: relationships,
             entityQueries: _entityQueries,
             entityCollections: _collections);
@@ -308,10 +309,12 @@ public sealed class GraphOpsQueryRuntime : IDisposable
             new Team { Id = teamId },
             new EntityTemplateKeyRef { TemplateKeyId = templateId },
             new AttributeBuffer(),
+            new DirtyFlags(),
             new GameplayTagContainer(),
             WorldPositionCm.FromCm(xCm, yCm));
-        ref AttributeBuffer attrs = ref _world.Get<AttributeBuffer>(entity);
-        attrs.SetBase(_bundle!.HealthAttrId, health);
+        TagOps tagOps = _tagOps
+            ?? throw new InvalidOperationException("GraphOpsQuery requires TagOps.");
+        AttributeMutationOps.SetBase(_world, entity, _bundle!.HealthAttrId, health, tagOps);
         ref GameplayTagContainer tags = ref _world.Get<GameplayTagContainer>(entity);
         if (enemy)
         {

--- a/mods/showcases/capability_standard/CapabilityStandardLiveSkillWorkbenchShowcaseMod/Runtime/LiveSkillWorkbenchVignetteRuntime.cs
+++ b/mods/showcases/capability_standard/CapabilityStandardLiveSkillWorkbenchShowcaseMod/Runtime/LiveSkillWorkbenchVignetteRuntime.cs
@@ -187,9 +187,10 @@ public sealed class LiveSkillWorkbenchVignetteRuntime
             if (_healthAttrId != AttributeRegistry.InvalidId)
             {
                 _mageEntity = _engine.World.Create(new AttributeBuffer(), new DirtyFlags());
-                ref AttributeBuffer buf = ref _engine.World.Get<AttributeBuffer>(_mageEntity);
-                buf.SetBase(_healthAttrId, 100f);
-                buf.SetCurrent(_healthAttrId, 35f);
+                TagOps tagOps = _engine.GetService(CoreServiceKeys.TagOps)
+                    ?? throw new InvalidOperationException("LiveSkillWorkbench requires TagOps.");
+                AttributeMutationOps.SetBase(_engine.World, _mageEntity, _healthAttrId, 100f, tagOps);
+                AttributeMutationOps.SetCurrent(_engine.World, _mageEntity, _healthAttrId, 35f, tagOps);
                 _attrExecutor?.SetSelectedEntity(_mageEntity);
             }
         }

--- a/mods/showcases/fourx_association/FourXAssociationShowcaseMod/Runtime/FourXAssociationRuntime.cs
+++ b/mods/showcases/fourx_association/FourXAssociationShowcaseMod/Runtime/FourXAssociationRuntime.cs
@@ -10,6 +10,7 @@ using Ludots.Core.Components;
 using Ludots.Core.Engine;
 using Ludots.Core.EntityCollections;
 using Ludots.Core.Gameplay.Exchange;
+using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Components;
 using Ludots.Core.Gameplay.GAS.Registry;
 using Ludots.Core.Gameplay.Items;
@@ -368,8 +369,9 @@ public sealed class FourXAssociationRuntime
             new ScopeRefBuffer(),
             new ScopeMemberTag());
 
-        ref AttributeBuffer attributes = ref world.Get<AttributeBuffer>(_playerA);
-        attributes.SetCurrent(_goldAttributeId, config.StartingGold);
+        TagOps tagOps = engine.GetService(CoreServiceKeys.TagOps)
+            ?? throw new InvalidOperationException("FourXAssociationShowcase requires TagOps.");
+        AttributeMutationOps.SetCurrent(world, _playerA, _goldAttributeId, config.StartingGold, tagOps);
 
         OwnershipResolver ownership = engine.GetService(CoreServiceKeys.OwnershipResolver)
             ?? throw new InvalidOperationException("OwnershipResolver missing.");

--- a/mods/showcases/gold_market/GoldMarketShowcaseMod/Runtime/GoldMarketRuntime.cs
+++ b/mods/showcases/gold_market/GoldMarketShowcaseMod/Runtime/GoldMarketRuntime.cs
@@ -7,6 +7,7 @@ using GoldMarketShowcaseMod.UI;
 using Ludots.Core.Components;
 using Ludots.Core.Engine;
 using Ludots.Core.Gameplay.Exchange;
+using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Components;
 using Ludots.Core.Gameplay.GAS.Registry;
 using Ludots.Core.Gameplay.Items;
@@ -107,8 +108,9 @@ public sealed class GoldMarketRuntime
     public void RefillGold(GameEngine engine)
     {
         EnsureScenario(engine);
-        ref AttributeBuffer attributes = ref engine.World.Get<AttributeBuffer>(_buyer);
-        attributes.SetCurrent(_goldAttributeId, _config!.RefillGold);
+        TagOps tagOps = engine.GetService(CoreServiceKeys.TagOps)
+            ?? throw new InvalidOperationException("GoldMarketShowcase requires TagOps.");
+        AttributeMutationOps.SetCurrent(engine.World, _buyer, _goldAttributeId, _config!.RefillGold, tagOps);
         _status = $"Gold refilled to {_config.RefillGold}.";
         PushLog(_status);
         RefreshPanelInternal(engine);
@@ -231,8 +233,9 @@ public sealed class GoldMarketRuntime
             new Name { Value = _config.MarketName },
             new MapEntity { MapId = new MapId(GoldMarketIds.ShowcaseMapId) });
 
-        ref AttributeBuffer attributes = ref world.Get<AttributeBuffer>(_buyer);
-        attributes.SetCurrent(_goldAttributeId, _config.StartingGold);
+        TagOps tagOps = engine.GetService(CoreServiceKeys.TagOps)
+            ?? throw new InvalidOperationException("GoldMarketShowcase requires TagOps.");
+        AttributeMutationOps.SetCurrent(world, _buyer, _goldAttributeId, _config.StartingGold, tagOps);
 
         InventoryRuntimeService inventory = engine.GetService(CoreServiceKeys.InventoryRuntimeService)
             ?? throw new InvalidOperationException("InventoryRuntimeService missing.");

--- a/mods/showcases/info_panels/GenreInfoShowcaseMod/Runtime/GenreInfoShowcaseRuntime.cs
+++ b/mods/showcases/info_panels/GenreInfoShowcaseMod/Runtime/GenreInfoShowcaseRuntime.cs
@@ -236,7 +236,7 @@ namespace GenreInfoShowcaseMod.Runtime
                 return;
             }
 
-            ApplyShowcaseEntityState(engine.World);
+            ApplyShowcaseEntityState(engine);
             SeedSelectionGroups(engine);
             RecallControlGroup(engine, 3);
             ShowLiveSelection(engine);
@@ -244,29 +244,32 @@ namespace GenreInfoShowcaseMod.Runtime
             engine.GlobalContext[GenreInfoShowcaseIds.SeededMapKey] = mapId;
         }
 
-        private static void ApplyShowcaseEntityState(World world)
+        private static void ApplyShowcaseEntityState(GameEngine engine)
         {
-            SetEntityAttributes(world, "Governor Aurelia", ("Health", 100f, 82f), ("Gold", 180f, 145f), ("Production", 22f, 18f), ("TechProgress", 80f, 62f), ("FoodProduction", 14f, 12f));
+            World world = engine.World;
+            TagOps tagOps = engine.GetService(CoreServiceKeys.TagOps)
+                ?? throw new InvalidOperationException("GenreInfoShowcase requires TagOps.");
+            SetEntityAttributes(world, tagOps, "Governor Aurelia", ("Health", 100f, 82f), ("Gold", 180f, 145f), ("Production", 22f, 18f), ("TechProgress", 80f, 62f), ("FoodProduction", 14f, 12f));
             SetEntityTags(world, "Governor Aurelia", "Status.CanColonize");
 
-            SetEntityAttributes(world, "Captain Nyx", ("Health", 920f, 640f), ("Energy", 450f, 310f), ("AttackSpeed", 115f, 115f));
+            SetEntityAttributes(world, tagOps, "Captain Nyx", ("Health", 920f, 640f), ("Energy", 450f, 310f), ("AttackSpeed", 115f, 115f));
             SetEntityTags(world, "Captain Nyx", "Cooldown.Skill.W");
 
-            SetEntityAttributes(world, "Field Barracks", ("Health", 1000f, 760f));
+            SetEntityAttributes(world, tagOps, "Field Barracks", ("Health", 1000f, 760f));
 
             for (int i = 1; i <= 18; i++)
             {
-                SetEntityAttributes(world, $"Marine {i:00}", ("Health", 40f, 24f + i), ("AttackSpeed", 100f, 100f));
+                SetEntityAttributes(world, tagOps, $"Marine {i:00}", ("Health", 40f, 24f + i), ("AttackSpeed", 100f, 100f));
             }
 
             for (int i = 1; i <= 4; i++)
             {
-                SetEntityAttributes(world, $"Siege Tank {i:00}", ("Health", 150f, 112f + (i * 6)), ("Shield", 0f, 0f));
-                SetEntityAttributes(world, $"Sky Vessel {i:00}", ("Health", 200f, 168f + (i * 8)), ("Energy", 200f, 120f + (i * 18)));
+                SetEntityAttributes(world, tagOps, $"Siege Tank {i:00}", ("Health", 150f, 112f + (i * 6)), ("Shield", 0f, 0f));
+                SetEntityAttributes(world, tagOps, $"Sky Vessel {i:00}", ("Health", 200f, 168f + (i * 8)), ("Energy", 200f, 120f + (i * 18)));
             }
         }
 
-        private static void SetEntityAttributes(World world, string entityName, params (string Name, float Base, float Current)[] values)
+        private static void SetEntityAttributes(World world, TagOps tagOps, string entityName, params (string Name, float Base, float Current)[] values)
         {
             Entity entity = FindNamedEntity(world, entityName);
             if (entity == Entity.Null)
@@ -274,26 +277,21 @@ namespace GenreInfoShowcaseMod.Runtime
                 return;
             }
 
-            AttributeBuffer attributes = world.TryGet(entity, out AttributeBuffer existing) ? existing : new AttributeBuffer();
-            for (int i = 0; i < values.Length; i++)
+            if (!world.Has<AttributeBuffer>(entity))
             {
-                int attributeId = AttributeRegistry.Register(values[i].Name);
-                attributes.SetBase(attributeId, values[i].Base);
-                attributes.SetCurrent(attributeId, values[i].Current);
-            }
-
-            if (world.Has<AttributeBuffer>(entity))
-            {
-                world.Set(entity, attributes);
-            }
-            else
-            {
-                world.Add(entity, attributes);
+                world.Add(entity, new AttributeBuffer());
             }
 
             if (!world.Has<DirtyFlags>(entity))
             {
                 world.Add(entity, new DirtyFlags());
+            }
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                int attributeId = AttributeRegistry.Register(values[i].Name);
+                AttributeMutationOps.SetBase(world, entity, attributeId, values[i].Base, tagOps);
+                AttributeMutationOps.SetCurrent(world, entity, attributeId, values[i].Current, tagOps);
             }
         }
 

--- a/mods/showcases/item_system/ItemSystemShowcaseMod/Runtime/ItemSystemShowcaseRuntime.cs
+++ b/mods/showcases/item_system/ItemSystemShowcaseMod/Runtime/ItemSystemShowcaseRuntime.cs
@@ -627,7 +627,7 @@ internal sealed class ItemSystemShowcaseRuntime
         world.Add(_hero, new AbilityStateBuffer());
         world.Add(_hero, OrderBuffer.CreateEmpty());
         OrderBlackboardStateInstaller.EnsureInstalled(world, _hero);
-        InitAttributes(ref world.Get<AttributeBuffer>(_hero), true);
+        InitAttributes(engine, _hero, true);
 
         _dummy = world.Create(new Name { Value = "Target Dummy" });
         TrackMapEntity(engine, _dummy);
@@ -635,7 +635,7 @@ internal sealed class ItemSystemShowcaseRuntime
         world.Add(_dummy, new AttributeBuffer());
         world.Add(_dummy, new ActiveEffectContainer());
         TagStateInstaller.EnsureInstalled(world, _dummy);
-        InitAttributes(ref world.Get<AttributeBuffer>(_dummy), false);
+        InitAttributes(engine, _dummy, false);
 
         _vendor = world.Create(new Name { Value = "Quartermaster" });
         TrackMapEntity(engine, _vendor);
@@ -690,13 +690,16 @@ internal sealed class ItemSystemShowcaseRuntime
         Log("Coverage live: MOBA boots/mythic, ARPG rings/charm, extraction stash/secure, rifle sockets, ammo stacks, vendor trade, and forge sockets.");
     }
 
-    private void InitAttributes(ref AttributeBuffer attrs, bool hero)
+    private void InitAttributes(GameEngine engine, Entity entity, bool hero)
     {
-        attrs.SetBase(_healthAttrId, hero ? 100f : 140f);
-        attrs.SetBase(_shieldAttrId, hero ? 20f : 0f);
-        attrs.SetBase(_moveSpeedAttrId, hero ? 100f : 0f);
-        attrs.SetBase(_attackAttrId, hero ? 12f : 0f);
-        attrs.SetBase(_armorAttrId, hero ? 5f : 1f);
+        TagOps tagOps = engine.GetService(CoreServiceKeys.TagOps)
+            ?? throw new InvalidOperationException("ItemSystemShowcase requires TagOps.");
+        World world = engine.World;
+        AttributeMutationOps.SetBase(world, entity, _healthAttrId, hero ? 100f : 140f, tagOps);
+        AttributeMutationOps.SetBase(world, entity, _shieldAttrId, hero ? 20f : 0f, tagOps);
+        AttributeMutationOps.SetBase(world, entity, _moveSpeedAttrId, hero ? 100f : 0f, tagOps);
+        AttributeMutationOps.SetBase(world, entity, _attackAttrId, hero ? 12f : 0f, tagOps);
+        AttributeMutationOps.SetBase(world, entity, _armorAttrId, hero ? 5f : 1f, tagOps);
     }
 
     private void EquipNamed(GameEngine engine, Entity item, string slotId)

--- a/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/Runtime/UiPlayerAggregateGraphMvpRuntime.cs
+++ b/mods/showcases/ui_player_aggregate_graph_mvp/UiPlayerAggregateGraphMvpShowcaseMod/Runtime/UiPlayerAggregateGraphMvpRuntime.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Arch.Core;
 using Ludots.Core.Components;
 using Ludots.Core.Engine;
+using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Components;
 using Ludots.Core.Gameplay.GAS.Registry;
 using Ludots.Core.Input.Runtime;
@@ -143,9 +144,10 @@ public sealed class UiPlayerAggregateGraphMvpRuntime
             throw new InvalidOperationException($"Shut-down building '{config.ShutDownBuildingName}' has no AttributeBuffer.");
         }
 
-        ref AttributeBuffer attributes = ref engine.World.Get<AttributeBuffer>(_shutDownBuilding);
-        attributes.SetBase(_oreAttributeId, 0f);
-        attributes.SetBase(_crystalAttributeId, 0f);
+        TagOps tagOps = engine.GetService(CoreServiceKeys.TagOps)
+            ?? throw new InvalidOperationException("UiPlayerAggregateGraphMvp requires TagOps.");
+        AttributeMutationOps.SetBase(engine.World, _shutDownBuilding, _oreAttributeId, 0f, tagOps);
+        AttributeMutationOps.SetBase(engine.World, _shutDownBuilding, _crystalAttributeId, 0f, tagOps);
         _buildingShutDown = true;
         _status = $"{config.ShutDownBuildingName} shut down; resource attributes set to 0.";
         ExecuteAggregateGraph(engine);

--- a/src/Core/Engine/GameEngine.cs
+++ b/src/Core/Engine/GameEngine.cs
@@ -933,7 +933,8 @@ namespace Ludots.Core.Engine
                 exchangeScopedOperations,
                 inventoryRuntime,
                 effectRequestQueue,
-                relationshipRuntime);
+                relationshipRuntime,
+                tagOps);
             var graphOutputValueStore = new GraphOutputValueStore(
                 graphOutputValueKeyRegistry,
                 gasRuntimeCapacity.GraphOutputValueCapacity);
@@ -1282,6 +1283,7 @@ namespace Ludots.Core.Engine
             GraphAttributeSinks.RegisterBuiltins(attributeSinks, graphEdgeCostOverlay);
             var attributeBindings = new AttributeBindingRegistry();
             new AttributeBindingLoader(ConfigPipeline, attributeSinks, attributeBindings).Load(ConfigCatalog, ConfigConflictReport);
+            attributeSinks.Freeze();
             var bindingSystem = new AttributeBindingSystem(World, attributeSinks, attributeBindings);
             var aggSystem = new AttributeAggregatorSystem(World, graphProgramRegistry, gasGraphApi, tagOps);
             var sessionSystem = new GameSessionSystem(GameSession);
@@ -1646,6 +1648,7 @@ namespace Ludots.Core.Engine
             var narrativeDirector = new NarrativeDirector(this, narrativeDefinitions, questRuntime);
             SetService(CoreServiceKeys.NarrativeDefinitions, narrativeDefinitions);
             SetService(CoreServiceKeys.NarrativeDirector, narrativeDirector);
+            AttributeRegistry.Freeze();
             var cameraRuntimeSystem = new CameraRuntimeSystem(World, GameSession.Camera, GlobalContext, virtualCameraRegistry);
             RegisterSystem(new GasBudgetResetSystem(gasBudget, orderTerminalResults, orderAdmissionResults), SystemGroup.SchemaUpdate);
             RegisterSystem(schemaUpdateSystem, SystemGroup.SchemaUpdate);
@@ -1665,7 +1668,7 @@ namespace Ludots.Core.Engine
             RegisterSystem(
                 new AxisMoveOrderSystem(World, GlobalContext, controlSchemeRuntime, orderQueue),
                 SystemGroup.InputCollection);
-            RegisterSystem(new InputActionAttributeBindingSystem(World, GlobalContext, inputActionAttributeBindings), SystemGroup.InputCollection);
+            RegisterSystem(new InputActionAttributeBindingSystem(World, GlobalContext, inputActionAttributeBindings, tagOps), SystemGroup.InputCollection);
             RegisterSystem(new NarrativeRuntimeSystem(narrativeDirector), SystemGroup.InputCollection);
             RegisterSystem(clockSystem, SystemGroup.InputCollection);
             RegisterSystem(entityLocalClockSystem, SystemGroup.InputCollection);

--- a/src/Core/Gameplay/AI/Utility/UtilityAiRuntimeEvaluator.cs
+++ b/src/Core/Gameplay/AI/Utility/UtilityAiRuntimeEvaluator.cs
@@ -6,6 +6,7 @@ using Ludots.Core.Gameplay.AI.Components;
 using Ludots.Core.Gameplay.Components;
 using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Registry;
 using Ludots.Core.Gameplay.GAS.Orders;
 using Ludots.Core.Gameplay.Teams;
 using Ludots.Core.GraphRuntime;
@@ -656,7 +657,7 @@ namespace Ludots.Core.Gameplay.AI.Utility
 
             if (ability.HasCooldown)
             {
-                if (ability.Cooldown.CooldownValueAttributeId > 0 &&
+                if (AttributeRegistry.IsValidId(ability.Cooldown.CooldownValueAttributeId) &&
                     _world.Has<AttributeBuffer>(actor) &&
                     _world.Get<AttributeBuffer>(actor).GetCurrent(ability.Cooldown.CooldownValueAttributeId) > 0f)
                 {

--- a/src/Core/Gameplay/Exchange/ExchangeRuntime.cs
+++ b/src/Core/Gameplay/Exchange/ExchangeRuntime.cs
@@ -17,6 +17,7 @@ namespace Ludots.Core.Gameplay.Exchange
         private readonly InventoryRuntimeService _inventory;
         private readonly EffectRequestQueue _effects;
         private readonly RelationshipRuntime _relationships;
+        private readonly TagOps _tagOps;
         private readonly List<ItemConsumptionRecord> _consumed = new(16);
         private readonly List<AttributeCostRecord> _attributeCosts = new(8);
         private readonly List<CreatedItemRecord> _created = new(8);
@@ -29,7 +30,8 @@ namespace Ludots.Core.Gameplay.Exchange
             ExchangeScopedOperationStore scopedOperations,
             InventoryRuntimeService inventory,
             EffectRequestQueue effects,
-            RelationshipRuntime relationships)
+            RelationshipRuntime relationships,
+            TagOps tagOps)
         {
             _world = world ?? throw new ArgumentNullException(nameof(world));
             _operations = operations ?? throw new ArgumentNullException(nameof(operations));
@@ -37,6 +39,7 @@ namespace Ludots.Core.Gameplay.Exchange
             _inventory = inventory ?? throw new ArgumentNullException(nameof(inventory));
             _effects = effects ?? throw new ArgumentNullException(nameof(effects));
             _relationships = relationships ?? throw new ArgumentNullException(nameof(relationships));
+            _tagOps = tagOps ?? throw new ArgumentNullException(nameof(tagOps));
         }
 
         public ExchangeExecutionResult TryExecute(int operationId, in ExchangeExecutionContext context)
@@ -373,7 +376,7 @@ namespace Ludots.Core.Gameplay.Exchange
                 }
 
                 _attributeCosts.Add(new AttributeCostRecord(actor, input.AttributeId, previousValue));
-                attributes.SetCurrent(input.AttributeId, previousValue - input.Quantity);
+                AttributeMutationOps.SetCurrent(_world, actor, input.AttributeId, previousValue - input.Quantity, _tagOps);
                 return true;
             }
 
@@ -427,8 +430,7 @@ namespace Ludots.Core.Gameplay.Exchange
                 AttributeCostRecord record = _attributeCosts[i];
                 if (_world.IsAlive(record.Actor) && _world.Has<AttributeBuffer>(record.Actor))
                 {
-                    ref AttributeBuffer attributes = ref _world.Get<AttributeBuffer>(record.Actor);
-                    attributes.SetCurrent(record.AttributeId, record.PreviousValue);
+                    AttributeMutationOps.SetCurrent(_world, record.Actor, record.AttributeId, record.PreviousValue, _tagOps);
                 }
             }
 

--- a/src/Core/Gameplay/GAS/AttributeMutationOps.cs
+++ b/src/Core/Gameplay/GAS/AttributeMutationOps.cs
@@ -43,7 +43,8 @@ namespace Ludots.Core.Gameplay.GAS
             try
             {
                 world.Get<DirtyFlags>(target).MarkAttributeDirty(attributeId);
-                tagOps?.MarkDirtyEntity(world, target);
+                tagOps.MarkDirtyEntity(world, target);
+                MarkAttributeAggregateDirty(world, target);
             }
             catch
             {
@@ -53,6 +54,16 @@ namespace Ludots.Core.Gameplay.GAS
             }
 
             MarkPresentationChanged(world, target, attributeId);
+        }
+
+        public static void ReplaceCurrentFromCap(World world, Entity target, int attributeId, TagOps tagOps)
+        {
+            if (!world.IsAlive(target) || !world.Has<AttributeBuffer>(target))
+            {
+                return;
+            }
+
+            SetCurrent(world, target, attributeId, world.Get<AttributeBuffer>(target).GetCap(attributeId), tagOps);
         }
 
         public static void SetBase(World world, Entity target, int attributeId, float value, TagOps tagOps)
@@ -80,7 +91,8 @@ namespace Ludots.Core.Gameplay.GAS
             try
             {
                 world.Get<DirtyFlags>(target).MarkAttributeDirty(attributeId);
-                tagOps?.MarkDirtyEntity(world, target);
+                tagOps.MarkDirtyEntity(world, target);
+                MarkAttributeAggregateDirty(world, target);
             }
             catch
             {
@@ -106,10 +118,7 @@ namespace Ludots.Core.Gameplay.GAS
             for (int i = 0; i < modifiers.Count; i++)
             {
                 int attributeId = modifiers.Get(i).AttributeId;
-                if (attributeId < 0 || attributeId >= AttributeBuffer.MAX_ATTRS)
-                {
-                    continue;
-                }
+                AttributeBuffer.ValidateAttributeId(attributeId);
 
                 ulong bit = 1UL << attributeId;
                 if ((touchedMask & bit) != 0UL)
@@ -159,7 +168,8 @@ namespace Ludots.Core.Gameplay.GAS
             {
                 try
                 {
-                    tagOps?.MarkDirtyEntity(world, target);
+                    tagOps.MarkDirtyEntity(world, target);
+                    MarkAttributeAggregateDirty(world, target);
                 }
                 catch
                 {
@@ -193,6 +203,16 @@ namespace Ludots.Core.Gameplay.GAS
             {
                 throw new InvalidOperationException(TagOps.MissingTagOpsError);
             }
+        }
+
+        private static void MarkAttributeAggregateDirty(World world, Entity target)
+        {
+            if (!world.Has<ActiveEffectContainer>(target) || world.Has<AttributeAggregateDirty>(target))
+            {
+                return;
+            }
+
+            world.Add(target, new AttributeAggregateDirty());
         }
 
         private static void MarkPresentationChanged(World world, Entity target, int attributeId)

--- a/src/Core/Gameplay/GAS/BuiltinHandlers.cs
+++ b/src/Core/Gameplay/GAS/BuiltinHandlers.cs
@@ -28,6 +28,11 @@ namespace Ludots.Core.Gameplay.GAS
     /// </summary>
     public static class BuiltinHandlers
     {
+        private static bool HasAssignedAttribute(int attributeId)
+        {
+            return attributeId != AttributeRegistry.InvalidId;
+        }
+
         private static void RejectNonTransactionalPersistentSideEffect(string operation)
         {
             if (BuiltinHandlerRuntimeScope.Current?.EffectSideEffects?.IsActive == true)
@@ -112,16 +117,16 @@ namespace Ludots.Core.Gameplay.GAS
             var transaction = BuiltinHandlerRuntimeScope.Current?.EffectSideEffects;
             if (transaction?.IsActive == true)
             {
-                if (AttributeRegistry.IsValidId(templateData.PresetAttribute0))
+                if (HasAssignedAttribute(templateData.PresetAttribute0))
                     transaction.StageAttributeAdd(context.Target, templateData.PresetAttribute0, fx);
-                if (AttributeRegistry.IsValidId(templateData.PresetAttribute1))
+                if (HasAssignedAttribute(templateData.PresetAttribute1))
                     transaction.StageAttributeAdd(context.Target, templateData.PresetAttribute1, fy);
                 return;
             }
 
-            if (AttributeRegistry.IsValidId(templateData.PresetAttribute0))
+            if (HasAssignedAttribute(templateData.PresetAttribute0))
                 AttributeMutationOps.AddCurrent(world, context.Target, templateData.PresetAttribute0, fx, BuiltinHandlerRuntimeScope.Current?.TagOps);
-            if (AttributeRegistry.IsValidId(templateData.PresetAttribute1))
+            if (HasAssignedAttribute(templateData.PresetAttribute1))
                 AttributeMutationOps.AddCurrent(world, context.Target, templateData.PresetAttribute1, fy, BuiltinHandlerRuntimeScope.Current?.TagOps);
         }
 

--- a/src/Core/Gameplay/GAS/BuiltinHandlers.cs
+++ b/src/Core/Gameplay/GAS/BuiltinHandlers.cs
@@ -7,6 +7,7 @@ using Ludots.Core.Association;
 using Ludots.Core.Gameplay.Components;
 using Ludots.Core.Gameplay.Exchange;
 using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Registry;
 using Ludots.Core.Gameplay.GAS.Orders;
 using Ludots.Core.Gameplay.Spawning;
 using Ludots.Core.Gameplay.Lifecycle;
@@ -111,16 +112,16 @@ namespace Ludots.Core.Gameplay.GAS
             var transaction = BuiltinHandlerRuntimeScope.Current?.EffectSideEffects;
             if (transaction?.IsActive == true)
             {
-                if (templateData.PresetAttribute0 > 0)
+                if (AttributeRegistry.IsValidId(templateData.PresetAttribute0))
                     transaction.StageAttributeAdd(context.Target, templateData.PresetAttribute0, fx);
-                if (templateData.PresetAttribute1 > 0)
+                if (AttributeRegistry.IsValidId(templateData.PresetAttribute1))
                     transaction.StageAttributeAdd(context.Target, templateData.PresetAttribute1, fy);
                 return;
             }
 
-            if (templateData.PresetAttribute0 > 0)
+            if (AttributeRegistry.IsValidId(templateData.PresetAttribute0))
                 AttributeMutationOps.AddCurrent(world, context.Target, templateData.PresetAttribute0, fx, BuiltinHandlerRuntimeScope.Current?.TagOps);
-            if (templateData.PresetAttribute1 > 0)
+            if (AttributeRegistry.IsValidId(templateData.PresetAttribute1))
                 AttributeMutationOps.AddCurrent(world, context.Target, templateData.PresetAttribute1, fy, BuiltinHandlerRuntimeScope.Current?.TagOps);
         }
 

--- a/src/Core/Gameplay/GAS/Components/AttributeBuffer.cs
+++ b/src/Core/Gameplay/GAS/Components/AttributeBuffer.cs
@@ -6,36 +6,31 @@ namespace Ludots.Core.Gameplay.GAS.Components
     /// <summary>
     /// Zero-GC storage for dynamic attributes.
     /// Uses a fixed buffer to avoid heap allocations.
-    /// Max 64 attributes supported per entity with this struct.
     /// </summary>
     public unsafe struct AttributeBuffer
     {
-        public const int MAX_ATTRS = 64;
+        public const int MAX_ATTRS = AttributeRegistry.MaxAttributes;
 
         public fixed float BaseValues[MAX_ATTRS];
         public fixed float CapValues[MAX_ATTRS];
         public fixed float CurrentValues[MAX_ATTRS];
         public ulong DefinedMask;
-        
-        // Modifiers could be aggregated here or calculated on the fly.
-        // For simplicity in this 0GC version, we update CurrentValues directly 
-        // when BaseValues change or when effects are applied.
-        
-        /// <summary>
-        /// Gets the current value of an attribute by ID.
-        /// </summary>
+
         public float GetCurrent(int attributeId)
         {
-            if (attributeId < 0 || attributeId >= MAX_ATTRS) return 0f;
+            ValidateAttributeId(attributeId);
             return CurrentValues[attributeId];
         }
 
-        /// <summary>
-        /// Gets the base value of an attribute by ID.
-        /// </summary>
+        public float GetCap(int attributeId)
+        {
+            ValidateAttributeId(attributeId);
+            return CapValues[attributeId];
+        }
+
         public float GetBase(int attributeId)
         {
-            if (attributeId < 0 || attributeId >= MAX_ATTRS) return 0f;
+            ValidateAttributeId(attributeId);
             if (AttributeRegistry.TryGetConstraints(attributeId, out var constraints) &&
                 constraints.ClampCurrentToBase)
             {
@@ -47,7 +42,7 @@ namespace Ludots.Core.Gameplay.GAS.Components
 
         public bool HasAttribute(int attributeId)
         {
-            if (attributeId < 0 || attributeId >= MAX_ATTRS)
+            if ((uint)attributeId >= (uint)MAX_ATTRS)
             {
                 return false;
             }
@@ -55,18 +50,12 @@ namespace Ludots.Core.Gameplay.GAS.Components
             return (DefinedMask & (1UL << attributeId)) != 0UL;
         }
 
-        /// <summary>
-        /// Sets the base value of an attribute by ID.
-        /// Also re-applies constraints to CurrentValue (e.g. ClampCurrentToBase, Min/Max).
-        /// </summary>
         public void SetBase(int attributeId, float value)
         {
-            if (attributeId < 0 || attributeId >= MAX_ATTRS) return;
+            ValidateAttributeId(attributeId);
             DefinedMask |= 1UL << attributeId;
             BaseValues[attributeId] = value;
             CapValues[attributeId] = value;
-            // Re-apply current value through constraints.
-            // Uses the new base as default current (reset to base), then SetCurrent applies clamping.
             SetCurrent(attributeId, value);
         }
 
@@ -80,9 +69,20 @@ namespace Ludots.Core.Gameplay.GAS.Components
             SetCurrentInternal(attributeId, value, clampToCapacity: false);
         }
 
+        public static void ValidateAttributeId(int attributeId)
+        {
+            if ((uint)attributeId >= (uint)MAX_ATTRS)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(attributeId),
+                    attributeId,
+                    $"attributeId must be in [0, {MAX_ATTRS}).");
+            }
+        }
+
         private void SetCurrentInternal(int attributeId, float value, bool clampToCapacity)
         {
-            if (attributeId < 0 || attributeId >= MAX_ATTRS) return;
+            ValidateAttributeId(attributeId);
             DefinedMask |= 1UL << attributeId;
             if (AttributeRegistry.TryGetConstraints(attributeId, out var constraints))
             {

--- a/src/Core/Gameplay/GAS/Components/DeferredTriggerComponents.cs
+++ b/src/Core/Gameplay/GAS/Components/DeferredTriggerComponents.cs
@@ -1,4 +1,5 @@
 using Arch.Core;
+using Ludots.Core.Gameplay.GAS.Registry;
 
 namespace Ludots.Core.Gameplay.GAS.Components
 {
@@ -40,7 +41,7 @@ namespace Ludots.Core.Gameplay.GAS.Components
     /// </summary>
     public unsafe struct DirtyFlags
     {
-        public const int MAX_ATTRS = 64;
+        public const int MAX_ATTRS = AttributeRegistry.MaxAttributes;
         public const int TAG_DIRTY_BYTES = 32; // 256 tags / 8
         
         public ulong AttributeDirtyMask;

--- a/src/Core/Gameplay/GAS/Config/AbilityExecLoader.cs
+++ b/src/Core/Gameplay/GAS/Config/AbilityExecLoader.cs
@@ -130,7 +130,7 @@ namespace Ludots.Core.Gameplay.GAS.Config
             if (obj["cooldown"] is JsonObject cooldownObj)
             {
                 def.Cooldown = CompileCooldown(cooldownObj, id, path);
-                def.HasCooldown = def.Cooldown.CooldownValueAttributeId > 0 || def.Cooldown.CooldownTagId > 0;
+                def.HasCooldown = AttributeRegistry.IsValidId(def.Cooldown.CooldownValueAttributeId) || def.Cooldown.CooldownTagId > 0;
             }
 
             // ── blockTags ──
@@ -339,7 +339,7 @@ namespace Ludots.Core.Gameplay.GAS.Config
             if (!string.IsNullOrWhiteSpace(attrName))
             {
                 int attrId = AttributeRegistry.GetId(attrName);
-                if (attrId <= 0)
+                if (!AttributeRegistry.IsValidId(attrId))
                 {
                     throw new InvalidOperationException(
                         $"Ability '{id}' in '{path}' cooldown.valueAttribute references unknown attribute '{attrName}'.");
@@ -354,7 +354,7 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 cooldown.CooldownTagId = TagRegistry.Register(tagName);
             }
 
-            if (cooldown.CooldownValueAttributeId <= 0 && cooldown.CooldownTagId <= 0)
+            if (!AttributeRegistry.IsValidId(cooldown.CooldownValueAttributeId) && cooldown.CooldownTagId <= 0)
             {
                 throw new InvalidOperationException(
                     $"Ability '{id}' in '{path}' cooldown must declare valueAttribute or tag.");

--- a/src/Core/Gameplay/GAS/Config/EffectTemplateLoader.cs
+++ b/src/Core/Gameplay/GAS/Config/EffectTemplateLoader.cs
@@ -213,8 +213,8 @@ namespace Ludots.Core.Gameplay.GAS.Config
                 : 0;
 
             EffectPresetType presetType = ParsePresetType(cfg.PresetType, cfg.Id, relativePath);
-            int presetAttr0 = 0;
-            int presetAttr1 = 0;
+            int presetAttr0 = AttributeRegistry.InvalidId;
+            int presetAttr1 = AttributeRegistry.InvalidId;
             int reserved = 0;
             if (presetType == EffectPresetType.ApplyForce2D)
             {

--- a/src/Core/Gameplay/GAS/EffectTemplateRegistry.cs
+++ b/src/Core/Gameplay/GAS/EffectTemplateRegistry.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.CompilerServices;
 using Ludots.Core.Association;
 using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Registry;
 using Ludots.Core.Gameplay.GAS.Orders;
 using Ludots.Core.Gameplay.Teams;
 using Ludots.Core.Vision;
@@ -327,6 +328,12 @@ namespace Ludots.Core.Gameplay.GAS
         public EffectPresetType PresetType;
         public int PresetAttribute0;
         public int PresetAttribute1;
+
+        public EffectTemplateData()
+        {
+            PresetAttribute0 = AttributeRegistry.InvalidId;
+            PresetAttribute1 = AttributeRegistry.InvalidId;
+        }
         public EffectLifetimeKind LifetimeKind;
         public GasClockId ClockId;
         public int DurationTicks;

--- a/src/Core/Gameplay/GAS/Registry/AttributeRegistry.cs
+++ b/src/Core/Gameplay/GAS/Registry/AttributeRegistry.cs
@@ -20,17 +20,34 @@ namespace Ludots.Core.Gameplay.GAS.Registry
 
         public static bool IsFrozen => _frozen;
 
-        public static void Clear()
+        public static bool IsValidId(int attributeId)
         {
-            if (_frozen)
+            return attributeId != InvalidId && _idToName.ContainsKey(attributeId);
+        }
+
+        public static int RequireId(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
             {
-                throw new System.InvalidOperationException("AttributeRegistry is frozen.");
+                throw new System.ArgumentException("Attribute name is empty.", nameof(name));
             }
 
+            int id = GetId(name);
+            if (id == InvalidId)
+            {
+                throw new System.ArgumentException($"Attribute '{name}' is not registered.", nameof(name));
+            }
+
+            return id;
+        }
+
+        public static void Clear()
+        {
             _nameToId.Clear();
             _idToName.Clear();
             System.Array.Clear(_constraints, 0, _constraints.Length);
             _nextId = 0;
+            _frozen = false;
         }
 
         public static void Freeze()
@@ -40,14 +57,15 @@ namespace Ludots.Core.Gameplay.GAS.Registry
 
         public static int Register(string name)
         {
-            if (_frozen)
-            {
-                throw new System.InvalidOperationException("AttributeRegistry is frozen.");
-            }
-
             if (_nameToId.TryGetValue(name, out var id))
             {
                 return id;
+            }
+
+            if (_frozen)
+            {
+                throw new System.InvalidOperationException(
+                    $"AttributeRegistry is frozen; '{name}' is not registered.");
             }
 
             if (_nextId >= MaxAttributes)
@@ -86,7 +104,11 @@ namespace Ludots.Core.Gameplay.GAS.Registry
 
         public static void SetConstraints(int attributeId, in AttributeConstraints constraints)
         {
-            if ((uint)attributeId >= (uint)MaxAttributes) return;
+            if (attributeId == InvalidId || (uint)attributeId >= (uint)MaxAttributes)
+            {
+                throw new ArgumentOutOfRangeException(nameof(attributeId), attributeId, "Attribute id is invalid.");
+            }
+
             _constraints[attributeId] = constraints;
         }
 

--- a/src/Core/Gameplay/GAS/Systems/AttributeAggregatorSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/AttributeAggregatorSystem.cs
@@ -129,15 +129,8 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             GraphProgramRegistry graphPrograms,
             IGraphRuntimeApi graphApi)
         {
-            ulong touchedMask = 0UL;
-
             for (int i = 0; i < AttributeBuffer.MAX_ATTRS; i++)
             {
-                if (attrBuffer.CapValues[i] != attrBuffer.BaseValues[i])
-                {
-                    touchedMask |= 1UL << i;
-                }
-
                 attrBuffer.CurrentValues[i] = attrBuffer.BaseValues[i];
             }
 
@@ -167,7 +160,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                     }
 
                     ref readonly var modifiers = ref world.Get<EffectModifiers>(effectEntity);
-                    touchedMask |= BuildTouchedMask(in modifiers);
                     EffectModifierOps.ApplyAggregated(in modifiers, ref attrBuffer);
                 }
             }
@@ -180,31 +172,16 @@ namespace Ludots.Core.Gameplay.GAS.Systems
 
             ExecuteDerivedGraphs(world, entity, ref attrBuffer, graphPrograms, graphApi);
 
+            ulong derivedWrittenMask = 0UL;
             for (int i = 0; i < AttributeBuffer.MAX_ATTRS; i++)
             {
                 if (beforeDerived[i] != attrBuffer.CurrentValues[i])
                 {
-                    touchedMask |= 1UL << i;
+                    derivedWrittenMask |= 1UL << i;
                 }
             }
 
-            return touchedMask;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe ulong BuildTouchedMask(in EffectModifiers modifiers)
-        {
-            ulong mask = 0UL;
-            for (int i = 0; i < modifiers.Count; i++)
-            {
-                int attributeId = modifiers.Get(i).AttributeId;
-                if ((uint)attributeId < AttributeBuffer.MAX_ATTRS)
-                {
-                    mask |= 1UL << attributeId;
-                }
-            }
-
-            return mask;
+            return derivedWrittenMask;
         }
 
         struct AttributeAggregatorWithDirtyJob : IForEachWithEntity<AttributeBuffer, ActiveEffectContainer, DirtyFlags>
@@ -226,14 +203,14 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                     oldValues[i] = attrBuffer.CurrentValues[i];
                 }
 
-                ulong touchedMask = RecomputeEffectiveValues(
+                ulong derivedWrittenMask = RecomputeEffectiveValues(
                     World,
                     entity,
                     ref attrBuffer,
                     ref effects,
                     GraphPrograms,
                     GraphApi);
-                RestorePersistentCurrentValues(ref attrBuffer, oldValues, touchedMask);
+                RestorePersistentCurrentValues(ref attrBuffer, oldValues, derivedWrittenMask);
                 bool hasPresentationChanged = World.Has<GameplayAttributeChangedBits>(entity);
                 GameplayAttributeChangedBits presentationChangedLocal = default;
 
@@ -292,7 +269,10 @@ namespace Ludots.Core.Gameplay.GAS.Systems
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe void RestorePersistentCurrentValues(ref AttributeBuffer attrBuffer, Span<float> previousCurrentValues, ulong touchedMask)
+        private static unsafe void RestorePersistentCurrentValues(
+            ref AttributeBuffer attrBuffer,
+            Span<float> previousCurrentValues,
+            ulong derivedWrittenMask)
         {
             ulong definedMask = attrBuffer.DefinedMask;
             for (int i = 0; i < AttributeBuffer.MAX_ATTRS; i++)
@@ -304,14 +284,12 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                 }
 
                 attrBuffer.CapValues[i] = attrBuffer.CurrentValues[i];
-                bool touchedByAggregation = (touchedMask & bit) != 0UL;
-                bool clampsToEffectiveCap =
-                    AttributeRegistry.TryGetConstraints(i, out var constraints) &&
-                    constraints.ClampCurrentToBase;
-                if (!touchedByAggregation || clampsToEffectiveCap)
+                if ((derivedWrittenMask & bit) != 0UL)
                 {
-                    attrBuffer.SetCurrent(i, previousCurrentValues[i]);
+                    continue;
                 }
+
+                attrBuffer.SetCurrent(i, previousCurrentValues[i]);
             }
         }
 

--- a/src/Core/Gameplay/GAS/Systems/AttributeAggregatorSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/AttributeAggregatorSystem.cs
@@ -198,9 +198,11 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                 AttributeBuffer attributesBefore = attrBuffer;
                 DirtyFlags dirtyBefore = dirtyFlags;
                 Span<float> oldValues = stackalloc float[AttributeBuffer.MAX_ATTRS];
+                Span<float> oldCaps = stackalloc float[AttributeBuffer.MAX_ATTRS];
                 for (int i = 0; i < AttributeBuffer.MAX_ATTRS; i++)
                 {
                     oldValues[i] = attrBuffer.CurrentValues[i];
+                    oldCaps[i] = attrBuffer.CapValues[i];
                 }
 
                 ulong derivedWrittenMask = RecomputeEffectiveValues(
@@ -218,7 +220,8 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                 ulong changedMask = 0UL;
                 for (int i = 0; i < AttributeBuffer.MAX_ATTRS; i++)
                 {
-                    if (oldValues[i] != attrBuffer.CurrentValues[i])
+                    if (oldValues[i] != attrBuffer.CurrentValues[i] ||
+                        oldCaps[i] != attrBuffer.CapValues[i])
                     {
                         dirtyFlags.MarkAttributeDirty(i);
                         changedMask |= 1UL << i;

--- a/src/Core/Gameplay/Narrative/NarrativeDirector.cs
+++ b/src/Core/Gameplay/Narrative/NarrativeDirector.cs
@@ -845,7 +845,7 @@ namespace Ludots.Core.Gameplay.Narrative
             }
 
             int attributeId = AttributeRegistry.GetId(condition.AttributeId);
-            if (attributeId <= 0)
+            if (!AttributeRegistry.IsValidId(attributeId))
             {
                 return false;
             }

--- a/src/Core/Input/Systems/InputActionAttributeBindingSystem.cs
+++ b/src/Core/Input/Systems/InputActionAttributeBindingSystem.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using Arch.Core;
 using Arch.System;
 using Ludots.Core.Gameplay.Camera;
+using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Components;
 using Ludots.Core.Input.Attributes;
 using Ludots.Core.Input.Runtime;
@@ -15,6 +16,7 @@ namespace Ludots.Core.Input.Systems
     {
         private readonly Dictionary<string, object> _globals;
         private readonly InputActionAttributeBindingRegistry _registry;
+        private readonly TagOps _tagOps;
         private readonly QueryDescription _cameraBehaviorInputTargetQuery =
             new QueryDescription().WithAll<AttributeBuffer, CameraBehaviorInputTarget>();
         private Entity _cameraBehaviorInputCarrier = Entity.Null;
@@ -22,11 +24,13 @@ namespace Ludots.Core.Input.Systems
         public InputActionAttributeBindingSystem(
             World world,
             Dictionary<string, object> globals,
-            InputActionAttributeBindingRegistry registry)
+            InputActionAttributeBindingRegistry registry,
+            TagOps tagOps)
             : base(world)
         {
             _globals = globals ?? throw new ArgumentNullException(nameof(globals));
             _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+            _tagOps = tagOps ?? throw new ArgumentNullException(nameof(tagOps));
         }
 
         public override void Update(in float dt)
@@ -66,8 +70,7 @@ namespace Ludots.Core.Input.Systems
                     ? 0f
                     : ReadValue(input, entry);
 
-                ref AttributeBuffer attributes = ref World.Get<AttributeBuffer>(target);
-                attributes.SetCurrent(entry.AttributeId, value);
+                AttributeMutationOps.SetCurrent(World, target, entry.AttributeId, value, _tagOps);
             }
         }
 

--- a/src/Tests/ArchitectureTests/ArchitectureTests.csproj
+++ b/src/Tests/ArchitectureTests/ArchitectureTests.csproj
@@ -23,6 +23,16 @@
     <ProjectReference Include="..\..\..\mods\capabilities\camera\CameraProfilesMod\CameraProfilesMod.csproj" />
     <ProjectReference Include="..\..\..\mods\capabilities\navigation\MassNavigationMod\MassNavigationMod.csproj" />
     <ProjectReference Include="..\..\..\mods\fixtures\camera\CameraAcceptanceMod\CameraAcceptanceMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\ui_player_aggregate_graph_mvp\UiPlayerAggregateGraphMvpShowcaseMod\UiPlayerAggregateGraphMvpShowcaseMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\item_system\ItemSystemShowcaseMod\ItemSystemShowcaseMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\info_panels\GenreInfoShowcaseMod\GenreInfoShowcaseMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\gold_market\GoldMarketShowcaseMod\GoldMarketShowcaseMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\fourx_association\FourXAssociationShowcaseMod\FourXAssociationShowcaseMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\capability_standard\CapabilityStandardLiveSkillWorkbenchShowcaseMod\CapabilityStandardLiveSkillWorkbenchShowcaseMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\capability_standard\CapabilityStandardGraphOpsQueryMod\CapabilityStandardGraphOpsQueryMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\showcases\capability_standard\CapabilityStandardGraphOpsAttrMod\CapabilityStandardGraphOpsAttrMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\PerformanceVisualizationMod\PerformanceVisualizationMod.csproj" />
+    <ProjectReference Include="..\..\..\mods\GasBenchmarkMod\GasBenchmarkMod.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/ArchitectureTests/Governance/ArchitectureGuardTests.cs
+++ b/src/Tests/ArchitectureTests/Governance/ArchitectureGuardTests.cs
@@ -7,10 +7,16 @@ using System.Reflection.Emit;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using Arch.Core;
+using Ludots.Core.Config;
 using Ludots.Core.Engine;
 using Ludots.Core.Engine.Pacemaker;
+using Ludots.Core.Gameplay.GAS;
+using Ludots.Core.Gameplay.GAS.Benchmarks;
+using Ludots.Core.Gameplay.GAS.Bindings;
 using Ludots.Core.Gameplay.GAS.Components;
 using Ludots.Core.Gameplay.GAS.Systems;
+using Ludots.Core.Gameplay.Quests;
+using Ludots.Core.NodeLibraries.GASGraph.Host;
 using Ludots.Core.Scripting;
 using NUnit.Framework;
 
@@ -971,6 +977,66 @@ namespace Ludots.Tests.Architecture.Governance
         }
 
         [Test]
+        public void AttributeBufferWrites_MustComeFromWhitelistedCallers()
+        {
+            Type[] allowed =
+            {
+                typeof(AttributeMutationOps),
+                typeof(AttributeAggregatorSystem),
+                typeof(EffectModifierOps),
+                typeof(EffectPhaseSideEffectTransaction),
+                typeof(GasGraphRuntimeApi),
+                typeof(Ludots.Core.Config.ComponentRegistry),
+                typeof(TemplateEntityBatchSpawner),
+                typeof(QuestDefinitionRegistry),
+                typeof(ForceInput2DSink),
+                typeof(CameraBehaviorInputSink),
+                typeof(GasBenchmark),
+            };
+
+            var writeNames = new HashSet<string>(StringComparer.Ordinal)
+            {
+                nameof(AttributeBuffer.SetBase),
+                nameof(AttributeBuffer.SetCurrent),
+                nameof(AttributeBuffer.SetAggregatedCurrent),
+            };
+
+            var hits = new List<string>();
+            foreach (Type type in typeof(AttributeBuffer).Assembly.GetTypes())
+            {
+                if (IsAllowedAttributeBufferWriter(type, allowed))
+                {
+                    continue;
+                }
+
+                const BindingFlags flags =
+                    BindingFlags.Instance |
+                    BindingFlags.Static |
+                    BindingFlags.Public |
+                    BindingFlags.NonPublic |
+                    BindingFlags.DeclaredOnly;
+                foreach (MethodInfo method in type.GetMethods(flags))
+                {
+                    foreach (MethodBase called in EnumerateCalledMethods(method))
+                    {
+                        if (called.DeclaringType == typeof(AttributeBuffer) &&
+                            writeNames.Contains(called.Name))
+                        {
+                            hits.Add($"{type.FullName}.{method.Name} -> {called.DeclaringType.FullName}.{called.Name}");
+                        }
+                    }
+                }
+            }
+
+            if (hits.Count > 0)
+            {
+                Assert.Fail(
+                    "AttributeBuffer write methods are not a gameplay API; callers must be on the settlement/init whitelist:\n" +
+                    string.Join("\n", hits));
+            }
+        }
+
+        [Test]
         public void GasAbilityExecHotPath_DoesNotCallWorldAddOrRemoveDirectly()
         {
             var hits = new List<string>();
@@ -1312,7 +1378,7 @@ namespace Ludots.Tests.Architecture.Governance
                 Assert.That(runtime, Does.Contain("AttributeBuffer"));
                 Assert.That(runtime, Does.Contain("_attributeCosts"));
                 Assert.That(runtime, Does.Contain("AttributeCostRecord"));
-                Assert.That(runtime, Does.Contain("attributes.SetCurrent"));
+                Assert.That(runtime, Does.Contain("AttributeMutationOps.SetCurrent"));
                 Assert.That(loader, Does.Contain("AttributeRegistry.Register"));
                 Assert.That(loader, Does.Contain("inputs[{index}].attribute"));
             });
@@ -2087,6 +2153,25 @@ namespace Ludots.Tests.Architecture.Governance
             {
                 return null;
             }
+        }
+
+        private static bool IsAllowedAttributeBufferWriter(Type type, IReadOnlyList<Type> allowed)
+        {
+            Type? current = type;
+            while (current != null)
+            {
+                for (int i = 0; i < allowed.Count; i++)
+                {
+                    if (current == allowed[i])
+                    {
+                        return true;
+                    }
+                }
+
+                current = current.DeclaringType;
+            }
+
+            return false;
         }
 
         private static bool IsForbiddenAbilityExecStructuralCall(MethodBase method)

--- a/src/Tests/ArchitectureTests/Governance/ArchitectureGuardTests.cs
+++ b/src/Tests/ArchitectureTests/Governance/ArchitectureGuardTests.cs
@@ -1003,27 +1003,46 @@ namespace Ludots.Tests.Architecture.Governance
             };
 
             var hits = new List<string>();
-            foreach (Type type in typeof(AttributeBuffer).Assembly.GetTypes())
+            Assembly[] assemblies = CollectAttributeBufferWriteScanAssemblies();
+            Assert.That(
+                assemblies.Any(static assembly => !string.Equals(assembly.GetName().Name, "Ludots.Core", StringComparison.Ordinal)),
+                Is.True,
+                "AttributeBuffer write guard must scan showcase assemblies, not only Core.");
+
+            foreach (Assembly assembly in assemblies)
             {
-                if (IsAllowedAttributeBufferWriter(type, allowed))
+                Type[] types;
+                try
                 {
-                    continue;
+                    types = assembly.GetTypes();
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    types = ex.Types.Where(static type => type != null).ToArray()!;
                 }
 
-                const BindingFlags flags =
-                    BindingFlags.Instance |
-                    BindingFlags.Static |
-                    BindingFlags.Public |
-                    BindingFlags.NonPublic |
-                    BindingFlags.DeclaredOnly;
-                foreach (MethodInfo method in type.GetMethods(flags))
+                foreach (Type type in types)
                 {
-                    foreach (MethodBase called in EnumerateCalledMethods(method))
+                    if (IsAllowedAttributeBufferWriter(type, allowed))
                     {
-                        if (called.DeclaringType == typeof(AttributeBuffer) &&
-                            writeNames.Contains(called.Name))
+                        continue;
+                    }
+
+                    const BindingFlags flags =
+                        BindingFlags.Instance |
+                        BindingFlags.Static |
+                        BindingFlags.Public |
+                        BindingFlags.NonPublic |
+                        BindingFlags.DeclaredOnly;
+                    foreach (MethodInfo method in type.GetMethods(flags))
+                    {
+                        foreach (MethodBase called in EnumerateCalledMethods(method))
                         {
-                            hits.Add($"{type.FullName}.{method.Name} -> {called.DeclaringType.FullName}.{called.Name}");
+                            if (called.DeclaringType == typeof(AttributeBuffer) &&
+                                writeNames.Contains(called.Name))
+                            {
+                                hits.Add($"{type.FullName}.{method.Name} -> {called.DeclaringType.FullName}.{called.Name}");
+                            }
                         }
                     }
                 }
@@ -2154,6 +2173,53 @@ namespace Ludots.Tests.Architecture.Governance
             {
                 return null;
             }
+        }
+
+        internal static Assembly[] CollectAttributeBufferWriteScanAssemblies()
+        {
+            string[] requiredNames =
+            {
+                "Ludots.Core",
+                "UiPlayerAggregateGraphMvpShowcaseMod",
+                "ItemSystemShowcaseMod",
+                "GenreInfoShowcaseMod",
+                "GoldMarketShowcaseMod",
+                "FourXAssociationShowcaseMod",
+                "CapabilityStandardLiveSkillWorkbenchShowcaseMod",
+                "CapabilityStandardGraphOpsQueryMod",
+                "CapabilityStandardGraphOpsAttrMod",
+                "PerformanceVisualizationMod",
+                "GasBenchmarkMod",
+            };
+
+            var assemblies = new List<Assembly>(requiredNames.Length);
+            for (int i = 0; i < requiredNames.Length; i++)
+            {
+                assemblies.Add(LoadRequiredAttributeWriteAssembly(requiredNames[i]));
+            }
+
+            return assemblies.ToArray();
+        }
+
+        private static Assembly LoadRequiredAttributeWriteAssembly(string assemblyName)
+        {
+            Assembly[] loaded = AppDomain.CurrentDomain.GetAssemblies();
+            for (int i = 0; i < loaded.Length; i++)
+            {
+                if (string.Equals(loaded[i].GetName().Name, assemblyName, StringComparison.Ordinal))
+                {
+                    return loaded[i];
+                }
+            }
+
+            string path = Path.Combine(AppContext.BaseDirectory, assemblyName + ".dll");
+            if (!File.Exists(path))
+            {
+                Assert.Fail(
+                    $"AttributeBuffer write guard must load showcase assembly '{assemblyName}' from '{path}'.");
+            }
+
+            return Assembly.LoadFrom(path);
         }
 
         private static bool IsAllowedAttributeBufferWriter(Type type, IReadOnlyList<Type> allowed)

--- a/src/Tests/ArchitectureTests/Governance/ArchitectureGuardTests.cs
+++ b/src/Tests/ArchitectureTests/Governance/ArchitectureGuardTests.cs
@@ -981,6 +981,7 @@ namespace Ludots.Tests.Architecture.Governance
         {
             Type[] allowed =
             {
+                typeof(AttributeBuffer),
                 typeof(AttributeMutationOps),
                 typeof(AttributeAggregatorSystem),
                 typeof(EffectModifierOps),

--- a/src/Tests/ArchitectureTests/Governance/AttributeWriteAuthorityGuardTests.cs
+++ b/src/Tests/ArchitectureTests/Governance/AttributeWriteAuthorityGuardTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Ludots.Tests.Architecture
+{
+    [Category("ci-gate")]
+    [Category("arch-guard")]
+    public sealed class AttributeWriteAuthorityGuardTests
+    {
+        [Test]
+        public void AttributeBufferWrites_MustComeFromWhitelistedCallers()
+        {
+            new Governance.ArchitectureGuardTests().AttributeBufferWrites_MustComeFromWhitelistedCallers();
+        }
+
+        [Test]
+        public void Guard_ScansShowcaseAssembliesNotOnlyCore()
+        {
+            Assembly[] assemblies = Governance.ArchitectureGuardTests.CollectAttributeBufferWriteScanAssemblies();
+            string[] names = assemblies.Select(static assembly => assembly.GetName().Name ?? string.Empty).ToArray();
+
+            Assert.That(names, Does.Contain("Ludots.Core"));
+            Assert.That(names, Does.Contain("GoldMarketShowcaseMod"));
+            Assert.That(names, Does.Contain("ItemSystemShowcaseMod"));
+            Assert.That(names, Does.Contain("GenreInfoShowcaseMod"));
+            Assert.That(names, Does.Contain("UiPlayerAggregateGraphMvpShowcaseMod"));
+            Assert.That(names, Does.Contain("FourXAssociationShowcaseMod"));
+            Assert.That(names, Does.Contain("CapabilityStandardLiveSkillWorkbenchShowcaseMod"));
+            Assert.That(names, Does.Contain("CapabilityStandardGraphOpsQueryMod"));
+            Assert.That(names, Does.Contain("CapabilityStandardGraphOpsAttrMod"));
+            Assert.That(names, Does.Contain("PerformanceVisualizationMod"));
+            Assert.That(names, Does.Contain("GasBenchmarkMod"));
+            Assert.That(names.Count(static name => !string.Equals(name, "Ludots.Core", StringComparison.Ordinal)), Is.GreaterThanOrEqualTo(10));
+        }
+    }
+}

--- a/src/Tests/GasTests/GasCore/AttributeAggregatorTests.cs
+++ b/src/Tests/GasTests/GasCore/AttributeAggregatorTests.cs
@@ -309,6 +309,7 @@ namespace Ludots.Tests.GAS
             AttributeRegistry.Clear();
             try
             {
+                EffectParamKeys.Initialize();
                 int forceXId = AttributeRegistry.Register("S2.ForceX");
                 int forceYId = AttributeRegistry.Register("S2.ForceY");
                 That(forceXId, Is.EqualTo(0));

--- a/src/Tests/GasTests/GasCore/AttributeAggregatorTests.cs
+++ b/src/Tests/GasTests/GasCore/AttributeAggregatorTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Arch.Core;
 using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Components;
@@ -245,7 +246,8 @@ namespace Ludots.Tests.GAS
 
             var aggregator = new AttributeAggregatorSystem(world, tagOps: new TagOps(new DirtyEntityQueue(GasConstants.MAX_EFFECT_REQUESTS_PER_FRAME), new TagRuleRegistry()));
             aggregator.Update(0f);
-            That(world.Get<AttributeBuffer>(entity).GetCurrent(moveSpeedId), Is.EqualTo(118f));
+            That(world.Get<AttributeBuffer>(entity).GetCurrent(moveSpeedId), Is.EqualTo(100f));
+            That(world.Get<AttributeBuffer>(entity).GetCap(moveSpeedId), Is.EqualTo(118f));
 
             world.Get<GameplayEffect>(effect).CancelRequested = true;
             world.Add(entity, new AttributeAggregateDirty());
@@ -254,7 +256,139 @@ namespace Ludots.Tests.GAS
 
             ref var recomputedAttr = ref world.Get<AttributeBuffer>(entity);
             That(recomputedAttr.GetCurrent(moveSpeedId), Is.EqualTo(100f));
+            That(recomputedAttr.GetCap(moveSpeedId), Is.EqualTo(100f));
             That(recomputedAttr.GetBase(moveSpeedId), Is.EqualTo(100f));
+        }
+
+        [Test]
+        public unsafe void UnconstrainedAttribute_DirectCurrentWriteSurvivesActiveAggregation()
+        {
+            int moveSpeedId = EnsureAttribute($"MoveSpeed.DirectWrite.{Guid.NewGuid():N}");
+            var tagOps = CreateTagOps();
+
+            using var world = World.Create();
+            var entity = world.Create(new AttributeBuffer(), new ActiveEffectContainer(), new DirtyFlags());
+            AttributeMutationOps.SetBase(world, entity, moveSpeedId, 100f, tagOps);
+            AttachAddModifier(world, entity, moveSpeedId, 18f);
+            AttributeMutationOps.SetCurrent(world, entity, moveSpeedId, 50f, tagOps);
+
+            using var aggregator = new AttributeAggregatorSystem(world, tagOps: tagOps);
+            aggregator.Update(0f);
+
+            ref var attributes = ref world.Get<AttributeBuffer>(entity);
+            That(attributes.GetCurrent(moveSpeedId), Is.EqualTo(50f));
+            That(attributes.GetCap(moveSpeedId), Is.EqualTo(118f));
+            That(attributes.GetBase(moveSpeedId), Is.EqualTo(100f));
+        }
+
+        [Test]
+        public unsafe void ClampToBaseAttribute_DirectCurrentWriteSurvivesActiveAggregation()
+        {
+            int healthId = EnsureAttribute($"Health.DirectWrite.{Guid.NewGuid():N}");
+            AttributeRegistry.SetConstraints(healthId, AttributeRegistry.AttributeConstraints.ClampToBase());
+            var tagOps = CreateTagOps();
+
+            using var world = World.Create();
+            var entity = world.Create(new AttributeBuffer(), new ActiveEffectContainer(), new DirtyFlags());
+            AttributeMutationOps.SetBase(world, entity, healthId, 100f, tagOps);
+            AttachAddModifier(world, entity, healthId, 18f);
+            AttributeMutationOps.SetCurrent(world, entity, healthId, 50f, tagOps);
+
+            using var aggregator = new AttributeAggregatorSystem(world, tagOps: tagOps);
+            aggregator.Update(0f);
+
+            ref var attributes = ref world.Get<AttributeBuffer>(entity);
+            That(attributes.GetCurrent(healthId), Is.EqualTo(50f));
+            That(attributes.GetCap(healthId), Is.EqualTo(118f));
+            That(attributes.GetBase(healthId), Is.EqualTo(118f));
+        }
+
+        [Test]
+        public unsafe void FirstRegisteredAttribute_ApplyForceWritesIdZero()
+        {
+            AttributeRegistry.Clear();
+            try
+            {
+                int forceXId = AttributeRegistry.Register("S2.ForceX");
+                int forceYId = AttributeRegistry.Register("S2.ForceY");
+                That(forceXId, Is.EqualTo(0));
+                That(AttributeRegistry.IsValidId(forceXId), Is.True);
+
+                using var world = World.Create();
+                var target = world.Create(new AttributeBuffer(), new DirtyFlags());
+                var effect = world.Create();
+                var registry = new BuiltinHandlerRegistry();
+                BuiltinHandlers.RegisterAll(registry);
+                var runtime = new BuiltinHandlerExecutionContext { TagOps = CreateTagOps() };
+                var ctx = new EffectContext { Source = effect, Target = target };
+                var tpl = new EffectTemplateData { PresetAttribute0 = forceXId, PresetAttribute1 = forceYId };
+                var mergedParams = new EffectConfigParams();
+                mergedParams.TryAddFloat(EffectParamKeys.ForceXAttribute, 10f);
+                mergedParams.TryAddFloat(EffectParamKeys.ForceYAttribute, -3f);
+
+                registry.Invoke(BuiltinHandlerId.ApplyForce, world, effect, ref ctx, in mergedParams, in tpl, runtime);
+
+                ref var attributes = ref world.Get<AttributeBuffer>(target);
+                That(attributes.GetCurrent(forceXId), Is.EqualTo(10f));
+                That(attributes.GetCurrent(forceYId), Is.EqualTo(-3f));
+            }
+            finally
+            {
+                AttributeRegistry.Clear();
+            }
+        }
+
+        [Test]
+        public void RequireId_UnknownName_ThrowsAndNamesTheAttribute()
+        {
+            var error = Throws<ArgumentException>(() => AttributeRegistry.RequireId("S2.Missing.NamedWrite"));
+            That(error!.Message, Does.Contain("S2.Missing.NamedWrite"));
+        }
+
+        [Test]
+        public unsafe void InvalidAndOutOfRangeAttributeIds_FailClosed()
+        {
+            var buffer = default(AttributeBuffer);
+            Throws<ArgumentOutOfRangeException>(() => buffer.GetCurrent(AttributeRegistry.InvalidId));
+            Throws<ArgumentOutOfRangeException>(() => buffer.SetCurrent(AttributeRegistry.InvalidId, 1f));
+            Throws<ArgumentOutOfRangeException>(() => buffer.SetCurrent(AttributeBuffer.MAX_ATTRS, 1f));
+            Throws<ArgumentOutOfRangeException>(() => buffer.GetCap(-1));
+
+            using var world = World.Create();
+            var tagOps = CreateTagOps();
+            var target = world.Create(new AttributeBuffer(), new DirtyFlags());
+            int missingId = AttributeRegistry.GetId("S2.Missing.WriteCurrent");
+            That(missingId, Is.EqualTo(AttributeRegistry.InvalidId));
+            Throws<ArgumentOutOfRangeException>(() =>
+                AttributeMutationOps.SetCurrent(world, target, missingId, 7f, tagOps));
+            var named = Throws<ArgumentException>(() =>
+                AttributeMutationOps.SetCurrent(
+                    world,
+                    target,
+                    AttributeRegistry.RequireId("S2.Missing.WriteCurrent"),
+                    7f,
+                    tagOps));
+            That(named!.Message, Does.Contain("S2.Missing.WriteCurrent"));
+        }
+
+        [Test]
+        public void AttributeRegistry_Freeze_RejectsNewIdentitiesAndKeepsExisting()
+        {
+            try
+            {
+                int existing = EnsureAttribute("S2.Frozen.Existing");
+                AttributeRegistry.Freeze();
+                That(AttributeRegistry.IsFrozen, Is.True);
+                That(AttributeRegistry.Register("S2.Frozen.Existing"), Is.EqualTo(existing));
+                var error = Throws<InvalidOperationException>(() => AttributeRegistry.Register("S2.Frozen.New"));
+                That(error!.Message, Does.Contain("S2.Frozen.New"));
+            }
+            finally
+            {
+                AttributeRegistry.Clear();
+            }
+
+            That(AttributeRegistry.IsFrozen, Is.False);
         }
 
         [Test]
@@ -500,6 +634,23 @@ namespace Ludots.Tests.GAS
                 builtinHandlers,
                 new GraphProgramRegistry(),
                 $"Test/AttributeAggregatorTests.{presetType}.json");
+        }
+
+        private static TagOps CreateTagOps()
+        {
+            return new TagOps(new DirtyEntityQueue(GasConstants.MAX_EFFECT_REQUESTS_PER_FRAME), new TagRuleRegistry());
+        }
+
+        private static void AttachAddModifier(World world, Entity entity, int attributeId, float value)
+        {
+            var gameplayEffect = new GameplayEffect
+            {
+                AggregatesModifiers = true,
+                State = EffectState.Committed,
+            };
+            var effect = world.Create(gameplayEffect, new EffectModifiers());
+            world.Get<EffectModifiers>(effect).Add(attributeId, ModifierOp.Add, value);
+            That(world.Get<ActiveEffectContainer>(entity).Add(effect), Is.True);
         }
 
         private static int EnsureAttribute(string name)

--- a/src/Tests/GasTests/Integration/ExchangeRuntimeTests.cs
+++ b/src/Tests/GasTests/Integration/ExchangeRuntimeTests.cs
@@ -474,7 +474,7 @@ namespace Ludots.Tests.GAS
         {
             using World world = World.Create();
             var fixture = CreateFixture(world, stashWidth: 3, stashHeight: 1);
-            Entity actor = world.Create(new AttributeBuffer());
+            Entity actor = world.Create(new AttributeBuffer(), new DirtyFlags());
             fixture.Inventory.CreateContainer(actor, fixture.StashLayout, ItemContainerPurpose.Stash);
             int goldId = AttributeRegistry.Register("Exchange.Tests.Gold");
             world.Get<AttributeBuffer>(actor).SetCurrent(goldId, 8f);
@@ -505,7 +505,7 @@ namespace Ludots.Tests.GAS
         {
             using World world = World.Create();
             var fixture = CreateFixture(world, stashWidth: 3, stashHeight: 1);
-            Entity actor = world.Create(new AttributeBuffer());
+            Entity actor = world.Create(new AttributeBuffer(), new DirtyFlags());
             fixture.Inventory.CreateContainer(actor, fixture.StashLayout, ItemContainerPurpose.Stash);
             int goldId = AttributeRegistry.Register("Exchange.Tests.SpendableGold");
             world.Get<AttributeBuffer>(actor).SetCurrent(goldId, 30f);
@@ -535,7 +535,7 @@ namespace Ludots.Tests.GAS
         {
             using World world = World.Create();
             var fixture = CreateFixture(world, stashWidth: 2, stashHeight: 1);
-            Entity actor = world.Create(new AttributeBuffer());
+            Entity actor = world.Create(new AttributeBuffer(), new DirtyFlags());
             Entity stash = fixture.Inventory.CreateContainer(actor, fixture.StashLayout, ItemContainerPurpose.Stash);
             Put(fixture.Inventory, CreditDef, stash, 0, 0);
             int goldId = AttributeRegistry.Register("Exchange.Tests.RollbackGold");
@@ -569,7 +569,7 @@ namespace Ludots.Tests.GAS
         {
             using World world = World.Create();
             var fixture = CreateFixture(world, stashWidth: 100, stashHeight: 1);
-            Entity actor = world.Create(new AttributeBuffer());
+            Entity actor = world.Create(new AttributeBuffer(), new DirtyFlags());
             fixture.Inventory.CreateContainer(actor, fixture.StashLayout, ItemContainerPurpose.Stash);
             int goldId = AttributeRegistry.Register("Exchange.Tests.HotPathGold");
             world.Get<AttributeBuffer>(actor).SetCurrent(goldId, 10_000f);
@@ -870,7 +870,8 @@ namespace Ludots.Tests.GAS
             var operations = new ExchangeOperationRegistry();
             var scoped = new ExchangeScopedOperationStore();
             var effects = new EffectRequestQueue();
-            var runtime = new ExchangeRuntime(world, operations, scoped, inventory, effects, relationships);
+            var tagOps = new TagOps(new DirtyEntityQueue(GasConstants.MAX_EFFECT_REQUESTS_PER_FRAME), new TagRuleRegistry());
+            var runtime = new ExchangeRuntime(world, operations, scoped, inventory, effects, relationships, tagOps);
             return new ExchangeFixture(inventory, operations, scoped, runtime, relationships, stashLayout, targetLayout, diplomacyTypeId, trustMetricId, embargoFlagId);
         }
 

--- a/src/Tests/GasTests/InteractionInput/AuthoritativeInputConvergenceTests.cs
+++ b/src/Tests/GasTests/InteractionInput/AuthoritativeInputConvergenceTests.cs
@@ -5,6 +5,7 @@ using Arch.Core;
 using Ludots.Core.EntityCollections;
 using Ludots.Core.Gameplay;
 using Ludots.Core.Gameplay.Camera;
+using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Bindings;
 using Ludots.Core.Gameplay.GAS.Components;
 using Ludots.Core.Gameplay.GAS.Input;
@@ -147,7 +148,7 @@ namespace Ludots.Tests.GAS
         {
             using var world = World.Create();
             Entity localPlayerIdentity = world.Create();
-            Entity cameraBehaviorInputTarget = world.Create(new AttributeBuffer(), new CameraBehaviorInputTarget());
+            Entity cameraBehaviorInputTarget = world.Create(new AttributeBuffer(), new DirtyFlags(), new CameraBehaviorInputTarget());
             int lookXAttribute = AttributeRegistry.Register(CameraBehaviorAttributes.LookX);
 
             var authoritativeInput = new FrozenInputActionReader();
@@ -179,7 +180,11 @@ namespace Ludots.Tests.GAS
                 [CoreServiceKeys.LocalPlayerEntity.Name] = localPlayerIdentity,
                 [CoreServiceKeys.UiCaptured.Name] = false,
             };
-            var system = new InputActionAttributeBindingSystem(world, globals, registry);
+            var system = new InputActionAttributeBindingSystem(
+                world,
+                globals,
+                registry,
+                new TagOps(new DirtyEntityQueue(GasConstants.MAX_EFFECT_REQUESTS_PER_FRAME), new TagRuleRegistry()));
 
             system.Update(0f);
 
@@ -315,7 +320,7 @@ namespace Ludots.Tests.GAS
             var session = new GameSession();
             using var world = World.Create();
             var behaviorInput = new CameraBehaviorInputState();
-            Entity localPlayer = world.Create(new AttributeBuffer(), new CameraBehaviorInputTarget());
+            Entity localPlayer = world.Create(new AttributeBuffer(), new DirtyFlags(), new CameraBehaviorInputTarget());
             var registry = new VirtualCameraRegistry();
             registry.Register(new VirtualCameraDefinition
             {
@@ -413,7 +418,11 @@ namespace Ludots.Tests.GAS
                 new[] { new AttributeBindingGroup(cameraSinkId, 0, 3) });
 
             var system = new InputRuntimeSystem(globals);
-            var actionBindingSystem = new InputActionAttributeBindingSystem(world, globals, actionBindings);
+            var actionBindingSystem = new InputActionAttributeBindingSystem(
+                world,
+                globals,
+                actionBindings,
+                new TagOps(new DirtyEntityQueue(GasConstants.MAX_EFFECT_REQUESTS_PER_FRAME), new TagRuleRegistry()));
             var attributeBindingSystem = new AttributeBindingSystem(world, sinks, attributeBindings);
 
             backend.MousePosition = Vector2.Zero;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# 概要

- 变更目标：直写永远存活。展厅裸写改走正式入口。守卫连展厅一起扫，裸写必须红。
- 影响范围：属性聚合器、正式写入面、展厅补金/铺数值、架构守卫。

# SSOT 落点

- 正式规则：无
- 正式架构：`gitbook/architecture/attribute-write-authority.md`（裸写必须 CI 红，含展厅）
- 正式查表或操作：无
- 仓库深度材料：无
- 审计或提案：#949 认定主故障已修、收口未完；本轮把收口做完

# 设计与挂靠点

- 挂靠点：`AttributeMutationOps`、`AttributeAggregatorSystem`、`ArchitectureGuardTests`
- 复用清单：正式写入面；脏标记与聚合排队
- 新增清单：守卫扫描展厅程序集

# 收口（#949 附录 B.1）

展厅 10 处裸写（含金币市场运行期补金）改走 `AttributeMutationOps`。守卫 IL 扫 Core + 展厅；缺 DLL 直接失败。文档不再缩成只约束内核。

# 验证证据

```
ArchitectureTests AttributeBufferWrites + AttributeWriteAuthorityGuardTests：3 passed
GasTests Attribute：43 passed
```

# 文档同步

- [x] 行为变更已同步更新 `gitbook/` 正式文档
- [x] 所属目录 `README.md` 或 `SUMMARY.md` 已同步 —— 不需要
- [x] 若影响入口或导航，`README.md` / `README_CN.md` / `AGENTS.md` / `CLAUDE.md` 已同步 —— 不影响

#949 之后：收口已走完，**可以关单**。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88eeeec8-f8e7-44e7-bfea-db2b5c012489?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88eeeec8-f8e7-44e7-bfea-db2b5c012489&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

