### PR TITLE
fix(tests): S11 覆盖表说覆盖了就必须真跑那个节点

### DIFF
--- a/.github/workflows/solution-verify.yml
+++ b/.github/workflows/solution-verify.yml
@@ -15,6 +15,9 @@ on:
       - 'scripts/acceptance/MassNavigationEvidencePortability.psm1'
       - 'scripts/acceptance/assert-portable-evidence.ps1'
       - 'scripts/acceptance/run-mass-navigation-large-world-uat.ps1'
+      - 'scripts/generate-graph-op-node-galleries.py'
+      - 'scripts/graph_op_coverage_index.py'
+      - 'showcase.registry.json'
       - 'src/**'
   push:
     branches:
@@ -32,6 +35,9 @@ on:
       - 'scripts/acceptance/MassNavigationEvidencePortability.psm1'
       - 'scripts/acceptance/assert-portable-evidence.ps1'
       - 'scripts/acceptance/run-mass-navigation-large-world-uat.ps1'
+      - 'scripts/generate-graph-op-node-galleries.py'
+      - 'scripts/graph_op_coverage_index.py'
+      - 'showcase.registry.json'
       - 'src/**'
   workflow_dispatch:
 
@@ -43,6 +49,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Check graph-op gallery generator has no drift
+        shell: pwsh
+        env:
+          PYTHONDONTWRITEBYTECODE: 1
+        run: |
+          python scripts/generate-graph-op-node-galleries.py --strict
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          git diff --exit-code
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "Graph-op gallery generator drifted. Run scripts/generate-graph-op-node-galleries.py --strict and commit the result."
+            exit 1
+          }
+          $porcelain = git status --porcelain
+          if ($porcelain) {
+            Write-Host "Graph-op gallery generator produced untracked or unstaged files:"
+            Write-Host $porcelain
+            exit 1
+          }
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ yarn-error.log*
 target/
 
 # ----- 临时文件与缓存 -----
+**/__pycache__/
+*.py[cod]
 .tmp/
 .trae/
 raylib_temp/

--- a/assets/Configs/GAS/graph_node_op_coverage.registry.json
+++ b/assets/Configs/GAS/graph_node_op_coverage.registry.json
@@ -1,24 +1,39 @@
 {
   "schemaVersion": 1,
-  "description": "P2 GraphNodeOp coverage SSOT for Epic #915. Each executable opcode must eventually reach status=covered with unitTestFilter and showcaseId.",
+  "description": "GraphNodeOp coverage SSOT. Each executable opcode must have status=covered, a per-op showcaseId, and unitTestRefs: Class.Method pairs measured to execute that op.",
   "entries": [
     {
       "op": "ConstBool",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectFloatAndBoolRuntimeOps_CompileAndEmit;GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps;GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_ValidationGraph_CompilesAndUsesClampAndCompare;GraphOpsFloatShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_ConstBool",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectFloatAndBoolRuntimeOps_CompileAndEmit",
+        "GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_ValidationGraph_CompilesAndUsesClampAndCompare"
+      ]
     },
     {
       "op": "ConstInt",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_ReadHealthStrikeApplyRemove_CompletesUnderBudget;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_PlayerFacingPhrases_ArePresentAcrossWaves;GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_CoreGraphs_EmitControlFlowOps",
       "showcaseId": "capability_standard_graph_op_ConstInt",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions",
+        "GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch"
+      ]
     },
     {
       "op": "ConstFloat",
@@ -26,9 +41,16 @@
         "Linear",
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption;GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps;GraphOpsFloatShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_ConstFloat",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryAcceptanceTests.ConstFloat_SetsTargetHealthToAuthoredConstant",
+        "GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps"
+      ]
     },
     {
       "op": "LoadCaster",
@@ -36,27 +58,49 @@
         "Linear",
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_ReadHealthStrikeApplyRemove_CompletesUnderBudget;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_PlayerFacingPhrases_ArePresentAcrossWaves;GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch",
       "showcaseId": "capability_standard_graph_op_LoadCaster",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions",
+        "GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch"
+      ]
     },
     {
       "op": "LoadExplicitTarget",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_ReadHealthStrikeApplyRemove_CompletesUnderBudget;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_PlayerFacingPhrases_ArePresentAcrossWaves;GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch",
       "showcaseId": "capability_standard_graph_op_LoadExplicitTarget",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions",
+        "GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch"
+      ]
     },
     {
       "op": "Jump",
       "authorableKinds": [
         "Script"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryScriptAcceptanceTests.ScriptOps_SmokeTick_SubstitutesCaption;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectBranchBool_CompilesToJumps;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_JumpOps_TiedToDrinkUntilFullPhrases",
       "showcaseId": "capability_standard_graph_op_Jump",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryScriptAcceptanceTests.ScriptOps_SmokeTick_SubstitutesCaption",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectBranchBool_CompilesToJumps",
+        "GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_JumpOps_TiedToDrinkUntilFullPhrases"
+      ]
     },
     {
       "op": "JumpIfFalse",
@@ -64,144 +108,261 @@
         "Effect",
         "Script"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryScriptAcceptanceTests.ScriptOps_SmokeTick_SubstitutesCaption;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectBranchBool_CompilesToJumps;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_JumpOps_TiedToDrinkUntilFullPhrases",
       "showcaseId": "capability_standard_graph_op_JumpIfFalse",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryScriptAcceptanceTests.JumpIfFalse_TeaFillsAcrossTicks",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectBranchBool_CompilesToJumps",
+        "GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_JumpOps_TiedToDrinkUntilFullPhrases"
+      ]
     },
     {
       "op": "LoadAttribute",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_ReadHealthStrikeApplyRemove_CompletesUnderBudget;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_PlayerFacingPhrases_ArePresentAcrossWaves;GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch",
       "showcaseId": "capability_standard_graph_op_LoadAttribute",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.LoadAttribute_CaptionContainsNumber",
+        "GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch"
+      ]
     },
     {
       "op": "AddFloat",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption;GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps;GraphOpsFloatShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_AddFloat",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryAcceptanceTests.AddFloat_SubtractsSumFromTargetHealth",
+        "GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps"
+      ]
     },
     {
       "op": "MulFloat",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption;GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps;GraphOpsFloatShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_MulFloat",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption",
+        "GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps"
+      ]
     },
     {
       "op": "SubFloat",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption;GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps;GraphOpsFloatShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_SubFloat",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption",
+        "GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps"
+      ]
     },
     {
       "op": "DivFloat",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption;GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps;GraphOpsFloatShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_DivFloat",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption",
+        "GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps"
+      ]
     },
     {
       "op": "MinFloat",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption;GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps;GraphOpsFloatShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_MinFloat",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption",
+        "GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps"
+      ]
     },
     {
       "op": "MaxFloat",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption;GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps;GraphOpsFloatShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_MaxFloat",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption",
+        "GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps"
+      ]
     },
     {
       "op": "ClampFloat",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption;GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps;GraphOpsFloatShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_ClampFloat",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryFloatAcceptanceTests.ClampFloat_SubtractsClampedForty",
+        "GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption",
+        "GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps"
+      ]
     },
     {
       "op": "AbsFloat",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption;GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps;GraphOpsFloatShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_AbsFloat",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption",
+        "GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps"
+      ]
     },
     {
       "op": "NegFloat",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption;GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps;GraphOpsFloatShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_NegFloat",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption",
+        "GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps"
+      ]
     },
     {
       "op": "RandomFloat01",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption;GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps;GraphOpsFloatShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_RandomFloat01",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption",
+        "GraphOpsNodeGalleryFloatAcceptanceTests.RandomFloat01_ResultStaysInUnitIntervalAcrossWaves",
+        "GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps"
+      ]
     },
     {
       "op": "AddInt",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_ReadHealthStrikeApplyRemove_CompletesUnderBudget;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_PlayerFacingPhrases_ArePresentAcrossWaves;GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch",
       "showcaseId": "capability_standard_graph_op_AddInt",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions",
+        "GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch"
+      ]
     },
     {
       "op": "CompareGtFloat",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption;GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps;GraphOpsFloatShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_CompareGtFloat",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryFloatAcceptanceTests.CompareGtFloat_CriticalCheckHolds",
+        "GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption",
+        "GraphOpsFloatShowcaseAcceptanceTests.FrontDoor_EffectGraph_ContainsAllFloatOps"
+      ]
     },
     {
       "op": "CompareLtInt",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_ReadHealthStrikeApplyRemove_CompletesUnderBudget;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_PlayerFacingPhrases_ArePresentAcrossWaves;GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch",
       "showcaseId": "capability_standard_graph_op_CompareLtInt",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions",
+        "GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch"
+      ]
     },
     {
       "op": "CompareEqInt",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_ReadHealthStrikeApplyRemove_CompletesUnderBudget;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_PlayerFacingPhrases_ArePresentAcrossWaves;GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch",
       "showcaseId": "capability_standard_graph_op_CompareEqInt",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions",
+        "GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch"
+      ]
     },
     {
       "op": "HasTag",
@@ -209,9 +370,17 @@
         "Linear",
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectTagAndDisplayOps_CompileAndEmit",
       "showcaseId": "capability_standard_graph_op_HasTag",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySandboxAcceptanceTests.HasTag_ScoutCarriesEnemyMark",
+        "GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectTagAndDisplayOps_CompileAndEmit"
+      ]
     },
     {
       "op": "CompareEqEntity",
@@ -219,9 +388,16 @@
         "Linear",
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_ReadHealthStrikeApplyRemove_CompletesUnderBudget;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_PlayerFacingPhrases_ArePresentAcrossWaves;GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch",
       "showcaseId": "capability_standard_graph_op_CompareEqEntity",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions",
+        "GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch"
+      ]
     },
     {
       "op": "SelectTagInMask",
@@ -229,9 +405,17 @@
         "Linear",
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectTagAndDisplayOps_CompileAndEmit;GraphEffectAuthoringExpressivenessTests.FrontDoor_QueryTagDisplayOps_CompileAndEmit",
       "showcaseId": "capability_standard_graph_op_SelectTagInMask",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectTagAndDisplayOps_CompileAndEmit",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_QueryTagDisplayOps_CompileAndEmit"
+      ]
     },
     {
       "op": "LookupTagDisplayToken",
@@ -239,18 +423,33 @@
         "Linear",
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectTagAndDisplayOps_CompileAndEmit;GraphEffectAuthoringExpressivenessTests.FrontDoor_QueryTagDisplayOps_CompileAndEmit",
       "showcaseId": "capability_standard_graph_op_LookupTagDisplayToken",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectTagAndDisplayOps_CompileAndEmit",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_QueryTagDisplayOps_CompileAndEmit"
+      ]
     },
     {
       "op": "SelectEntity",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_ReadHealthStrikeApplyRemove_CompletesUnderBudget;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_PlayerFacingPhrases_ArePresentAcrossWaves;GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch",
       "showcaseId": "capability_standard_graph_op_SelectEntity",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions",
+        "GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch"
+      ]
     },
     {
       "op": "QueryRadius",
@@ -258,9 +457,19 @@
         "Linear",
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectQueryListOps_CompileAndEmit;GraphEffectAuthoringExpressivenessTests.FrontDoor_QueryKind_QueryListOps_CompileAndEmit;GraphEffectAuthoringExpressivenessTests.FrontDoor_QueryRadius_RequiresCapacityPolicy",
       "showcaseId": "capability_standard_graph_op_QueryRadius",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySandboxAcceptanceTests.QueryRadius_LightsInRangeAndLeavesFarUnits",
+        "GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectQueryListOps_CompileAndEmit",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_QueryKind_QueryListOps_CompileAndEmit",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_QueryRadius_RequiresCapacityPolicy"
+      ]
     },
     {
       "op": "QuerySortStable",
@@ -268,9 +477,17 @@
         "Linear",
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectQueryListOps_CompileAndEmit;GraphEffectAuthoringExpressivenessTests.FrontDoor_QueryKind_QueryListOps_CompileAndEmit",
       "showcaseId": "capability_standard_graph_op_QuerySortStable",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectQueryListOps_CompileAndEmit",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_QueryKind_QueryListOps_CompileAndEmit"
+      ]
     },
     {
       "op": "QueryLimit",
@@ -278,63 +495,109 @@
         "Linear",
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectQueryListOps_CompileAndEmit;GraphEffectAuthoringExpressivenessTests.FrontDoor_QueryKind_QueryListOps_CompileAndEmit",
       "showcaseId": "capability_standard_graph_op_QueryLimit",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectQueryListOps_CompileAndEmit",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_QueryKind_QueryListOps_CompileAndEmit"
+      ]
     },
     {
       "op": "QueryCone",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_ConeRectLineHex_UnderBudgetWithPlayerReadableDetail;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_PlayerFacingPhrases_LockFiltersHexAndFirstHit",
       "showcaseId": "capability_standard_graph_op_QueryCone",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySpatialAcceptanceTests.QueryCone_LightsPeopleInsideTheFan",
+        "GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty"
+      ]
     },
     {
       "op": "QueryRectangle",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_ConeRectLineHex_UnderBudgetWithPlayerReadableDetail;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_PlayerFacingPhrases_LockFiltersHexAndFirstHit",
       "showcaseId": "capability_standard_graph_op_QueryRectangle",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty"
+      ]
     },
     {
       "op": "QueryLine",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_ConeRectLineHex_UnderBudgetWithPlayerReadableDetail;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_PlayerFacingPhrases_LockFiltersHexAndFirstHit",
       "showcaseId": "capability_standard_graph_op_QueryLine",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty"
+      ]
     },
     {
       "op": "QueryFilterNotEntity",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_ConeRectLineHex_UnderBudgetWithPlayerReadableDetail;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_PlayerFacingPhrases_LockFiltersHexAndFirstHit",
       "showcaseId": "capability_standard_graph_op_QueryFilterNotEntity",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySpatialAcceptanceTests.QueryFilterNotEntity_LeavesSelfOffTheList",
+        "GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty"
+      ]
     },
     {
       "op": "QueryFilterLayer",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_ConeRectLineHex_UnderBudgetWithPlayerReadableDetail;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_PlayerFacingPhrases_LockFiltersHexAndFirstHit",
       "showcaseId": "capability_standard_graph_op_QueryFilterLayer",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty"
+      ]
     },
     {
       "op": "QueryFilterRelationship",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_ConeRectLineHex_UnderBudgetWithPlayerReadableDetail;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_PlayerFacingPhrases_LockFiltersHexAndFirstHit",
       "showcaseId": "capability_standard_graph_op_QueryFilterRelationship",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty"
+      ]
     },
     {
       "op": "AggCount",
@@ -342,9 +605,15 @@
         "Linear",
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_ConeRectLineHex_UnderBudgetWithPlayerReadableDetail;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_PlayerFacingPhrases_LockFiltersHexAndFirstHit",
       "showcaseId": "capability_standard_graph_op_AggCount",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty"
+      ]
     },
     {
       "op": "AggMinByDistance",
@@ -352,297 +621,543 @@
         "Linear",
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_ConeRectLineHex_UnderBudgetWithPlayerReadableDetail;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_PlayerFacingPhrases_LockFiltersHexAndFirstHit",
       "showcaseId": "capability_standard_graph_op_AggMinByDistance",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty"
+      ]
     },
     {
       "op": "TargetListGet",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_ConeRectLineHex_UnderBudgetWithPlayerReadableDetail;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_PlayerFacingPhrases_LockFiltersHexAndFirstHit",
       "showcaseId": "capability_standard_graph_op_TargetListGet",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty",
+        "GraphOpsNodeGallerySpatialAcceptanceTests.TargetListGet_NamesTheFirstPerson"
+      ]
     },
     {
       "op": "QueryHexRange",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_ConeRectLineHex_UnderBudgetWithPlayerReadableDetail;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_PlayerFacingPhrases_LockFiltersHexAndFirstHit",
       "showcaseId": "capability_standard_graph_op_QueryHexRange",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySpatialAcceptanceTests.QueryHexRange_LightsPeopleInsideTwoHexes_NotTheOuterOne",
+        "GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty"
+      ]
     },
     {
       "op": "QueryHexRing",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_ConeRectLineHex_UnderBudgetWithPlayerReadableDetail;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_PlayerFacingPhrases_LockFiltersHexAndFirstHit",
       "showcaseId": "capability_standard_graph_op_QueryHexRing",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySpatialAcceptanceTests.QueryHexRing_LightsOnlyTheRing_NotInsideOrOutside",
+        "GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty"
+      ]
     },
     {
       "op": "QueryHexNeighbors",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_ConeRectLineHex_UnderBudgetWithPlayerReadableDetail;GraphOpsSpatialShowcaseAcceptanceTests.SpatialQueries_PlayerFacingPhrases_LockFiltersHexAndFirstHit",
       "showcaseId": "capability_standard_graph_op_QueryHexNeighbors",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySpatialAcceptanceTests.QueryHexNeighbors_LightsTheSixAdjacentPeople_NotTheOuterOne",
+        "GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty"
+      ]
     },
     {
       "op": "ApplyEffectTemplate",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_ReadHealthStrikeApplyRemove_CompletesUnderBudget;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_PlayerFacingPhrases_ArePresentAcrossWaves;GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch",
       "showcaseId": "capability_standard_graph_op_ApplyEffectTemplate",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.ApplyEffectTemplate_EnqueuesMark",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions",
+        "GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch"
+      ]
     },
     {
       "op": "FanOutApplyEffect",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectDynamicAndFanOutEffectOps_CompileAndEmit;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectFanOutApplyEffect_RequiresEffectTemplate",
       "showcaseId": "capability_standard_graph_op_FanOutApplyEffect",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectDynamicAndFanOutEffectOps_CompileAndEmit",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectFanOutApplyEffect_RequiresEffectTemplate"
+      ]
     },
     {
       "op": "ApplyEffectDynamic",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectDynamicAndFanOutEffectOps_CompileAndEmit;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectApplyEffectDynamic_RequiresTargetAndValueInputs",
       "showcaseId": "capability_standard_graph_op_ApplyEffectDynamic",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectDynamicAndFanOutEffectOps_CompileAndEmit",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectApplyEffectDynamic_RequiresTargetAndValueInputs"
+      ]
     },
     {
       "op": "FanOutApplyEffectDynamic",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectDynamicAndFanOutEffectOps_CompileAndEmit;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectFanOutApplyEffectDynamic_RequiresValueInput",
       "showcaseId": "capability_standard_graph_op_FanOutApplyEffectDynamic",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectDynamicAndFanOutEffectOps_CompileAndEmit",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectFanOutApplyEffectDynamic_RequiresValueInput"
+      ]
     },
     {
       "op": "RemoveEffectTemplate",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_ReadHealthStrikeApplyRemove_CompletesUnderBudget;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_PlayerFacingPhrases_ArePresentAcrossWaves;GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch",
       "showcaseId": "capability_standard_graph_op_RemoveEffectTemplate",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.RemoveEffectTemplate_CaptionUnloadsMark",
+        "GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch"
+      ]
     },
     {
       "op": "FanOutDispatchEffect",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryEventAcceptanceTests.SnapToNearestInCollection_SucceedsWithPlayerCaption;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectDynamicAndFanOutEffectOps_CompileAndEmit;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchControlDomainAndSnap_PlayerReadable",
       "showcaseId": "capability_standard_graph_op_FanOutDispatchEffect",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryEventAcceptanceTests.EventFamilyOp_RendersPlayerCaption",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectDynamicAndFanOutEffectOps_CompileAndEmit"
+      ]
     },
     {
       "op": "FanOutDispatchEffectDynamic",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryEventAcceptanceTests.SnapToNearestInCollection_SucceedsWithPlayerCaption;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectDynamicAndFanOutEffectOps_CompileAndEmit;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchControlDomainAndSnap_PlayerReadable",
       "showcaseId": "capability_standard_graph_op_FanOutDispatchEffectDynamic",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryEventAcceptanceTests.EventFamilyOp_RendersPlayerCaption",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectDynamicAndFanOutEffectOps_CompileAndEmit"
+      ]
     },
     {
       "op": "ModifyAttributeAdd",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_ReadHealthStrikeApplyRemove_CompletesUnderBudget;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_PlayerFacingPhrases_ArePresentAcrossWaves;GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch",
       "showcaseId": "capability_standard_graph_op_ModifyAttributeAdd",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.EnsureWorld_HeadlessWithoutStage_DoesNotThrow",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.ModifyAttributeAdd_DropsTargetHealth",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.ModifyAttributeAdd_SecondThinkStillDropsFromOpening",
+        "GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch"
+      ]
     },
     {
       "op": "SendEvent",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryEventAcceptanceTests.SnapToNearestInCollection_SucceedsWithPlayerCaption;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectEventControlKnowledgeOps_CompileAndEmit;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchControlDomainAndSnap_PlayerReadable",
       "showcaseId": "capability_standard_graph_op_SendEvent",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryEventAcceptanceTests.SendEvent_BroadcastsPlayerReadableHit",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectEventControlKnowledgeOps_CompileAndEmit"
+      ]
     },
     {
       "op": "ReadBlackboardFloat",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase;GraphOpsBlackboardShowcaseAcceptanceTests.RegistryName_MemoConfigAndLifecycleTransaction_DetailIsPlayerReadable;GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps",
       "showcaseId": "capability_standard_graph_op_ReadBlackboardFloat",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryBlackboardAcceptanceTests.WriteThenReadFloat_VisibleOnHealthAndCaption",
+        "GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps"
+      ]
     },
     {
       "op": "ReadBlackboardInt",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase;GraphOpsBlackboardShowcaseAcceptanceTests.RegistryName_MemoConfigAndLifecycleTransaction_DetailIsPlayerReadable;GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps",
       "showcaseId": "capability_standard_graph_op_ReadBlackboardInt",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase",
+        "GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps"
+      ]
     },
     {
       "op": "ReadBlackboardEntity",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase;GraphOpsBlackboardShowcaseAcceptanceTests.RegistryName_MemoConfigAndLifecycleTransaction_DetailIsPlayerReadable;GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps",
       "showcaseId": "capability_standard_graph_op_ReadBlackboardEntity",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase",
+        "GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps"
+      ]
     },
     {
       "op": "WriteBlackboardFloat",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase;GraphOpsBlackboardShowcaseAcceptanceTests.RegistryName_MemoConfigAndLifecycleTransaction_DetailIsPlayerReadable;GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps",
       "showcaseId": "capability_standard_graph_op_WriteBlackboardFloat",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryBlackboardAcceptanceTests.WriteThenReadFloat_VisibleOnHealthAndCaption",
+        "GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps"
+      ]
     },
     {
       "op": "WriteBlackboardInt",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase;GraphOpsBlackboardShowcaseAcceptanceTests.RegistryName_MemoConfigAndLifecycleTransaction_DetailIsPlayerReadable;GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps",
       "showcaseId": "capability_standard_graph_op_WriteBlackboardInt",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase",
+        "GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps"
+      ]
     },
     {
       "op": "WriteBlackboardEntity",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase;GraphOpsBlackboardShowcaseAcceptanceTests.RegistryName_MemoConfigAndLifecycleTransaction_DetailIsPlayerReadable;GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps",
       "showcaseId": "capability_standard_graph_op_WriteBlackboardEntity",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase",
+        "GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps"
+      ]
     },
     {
       "op": "LoadConfigFloat",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase;GraphOpsBlackboardShowcaseAcceptanceTests.RegistryName_MemoConfigAndLifecycleTransaction_DetailIsPlayerReadable;GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps",
       "showcaseId": "capability_standard_graph_op_LoadConfigFloat",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryBlackboardAcceptanceTests.LoadConfigFloat_NotZero_CaptionContainsConfigPower",
+        "GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps"
+      ]
     },
     {
       "op": "LoadConfigInt",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase;GraphOpsBlackboardShowcaseAcceptanceTests.RegistryName_MemoConfigAndLifecycleTransaction_DetailIsPlayerReadable;GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps",
       "showcaseId": "capability_standard_graph_op_LoadConfigInt",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase",
+        "GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps"
+      ]
     },
     {
       "op": "LoadConfigEffectId",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase;GraphOpsBlackboardShowcaseAcceptanceTests.RegistryName_MemoConfigAndLifecycleTransaction_DetailIsPlayerReadable;GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps",
       "showcaseId": "capability_standard_graph_op_LoadConfigEffectId",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase",
+        "GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps"
+      ]
     },
     {
       "op": "LoadContextSource",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectEventControlKnowledgeOps_CompileAndEmit;GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchControlDomainAndSnap_PlayerReadable",
       "showcaseId": "capability_standard_graph_op_LoadContextSource",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectEventControlKnowledgeOps_CompileAndEmit",
+        "GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps"
+      ]
     },
     {
       "op": "LoadContextTarget",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_ReadHealthStrikeApplyRemove_CompletesUnderBudget;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_PlayerFacingPhrases_ArePresentAcrossWaves;GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch",
       "showcaseId": "capability_standard_graph_op_LoadContextTarget",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions",
+        "GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch"
+      ]
     },
     {
       "op": "LoadContextTargetContext",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectEventControlKnowledgeOps_CompileAndEmit;GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchControlDomainAndSnap_PlayerReadable",
       "showcaseId": "capability_standard_graph_op_LoadContextTargetContext",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectEventControlKnowledgeOps_CompileAndEmit",
+        "GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_MemoGraph_ContainsAllBlackboardAndConfigOps"
+      ]
     },
     {
       "op": "LoadSelfAttribute",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_ReadHealthStrikeApplyRemove_CompletesUnderBudget;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_PlayerFacingPhrases_ArePresentAcrossWaves;GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch",
       "showcaseId": "capability_standard_graph_op_LoadSelfAttribute",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions",
+        "GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch"
+      ]
     },
     {
       "op": "WriteSelfAttribute",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_ReadHealthStrikeApplyRemove_CompletesUnderBudget;GraphOpsAttrShowcaseAcceptanceTests.AttrVignette_PlayerFacingPhrases_ArePresentAcrossWaves;GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch",
       "showcaseId": "capability_standard_graph_op_WriteSelfAttribute",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.WriteSelfAttribute_RaisesCasterHealth",
+        "GraphOpsNodeGalleryAttrAcceptanceTests.WriteSelfAttribute_SecondThinkStillHealsFromOpening",
+        "GraphOpsAttrShowcaseAcceptanceTests.FrontDoor_AttrGraphs_EmitCompareSelectAndBranch"
+      ]
     },
     {
       "op": "RelationshipEnsureLink",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectRelationshipPairMutationAndReadOps_CompileAndEmit;GraphEffectAuthoringExpressivenessTests.FrontDoor_RelationshipOpsRequireAuthoredSymbols",
       "showcaseId": "capability_standard_graph_op_RelationshipEnsureLink",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectRelationshipPairMutationAndReadOps_CompileAndEmit",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_RelationshipOpsRequireAuthoredSymbols"
+      ]
     },
     {
       "op": "RelationshipRemoveLink",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption;GraphOpsRelShowcaseAcceptanceTests.GraphOpsRel_FriendChainRankAndUnlink_UnderBudget;GraphOpsRelShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_RelationshipRemoveLink",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RemoveLink_DecreasesLinks",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RemoveLink_SecondThinkStillBreaksALink"
+      ]
     },
     {
       "op": "RelationshipSetMetric",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectRelationshipPairMutationAndReadOps_CompileAndEmit;GraphEffectAuthoringExpressivenessTests.FrontDoor_RelationshipOpsRequireAuthoredSymbols",
       "showcaseId": "capability_standard_graph_op_RelationshipSetMetric",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySandboxAcceptanceTests.RelationshipSetMetric_MapsLoyaltyEightyOntoAllyBar",
+        "GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectRelationshipPairMutationAndReadOps_CompileAndEmit",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_RelationshipOpsRequireAuthoredSymbols"
+      ]
     },
     {
       "op": "RelationshipAddMetric",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectRelationshipPairMutationAndReadOps_CompileAndEmit",
       "showcaseId": "capability_standard_graph_op_RelationshipAddMetric",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectRelationshipPairMutationAndReadOps_CompileAndEmit"
+      ]
     },
     {
       "op": "RelationshipGetMetric",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption;GraphOpsRelShowcaseAcceptanceTests.GraphOpsRel_FriendChainRankAndUnlink_UnderBudget;GraphOpsRelShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_RelationshipGetMetric",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryRelAcceptanceTests.GetMetric_CaptionContainsNumber",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption"
+      ]
     },
     {
       "op": "RelationshipHasFlag",
@@ -650,261 +1165,444 @@
         "Linear",
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectRelationshipPairMutationAndReadOps_CompileAndEmit;GraphEffectAuthoringExpressivenessTests.FrontDoor_QueryRelationshipPairAndPredicateOps_CompileAndEmit;GraphEffectAuthoringExpressivenessTests.FrontDoor_RelationshipOpsRequireAuthoredSymbols",
       "showcaseId": "capability_standard_graph_op_RelationshipHasFlag",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectRelationshipPairMutationAndReadOps_CompileAndEmit",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_QueryRelationshipPairAndPredicateOps_CompileAndEmit",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_RelationshipOpsRequireAuthoredSymbols"
+      ]
     },
     {
       "op": "RelationshipSetFlag",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption;GraphOpsRelShowcaseAcceptanceTests.GraphOpsRel_FriendChainRankAndUnlink_UnderBudget;GraphOpsRelShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_RelationshipSetFlag",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption"
+      ]
     },
     {
       "op": "RelationshipQueryOutgoing",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption;GraphOpsRelShowcaseAcceptanceTests.GraphOpsRel_FriendChainRankAndUnlink_UnderBudget;GraphOpsRelShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_RelationshipQueryOutgoing",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryRelAcceptanceTests.QueryOutgoing_FriendCountGreaterThanZero",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption"
+      ]
     },
     {
       "op": "RelationshipQueryIncoming",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption;GraphOpsRelShowcaseAcceptanceTests.GraphOpsRel_FriendChainRankAndUnlink_UnderBudget;GraphOpsRelShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_RelationshipQueryIncoming",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption"
+      ]
     },
     {
       "op": "RelationshipQueryMutual",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption;GraphOpsRelShowcaseAcceptanceTests.GraphOpsRel_FriendChainRankAndUnlink_UnderBudget;GraphOpsRelShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_RelationshipQueryMutual",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption"
+      ]
     },
     {
       "op": "RelationshipQueryBetweenPair",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption;GraphOpsRelShowcaseAcceptanceTests.GraphOpsRel_FriendChainRankAndUnlink_UnderBudget;GraphOpsRelShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_RelationshipQueryBetweenPair",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption"
+      ]
     },
     {
       "op": "RelationshipFilterMetricRange",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption;GraphOpsRelShowcaseAcceptanceTests.GraphOpsRel_FriendChainRankAndUnlink_UnderBudget;GraphOpsRelShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_RelationshipFilterMetricRange",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption"
+      ]
     },
     {
       "op": "RelationshipFilterFlag",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption;GraphOpsRelShowcaseAcceptanceTests.GraphOpsRel_FriendChainRankAndUnlink_UnderBudget;GraphOpsRelShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_RelationshipFilterFlag",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption"
+      ]
     },
     {
       "op": "RelationshipSortByMetric",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption;GraphOpsRelShowcaseAcceptanceTests.GraphOpsRel_FriendChainRankAndUnlink_UnderBudget;GraphOpsRelShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_RelationshipSortByMetric",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption"
+      ]
     },
     {
       "op": "RelationshipAggSumMetric",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption;GraphOpsRelShowcaseAcceptanceTests.GraphOpsRel_FriendChainRankAndUnlink_UnderBudget;GraphOpsRelShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_RelationshipAggSumMetric",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption"
+      ]
     },
     {
       "op": "RelationshipAggMaxMetric",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption;GraphOpsRelShowcaseAcceptanceTests.GraphOpsRel_FriendChainRankAndUnlink_UnderBudget;GraphOpsRelShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_RelationshipAggMaxMetric",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption"
+      ]
     },
     {
       "op": "RelationshipAggAverageMetric",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption;GraphOpsRelShowcaseAcceptanceTests.GraphOpsRel_FriendChainRankAndUnlink_UnderBudget;GraphOpsRelShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_RelationshipAggAverageMetric",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption"
+      ]
     },
     {
       "op": "QueryAllMapEntities",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount",
       "showcaseId": "capability_standard_graph_op_QueryAllMapEntities",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount",
+        "GraphOpsNodeGalleryQueryAcceptanceTests.QueryAllMapEntities_CountMatchesSeededMapEntities"
+      ]
     },
     {
       "op": "QueryFromCollection",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount",
       "showcaseId": "capability_standard_graph_op_QueryFromCollection",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount",
+        "GraphOpsNodeGalleryQueryAcceptanceTests.QueryFromCollection_LightsTheRoster"
+      ]
     },
     {
       "op": "QueryFilterTeam",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount",
       "showcaseId": "capability_standard_graph_op_QueryFilterTeam",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount",
+        "GraphOpsNodeGalleryQueryAcceptanceTests.QueryFilterTeam_KeepsHostileCamp"
+      ]
     },
     {
       "op": "QueryFilterTemplate",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount",
       "showcaseId": "capability_standard_graph_op_QueryFilterTemplate",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount"
+      ]
     },
     {
       "op": "QueryFilterAttributeRange",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount",
       "showcaseId": "capability_standard_graph_op_QueryFilterAttributeRange",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount"
+      ]
     },
     {
       "op": "QueryFilterTagAny",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount",
       "showcaseId": "capability_standard_graph_op_QueryFilterTagAny",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount"
+      ]
     },
     {
       "op": "QueryFilterTagNone",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount",
       "showcaseId": "capability_standard_graph_op_QueryFilterTagNone",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount"
+      ]
     },
     {
       "op": "QuerySortByAttribute",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount",
       "showcaseId": "capability_standard_graph_op_QuerySortByAttribute",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount"
+      ]
     },
     {
       "op": "AggSumAttribute",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount",
       "showcaseId": "capability_standard_graph_op_AggSumAttribute",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount"
+      ]
     },
     {
       "op": "AggAverageAttribute",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount",
       "showcaseId": "capability_standard_graph_op_AggAverageAttribute",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount"
+      ]
     },
     {
       "op": "AggMaxAttribute",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount",
       "showcaseId": "capability_standard_graph_op_AggMaxAttribute",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount"
+      ]
     },
     {
       "op": "AggMinAttribute",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount",
       "showcaseId": "capability_standard_graph_op_AggMinAttribute",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount"
+      ]
     },
     {
       "op": "AggMaxEntityByAttribute",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount",
       "showcaseId": "capability_standard_graph_op_AggMaxEntityByAttribute",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryQueryAcceptanceTests.AggMaxEntityByAttribute_NamesTheThickest",
+        "GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount"
+      ]
     },
     {
       "op": "AggMinEntityByAttribute",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount",
       "showcaseId": "capability_standard_graph_op_AggMinEntityByAttribute",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount"
+      ]
     },
     {
       "op": "RelationshipAggMinMetric",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption;GraphOpsRelShowcaseAcceptanceTests.GraphOpsRel_FriendChainRankAndUnlink_UnderBudget;GraphOpsRelShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_RelationshipAggMinMetric",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption"
+      ]
     },
     {
       "op": "RelationshipAggMaxEntityByMetric",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption;GraphOpsRelShowcaseAcceptanceTests.GraphOpsRel_FriendChainRankAndUnlink_UnderBudget;GraphOpsRelShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_RelationshipAggMaxEntityByMetric",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryRelAcceptanceTests.AggMaxEntityByMetric_NamesHighestPerson",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption"
+      ]
     },
     {
       "op": "RelationshipAggMinEntityByMetric",
       "authorableKinds": [
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption;GraphOpsRelShowcaseAcceptanceTests.GraphOpsRel_FriendChainRankAndUnlink_UnderBudget;GraphOpsRelShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_RelationshipAggMinEntityByMetric",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption"
+      ]
     },
     {
       "op": "RelationshipHasLink",
@@ -912,189 +1610,347 @@
         "Linear",
         "Query"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption;GraphOpsRelShowcaseAcceptanceTests.GraphOpsRel_FriendChainRankAndUnlink_UnderBudget;GraphOpsRelShowcaseAcceptanceTests.RegistryName_DelegatesToSeparatedSuite",
       "showcaseId": "capability_standard_graph_op_RelationshipHasLink",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption"
+      ]
     },
     {
       "op": "BeginLifecycleTransaction",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase;GraphOpsBlackboardShowcaseAcceptanceTests.RegistryName_MemoConfigAndLifecycleTransaction_DetailIsPlayerReadable;GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_LifecycleGraph_ContainsTransactionAndBuiltinOps",
       "showcaseId": "capability_standard_graph_op_BeginLifecycleTransaction",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryBlackboardAcceptanceTests.BeginLifecycleTransaction_CaptionContainsTransaction",
+        "GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_LifecycleGraph_ContainsTransactionAndBuiltinOps"
+      ]
     },
     {
       "op": "InvokeBuiltin",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase;GraphOpsBlackboardShowcaseAcceptanceTests.RegistryName_MemoConfigAndLifecycleTransaction_DetailIsPlayerReadable;GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_LifecycleGraph_ContainsTransactionAndBuiltinOps",
       "showcaseId": "capability_standard_graph_op_InvokeBuiltin",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryBlackboardAcceptanceTests.InvokeBuiltin_ClearsMark_CaptionIsPlayerChinese",
+        "GraphOpsBlackboardShowcaseAcceptanceTests.FrontDoor_LifecycleGraph_ContainsTransactionAndBuiltinOps"
+      ]
     },
     {
       "op": "LoadTargetPosX",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryEventAcceptanceTests.SnapToNearestInCollection_SucceedsWithPlayerCaption;GraphEffectAuthoringExpressivenessTests.FrontDoor_ValidationPlacementOps_CompileAndEmit;GraphOpsEventShowcaseAcceptanceTests.EventVignette_PlacementGraph_ContainsSnapOps;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchControlDomainAndSnap_PlayerReadable",
       "showcaseId": "capability_standard_graph_op_LoadTargetPosX",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryEventAcceptanceTests.EventFamilyOp_RendersPlayerCaption",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_ValidationPlacementOps_CompileAndEmit",
+        "GraphOpsEventShowcaseAcceptanceTests.EventVignette_PlacementGraph_ContainsSnapOps"
+      ]
     },
     {
       "op": "LoadTargetPosY",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryEventAcceptanceTests.SnapToNearestInCollection_SucceedsWithPlayerCaption;GraphEffectAuthoringExpressivenessTests.FrontDoor_ValidationPlacementOps_CompileAndEmit;GraphOpsEventShowcaseAcceptanceTests.EventVignette_PlacementGraph_ContainsSnapOps;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchControlDomainAndSnap_PlayerReadable",
       "showcaseId": "capability_standard_graph_op_LoadTargetPosY",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryEventAcceptanceTests.EventFamilyOp_RendersPlayerCaption",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_ValidationPlacementOps_CompileAndEmit",
+        "GraphOpsEventShowcaseAcceptanceTests.EventVignette_PlacementGraph_ContainsSnapOps"
+      ]
     },
     {
       "op": "ClampTargetToRange",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryEventAcceptanceTests.SnapToNearestInCollection_SucceedsWithPlayerCaption;GraphEffectAuthoringExpressivenessTests.FrontDoor_ValidationPlacementOps_CompileAndEmit;GraphOpsEventShowcaseAcceptanceTests.EventVignette_PlacementGraph_ContainsSnapOps;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchControlDomainAndSnap_PlayerReadable",
       "showcaseId": "capability_standard_graph_op_ClampTargetToRange",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryEventAcceptanceTests.ClampTargetToRange_PullsLandingPointInRange",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_ValidationPlacementOps_CompileAndEmit",
+        "GraphOpsEventShowcaseAcceptanceTests.EventVignette_PlacementGraph_ContainsSnapOps"
+      ]
     },
     {
       "op": "IsPointInCircle",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryEventAcceptanceTests.SnapToNearestInCollection_SucceedsWithPlayerCaption;GraphEffectAuthoringExpressivenessTests.FrontDoor_ValidationPlacementOps_CompileAndEmit;GraphOpsEventShowcaseAcceptanceTests.EventVignette_PlacementGraph_ContainsSnapOps;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchControlDomainAndSnap_PlayerReadable",
       "showcaseId": "capability_standard_graph_op_IsPointInCircle",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryEventAcceptanceTests.EventFamilyOp_RendersPlayerCaption",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_ValidationPlacementOps_CompileAndEmit",
+        "GraphOpsEventShowcaseAcceptanceTests.EventVignette_PlacementGraph_ContainsSnapOps"
+      ]
     },
     {
       "op": "SnapToNearestInCollection",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryEventAcceptanceTests.SnapToNearestInCollection_SucceedsWithPlayerCaption;GraphEffectAuthoringExpressivenessTests.FrontDoor_ValidationPlacementOps_CompileAndEmit;GraphOpsEventShowcaseAcceptanceTests.EventVignette_PlacementGraph_ContainsSnapOps;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchControlDomainAndSnap_PlayerReadable",
       "showcaseId": "capability_standard_graph_op_SnapToNearestInCollection",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryEventAcceptanceTests.SnapToNearestInCollection_SucceedsWithPlayerCaption",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_ValidationPlacementOps_CompileAndEmit",
+        "GraphOpsEventShowcaseAcceptanceTests.EventVignette_PlacementGraph_ContainsSnapOps"
+      ]
     },
     {
       "op": "SnapToNearestGraphEdge",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryEventAcceptanceTests.SnapToNearestInCollection_SucceedsWithPlayerCaption;GraphEffectAuthoringExpressivenessTests.FrontDoor_ValidationPlacementOps_CompileAndEmit;GraphOpsEventShowcaseAcceptanceTests.EventVignette_PlacementGraph_ContainsSnapOps;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchControlDomainAndSnap_PlayerReadable",
       "showcaseId": "capability_standard_graph_op_SnapToNearestGraphEdge",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryEventAcceptanceTests.SnapToNearestGraphEdge_SnapsOntoTheRoad",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_ValidationPlacementOps_CompileAndEmit",
+        "GraphOpsEventShowcaseAcceptanceTests.EventVignette_PlacementGraph_ContainsSnapOps"
+      ]
     },
     {
       "op": "LoadViewer",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryEventAcceptanceTests.SnapToNearestInCollection_SucceedsWithPlayerCaption;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchGraph_ContainsEventControlOps;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchControlDomainAndSnap_PlayerReadable",
       "showcaseId": "capability_standard_graph_op_LoadViewer",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryEventAcceptanceTests.LoadViewer_ReadsTheAudience",
+        "GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchGraph_ContainsEventControlOps"
+      ]
     },
     {
       "op": "LoadEventPayloadInt",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryEventAcceptanceTests.SnapToNearestInCollection_SucceedsWithPlayerCaption;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectEventControlKnowledgeOps_CompileAndEmit;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchGraph_ContainsEventControlOps;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchControlDomainAndSnap_PlayerReadable",
       "showcaseId": "capability_standard_graph_op_LoadEventPayloadInt",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryEventAcceptanceTests.EventFamilyOp_RendersPlayerCaption",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectEventControlKnowledgeOps_CompileAndEmit",
+        "GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchGraph_ContainsEventControlOps"
+      ]
     },
     {
       "op": "LoadEventPayloadFloat",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryEventAcceptanceTests.SnapToNearestInCollection_SucceedsWithPlayerCaption;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectEventControlKnowledgeOps_CompileAndEmit;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchGraph_ContainsEventControlOps;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchControlDomainAndSnap_PlayerReadable",
       "showcaseId": "capability_standard_graph_op_LoadEventPayloadFloat",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryEventAcceptanceTests.EventFamilyOp_RendersPlayerCaption",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectEventControlKnowledgeOps_CompileAndEmit",
+        "GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchGraph_ContainsEventControlOps"
+      ]
     },
     {
       "op": "ControlDomainResolve",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryEventAcceptanceTests.SnapToNearestInCollection_SucceedsWithPlayerCaption;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectEventControlKnowledgeOps_CompileAndEmit;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchGraph_ContainsEventControlOps;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchControlDomainAndSnap_PlayerReadable",
       "showcaseId": "capability_standard_graph_op_ControlDomainResolve",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryEventAcceptanceTests.EventFamilyOp_RendersPlayerCaption",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectEventControlKnowledgeOps_CompileAndEmit",
+        "GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchGraph_ContainsEventControlOps"
+      ]
     },
     {
       "op": "ControlDomainControls",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryEventAcceptanceTests.SnapToNearestInCollection_SucceedsWithPlayerCaption;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectEventControlKnowledgeOps_CompileAndEmit;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchGraph_ContainsEventControlOps;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchControlDomainAndSnap_PlayerReadable",
       "showcaseId": "capability_standard_graph_op_ControlDomainControls",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryEventAcceptanceTests.EventFamilyOp_RendersPlayerCaption",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectEventControlKnowledgeOps_CompileAndEmit",
+        "GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchGraph_ContainsEventControlOps"
+      ]
     },
     {
       "op": "KnowledgeHasProjection",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryEventAcceptanceTests.SnapToNearestInCollection_SucceedsWithPlayerCaption;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectEventControlKnowledgeOps_CompileAndEmit;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchGraph_ContainsEventControlOps;GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchControlDomainAndSnap_PlayerReadable",
       "showcaseId": "capability_standard_graph_op_KnowledgeHasProjection",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryEventAcceptanceTests.KnowledgeHasProjection_ShowsVisible",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectEventControlKnowledgeOps_CompileAndEmit",
+        "GraphOpsEventShowcaseAcceptanceTests.EventVignette_DispatchGraph_ContainsEventControlOps"
+      ]
     },
     {
       "op": "Call",
       "authorableKinds": [
         "Script"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryScriptAcceptanceTests.ScriptOps_SmokeTick_SubstitutesCaption;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_DrinkAndPatrol_YieldThenHalt;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_PlayerFacingPhrases_LockDrinkPatrolConstAcrossWaves;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_CoreGraphs_EmitControlFlowOps",
       "showcaseId": "capability_standard_graph_op_Call",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryScriptAcceptanceTests.ScriptOps_SmokeTick_SubstitutesCaption",
+        "GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_CoreGraphs_EmitControlFlowOps"
+      ]
     },
     {
       "op": "Return",
       "authorableKinds": [
         "Script"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryScriptAcceptanceTests.ScriptOps_SmokeTick_SubstitutesCaption;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_DrinkAndPatrol_YieldThenHalt;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_PlayerFacingPhrases_LockDrinkPatrolConstAcrossWaves;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_CoreGraphs_EmitControlFlowOps",
       "showcaseId": "capability_standard_graph_op_Return",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryScriptAcceptanceTests.ScriptOps_SmokeTick_SubstitutesCaption",
+        "GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_CoreGraphs_EmitControlFlowOps"
+      ]
     },
     {
       "op": "Yield",
       "authorableKinds": [
         "Script"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryScriptAcceptanceTests.ScriptOps_SmokeTick_SubstitutesCaption;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_DrinkAndPatrol_YieldThenHalt;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_PlayerFacingPhrases_LockDrinkPatrolConstAcrossWaves;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_CoreGraphs_EmitControlFlowOps",
       "showcaseId": "capability_standard_graph_op_Yield",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryScriptAcceptanceTests.Yield_FillsWaterAcrossTicks_AndCaptionRests",
+        "GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_CoreGraphs_EmitControlFlowOps"
+      ]
     },
     {
       "op": "HaltReturnInt",
       "authorableKinds": [
         "Script"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryScriptAcceptanceTests.ScriptOps_SmokeTick_SubstitutesCaption;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_ConstPipeline_ReturnsSeven;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_PlayerFacingPhrases_LockDrinkPatrolConstAcrossWaves;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_CoreGraphs_EmitControlFlowOps",
       "showcaseId": "capability_standard_graph_op_HaltReturnInt",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryScriptAcceptanceTests.HaltReturnInt_CaptionReportsSeven",
+        "GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_CoreGraphs_EmitControlFlowOps"
+      ]
     },
     {
       "op": "InvokeScript",
       "authorableKinds": [
         "Linear"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryScriptAcceptanceTests.ScriptOps_SmokeTick_SubstitutesCaption;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_ConstPipeline_ReturnsSeven;GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectInvokeScriptFunctionName_CompilesAndPatchesViaFuncLib;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_PlayerFacingPhrases_LockDrinkPatrolConstAcrossWaves;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_CoreGraphs_EmitControlFlowOps",
       "showcaseId": "capability_standard_graph_op_InvokeScript",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryScriptAcceptanceTests.ScriptOps_SmokeTick_SubstitutesCaption",
+        "GraphEffectAuthoringExpressivenessTests.FrontDoor_EffectInvokeScriptFunctionName_CompilesAndPatchesViaFuncLib",
+        "GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_CoreGraphs_EmitControlFlowOps"
+      ]
     },
     {
       "op": "MoveInt",
       "authorableKinds": [
         "Script"
       ],
-      "unitTestFilter": "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId;GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption;GraphOpsNodeGalleryScriptAcceptanceTests.ScriptOps_SmokeTick_SubstitutesCaption;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_DrinkAndPatrol_YieldThenHalt;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_PlayerFacingPhrases_LockDrinkPatrolConstAcrossWaves;GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_CoreGraphs_EmitControlFlowOps",
       "showcaseId": "capability_standard_graph_op_MoveInt",
-      "status": "covered"
+      "status": "covered",
+      "unitTestRefs": [
+        "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+        "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption",
+        "GraphOpsNodeGalleryAcceptanceTests.ExistingVignettes_CompileWithFeaturedOp",
+        "GraphOpsNodeGalleryAcceptanceTests.GeneratedMaps_SpawnEveryVignetteActor",
+        "GraphOpsNodeGalleryScriptAcceptanceTests.ScriptOps_SmokeTick_SubstitutesCaption",
+        "GraphOpsScriptShowcaseAcceptanceTests.ScriptControl_CoreGraphs_EmitControlFlowOps"
+      ]
     }
   ]
 }

--- a/scripts/generate-graph-op-node-galleries.py
+++ b/scripts/generate-graph-op-node-galleries.py
@@ -9,7 +9,7 @@ Writes/upserts (do not hand-edit these outputs):
   - launcher.config.json bindings
   - launcher.presets.json raylib presets
   - showcase.registry.json entries + gallery csproj exemption
-  - assets/Configs/GAS/graph_node_op_coverage.registry.json showcaseId + gallery unitTestFilter
+  - assets/Configs/GAS/graph_node_op_coverage.registry.json showcaseId + gallery unitTestRefs
   - family capability_standard_graph_ops_* registry status=retired and player presets removed
 
 Subagents own vignettes, FrontDoor graphs, and family driver files only.
@@ -18,8 +18,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 import sys
 from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+from graph_op_coverage_index import coverage_refs_for_op, index_gas_tests
 
 PREFIX = "capability_standard_graph_op_"
 GALLERY_REL = "mods/showcases/capability_standard/CapabilityStandardGraphOpsNodeGalleryMod"
@@ -27,19 +33,7 @@ ENTRY_ROOT_REL = "mods/showcases/capability_standard/graph_op_entries"
 COVERAGE_REL = "assets/Configs/GAS/graph_node_op_coverage.registry.json"
 ACCEPTANCE = "GraphOpsNodeGalleryAcceptanceTests"
 WIKI_DOCS = "gitbook/reference/graph-node-op-wiki"
-GALLERY_ID_TEST = "GraphOpsNodeGalleryAcceptanceTests.EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId"
-GALLERY_TICK_TEST = "GraphOpsNodeGalleryAcceptanceTests.EveryVignette_TicksOnce_WithChineseCaption"
-DRIVER_FAMILY_TEST = {
-    "linear": "GraphOpsNodeGalleryFloatAcceptanceTests.FloatFamilyOp_RendersPlayerCaption",
-    "attr": "GraphOpsNodeGalleryAttrAcceptanceTests.AttrFamilyOps_RenderPlayerCaptions",
-    "script": "GraphOpsNodeGalleryScriptAcceptanceTests.ScriptOps_SmokeTick_SubstitutesCaption",
-    "sandbox": "GraphOpsNodeGallerySandboxAcceptanceTests.SandboxVignettes_TickWithChineseCaptions",
-    "spatial": "GraphOpsNodeGallerySpatialAcceptanceTests.SpatialGalleries_PlayerCopyStaysChinese_AndTargetListIsNonEmpty",
-    "event": "GraphOpsNodeGalleryEventAcceptanceTests.SnapToNearestInCollection_SucceedsWithPlayerCaption",
-    "blackboard": "GraphOpsNodeGalleryBlackboardAcceptanceTests.BlackboardOp_CaptionContainsAssertPhrase",
-    "rel": "GraphOpsNodeGalleryRelAcceptanceTests.RelFamilyOp_RendersPlayerCaption",
-    "query": "GraphOpsNodeGalleryQueryAcceptanceTests.EveryQueryGallery_HasChineseNumbers_AndNonZeroCount",
-}
+FAMILY_PREFIX = "capability_standard_graph_ops_"
 FAMILY_SHOWCASE_IDS = (
     "capability_standard_graph_ops_attr",
     "capability_standard_graph_ops_float",
@@ -132,22 +126,6 @@ def collect_team_bindings(actors: list, template_teams: dict[str, int]) -> list[
         {"TeamId": team_id, "RepresentativeInstanceId": instance_id}
         for team_id, instance_id in sorted(representatives.items())
     ]
-
-
-def coverage_filters(driver: str, existing: str) -> str:
-    parts: list[str] = [GALLERY_ID_TEST, GALLERY_TICK_TEST]
-    family = DRIVER_FAMILY_TEST.get(driver)
-    if family:
-        parts.append(family)
-    for token in (existing or "").split(";"):
-        token = token.strip()
-        if token.startswith("FullyQualifiedName~"):
-            token = token.split("~", 1)[1].strip()
-        if "." not in token:
-            continue
-        if token and token not in parts:
-            parts.append(token)
-    return ";".join(parts)
 
 
 def write_map(
@@ -258,6 +236,68 @@ def upsert_by_key(items: list, key: str, value: str, entry: dict) -> None:
     items.append(entry)
 
 
+def is_per_op_showcase_id(sid: str) -> bool:
+    return sid.startswith(PREFIX) and not sid.startswith(FAMILY_PREFIX)
+
+
+def remove_orphan_per_op_artifacts(
+    repo: Path,
+    live_ops: set[str],
+    maps_dir: Path,
+    bindings: list,
+    preset_list: list,
+    showcases: list,
+) -> list[str]:
+    live_ids = {PREFIX + op for op in live_ops}
+    removed: list[str] = []
+
+    for path in list(maps_dir.glob("*.json")):
+        sid = path.stem
+        if is_per_op_showcase_id(sid) and sid not in live_ids:
+            path.unlink()
+            removed.append(str(path.relative_to(repo)))
+
+    entry_root = repo / ENTRY_ROOT_REL
+    if entry_root.is_dir():
+        for folder in list(entry_root.iterdir()):
+            name = folder.name
+            if not name.startswith("CapabilityStandardGraphOp") or not name.endswith("EntryMod"):
+                continue
+            op = name[len("CapabilityStandardGraphOp") : -len("EntryMod")]
+            if op not in live_ops:
+                shutil.rmtree(folder)
+                removed.append(str(folder.relative_to(repo)))
+
+    kept_bindings = []
+    for binding in bindings:
+        name = binding.get("name", "") if isinstance(binding, dict) else ""
+        if is_per_op_showcase_id(name) and name not in live_ids:
+            removed.append(f"launcher.binding:{name}")
+            continue
+        kept_bindings.append(binding)
+    bindings[:] = kept_bindings
+
+    kept_presets = []
+    for preset in preset_list:
+        preset_id = preset.get("id", "") if isinstance(preset, dict) else ""
+        sid = preset_id[: -len("_raylib")] if preset_id.endswith("_raylib") else ""
+        if is_per_op_showcase_id(sid) and sid not in live_ids:
+            removed.append(f"launcher.preset:{preset_id}")
+            continue
+        kept_presets.append(preset)
+    preset_list[:] = kept_presets
+
+    kept_showcases = []
+    for showcase in showcases:
+        sid = showcase.get("id", "") if isinstance(showcase, dict) else ""
+        if is_per_op_showcase_id(sid) and sid not in live_ids:
+            removed.append(f"showcase:{sid}")
+            continue
+        kept_showcases.append(showcase)
+    showcases[:] = kept_showcases
+    return removed
+
+
 def write_entry_mod(repo: Path, op: str, title: str) -> None:
     ns = f"CapabilityStandardGraphOp{op}EntryMod"
     folder = repo / ENTRY_ROOT_REL / ns
@@ -304,15 +344,23 @@ def main() -> int:
     if args.strict and missing:
         raise SystemExit("Missing vignettes:\n" + "\n".join(missing))
 
-    template_teams = load_template_teams(gallery / "assets" / "Entities" / "templates.json")
+    test_index = index_gas_tests(repo, ops)
+    coverage["description"] = (
+        "GraphNodeOp coverage SSOT. Each executable opcode must have status=covered, "
+        "a per-op showcaseId, and unitTestRefs: Class.Method pairs measured to execute that op."
+    )
     for entry in coverage["entries"]:
         op = entry["op"]
         entry["showcaseId"] = PREFIX + op
         vignette = vignettes.get(op)
         driver = vignette["driver"] if vignette else None
         if not driver:
-            raise SystemExit(f"Coverage op '{op}' has no vignette driver; cannot write gallery unitTestFilter.")
-        entry["unitTestFilter"] = coverage_filters(driver, entry.get("unitTestFilter", ""))
+            raise SystemExit(f"Coverage op '{op}' has no vignette driver; cannot write gallery unitTestRefs.")
+        existing = entry.get("unitTestRefs")
+        if existing is None:
+            existing = entry.get("unitTestFilter", "")
+        entry.pop("unitTestFilter", None)
+        entry["unitTestRefs"] = coverage_refs_for_op(op, existing, test_index)
         if entry.get("status") != "covered":
             raise SystemExit(f"Coverage op '{op}' status is {entry.get('status')!r}; generator only emits covered per-op galleries.")
     dump(coverage_path, coverage)
@@ -339,6 +387,7 @@ def main() -> int:
     showcases = registry.setdefault("showcases", [])
     bindings = launcher.setdefault("bindings", [])
     preset_list = presets.setdefault("presets", [])
+    template_teams = load_template_teams(gallery / "assets" / "Entities" / "templates.json")
 
     for op, vignette in vignettes.items():
         sid = PREFIX + op
@@ -422,14 +471,24 @@ def main() -> int:
         )
     presets["presets"] = [preset for preset in preset_list if preset.get("id") not in family_presets]
 
+    orphans = remove_orphan_per_op_artifacts(
+        repo,
+        set(vignettes),
+        maps_dir,
+        bindings,
+        presets["presets"],
+        showcases,
+    )
+
     dump(launcher_path, launcher)
     dump(presets_path, presets)
     dump(registry_path, registry)
 
     print(
         f"Generated {len(vignettes)} per-op galleries; "
-        f"coverage showcaseIds+filters updated for {len(ops)} ops; "
+        f"coverage showcaseIds+unitTestRefs updated for {len(ops)} ops; "
         f"retired {len(FAMILY_SHOWCASE_IDS)} family player entries; "
+        f"removed {len(orphans)} per-op orphans; "
         f"missing vignettes: {len(missing)}"
     )
     if missing:

--- a/scripts/graph_op_coverage_index.py
+++ b/scripts/graph_op_coverage_index.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Measure which GasTests methods actually execute which GraphNodeOp.
+
+Coverage attribution must be measured from test source, not inferred from
+driver family tables. The gallery generator and the C# guard implement the
+same expansion rules independently.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+COVERAGE_REL = "assets/Configs/GAS/graph_node_op_coverage.registry.json"
+GAS_TESTS_REL = "src/Tests/GasTests"
+GALLERY_PREFIX = "GraphOpsNodeGallery"
+
+UNIVERSAL_GALLERY_METHODS = (
+    "EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+    "EveryVignette_TicksOnce_WithChineseCaption",
+    "ExistingVignettes_CompileWithFeaturedOp",
+    "GeneratedMaps_SpawnEveryVignetteActor",
+)
+
+UNIVERSAL_GALLERY_REFS = tuple(
+    f"GraphOpsNodeGalleryAcceptanceTests.{name}" for name in UNIVERSAL_GALLERY_METHODS
+)
+
+_CLASS_RE = re.compile(r"(?:public\s+)?(?:sealed\s+)?class\s+(\w+)")
+_METHOD_RE = re.compile(r"public\s+void\s+([A-Za-z0-9_]+)\s*\(")
+_STRING_LIT_RE = re.compile(r'"([A-Za-z][A-Za-z0-9_]*)"')
+_ARRAY_RE = re.compile(
+    r"(?:readonly\s+)?string\[\s*\]\s+(\w+)\s*=\s*\[(.*?)\];",
+    re.DOTALL,
+)
+_TEST_CASE_RE = re.compile(r'\[TestCase\(\s*"([A-Za-z][A-Za-z0-9_]*)"')
+_TEST_CASE_SOURCE_RE = re.compile(r"\[TestCaseSource\(\s*nameof\((\w+)\)\s*\)\]")
+_GRAPH_OP_ENUM_RE = re.compile(r"GraphNodeOp\.([A-Za-z][A-Za-z0-9_]*)")
+_JSON_OP_RE = re.compile(r'"op"\s*:\s*"([A-Za-z][A-Za-z0-9_]*)"')
+_BIND_LIT_RE = re.compile(
+    r"(?:BindOp|Play|TickOp|BindAndTick)\(\s*\"([A-Za-z][A-Za-z0-9_]*)\"\s*\)"
+)
+_BIND_PARAM_RE = re.compile(r"(?:BindOp|Play|TickOp|BindAndTick)\(\s*(\w+)\s*\)")
+_FOREACH_OP_RE = re.compile(r"foreach\s*\(\s*string\s+(\w+)\s+in\s+(\w+)")
+_ENUM_ALL_RE = re.compile(r"Enum\.GetValues(?:<GraphNodeOp>| \(\s*typeof\s*\(\s*GraphNodeOp\s*\)\s*\))")
+_GET_FILES_RE = re.compile(r"GetFiles\s*\(")
+
+
+def read_text(path: Path) -> str:
+    raw = path.read_bytes()
+    for enc in ("utf-8", "utf-8-sig", "utf-16", "latin-1"):
+        try:
+            return raw.decode(enc)
+        except UnicodeDecodeError:
+            continue
+    return raw.decode("utf-8", errors="replace")
+
+
+def load_coverage_ops(repo: Path) -> list[str]:
+    coverage = json.loads((repo / COVERAGE_REL).read_text(encoding="utf-8"))
+    return [entry["op"] for entry in coverage["entries"]]
+
+
+def extract_leading_attributes(text: str, method_start: int) -> str:
+    i = method_start
+    while i > 0 and text[i - 1].isspace():
+        i -= 1
+    chunks: list[str] = []
+    while i > 0 and text[i - 1] == "]":
+        depth = 0
+        j = i - 1
+        found = False
+        while j >= 0:
+            if text[j] == "]":
+                depth += 1
+            elif text[j] == "[":
+                depth -= 1
+                if depth == 0:
+                    chunks.append(text[j:i])
+                    i = j
+                    while i > 0 and text[i - 1].isspace():
+                        i -= 1
+                    found = True
+                    break
+            j -= 1
+        if not found:
+            break
+    chunks.reverse()
+    return "".join(chunks)
+
+
+def extract_balanced(text: str, start: int) -> str:
+    """Return the brace-balanced span starting at text[start] == '{'."""
+    if start >= len(text) or text[start] != "{":
+        return ""
+    depth = 0
+    i = start
+    in_str = None
+    while i < len(text):
+        ch = text[i]
+        if in_str is None:
+            if text.startswith("//", i):
+                nl = text.find("\n", i)
+                i = len(text) if nl < 0 else nl + 1
+                continue
+            if text.startswith("/*", i):
+                end = text.find("*/", i + 2)
+                i = len(text) if end < 0 else end + 2
+                continue
+            if text.startswith('"""', i):
+                end = text.find('"""', i + 3)
+                i = len(text) if end < 0 else end + 3
+                continue
+            if ch in "\"'":
+                in_str = ch
+                i += 1
+                continue
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[start : i + 1]
+        else:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == in_str:
+                in_str = None
+        i += 1
+    return text[start:]
+
+
+def _string_ops(blob: str, op_set: set[str]) -> set[str]:
+    return {lit for lit in _STRING_LIT_RE.findall(blob) if lit in op_set}
+
+
+@dataclass
+class TestMethodIndex:
+    ops: list[str]
+    executed: dict[tuple[str, str], set[str]] = field(default_factory=dict)
+
+    @property
+    def op_set(self) -> set[str]:
+        return set(self.ops)
+
+    def executes(self, class_name: str, method: str, op: str) -> bool:
+        return op in self.executed.get((class_name, method), set())
+
+    def has_method(self, class_name: str, method: str) -> bool:
+        return (class_name, method) in self.executed
+
+    def gallery_specific_refs(self, op: str) -> list[str]:
+        refs: list[str] = []
+        for (cls, method), executed in sorted(self.executed.items()):
+            if not cls.startswith(GALLERY_PREFIX):
+                continue
+            if method in UNIVERSAL_GALLERY_METHODS:
+                continue
+            if op in executed:
+                refs.append(f"{cls}.{method}")
+        return refs
+
+    def is_universal_gallery(self, class_name: str, method: str) -> bool:
+        return class_name.startswith(GALLERY_PREFIX) and method in UNIVERSAL_GALLERY_METHODS
+
+
+def index_gas_tests(repo: Path, ops: list[str] | None = None) -> TestMethodIndex:
+    op_list = list(ops) if ops is not None else load_coverage_ops(repo)
+    op_set = set(op_list)
+    index = TestMethodIndex(ops=op_list)
+    tests_root = repo / GAS_TESTS_REL
+    for path in tests_root.rglob("*Tests.cs"):
+        text = read_text(path)
+        class_match = _CLASS_RE.search(text)
+        if not class_match:
+            continue
+        class_name = class_match.group(1)
+        arrays = {
+            name: {lit for lit in _STRING_LIT_RE.findall(body) if lit in op_set}
+            for name, body in _ARRAY_RE.findall(text)
+        }
+        for match in _METHOD_RE.finditer(text):
+            method = match.group(1)
+            attrs = extract_leading_attributes(text, match.start())
+            after = text[match.end() :]
+            brace = after.find("{")
+            body = extract_balanced(text, match.end() + brace) if brace >= 0 else ""
+            executed = _ops_for_method(method, attrs, body, arrays, op_list, op_set)
+            index.executed[(class_name, method)] = executed
+    return index
+
+
+def _iterates_vignette_files(body: str) -> bool:
+    if not _GET_FILES_RE.search(body) or "*.json" not in body:
+        return False
+    lowered = body.lower()
+    return "vignette" in lowered
+
+
+def _ops_for_method(
+    method: str,
+    attrs: str,
+    body: str,
+    arrays: dict[str, set[str]],
+    op_list: list[str],
+    op_set: set[str],
+) -> set[str]:
+    if _ENUM_ALL_RE.search(body) or _iterates_vignette_files(body):
+        return set(op_list)
+
+    executed: set[str] = set()
+    executed.update(op for op in _TEST_CASE_RE.findall(attrs) if op in op_set)
+    for source in _TEST_CASE_SOURCE_RE.findall(attrs):
+        executed.update(arrays.get(source, set()))
+    executed.update(op for op in _BIND_LIT_RE.findall(body) if op in op_set)
+    executed.update(op for op in _GRAPH_OP_ENUM_RE.findall(body) if op in op_set)
+    executed.update(op for op in _JSON_OP_RE.findall(body) if op in op_set)
+
+    local_arrays = {
+        name: {lit for lit in _STRING_LIT_RE.findall(blob) if lit in op_set}
+        for name, blob in _ARRAY_RE.findall(body)
+    }
+    foreach_vars = {var: src for var, src in _FOREACH_OP_RE.findall(body)}
+    for param in _BIND_PARAM_RE.findall(body):
+        if param in local_arrays:
+            executed.update(local_arrays[param])
+        if param in arrays:
+            executed.update(arrays[param])
+        if param in foreach_vars:
+            src = foreach_vars[param]
+            executed.update(local_arrays.get(src, set()))
+            executed.update(arrays.get(src, set()))
+
+    for op in op_list:
+        if method.startswith(op + "_"):
+            executed.add(op)
+    return executed
+
+
+def normalize_ref(token: str) -> str | None:
+    token = token.strip()
+    if token.startswith("FullyQualifiedName~"):
+        token = token.split("~", 1)[1].strip()
+    if token.count(".") != 1:
+        return None
+    cls, method = token.split(".", 1)
+    if not cls or not method:
+        return None
+    return f"{cls}.{method}"
+
+
+def parse_existing_refs(raw) -> list[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        refs = []
+        for item in raw:
+            ref = normalize_ref(str(item))
+            if ref and ref not in refs:
+                refs.append(ref)
+        return refs
+    refs = []
+    for part in str(raw).split(";"):
+        ref = normalize_ref(part)
+        if ref and ref not in refs:
+            refs.append(ref)
+    return refs
+
+
+def coverage_refs_for_op(op: str, existing, index: TestMethodIndex) -> list[str]:
+    refs: list[str] = list(UNIVERSAL_GALLERY_REFS)
+    specific = index.gallery_specific_refs(op)
+    if not specific:
+        raise SystemExit(
+            f"Coverage op '{op}' has no op-specific GraphOpsNodeGallery test. "
+            "Point it at a test that actually executes this op; do not mark covered by structure."
+        )
+    for ref in specific:
+        if ref not in refs:
+            refs.append(ref)
+    for token in parse_existing_refs(existing):
+        if token in refs:
+            continue
+        cls, method = token.split(".", 1)
+        if index.executes(cls, method, op):
+            refs.append(token)
+    return refs

--- a/src/Tests/GasTests/Graph/GraphNodeOpCoverageRegistryTests.cs
+++ b/src/Tests/GasTests/Graph/GraphNodeOpCoverageRegistryTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using Ludots.Core.NodeLibraries.GASGraph;
 using NUnit.Framework;
 
@@ -14,6 +13,10 @@ namespace Ludots.Tests.GAS
     public sealed class GraphNodeOpCoverageRegistryTests
     {
         private const string RegistryRelativePath = "assets/Configs/GAS/graph_node_op_coverage.registry.json";
+        private const string GalleryMapsRelative =
+            "mods/showcases/capability_standard/CapabilityStandardGraphOpsNodeGalleryMod/assets/Maps";
+        private const string EntryRootRelative =
+            "mods/showcases/capability_standard/graph_op_entries";
 
         [Test]
         public void Registry_ShowcaseId_MustBeUniquePerOp()
@@ -26,7 +29,7 @@ namespace Ludots.Tests.GAS
             {
                 string op = entry.GetProperty("op").GetString() ?? string.Empty;
                 string showcaseId = entry.GetProperty("showcaseId").GetString() ?? string.Empty;
-                Assert.That(showcaseId, Is.EqualTo("capability_standard_graph_op_" + op),
+                Assert.That(showcaseId, Is.EqualTo(GraphOpTestAttribution.PerOpShowcasePrefix + op),
                     $"Coverage showcaseId for {op} must be the per-op gallery, not a family aggregate.");
                 Assert.That(seen.Add(showcaseId), Is.True, $"Duplicate coverage showcaseId '{showcaseId}'.");
             }
@@ -71,60 +74,243 @@ namespace Ludots.Tests.GAS
         }
 
         [Test]
-        public void CoveredEntries_RequireRegisteredGalleryAndGalleryTestFilters()
+        public void CoveredEntries_RequireMeasuredGalleryRefsThatExecuteTheOp()
         {
             string repoRoot = FindRepoRoot();
             HashSet<string> showcaseIds = LoadActiveOrExperimentalShowcaseIds(repoRoot);
-            HashSet<string> testMethods = LoadGasTestMethodNames(repoRoot);
-            using JsonDocument doc = JsonDocument.Parse(File.ReadAllText(Path.Combine(repoRoot, RegistryRelativePath)));
+            List<CoverageEntry> entries = LoadCoverageEntries(repoRoot);
+            GraphOpTestAttribution attribution = GraphOpTestAttribution.Load(
+                repoRoot,
+                entries.Select(e => e.Op));
             var failures = new List<string>();
-            foreach (JsonElement entry in doc.RootElement.GetProperty("entries").EnumerateArray())
+            foreach (CoverageEntry entry in entries)
             {
-                string op = entry.GetProperty("op").GetString() ?? string.Empty;
-                string status = entry.GetProperty("status").GetString() ?? string.Empty;
-                string showcaseId = entry.GetProperty("showcaseId").GetString() ?? string.Empty;
-                string filter = entry.GetProperty("unitTestFilter").GetString() ?? string.Empty;
-                if (!string.Equals(status, "covered", StringComparison.Ordinal))
+                if (!string.Equals(entry.Status, "covered", StringComparison.Ordinal))
                 {
-                    failures.Add($"{op}: status is '{status}', expected covered.");
+                    failures.Add($"{entry.Op}: status is '{entry.Status}', expected covered.");
                     continue;
                 }
 
-                if (!showcaseIds.Contains(showcaseId))
+                if (!showcaseIds.Contains(entry.ShowcaseId))
                 {
-                    failures.Add($"{op}: showcaseId '{showcaseId}' is missing from showcase.registry.json.");
+                    failures.Add($"{entry.Op}: showcaseId '{entry.ShowcaseId}' is missing from showcase.registry.json.");
                 }
 
-                string[] tokens = filter.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-                bool hasGalleryTest = false;
-                foreach (string token in tokens)
+                if (entry.UnitTestRefs.Count == 0)
+                {
+                    failures.Add($"{entry.Op}: unitTestRefs is empty.");
+                    continue;
+                }
+
+                bool hasSpecificGallery = false;
+                foreach (string token in entry.UnitTestRefs)
                 {
                     int dot = token.IndexOf('.');
-                    if (dot <= 0 || dot >= token.Length - 1)
+                    if (dot <= 0 || dot != token.LastIndexOf('.') || dot >= token.Length - 1)
                     {
-                        failures.Add($"{op}: unitTestFilter token '{token}' is not Class.Method.");
+                        failures.Add($"{entry.Op}: unitTestRefs token '{token}' is not Class.Method.");
                         continue;
                     }
 
+                    string className = token[..dot];
                     string method = token[(dot + 1)..];
-                    if (!testMethods.Contains(method))
+                    if (!attribution.HasMethod(className, method))
                     {
-                        failures.Add($"{op}: unitTestFilter '{token}' does not match a GasTests method.");
+                        failures.Add($"{entry.Op}: unitTestRefs '{token}' is not a GasTests (Class, Method) pair.");
+                        continue;
                     }
 
-                    if (token.StartsWith("GraphOpsNodeGallery", StringComparison.Ordinal))
+                    if (!attribution.Executes(className, method, entry.Op))
                     {
-                        hasGalleryTest = true;
+                        failures.Add($"{entry.Op}: unitTestRefs '{token}' does not execute this op.");
+                    }
+
+                    if (GraphOpTestAttribution.IsGallerySpecific(className, method))
+                    {
+                        hasSpecificGallery = true;
                     }
                 }
 
-                if (!hasGalleryTest)
+                if (!hasSpecificGallery)
                 {
-                    failures.Add($"{op}: covered filter has no GraphOpsNodeGallery* test.");
+                    failures.Add($"{entry.Op}: covered refs have no op-specific GraphOpsNodeGallery test.");
                 }
             }
 
             Assert.That(failures, Is.Empty, string.Join(Environment.NewLine, failures));
+        }
+
+        [Test]
+        public void Attribution_RejectsTheKnownFamilyMispointers()
+        {
+            string repoRoot = FindRepoRoot();
+            List<CoverageEntry> entries = LoadCoverageEntries(repoRoot);
+            GraphOpTestAttribution attribution = GraphOpTestAttribution.Load(
+                repoRoot,
+                entries.Select(e => e.Op));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    attribution.Executes(
+                        "GraphOpsNodeGalleryFloatAcceptanceTests",
+                        "FloatFamilyOp_RendersPlayerCaption",
+                        "ConstFloat"),
+                    Is.False);
+                Assert.That(
+                    attribution.Executes(
+                        "GraphOpsNodeGalleryFloatAcceptanceTests",
+                        "FloatFamilyOp_RendersPlayerCaption",
+                        "AddFloat"),
+                    Is.False);
+                Assert.That(
+                    attribution.Executes(
+                        "GraphOpsNodeGalleryEventAcceptanceTests",
+                        "SnapToNearestInCollection_SucceedsWithPlayerCaption",
+                        "SendEvent"),
+                    Is.False);
+                Assert.That(
+                    attribution.Executes(
+                        "GraphOpsNodeGalleryAcceptanceTests",
+                        "ConstFloat_SetsTargetHealthToAuthoredConstant",
+                        "ConstFloat"),
+                    Is.True);
+                Assert.That(
+                    attribution.Executes(
+                        "GraphOpsNodeGalleryEventAcceptanceTests",
+                        "SendEvent_BroadcastsPlayerReadableHit",
+                        "SendEvent"),
+                    Is.True);
+                Assert.That(
+                    attribution.Executes(
+                        "GraphOpsNodeGalleryAcceptanceTests",
+                        "ExistingVignettes_CompileWithFeaturedOp",
+                        "ConstFloat"),
+                    Is.True);
+                Assert.That(
+                    attribution.Executes(
+                        "GraphOpsNodeGalleryAcceptanceTests",
+                        "GeneratedMaps_SpawnEveryVignetteActor",
+                        "AddFloat"),
+                    Is.True);
+            });
+        }
+
+        [Test]
+        public void GeneratedPerOpArtifacts_HaveNoOrphans()
+        {
+            string repoRoot = FindRepoRoot();
+            var liveOps = new HashSet<string>(
+                LoadCoverageEntries(repoRoot).Select(e => e.Op),
+                StringComparer.Ordinal);
+            var failures = new List<string>();
+
+            string mapsDir = Path.Combine(repoRoot, GalleryMapsRelative);
+            if (Directory.Exists(mapsDir))
+            {
+                foreach (string map in Directory.GetFiles(mapsDir, "*.json"))
+                {
+                    string sid = Path.GetFileNameWithoutExtension(map);
+                    if (!GraphOpTestAttribution.IsPerOpShowcaseId(sid))
+                    {
+                        continue;
+                    }
+
+                    string op = sid[GraphOpTestAttribution.PerOpShowcasePrefix.Length..];
+                    if (!liveOps.Contains(op))
+                    {
+                        failures.Add($"orphan map {sid}");
+                    }
+                }
+            }
+
+            string entryRoot = Path.Combine(repoRoot, EntryRootRelative);
+            if (Directory.Exists(entryRoot))
+            {
+                foreach (string folder in Directory.GetDirectories(entryRoot))
+                {
+                    string name = Path.GetFileName(folder);
+                    const string prefix = "CapabilityStandardGraphOp";
+                    const string suffix = "EntryMod";
+                    if (!name.StartsWith(prefix, StringComparison.Ordinal) ||
+                        !name.EndsWith(suffix, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    string op = name[prefix.Length..^suffix.Length];
+                    if (!liveOps.Contains(op))
+                    {
+                        failures.Add($"orphan entry mod {name}");
+                    }
+                }
+            }
+
+            using JsonDocument registry = JsonDocument.Parse(
+                File.ReadAllText(Path.Combine(repoRoot, "showcase.registry.json")));
+            foreach (JsonElement showcase in registry.RootElement.GetProperty("showcases").EnumerateArray())
+            {
+                string id = showcase.GetProperty("id").GetString() ?? string.Empty;
+                if (!GraphOpTestAttribution.IsPerOpShowcaseId(id))
+                {
+                    continue;
+                }
+
+                string op = id[GraphOpTestAttribution.PerOpShowcasePrefix.Length..];
+                if (!liveOps.Contains(op))
+                {
+                    failures.Add($"orphan showcase {id}");
+                }
+            }
+
+            using JsonDocument launcher = JsonDocument.Parse(
+                File.ReadAllText(Path.Combine(repoRoot, "launcher.config.json")));
+            foreach (JsonElement binding in launcher.RootElement.GetProperty("bindings").EnumerateArray())
+            {
+                string name = binding.GetProperty("name").GetString() ?? string.Empty;
+                if (!GraphOpTestAttribution.IsPerOpShowcaseId(name))
+                {
+                    continue;
+                }
+
+                string op = name[GraphOpTestAttribution.PerOpShowcasePrefix.Length..];
+                if (!liveOps.Contains(op))
+                {
+                    failures.Add($"orphan binding {name}");
+                }
+            }
+
+            Assert.That(failures, Is.Empty, string.Join(Environment.NewLine, failures));
+        }
+
+        private static List<CoverageEntry> LoadCoverageEntries(string repoRoot)
+        {
+            using JsonDocument doc = JsonDocument.Parse(File.ReadAllText(Path.Combine(repoRoot, RegistryRelativePath)));
+            var entries = new List<CoverageEntry>();
+            foreach (JsonElement entry in doc.RootElement.GetProperty("entries").EnumerateArray())
+            {
+                var refs = new List<string>();
+                if (entry.TryGetProperty("unitTestRefs", out JsonElement refsEl) &&
+                    refsEl.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (JsonElement item in refsEl.EnumerateArray())
+                    {
+                        string? token = item.GetString();
+                        if (!string.IsNullOrWhiteSpace(token))
+                        {
+                            refs.Add(token);
+                        }
+                    }
+                }
+
+                entries.Add(new CoverageEntry(
+                    entry.GetProperty("op").GetString() ?? string.Empty,
+                    entry.GetProperty("status").GetString() ?? string.Empty,
+                    entry.GetProperty("showcaseId").GetString() ?? string.Empty,
+                    refs));
+            }
+
+            return entries;
         }
 
         private static HashSet<string> LoadActiveOrExperimentalShowcaseIds(string repoRoot)
@@ -147,22 +333,6 @@ namespace Ludots.Tests.GAS
             return ids;
         }
 
-        private static HashSet<string> LoadGasTestMethodNames(string repoRoot)
-        {
-            var methods = new HashSet<string>(StringComparer.Ordinal);
-            string testsRoot = Path.Combine(repoRoot, "src", "Tests", "GasTests");
-            var methodPattern = new Regex(@"public void ([A-Za-z0-9_]+)\s*\(", RegexOptions.Compiled);
-            foreach (string file in Directory.EnumerateFiles(testsRoot, "*Tests.cs", SearchOption.AllDirectories))
-            {
-                foreach (Match match in methodPattern.Matches(File.ReadAllText(file)))
-                {
-                    methods.Add(match.Groups[1].Value);
-                }
-            }
-
-            return methods;
-        }
-
         private static string FindRepoRoot()
         {
             var dir = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
@@ -174,5 +344,11 @@ namespace Ludots.Tests.GAS
             Assert.That(dir, Is.Not.Null, "Repository root not found from test output directory.");
             return dir!.FullName;
         }
+
+        private readonly record struct CoverageEntry(
+            string Op,
+            string Status,
+            string ShowcaseId,
+            List<string> UnitTestRefs);
     }
 }

--- a/src/Tests/GasTests/Graph/GraphOpTestAttribution.cs
+++ b/src/Tests/GasTests/Graph/GraphOpTestAttribution.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Ludots.Tests.GAS
+{
+    internal sealed class GraphOpTestAttribution
+    {
+        internal const string GalleryPrefix = "GraphOpsNodeGallery";
+        internal const string PerOpShowcasePrefix = "capability_standard_graph_op_";
+        internal const string FamilyShowcasePrefix = "capability_standard_graph_ops_";
+
+        internal static readonly string[] UniversalGalleryMethods =
+        [
+            "EveryExecutableOp_HasVignetteGraphAndUniqueShowcaseId",
+            "EveryVignette_TicksOnce_WithChineseCaption",
+            "ExistingVignettes_CompileWithFeaturedOp",
+            "GeneratedMaps_SpawnEveryVignetteActor"
+        ];
+
+        private static readonly Regex ClassPattern = new(
+            @"(?:public\s+)?(?:sealed\s+)?class\s+(\w+)",
+            RegexOptions.Compiled);
+        private static readonly Regex MethodPattern = new(
+            @"public\s+void\s+([A-Za-z0-9_]+)\s*\(",
+            RegexOptions.Compiled);
+        private static readonly Regex StringLitPattern = new(
+            @"""([A-Za-z][A-Za-z0-9_]*)""",
+            RegexOptions.Compiled);
+        private static readonly Regex ArrayPattern = new(
+            @"(?:readonly\s+)?string\[\s*\]\s+(\w+)\s*=\s*\[(.*?)\];",
+            RegexOptions.Compiled | RegexOptions.Singleline);
+        private static readonly Regex TestCasePattern = new(
+            @"\[TestCase\(\s*""([A-Za-z][A-Za-z0-9_]*)""",
+            RegexOptions.Compiled);
+        private static readonly Regex TestCaseSourcePattern = new(
+            @"\[TestCaseSource\(\s*nameof\((\w+)\)\s*\)\]",
+            RegexOptions.Compiled);
+        private static readonly Regex GraphOpEnumPattern = new(
+            @"GraphNodeOp\.([A-Za-z][A-Za-z0-9_]*)",
+            RegexOptions.Compiled);
+        private static readonly Regex JsonOpPattern = new(
+            @"""op""\s*:\s*""([A-Za-z][A-Za-z0-9_]*)""",
+            RegexOptions.Compiled);
+        private static readonly Regex BindLitPattern = new(
+            @"(?:BindOp|Play|TickOp|BindAndTick)\(\s*""([A-Za-z][A-Za-z0-9_]*)""\s*\)",
+            RegexOptions.Compiled);
+        private static readonly Regex BindParamPattern = new(
+            @"(?:BindOp|Play|TickOp|BindAndTick)\(\s*(\w+)\s*\)",
+            RegexOptions.Compiled);
+        private static readonly Regex ForeachOpPattern = new(
+            @"foreach\s*\(\s*string\s+(\w+)\s+in\s+(\w+)",
+            RegexOptions.Compiled);
+        private static readonly Regex EnumAllPattern = new(
+            @"Enum\.GetValues(?:<GraphNodeOp>|\(\s*typeof\s*\(\s*GraphNodeOp\s*\)\s*\))",
+            RegexOptions.Compiled);
+        private static readonly Regex GetFilesPattern = new(@"GetFiles\s*\(", RegexOptions.Compiled);
+
+        private readonly HashSet<string> _ops;
+        private readonly Dictionary<(string ClassName, string Method), HashSet<string>> _executed;
+
+        private GraphOpTestAttribution(
+            HashSet<string> ops,
+            Dictionary<(string ClassName, string Method), HashSet<string>> executed)
+        {
+            _ops = ops;
+            _executed = executed;
+        }
+
+        internal static GraphOpTestAttribution Load(string repoRoot, IEnumerable<string> ops)
+        {
+            var opSet = new HashSet<string>(ops, StringComparer.Ordinal);
+            var executed = new Dictionary<(string, string), HashSet<string>>();
+            string testsRoot = Path.Combine(repoRoot, "src", "Tests", "GasTests");
+            foreach (string file in Directory.EnumerateFiles(testsRoot, "*Tests.cs", SearchOption.AllDirectories))
+            {
+                string text = Encoding.UTF8.GetString(File.ReadAllBytes(file));
+                Match classMatch = ClassPattern.Match(text);
+                if (!classMatch.Success)
+                {
+                    continue;
+                }
+
+                string className = classMatch.Groups[1].Value;
+                Dictionary<string, HashSet<string>> arrays = LoadStringArrays(text, opSet);
+                foreach (Match methodMatch in MethodPattern.Matches(text))
+                {
+                    string method = methodMatch.Groups[1].Value;
+                    string attrs = ExtractLeadingAttributes(text, methodMatch.Index);
+                    int brace = text.IndexOf('{', methodMatch.Index + methodMatch.Length);
+                    string body = brace >= 0 ? ExtractBalanced(text, brace) : string.Empty;
+                    executed[(className, method)] = OpsForMethod(method, attrs, body, arrays, opSet);
+                }
+            }
+
+            return new GraphOpTestAttribution(opSet, executed);
+        }
+
+        internal bool HasMethod(string className, string method)
+        {
+            return _executed.ContainsKey((className, method));
+        }
+
+        internal bool Executes(string className, string method, string op)
+        {
+            return _executed.TryGetValue((className, method), out HashSet<string>? ops) && ops.Contains(op);
+        }
+
+        internal static bool IsUniversalGallery(string className, string method)
+        {
+            return className.StartsWith(GalleryPrefix, StringComparison.Ordinal)
+                   && Array.IndexOf(UniversalGalleryMethods, method) >= 0;
+        }
+
+        internal static bool IsGallerySpecific(string className, string method)
+        {
+            return className.StartsWith(GalleryPrefix, StringComparison.Ordinal)
+                   && !IsUniversalGallery(className, method);
+        }
+
+        internal static bool IsPerOpShowcaseId(string id)
+        {
+            return id.StartsWith(PerOpShowcasePrefix, StringComparison.Ordinal)
+                   && !id.StartsWith(FamilyShowcasePrefix, StringComparison.Ordinal);
+        }
+
+        private static Dictionary<string, HashSet<string>> LoadStringArrays(string text, HashSet<string> opSet)
+        {
+            var arrays = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+            foreach (Match match in ArrayPattern.Matches(text))
+            {
+                arrays[match.Groups[1].Value] = CollectOps(match.Groups[2].Value, StringLitPattern, opSet);
+            }
+
+            return arrays;
+        }
+
+        private static HashSet<string> OpsForMethod(
+            string method,
+            string attrs,
+            string body,
+            Dictionary<string, HashSet<string>> arrays,
+            HashSet<string> opSet)
+        {
+            if (EnumAllPattern.IsMatch(body) || IteratesVignetteFiles(body))
+            {
+                return new HashSet<string>(opSet, StringComparer.Ordinal);
+            }
+
+            var executed = new HashSet<string>(StringComparer.Ordinal);
+            foreach (Match match in TestCasePattern.Matches(attrs))
+            {
+                if (opSet.Contains(match.Groups[1].Value))
+                {
+                    executed.Add(match.Groups[1].Value);
+                }
+            }
+
+            foreach (Match match in TestCaseSourcePattern.Matches(attrs))
+            {
+                if (arrays.TryGetValue(match.Groups[1].Value, out HashSet<string>? sourceOps))
+                {
+                    executed.UnionWith(sourceOps);
+                }
+            }
+
+            executed.UnionWith(CollectOps(body, BindLitPattern, opSet));
+            executed.UnionWith(CollectOps(body, GraphOpEnumPattern, opSet));
+            executed.UnionWith(CollectOps(body, JsonOpPattern, opSet));
+
+            Dictionary<string, HashSet<string>> localArrays = LoadStringArrays(body, opSet);
+            var foreachVars = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (Match match in ForeachOpPattern.Matches(body))
+            {
+                foreachVars[match.Groups[1].Value] = match.Groups[2].Value;
+            }
+
+            foreach (Match match in BindParamPattern.Matches(body))
+            {
+                string param = match.Groups[1].Value;
+                if (localArrays.TryGetValue(param, out HashSet<string>? local))
+                {
+                    executed.UnionWith(local);
+                }
+
+                if (arrays.TryGetValue(param, out HashSet<string>? field))
+                {
+                    executed.UnionWith(field);
+                }
+
+                if (foreachVars.TryGetValue(param, out string? source))
+                {
+                    if (localArrays.TryGetValue(source, out HashSet<string>? localSource))
+                    {
+                        executed.UnionWith(localSource);
+                    }
+
+                    if (arrays.TryGetValue(source, out HashSet<string>? fieldSource))
+                    {
+                        executed.UnionWith(fieldSource);
+                    }
+                }
+            }
+
+            foreach (string op in opSet)
+            {
+                if (method.StartsWith(op + "_", StringComparison.Ordinal))
+                {
+                    executed.Add(op);
+                }
+            }
+
+            return executed;
+        }
+
+        private static bool IteratesVignetteFiles(string body)
+        {
+            return GetFilesPattern.IsMatch(body)
+                   && body.Contains("*.json", StringComparison.Ordinal)
+                   && body.Contains("vignette", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static HashSet<string> CollectOps(string text, Regex pattern, HashSet<string> opSet)
+        {
+            var ops = new HashSet<string>(StringComparer.Ordinal);
+            foreach (Match match in pattern.Matches(text))
+            {
+                string value = match.Groups[1].Value;
+                if (opSet.Contains(value))
+                {
+                    ops.Add(value);
+                }
+            }
+
+            return ops;
+        }
+
+        private static string ExtractLeadingAttributes(string text, int methodStart)
+        {
+            int i = methodStart;
+            while (i > 0 && char.IsWhiteSpace(text[i - 1]))
+            {
+                i--;
+            }
+
+            var chunks = new List<string>();
+            while (i > 0 && text[i - 1] == ']')
+            {
+                int depth = 0;
+                bool found = false;
+                for (int j = i - 1; j >= 0; j--)
+                {
+                    if (text[j] == ']')
+                    {
+                        depth++;
+                    }
+                    else if (text[j] == '[')
+                    {
+                        depth--;
+                        if (depth == 0)
+                        {
+                            chunks.Add(text.Substring(j, i - j));
+                            i = j;
+                            while (i > 0 && char.IsWhiteSpace(text[i - 1]))
+                            {
+                                i--;
+                            }
+
+                            found = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!found)
+                {
+                    break;
+                }
+            }
+
+            chunks.Reverse();
+            return string.Concat(chunks);
+        }
+
+        private static string ExtractBalanced(string text, int start)
+        {
+            if (start >= text.Length || text[start] != '{')
+            {
+                return string.Empty;
+            }
+
+            int depth = 0;
+            int i = start;
+            char? inStr = null;
+            while (i < text.Length)
+            {
+                char ch = text[i];
+                if (inStr is null)
+                {
+                    if (i + 1 < text.Length && ch == '/' && text[i + 1] == '/')
+                    {
+                        int nl = text.IndexOf('\n', i);
+                        i = nl < 0 ? text.Length : nl + 1;
+                        continue;
+                    }
+
+                    if (i + 1 < text.Length && ch == '/' && text[i + 1] == '*')
+                    {
+                        int end = text.IndexOf("*/", i + 2, StringComparison.Ordinal);
+                        i = end < 0 ? text.Length : end + 2;
+                        continue;
+                    }
+
+                    if (i + 2 < text.Length && ch == '"' && text[i + 1] == '"' && text[i + 2] == '"')
+                    {
+                        int end = text.IndexOf("\"\"\"", i + 3, StringComparison.Ordinal);
+                        i = end < 0 ? text.Length : end + 3;
+                        continue;
+                    }
+
+                    if (ch is '"' or '\'')
+                    {
+                        inStr = ch;
+                        i++;
+                        continue;
+                    }
+
+                    if (ch == '{')
+                    {
+                        depth++;
+                    }
+                    else if (ch == '}')
+                    {
+                        depth--;
+                        if (depth == 0)
+                        {
+                            return text.Substring(start, i - start + 1);
+                        }
+                    }
+                }
+                else
+                {
+                    if (ch == '\\')
+                    {
+                        i += 2;
+                        continue;
+                    }
+
+                    if (ch == inStr)
+                    {
+                        inStr = null;
+                    }
+                }
+
+                i++;
+            }
+
+            return text.Substring(start);
+        }
+    }
+}

--- a/src/Tests/GasTests/Production/GraphOpsNodeGalleryEventAcceptanceTests.cs
+++ b/src/Tests/GasTests/Production/GraphOpsNodeGalleryEventAcceptanceTests.cs
@@ -8,6 +8,30 @@ namespace Ludots.Tests.Gas.Production;
 [Category("ci-gate")]
 public sealed class GraphOpsNodeGalleryEventAcceptanceTests
 {
+    private static readonly string[] EventFamilyOpsWithoutDedicatedMethod =
+    [
+        "FanOutDispatchEffect",
+        "FanOutDispatchEffectDynamic",
+        "LoadTargetPosX",
+        "LoadTargetPosY",
+        "IsPointInCircle",
+        "LoadEventPayloadInt",
+        "LoadEventPayloadFloat",
+        "ControlDomainResolve",
+        "ControlDomainControls"
+    ];
+
+    [TestCaseSource(nameof(EventFamilyOpsWithoutDedicatedMethod))]
+    public void EventFamilyOp_RendersPlayerCaption(string op)
+    {
+        using GraphOpsNodeGalleryRuntime runtime = BindAndTick(op);
+        AssertBannedPlayerCopy(runtime.Metrics.Detail);
+        foreach (string phrase in runtime.Vignette.AssertDetailContains)
+        {
+            Assert.That(runtime.Metrics.Detail, Does.Contain(phrase), op);
+        }
+    }
+
     [Test]
     public void SnapToNearestInCollection_SucceedsWithPlayerCaption()
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# 概要

- 变更目标：按 #942 S11，让覆盖表的「已覆盖」是被度量出来的，而不是被结构保证的。
- 影响范围：生成器、覆盖表指针、守卫、CI 闸门。不改 Query 编译器、VM、逐节点展厅玩法。不删八家族 Mod。

# SSOT 落点

- 正式规则：`gitbook/contributing/ai-assisted-development.md`
- 正式架构：无
- 正式查表或操作：`assets/Configs/GAS/graph_node_op_coverage.registry.json`
- 仓库深度材料：无
- 审计或提案：`docs/audits/gas_graph_architecture_fix_plan.md` S11（#942）；前序 M3 / M4

# 设计与挂靠点

- 挂靠点：`scripts/generate-graph-op-node-galleries.py`、`GraphNodeOpCoverageRegistryTests`
- 复用清单：已有 op 专属画廊测试；`ExistingVignettes_CompileWithFeaturedOp` / `GeneratedMaps_SpawnEveryVignetteActor`
- 新增清单：`unitTestRefs`（取代名不副实的 `unitTestFilter`）；CI 复跑生成器比对漂移

# 21 条指针

先修指针，不降成 `missing`。事件族 14 条不再盲指同一个单 op 测试（5 条改到已有专属方法，9 条补 `EventFamilyOp_RendersPlayerCaption` 再指向它）。`ConstFloat` / `AddFloat` 改到自己的专属测试。黑板 5 条改到已有专属方法。120/120 都有至少一条展开后真跑该 op 的专属画廊测试。

# 验证证据

- 编译/测试命令：`dotnet test … GraphNodeOpCoverageRegistryTests|GraphOpsNodeGallery`；`python3 scripts/generate-graph-op-node-galleries.py --strict`；`git diff --exit-code`；`python3 scripts/validate-registry.py`
- 结果摘要：105 通过；生成器零漂移；登记表 0 错
- CI 闸门：`.github/workflows/solution-verify.yml` checkout 后复跑生成器

# 文档同步

- [ ] 本票不改 `gitbook/` 正式文档
- [ ] 所属目录无需改导航

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88eeeec8-f8e7-44e7-bfea-db2b5c012489?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88eeeec8-f8e7-44e7-bfea-db2b5c012489&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

