### PR TITLE
fix(input): S10 选中和点选读模拟位置，不读相机裁剪

### DIFF
--- a/gitbook/architecture/entity-simulation-layering.md
+++ b/gitbook/architecture/entity-simulation-layering.md
@@ -171,6 +171,8 @@ Formation 是 Mod 业务聚合，不是 Core 仿真车道。`FormationCapability
 - crowd SoA 位置只服务 `MassNavigation` 热路径
 - 同一个 entity 不能同时被 `FullPhysics2D` 与 `MassNavigation` 双写
 - `ForceInput2D` 和 MassNavigationFlow desired movement state 是派生输出，不是位置真相
+- 谁能被选中、谁能收指令只由模拟状态决定：位置用 `WorldPositionCm`，可选中性用 `CommandSourceSelectableTag`，玩法可见性用 `KnowledgeProjectionStore`。`CullState` 与 `VisualTransform` 不得参与选中或下单判定
+- InputCollection / AbilityActivation / EffectProcessing / AttributeCalculation 等模拟相系统不得读取 `VisualTransform` 或 `CullState`
 
 允许存在的重复数据只有两类：
 
@@ -180,6 +182,18 @@ Formation 是 Mod 业务聚合，不是 Core 仿真车道。`FormationCapability
 禁止存在的重复真相只有一类：
 
 - 没有明确 owner 的双向可写位置状态
+
+这些规则由 `ArchitectureGuardTests` 执行：模拟相选中/输入/GAS 系统不得读 `VisualTransform`/`CullState`；`CullState.IsVisible` 的运行时写入只属于 `CameraCullingSystem`。
+
+### 5.1 跨层组件所有权
+
+下列组件跨越模拟与表现，必须有唯一 write owner。partial-world 隔离不在本页范围。
+
+| 组件 | write owner | 读方 | 允许的非 owner 动作 |
+|------|-------------|------|---------------------|
+| `PresentationStableId` | 模拟侧分配器与 spawn/lifecycle（`PresentationStableIdAllocator`、`RuntimeEntitySpawnSystem`、`TemplateEntityBatchSpawner`、L0 lifecycle API） | 表现侧消费（performer / HUD / adapter） | 表现 bootstrap 只能在缺失时补挂已分配 id，不得另造第二套身份真相 |
+| `PresentationDestroyPending` | 模拟侧 lifecycle（spawn/projectile/L0 API 标记待销毁） | 表现侧消费并 finalize destroy；L0 可读以便 fail-closed 拒绝已 pending 的 lifecycle txn | 表现侧可 Remove 以完成销毁，不得把该标记当作玩法存活真相 |
+| `CullState` | `CameraCullingSystem` 写 `IsVisible` / 视觉 LOD | 仅表现侧（culling、performer visibility、HUD） | 模拟 spawn 可挂默认隐藏值；模拟相不得读取该组件做选中、下单或玩法可见性 |
 
 ## 6 AOI 服务语义
 

--- a/gitbook/architecture/gas-order-input-runtime-contract.md
+++ b/gitbook/architecture/gas-order-input-runtime-contract.md
@@ -33,6 +33,7 @@
 ## 不变量
 
 - Core 不读取表现层 `VisualTransform` 作为玩法真相。
+- 选中与收令只读模拟真相：`WorldPositionCm`、`CommandSourceSelectableTag`、以及已有的 `KnowledgeProjectionStore` live inspect 通道；不读相机 `CullState`。
 - 热路径不调用 `World.Add`/`World.Remove`，不隐式扩容，不在查询中改变 archetype。
 - 配置、Registry、容量、Graph 服务和运行时状态装配各自只有一个 owner 和一个 SSOT。
 - 轻量 Ability Tag Grant 只由 Ability 执行域写入；有来源、叠层、刷新、驱散或条件结束的状态由 Effect 管理。

--- a/mods/CoreInputMod/Systems/TabTargetCycleSystem.cs
+++ b/mods/CoreInputMod/Systems/TabTargetCycleSystem.cs
@@ -1,11 +1,10 @@
 using System.Collections.Generic;
-using System.Numerics;
 using Arch.Core;
 using Arch.System;
+using Ludots.Core.Components;
 using Ludots.Core.Gameplay.Components;
 using Ludots.Core.Input.CommandSources;
 using Ludots.Core.Input.Runtime;
-using Ludots.Core.Presentation.Components;
 using Ludots.Core.Scripting;
 
 namespace CoreInputMod.Systems
@@ -21,7 +20,7 @@ namespace CoreInputMod.Systems
         private readonly Entity[] _candidateScratch = new Entity[64];
         private readonly float[] _distanceScratch = new float[64];
         private int _lastCycleIndex = -1;
-        private static readonly QueryDescription CandidateQuery = new QueryDescription().WithAll<VisualTransform, CommandSourceSelectableTag>();
+        private static readonly QueryDescription CandidateQuery = new QueryDescription().WithAll<WorldPositionCm, CommandSourceSelectableTag>();
 
         public TabTargetCycleSystem(World world, Dictionary<string, object> globals, int searchRadiusCm = 3000)
         {
@@ -51,18 +50,20 @@ namespace CoreInputMod.Systems
                 return;
             }
 
-            if (!_world.IsAlive(local) || !_world.Has<VisualTransform>(local))
+            if (!_world.IsAlive(local) || !_world.Has<WorldPositionCm>(local))
             {
                 return;
             }
 
             int localTeam = _world.Has<Team>(local) ? _world.Get<Team>(local).Id : 0;
-            Vector3 localPos = _world.Get<VisualTransform>(local).Position;
-            float maxDistanceSq = _searchRadiusCm * _searchRadiusCm;
+            WorldPositionCm localPos = _world.Get<WorldPositionCm>(local);
+            float localXcm = localPos.Value.X.ToFloat();
+            float localYcm = localPos.Value.Y.ToFloat();
+            float maxDistanceSq = (float)_searchRadiusCm * _searchRadiusCm;
 
             int count = 0;
 
-            _world.Query(in CandidateQuery, (Entity entity, ref VisualTransform transform, ref CommandSourceSelectableTag selectable) =>
+            _world.Query(in CandidateQuery, (Entity entity, ref WorldPositionCm position, ref CommandSourceSelectableTag selectable) =>
             {
                 if (count >= 64 || entity.Id == local.Id || !CommandSourceEligibility.IsSelectableNow(_world, entity))
                 {
@@ -83,10 +84,9 @@ namespace CoreInputMod.Systems
                     }
                 }
 
-                Vector3 position = transform.Position;
-                float dx = position.X - localPos.X;
-                float dz = position.Z - localPos.Z;
-                float distanceSq = dx * dx + dz * dz;
+                float dx = position.Value.X.ToFloat() - localXcm;
+                float dy = position.Value.Y.ToFloat() - localYcm;
+                float distanceSq = dx * dx + dy * dy;
                 if (distanceSq > maxDistanceSq)
                 {
                     return;

--- a/src/Core/Input/CommandSources/CommandSourceAcquisitionSystem.cs
+++ b/src/Core/Input/CommandSources/CommandSourceAcquisitionSystem.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Numerics;
 using Arch.Core;
 using Arch.System;
+using Ludots.Core.Components;
 using Ludots.Core.EntityCollections;
 using Ludots.Core.Input.Interaction;
 using Ludots.Core.Mathematics;
-using Ludots.Core.Presentation.Components;
 using Ludots.Core.Scripting;
 using Ludots.Core.Spatial;
 using Ludots.Platform.Abstractions;
@@ -21,7 +21,7 @@ namespace Ludots.Core.Input.CommandSources
     {
         public delegate bool CommandSourceOwnerProvider(out Entity owner);
 
-        private static readonly QueryDescription SelectableQuery = new QueryDescription().WithAll<VisualTransform, CullState, CommandSourceSelectableTag>();
+        private static readonly QueryDescription SelectableQuery = new QueryDescription().WithAll<WorldPositionCm, CommandSourceSelectableTag>();
 
         private readonly World _world;
         private readonly Dictionary<string, object> _globals;
@@ -247,10 +247,9 @@ namespace Ludots.Core.Input.CommandSources
 
             ScreenRect marquee = ScreenRect.FromPoints(drag.StartScreen, drag.CurrentScreen);
             int nextCount = 0;
-            _world.Query(in SelectableQuery, (Entity entity, ref VisualTransform transform, ref CullState cull, ref CommandSourceSelectableTag selectable) =>
+            _world.Query(in SelectableQuery, (Entity entity, ref CommandSourceSelectableTag selectable) =>
             {
-                if (!cull.IsVisible ||
-                    !CommandSourceEligibility.CanAcquire(_world, _globals, owner, entity, _targetRelationFilter))
+                if (!CommandSourceEligibility.CanAcquire(_world, _globals, owner, entity, _targetRelationFilter))
                 {
                     return;
                 }

--- a/src/Core/Input/CommandSources/CommandSourcePointerHitResolver.cs
+++ b/src/Core/Input/CommandSources/CommandSourcePointerHitResolver.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using Arch.Core;
-using Ludots.Core.Presentation.Components;
+using Ludots.Core.Components;
 using Ludots.Core.Scripting;
 using Ludots.Core.Spatial;
 using Ludots.Platform.Abstractions;
@@ -11,11 +11,13 @@ namespace Ludots.Core.Input.CommandSources
 {
     /// <summary>
     /// Shared screen-pointer entity hit resolver for command-source acquisition and command intents.
+    /// Selectability is simulation-owned: WorldPositionCm plus CommandSourceSelectableTag.
+    /// Live inspectability uses KnowledgeProjectionStore, never camera frustum visibility.
     /// </summary>
     public static class CommandSourcePointerHitResolver
     {
         private static readonly QueryDescription SelectableQuery =
-            new QueryDescription().WithAll<VisualTransform, CullState, CommandSourceSelectableTag>();
+            new QueryDescription().WithAll<WorldPositionCm, CommandSourceSelectableTag>();
 
         public static Entity FindNearestInspectableEntity(
             World world,
@@ -38,13 +40,8 @@ namespace Ludots.Core.Input.CommandSources
             ScreenRect bestBounds = default;
             bool hasBestBounds = false;
 
-            world.Query(in SelectableQuery, (Entity entity, ref VisualTransform transform, ref CullState cull, ref CommandSourceSelectableTag selectable) =>
+            world.Query(in SelectableQuery, (Entity entity, ref CommandSourceSelectableTag selectable) =>
             {
-                if (!cull.IsVisible)
-                {
-                    return;
-                }
-
                 if (!CommandSourceEligibility.CanInspectLive(world, globals, owner, entity))
                 {
                     return;

--- a/src/Core/Spatial/SpatialBoundsComponents.cs
+++ b/src/Core/Spatial/SpatialBoundsComponents.cs
@@ -12,7 +12,7 @@ namespace Ludots.Core.Spatial
 
     /// <summary>
     /// Core-owned local-space spatial bounds contract.
-    /// The local center is resolved through VisualTransform at runtime.
+    /// The local center is resolved through WorldPositionCm and optional FacingDirection.
     /// </summary>
     public struct SpatialBounds
     {
@@ -41,7 +41,7 @@ namespace Ludots.Core.Spatial
     }
 
     /// <summary>
-    /// Footprint polygons live on the local XZ plane and are transformed by VisualTransform.
+    /// Footprint polygons live on the local XZ plane and are transformed by WorldPositionCm plus FacingDirection.
     /// Multiple disjoint polygons are supported for selection and other screen-space queries.
     /// </summary>
     public unsafe struct SpatialFootprint2D

--- a/src/Core/Spatial/SpatialBoundsUtility.cs
+++ b/src/Core/Spatial/SpatialBoundsUtility.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Numerics;
 using Arch.Core;
-using Ludots.Core.Presentation.Components;
+using Ludots.Core.Components;
+using Ludots.Core.Mathematics;
 using Ludots.Platform.Abstractions;
 
 namespace Ludots.Core.Spatial
@@ -39,13 +40,11 @@ namespace Ludots.Core.Spatial
             out ScreenRect bounds)
         {
             bounds = default;
-            if (!world.IsAlive(entity) ||
-                !world.Has<VisualTransform>(entity))
+            if (!TryGetSimulationPose(world, entity, out SimPose pose))
             {
                 return false;
             }
 
-            ref readonly var transform = ref world.Get<VisualTransform>(entity);
             SpatialBounds spatialBounds = world.Has<SpatialBounds>(entity)
                 ? world.Get<SpatialBounds>(entity)
                 : SpatialBounds.Point;
@@ -54,7 +53,7 @@ namespace Ludots.Core.Spatial
             {
                 case SpatialBoundsKind.Point:
                     {
-                        if (!TryProjectPoint(projector, ResolveWorldPoint(transform, in spatialBounds), out Vector2 point))
+                        if (!TryProjectPoint(projector, ResolveWorldPoint(in pose, in spatialBounds), out Vector2 point))
                         {
                             return false;
                         }
@@ -69,7 +68,7 @@ namespace Ludots.Core.Spatial
                         throw new InvalidOperationException($"Entity {entity} declares SpatialBounds.Box3D but is missing SpatialBox3D.");
                     }
 
-                    return TryProjectBox(projector, transform, in spatialBounds, world.Get<SpatialBox3D>(entity), out bounds);
+                    return TryProjectBox(projector, in pose, in spatialBounds, world.Get<SpatialBox3D>(entity), out bounds);
 
                 case SpatialBoundsKind.Footprint2D:
                     if (!world.Has<SpatialFootprint2D>(entity))
@@ -77,7 +76,7 @@ namespace Ludots.Core.Spatial
                         throw new InvalidOperationException($"Entity {entity} declares SpatialBounds.Footprint2D but is missing SpatialFootprint2D.");
                     }
 
-                    return TryProjectFootprintBounds(projector, transform, in spatialBounds, world.Get<SpatialFootprint2D>(entity), out bounds);
+                    return TryProjectFootprintBounds(projector, in pose, in spatialBounds, world.Get<SpatialFootprint2D>(entity), out bounds);
 
                 default:
                     throw new InvalidOperationException($"Unsupported SpatialBoundsKind '{spatialBounds.Kind}'.");
@@ -93,15 +92,13 @@ namespace Ludots.Core.Spatial
             out int count)
         {
             count = 0;
-            if (!world.IsAlive(entity) ||
-                !world.Has<VisualTransform>(entity) ||
+            if (!TryGetSimulationPose(world, entity, out SimPose pose) ||
                 !world.Has<SpatialBounds>(entity) ||
                 !world.Has<SpatialFootprint2D>(entity))
             {
                 return false;
             }
 
-            ref readonly var transform = ref world.Get<VisualTransform>(entity);
             SpatialBounds spatialBounds = world.Get<SpatialBounds>(entity);
             if (spatialBounds.Kind != SpatialBoundsKind.Footprint2D)
             {
@@ -110,7 +107,7 @@ namespace Ludots.Core.Spatial
 
             return TryProjectFootprintPolygon(
                 projector,
-                transform,
+                in pose,
                 in spatialBounds,
                 world.Get<SpatialFootprint2D>(entity),
                 polygonIndex,
@@ -125,23 +122,22 @@ namespace Ludots.Core.Spatial
             Vector2 pointer,
             float pointPickRadiusPixels)
         {
-            if (!world.IsAlive(entity) || !world.Has<VisualTransform>(entity))
+            if (!TryGetSimulationPose(world, entity, out SimPose pose))
             {
                 return false;
             }
 
-            ref readonly var transform = ref world.Get<VisualTransform>(entity);
             SpatialBounds spatialBounds = world.Has<SpatialBounds>(entity)
                 ? world.Get<SpatialBounds>(entity)
                 : SpatialBounds.Point;
 
             return spatialBounds.Kind switch
             {
-                SpatialBoundsKind.Point => PointerHitsPoint(projector, transform, in spatialBounds, pointer, pointPickRadiusPixels),
+                SpatialBoundsKind.Point => PointerHitsPoint(projector, in pose, in spatialBounds, pointer, pointPickRadiusPixels),
                 SpatialBoundsKind.Box3D => world.Has<SpatialBox3D>(entity) &&
-                                           PointerHitsBox(projector, transform, in spatialBounds, world.Get<SpatialBox3D>(entity), pointer),
+                                           PointerHitsBox(projector, in pose, in spatialBounds, world.Get<SpatialBox3D>(entity), pointer),
                 SpatialBoundsKind.Footprint2D => world.Has<SpatialFootprint2D>(entity) &&
-                                                 PointerHitsFootprint(projector, transform, in spatialBounds, world.Get<SpatialFootprint2D>(entity), pointer),
+                                                 PointerHitsFootprint(projector, in pose, in spatialBounds, world.Get<SpatialFootprint2D>(entity), pointer),
                 _ => false,
             };
         }
@@ -152,37 +148,36 @@ namespace Ludots.Core.Spatial
             IScreenProjector projector,
             in ScreenRect marquee)
         {
-            if (!world.IsAlive(entity) || !world.Has<VisualTransform>(entity))
+            if (!TryGetSimulationPose(world, entity, out SimPose pose))
             {
                 return false;
             }
 
-            ref readonly var transform = ref world.Get<VisualTransform>(entity);
             SpatialBounds spatialBounds = world.Has<SpatialBounds>(entity)
                 ? world.Get<SpatialBounds>(entity)
                 : SpatialBounds.Point;
 
             return spatialBounds.Kind switch
             {
-                SpatialBoundsKind.Point => TryProjectPoint(projector, ResolveWorldPoint(transform, in spatialBounds), out Vector2 point) &&
+                SpatialBoundsKind.Point => TryProjectPoint(projector, ResolveWorldPoint(in pose, in spatialBounds), out Vector2 point) &&
                                            marquee.Contains(point),
                 SpatialBoundsKind.Box3D => world.Has<SpatialBox3D>(entity) &&
-                                           TryProjectBox(projector, transform, in spatialBounds, world.Get<SpatialBox3D>(entity), out ScreenRect boxRect) &&
+                                           TryProjectBox(projector, in pose, in spatialBounds, world.Get<SpatialBox3D>(entity), out ScreenRect boxRect) &&
                                            marquee.Intersects(in boxRect),
                 SpatialBoundsKind.Footprint2D => world.Has<SpatialFootprint2D>(entity) &&
-                                                 FootprintIntersectsRect(projector, transform, in spatialBounds, world.Get<SpatialFootprint2D>(entity), in marquee),
+                                                 FootprintIntersectsRect(projector, in pose, in spatialBounds, world.Get<SpatialFootprint2D>(entity), in marquee),
                 _ => false,
             };
         }
 
         private static bool PointerHitsPoint(
             IScreenProjector projector,
-            in VisualTransform transform,
+            in SimPose pose,
             in SpatialBounds spatialBounds,
             Vector2 pointer,
             float radiusPixels)
         {
-            if (!TryProjectPoint(projector, ResolveWorldPoint(transform, in spatialBounds), out Vector2 point))
+            if (!TryProjectPoint(projector, ResolveWorldPoint(in pose, in spatialBounds), out Vector2 point))
             {
                 return false;
             }
@@ -194,18 +189,18 @@ namespace Ludots.Core.Spatial
 
         private static bool PointerHitsBox(
             IScreenProjector projector,
-            in VisualTransform transform,
+            in SimPose pose,
             in SpatialBounds spatialBounds,
             in SpatialBox3D box,
             Vector2 pointer)
         {
-            return TryProjectBox(projector, transform, in spatialBounds, in box, out ScreenRect bounds) &&
+            return TryProjectBox(projector, in pose, in spatialBounds, in box, out ScreenRect bounds) &&
                    bounds.Contains(pointer);
         }
 
         private static bool PointerHitsFootprint(
             IScreenProjector projector,
-            in VisualTransform transform,
+            in SimPose pose,
             in SpatialBounds spatialBounds,
             in SpatialFootprint2D footprint,
             Vector2 pointer)
@@ -219,7 +214,7 @@ namespace Ludots.Core.Spatial
                     continue;
                 }
 
-                if (!TryProjectFootprintPolygon(projector, transform, in spatialBounds, in footprint, polygonIndex, projected, out int projectedCount))
+                if (!TryProjectFootprintPolygon(projector, in pose, in spatialBounds, in footprint, polygonIndex, projected, out int projectedCount))
                 {
                     continue;
                 }
@@ -235,7 +230,7 @@ namespace Ludots.Core.Spatial
 
         private static bool FootprintIntersectsRect(
             IScreenProjector projector,
-            in VisualTransform transform,
+            in SimPose pose,
             in SpatialBounds spatialBounds,
             in SpatialFootprint2D footprint,
             in ScreenRect marquee)
@@ -249,7 +244,7 @@ namespace Ludots.Core.Spatial
                     continue;
                 }
 
-                if (!TryProjectFootprintPolygon(projector, transform, in spatialBounds, in footprint, polygonIndex, projected, out int projectedCount))
+                if (!TryProjectFootprintPolygon(projector, in pose, in spatialBounds, in footprint, polygonIndex, projected, out int projectedCount))
                 {
                     continue;
                 }
@@ -265,7 +260,7 @@ namespace Ludots.Core.Spatial
 
         private static bool TryProjectFootprintBounds(
             IScreenProjector projector,
-            in VisualTransform transform,
+            in SimPose pose,
             in SpatialBounds spatialBounds,
             in SpatialFootprint2D footprint,
             out ScreenRect bounds)
@@ -280,7 +275,7 @@ namespace Ludots.Core.Spatial
 
             for (int polygonIndex = 0; polygonIndex < footprint.PolygonCount; polygonIndex++)
             {
-                if (!TryProjectFootprintPolygon(projector, transform, in spatialBounds, in footprint, polygonIndex, projected, out int projectedCount))
+                if (!TryProjectFootprintPolygon(projector, in pose, in spatialBounds, in footprint, polygonIndex, projected, out int projectedCount))
                 {
                     continue;
                 }
@@ -315,18 +310,18 @@ namespace Ludots.Core.Spatial
 
         private static bool TryProjectBox(
             IScreenProjector projector,
-            in VisualTransform transform,
+            in SimPose pose,
             in SpatialBounds spatialBounds,
             in SpatialBox3D box,
             out ScreenRect bounds)
         {
             bounds = default;
 
-            Vector3 center = ResolveWorldPoint(transform, in spatialBounds);
+            Vector3 center = ResolveWorldPoint(in pose, in spatialBounds);
             Vector3 half = new(
-                CmToMeters(box.HalfSizeXCm) * transform.Scale.X,
-                CmToMeters(box.HalfSizeYCm) * transform.Scale.Y,
-                CmToMeters(box.HalfSizeZCm) * transform.Scale.Z);
+                CmToMeters(box.HalfSizeXCm),
+                CmToMeters(box.HalfSizeYCm),
+                CmToMeters(box.HalfSizeZCm));
 
             Span<Vector3> corners = stackalloc Vector3[8];
             corners[0] = new Vector3(-half.X, -half.Y, -half.Z);
@@ -345,7 +340,7 @@ namespace Ludots.Core.Spatial
             float maxY = 0f;
             for (int i = 0; i < corners.Length; i++)
             {
-                Vector3 worldPoint = center + Vector3.Transform(corners[i], transform.Rotation);
+                Vector3 worldPoint = center + Vector3.Transform(corners[i], pose.Rotation);
                 if (!TryProjectPoint(projector, worldPoint, out Vector2 projected))
                 {
                     continue;
@@ -377,7 +372,7 @@ namespace Ludots.Core.Spatial
 
         private static bool TryProjectFootprintPolygon(
             IScreenProjector projector,
-            in VisualTransform transform,
+            in SimPose pose,
             in SpatialBounds spatialBounds,
             in SpatialFootprint2D footprint,
             int polygonIndex,
@@ -391,15 +386,15 @@ namespace Ludots.Core.Spatial
                 return false;
             }
 
-            Vector3 center = ResolveWorldPoint(transform, in spatialBounds);
+            Vector3 center = ResolveWorldPoint(in pose, in spatialBounds);
             for (int i = 0; i < count; i++)
             {
                 var vertex = footprint.GetVertex(polygonIndex, i);
                 Vector3 local = new(
-                    CmToMeters(vertex.X) * transform.Scale.X,
+                    CmToMeters(vertex.X),
                     0f,
-                    CmToMeters(vertex.Y) * transform.Scale.Z);
-                Vector3 worldPoint = center + Vector3.Transform(local, transform.Rotation);
+                    CmToMeters(vertex.Y));
+                Vector3 worldPoint = center + Vector3.Transform(local, pose.Rotation);
                 if (!TryProjectPoint(projector, worldPoint, out destination[i]))
                 {
                     count = 0;
@@ -410,14 +405,35 @@ namespace Ludots.Core.Spatial
             return true;
         }
 
-        private static Vector3 ResolveWorldPoint(in VisualTransform transform, in SpatialBounds spatialBounds)
+        private static Vector3 ResolveWorldPoint(in SimPose pose, in SpatialBounds spatialBounds)
         {
             Vector3 local = new(
-                CmToMeters(spatialBounds.LocalCenterXCm) * transform.Scale.X,
-                CmToMeters(spatialBounds.LocalCenterYCm) * transform.Scale.Y,
-                CmToMeters(spatialBounds.LocalCenterZCm) * transform.Scale.Z);
-            return transform.Position + Vector3.Transform(local, transform.Rotation);
+                CmToMeters(spatialBounds.LocalCenterXCm),
+                CmToMeters(spatialBounds.LocalCenterYCm),
+                CmToMeters(spatialBounds.LocalCenterZCm));
+            return pose.Position + Vector3.Transform(local, pose.Rotation);
         }
+
+        private static bool TryGetSimulationPose(World world, Entity entity, out SimPose pose)
+        {
+            pose = default;
+            if (!world.IsAlive(entity) || !world.Has<WorldPositionCm>(entity))
+            {
+                return false;
+            }
+
+            WorldPositionCm worldPosition = world.Get<WorldPositionCm>(entity);
+            Quaternion rotation = Quaternion.Identity;
+            if (world.Has<FacingDirection>(entity))
+            {
+                rotation = WorldPlane2D.FacingRadToVisualYRotation(world.Get<FacingDirection>(entity).AngleRad);
+            }
+
+            pose = new SimPose(WorldPlane2D.LogicCmToVisualMeters(in worldPosition.Value), rotation);
+            return true;
+        }
+
+        private readonly record struct SimPose(Vector3 Position, Quaternion Rotation);
 
         private static bool TryProjectPoint(IScreenProjector projector, Vector3 worldPoint, out Vector2 projected)
         {

--- a/src/Tests/ArchitectureTests/Governance/ArchitectureGuardTests.cs
+++ b/src/Tests/ArchitectureTests/Governance/ArchitectureGuardTests.cs
@@ -7,6 +7,8 @@ using System.Reflection.Emit;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using Arch.Core;
+using Arch.System;
+using CoreInputMod.Systems;
 using Ludots.Core.Config;
 using Ludots.Core.Engine;
 using Ludots.Core.Engine.Pacemaker;
@@ -16,8 +18,13 @@ using Ludots.Core.Gameplay.GAS.Bindings;
 using Ludots.Core.Gameplay.GAS.Components;
 using Ludots.Core.Gameplay.GAS.Systems;
 using Ludots.Core.Gameplay.Quests;
+using Ludots.Core.Input.CommandSources;
+using Ludots.Core.Input.Interaction;
+using Ludots.Core.Input.Systems;
 using Ludots.Core.NodeLibraries.GASGraph.Host;
+using Ludots.Core.Presentation.Components;
 using Ludots.Core.Scripting;
+using Ludots.Core.Spatial;
 using NUnit.Framework;
 
 namespace Ludots.Tests.Architecture.Governance
@@ -974,6 +981,149 @@ namespace Ludots.Tests.Architecture.Governance
                     "Exchange runtime hot path should stay allocation-conscious and avoid LINQ/iterator patterns:\n" +
                     string.Join("\n", hits));
             }
+        }
+
+        [Test]
+        public void SimulationPhaseSelectionAndInputSystems_MustNotReadVisualTransformOrCullState()
+        {
+            var hits = new List<string>();
+            Type[] types =
+            {
+                typeof(CommandSourceAcquisitionSystem),
+                typeof(CommandSourcePointerHitResolver),
+                typeof(CommandSourceEligibility),
+                typeof(SpatialBoundsUtility),
+                typeof(TabTargetCycleSystem),
+                typeof(LocalOrderSourceHelper),
+                typeof(AxisMoveOrderSystem),
+                typeof(GasInputResponseSystem),
+                typeof(AuthoritativeInputSnapshotSystem),
+                typeof(AuthoritativePointerButtonSnapshotSystem),
+                typeof(LocalPlayerEntityResolverSystem),
+                typeof(InputRuntimeSystem),
+            };
+
+            for (int i = 0; i < types.Length; i++)
+            {
+                AppendPresentationVisualReads(types[i], hits);
+            }
+
+            var repoRoot = FindRepoRoot();
+            string[] files =
+            {
+                Path.Combine(repoRoot, "src", "Core", "Input", "CommandSources", "CommandSourceAcquisitionSystem.cs"),
+                Path.Combine(repoRoot, "src", "Core", "Input", "CommandSources", "CommandSourcePointerHitResolver.cs"),
+                Path.Combine(repoRoot, "src", "Core", "Input", "CommandSources", "CommandSourceEligibility.cs"),
+                Path.Combine(repoRoot, "src", "Core", "Spatial", "SpatialBoundsUtility.cs"),
+                Path.Combine(repoRoot, "mods", "CoreInputMod", "Systems", "TabTargetCycleSystem.cs"),
+                Path.Combine(repoRoot, "mods", "CoreInputMod", "Systems", "LocalOrderSourceHelper.cs"),
+            };
+            for (int fileIndex = 0; fileIndex < files.Length; fileIndex++)
+            {
+                AppendForbiddenSourceTokens(repoRoot, files[fileIndex], new[] { "VisualTransform", "CullState" }, hits);
+            }
+
+            if (hits.Count > 0)
+            {
+                Assert.Fail(
+                    "Simulation-phase selection/input must use WorldPositionCm and Knowledge, not VisualTransform or CullState:\n" +
+                    string.Join("\n", hits));
+            }
+        }
+
+        [Test]
+        public void SimulationPhaseGasSystems_MustNotReadVisualTransformOrCullState()
+        {
+            var hits = new List<string>();
+            foreach (Type type in typeof(AbilityExecSystem).Assembly.GetTypes())
+            {
+                if (type.Namespace == null ||
+                    !type.Namespace.StartsWith("Ludots.Core.Gameplay.GAS", StringComparison.Ordinal) ||
+                    !typeof(ISystem<float>).IsAssignableFrom(type) ||
+                    type.IsAbstract)
+                {
+                    continue;
+                }
+
+                AppendPresentationVisualReads(type, hits);
+            }
+
+            if (hits.Count > 0)
+            {
+                Assert.Fail(
+                    "GAS simulation-phase systems must not read VisualTransform or CullState:\n" +
+                    string.Join("\n", hits));
+            }
+        }
+
+        [Test]
+        public void CullStateIsVisible_RuntimeWriteOwnerIsCameraCullingSystem()
+        {
+            var repoRoot = FindRepoRoot();
+            string[] roots =
+            {
+                Path.Combine(repoRoot, "src", "Core"),
+                Path.Combine(repoRoot, "mods", "CoreInputMod"),
+            };
+            var hits = new List<string>();
+            for (int rootIndex = 0; rootIndex < roots.Length; rootIndex++)
+            {
+                foreach (string file in Directory.EnumerateFiles(roots[rootIndex], "*.cs", SearchOption.AllDirectories))
+                {
+                    string relative = ToRepoRelativePath(repoRoot, file);
+                    if (relative.Equals("src/Core/Systems/CameraCullingSystem.cs", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    string[] lines = File.ReadAllLines(file);
+                    for (int lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+                    {
+                        string trimmed = lines[lineIndex].Trim();
+                        if (trimmed.StartsWith("//", StringComparison.Ordinal) ||
+                            trimmed.StartsWith("*", StringComparison.Ordinal))
+                        {
+                            continue;
+                        }
+
+                        if (trimmed.Contains("cull.IsVisible =", StringComparison.Ordinal) ||
+                            trimmed.Contains("cullState.IsVisible =", StringComparison.Ordinal))
+                        {
+                            hits.Add($"{relative}:{lineIndex + 1}: {trimmed}");
+                        }
+                    }
+                }
+            }
+
+            if (hits.Count > 0)
+            {
+                Assert.Fail(
+                    "CullState.IsVisible runtime writes belong to CameraCullingSystem. Spawn may only construct a default hidden value:\n" +
+                    string.Join("\n", hits));
+            }
+        }
+
+        [Test]
+        public void CrossLayerPresentationComponents_HaveDocumentedSingleWriteOwners()
+        {
+            var repoRoot = FindRepoRoot();
+            string layering = File.ReadAllText(Path.Combine(
+                repoRoot,
+                "gitbook",
+                "architecture",
+                "entity-simulation-layering.md"));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(layering, Does.Contain("### 5.1 跨层组件所有权"));
+                Assert.That(layering, Does.Contain("PresentationStableId"));
+                Assert.That(layering, Does.Contain("PresentationDestroyPending"));
+                Assert.That(layering, Does.Contain("CullState"));
+                Assert.That(layering, Does.Contain("write owner"));
+                Assert.That(layering, Does.Contain("CameraCullingSystem"));
+                Assert.That(layering, Does.Contain("WorldPositionCm"));
+                Assert.That(layering, Does.Contain("KnowledgeProjectionStore"));
+            });
         }
 
         [Test]
@@ -2172,6 +2322,117 @@ namespace Ludots.Tests.Architecture.Governance
             {
                 return null;
             }
+        }
+
+        private static void AppendPresentationVisualReads(Type type, List<string> hits)
+        {
+            foreach (Type current in EnumerateTypeAndNested(type))
+            {
+                foreach (FieldInfo field in current.GetFields(
+                             BindingFlags.Instance |
+                             BindingFlags.Static |
+                             BindingFlags.Public |
+                             BindingFlags.NonPublic |
+                             BindingFlags.DeclaredOnly))
+                {
+                    if (ContainsPresentationVisual(field.FieldType))
+                    {
+                        hits.Add($"{current.FullName}.{field.Name} field {field.FieldType}");
+                    }
+                }
+
+                foreach (MethodInfo method in current.GetMethods(
+                             BindingFlags.Instance |
+                             BindingFlags.Static |
+                             BindingFlags.Public |
+                             BindingFlags.NonPublic |
+                             BindingFlags.DeclaredOnly))
+                {
+                    ParameterInfo[] parameters = method.GetParameters();
+                    for (int i = 0; i < parameters.Length; i++)
+                    {
+                        if (ContainsPresentationVisual(parameters[i].ParameterType))
+                        {
+                            hits.Add($"{current.FullName}.{method.Name} param {parameters[i].ParameterType}");
+                        }
+                    }
+
+                    if (method.IsAbstract)
+                    {
+                        continue;
+                    }
+
+                    foreach (MethodBase called in EnumerateCalledMethods(method))
+                    {
+                        if (called.IsGenericMethod)
+                        {
+                            Type[] genericArguments = called.GetGenericArguments();
+                            for (int i = 0; i < genericArguments.Length; i++)
+                            {
+                                if (genericArguments[i] == typeof(VisualTransform) ||
+                                    genericArguments[i] == typeof(CullState))
+                                {
+                                    hits.Add($"{current.FullName}.{method.Name} -> {called.DeclaringType?.FullName}.{called.Name}<{genericArguments[i].Name}>");
+                                }
+                            }
+                        }
+
+                        ParameterInfo[] calledParameters = called.GetParameters();
+                        for (int i = 0; i < calledParameters.Length; i++)
+                        {
+                            if (ContainsPresentationVisual(calledParameters[i].ParameterType))
+                            {
+                                hits.Add($"{current.FullName}.{method.Name} -> {called.DeclaringType?.FullName}.{called.Name}({calledParameters[i].ParameterType})");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private static IEnumerable<Type> EnumerateTypeAndNested(Type type)
+        {
+            yield return type;
+            Type[] nested = type.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic);
+            for (int i = 0; i < nested.Length; i++)
+            {
+                foreach (Type child in EnumerateTypeAndNested(nested[i]))
+                {
+                    yield return child;
+                }
+            }
+        }
+
+        private static bool ContainsPresentationVisual(Type type)
+        {
+            if (type == typeof(VisualTransform) || type == typeof(CullState))
+            {
+                return true;
+            }
+
+            if (type.IsByRef && type.HasElementType)
+            {
+                return ContainsPresentationVisual(type.GetElementType()!);
+            }
+
+            if (type.IsArray && type.HasElementType)
+            {
+                return ContainsPresentationVisual(type.GetElementType()!);
+            }
+
+            if (type.IsGenericType)
+            {
+                Type[] arguments = type.GetGenericArguments();
+                for (int i = 0; i < arguments.Length; i++)
+                {
+                    if (ContainsPresentationVisual(arguments[i]))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         internal static Assembly[] CollectAttributeBufferWriteScanAssemblies()

--- a/src/Tests/GasTests/InteractionInput/InteractionSelectionConvergenceTests.cs
+++ b/src/Tests/GasTests/InteractionInput/InteractionSelectionConvergenceTests.cs
@@ -542,6 +542,130 @@ namespace Ludots.Tests.GAS
         }
 
         [Test]
+        public void CommandSourceAcquisitionSystem_CameraCulledEntity_RemainsSelectableAndReceivesOrders()
+        {
+            using var world = World.Create();
+
+            var input = new PlayerInputHandler(new NullInputBackend(), CreateInputConfig());
+            var local = world.Create();
+            var culled = world.Create(
+                WorldPositionCm.FromCm(1600, 1200),
+                new CullState { IsVisible = false, LOD = LODLevel.Culled },
+                new CommandSourceSelectableTag());
+            var offCamera = world.Create(
+                WorldPositionCm.FromCm(2600, 1600),
+                new CommandSourceSelectableTag());
+
+            var globals = new Dictionary<string, object>
+            {
+                [CoreServiceKeys.AuthoritativeInput.Name] = input,
+                [CoreServiceKeys.AuthoritativePointerButtons.Name] = new AuthoritativePointerButtonSnapshot(),
+                [CoreServiceKeys.ScreenRayProvider.Name] = new WorldMappedScreenRayProvider(),
+                [CoreServiceKeys.VisualHeightmap.Name] = CreateFlatHeightmap(),
+                [CoreServiceKeys.ScreenProjector.Name] = new WorldMappedScreenProjector(),
+                [CoreServiceKeys.WorldSizeSpec.Name] = CreateWorldSizeSpec(),
+                [CoreServiceKeys.LocalPlayerEntity.Name] = local,
+                [CoreServiceKeys.InteractionActionBindings.Name] = new InteractionActionBindings(),
+            };
+            CreateCommandSourceRuntime(world, globals);
+
+            var system = CreateCommandSourceAcquisitionSystem(world, globals, local);
+
+            Click(system, globals, input, new Vector2(1600f, 1200f));
+            AssertCommandSource(globals, local, culled);
+
+            DragSelect(system, globals, input, new Vector2(1500f, 1100f), new Vector2(2700f, 1700f));
+            AssertCommandSource(globals, local, culled, offCamera);
+
+            var mapping = new InputOrderMappingSystem(input, new InputOrderMappingConfig
+            {
+                InteractionMode = InteractionModeType.TargetFirst,
+                Mappings = new List<InputOrderMapping>
+                {
+                    new()
+                    {
+                        ActionId = "Stop",
+                        ActorCollectionKey = EntityCollectionKeys.CommandSource,
+                        Trigger = InputTriggerType.PressedThisFrame,
+                        OrderTypeKey = "stop",
+                        RequireTarget = false,
+                        TargetType = OrderTargetType.None,
+                        IsSkillMapping = false,
+                    },
+                },
+            });
+            mapping.SetLocalPlayer(local, 1);
+            mapping.SetOrderTypeKeyResolver(key => key == "stop" ? 1003 : 0);
+            mapping.SetCollectionEntityListProvider((string collectionKey, List<Entity> entities, int capacity, out OrderSubmitResult rejection) =>
+            {
+                That(collectionKey, Is.EqualTo(EntityCollectionKeys.CommandSource));
+                var collections = (EntityCollectionStore)globals[CoreServiceKeys.EntityCollectionStore.Name];
+                That(collections.TryGet(local, EntityCollectionKeys.CommandSource, out EntityCollectionHandle handle), Is.True);
+                entities.Clear();
+                Entity[] members = new Entity[2];
+                int written = collections.CopyEntities(handle, 0, members);
+                for (int i = 0; i < written; i++)
+                {
+                    entities.Add(members[i]);
+                }
+
+                rejection = OrderSubmitResult.Activated;
+                return written > 0;
+            });
+
+            var orders = new List<Order>();
+            mapping.SetOrderSubmitHandler((in Order _) =>
+            {
+                Fail("Multi-actor command-source fan-out must use the atomic batch submit handler.");
+                return OrderSubmitResult.RejectedValidation;
+            });
+            mapping.SetOrderBatchSubmitHandler((Span<Order> batch) =>
+            {
+                for (int i = 0; i < batch.Length; i++)
+                {
+                    orders.Add(batch[i]);
+                }
+
+                return OrderSubmitResult.Queued;
+            });
+
+            input.InjectButtonPress("Stop");
+            input.Update();
+            mapping.Update(0f);
+
+            That(orders.Count, Is.EqualTo(2));
+            That(orders[0].Actor, Is.EqualTo(culled));
+            That(orders[1].Actor, Is.EqualTo(offCamera));
+            That(orders[0].OrderTypeId, Is.EqualTo(1003));
+            That(orders[1].OrderTypeId, Is.EqualTo(1003));
+        }
+
+        [Test]
+        public void CommandSourcePointerHitResolver_UsesWorldPositionCm_NotVisualTransformOrCull()
+        {
+            using var world = World.Create();
+            var local = world.Create();
+            var actor = world.Create(
+                WorldPositionCm.FromCm(1600, 1200),
+                new VisualTransform { Position = new Vector3(80f, 0f, 80f) },
+                new CullState { IsVisible = false, LOD = LODLevel.Culled },
+                new CommandSourceSelectableTag());
+            var globals = new Dictionary<string, object>
+            {
+                [CoreServiceKeys.ScreenProjector.Name] = new WorldMappedScreenProjector(),
+            };
+
+            Entity hit = CommandSourcePointerHitResolver.FindNearestInspectableEntity(
+                world,
+                globals,
+                local,
+                new Vector2(1600f, 1200f),
+                radiusPixels: 16f);
+
+            That(hit, Is.EqualTo(actor));
+        }
+
+        [Test]
         public void CommandSourceAcquisitionSystem_AcquisitionPublishesCommandSourceCollection()
         {
             using var world = World.Create();
@@ -1175,15 +1299,15 @@ namespace Ludots.Tests.GAS
             var input = new PlayerInputHandler(new NullInputBackend(), CreateInputConfig());
             var local = world.Create(
                 new Team { Id = 1 },
-                new VisualTransform { Position = Vector3.Zero });
+                WorldPositionCm.FromCm(0, 0));
             _ = world.Create(
                 new Team { Id = 2 },
-                new VisualTransform { Position = new Vector3(5f, 0f, 0f) },
+                WorldPositionCm.FromCm(500, 0),
                 new CommandSourceSelectableTag(),
                 CommandSourceSelectableState.Disabled);
             var enabledEnemy = world.Create(
                 new Team { Id = 2 },
-                new VisualTransform { Position = new Vector3(10f, 0f, 0f) },
+                WorldPositionCm.FromCm(1000, 0),
                 new CommandSourceSelectableTag());
 
             var globals = new Dictionary<string, object>

--- a/src/Tests/GasTests/Vision/SelectionKnowledgeProjectionTests.cs
+++ b/src/Tests/GasTests/Vision/SelectionKnowledgeProjectionTests.cs
@@ -144,18 +144,18 @@ public sealed class SelectionKnowledgeProjectionTests
         var input = new PlayerInputHandler(new NullInputBackend(), CreateInputConfig());
         Entity local = world.Create(
             new Team { Id = 1 },
-            new VisualTransform { Position = Vector3.Zero });
+            WorldPositionCm.FromCm(0, 0));
         Entity unknown = world.Create(
             new Team { Id = 2 },
-            new VisualTransform { Position = new Vector3(5f, 0f, 0f) },
+            WorldPositionCm.FromCm(500, 0),
             new CommandSourceSelectableTag());
         Entity lastKnown = world.Create(
             new Team { Id = 2 },
-            new VisualTransform { Position = new Vector3(10f, 0f, 0f) },
+            WorldPositionCm.FromCm(1000, 0),
             new CommandSourceSelectableTag());
         Entity live = world.Create(
             new Team { Id = 2 },
-            new VisualTransform { Position = new Vector3(15f, 0f, 0f) },
+            WorldPositionCm.FromCm(1500, 0),
             new CommandSourceSelectableTag());
         var globals = new Dictionary<string, object>
         {

--- a/src/Tests/ThreeCTests/CameraAcceptanceModTests.cs
+++ b/src/Tests/ThreeCTests/CameraAcceptanceModTests.cs
@@ -28,6 +28,7 @@ using Ludots.Core.Presentation.Rendering;
 using Ludots.Core.Presentation.Systems;
 using Ludots.Core.Presentation.Utils;
 using Ludots.Core.Scripting;
+using Ludots.Core.Spatial;
 using Ludots.Core.Systems;
 using Ludots.Launcher.Backend;
 using Ludots.Presentation.Skia;
@@ -700,7 +701,7 @@ namespace Ludots.Tests.ThreeC.Acceptance
         }
 
         [Test]
-        public void CameraAcceptanceMod_ProjectionMap_BoxSelect_UsesVisualTransformHeightForScreenSpaceHitTesting()
+        public void CameraAcceptanceMod_ProjectionMap_BoxSelect_UsesSpatialBoundsHeightForScreenSpaceHitTesting()
         {
             using var engine = CreateEngine(AcceptanceMods);
             LoadMap(engine, CameraAcceptanceIds.ProjectionMapId);
@@ -716,17 +717,21 @@ namespace Ludots.Tests.ThreeC.Acceptance
             var sharedWorldCm = new WorldCmInt2(2600, 1600);
             ApplyEntityProjectionOverride(engine, hero, sharedWorldCm, WorldUnits.WorldCmToVisualMeters(sharedWorldCm, yMeters: 0f));
             ApplyEntityProjectionOverride(engine, scout, sharedWorldCm, WorldUnits.WorldCmToVisualMeters(sharedWorldCm, yMeters: 4.5f));
+            ApplySimulationBoundsHeight(engine, hero, localCenterYCm: 0);
+            ApplySimulationBoundsHeight(engine, scout, localCenterYCm: 450);
 
-            Vector2 heroScreen = ProjectEntity(engine, projector!, hero);
-            Vector2 scoutScreen = ProjectEntity(engine, projector!, scout);
+            Vector2 heroScreen = ProjectEntityBySimulationPose(engine, projector!, hero);
+            Vector2 scoutScreen = ProjectEntityBySimulationPose(engine, projector!, scout);
             Assert.That(Vector2.Distance(heroScreen, scoutScreen), Is.GreaterThan(40f),
-                "Regression setup must create a visible screen-space separation from VisualTransform height alone.");
+                "Regression setup must create a visible screen-space separation from SpatialBounds height alone.");
 
             var backend = GetInputBackend(engine);
             Action<GameEngine> reapplyVisualOverrides = runtime =>
             {
                 ApplyEntityProjectionOverride(runtime, hero, sharedWorldCm, WorldUnits.WorldCmToVisualMeters(sharedWorldCm, yMeters: 0f));
                 ApplyEntityProjectionOverride(runtime, scout, sharedWorldCm, WorldUnits.WorldCmToVisualMeters(sharedWorldCm, yMeters: 4.5f));
+                ApplySimulationBoundsHeight(runtime, hero, localCenterYCm: 0);
+                ApplySimulationBoundsHeight(runtime, scout, localCenterYCm: 450);
             };
 
             DragMouse(
@@ -1804,6 +1809,31 @@ namespace Ludots.Tests.ThreeC.Acceptance
 
             ref var visual = ref engine.World.Get<VisualTransform>(entity);
             visual.Position = visualPosition;
+        }
+
+        private static void ApplySimulationBoundsHeight(GameEngine engine, Entity entity, int localCenterYCm)
+        {
+            if (engine.World.Has<SpatialBounds>(entity))
+            {
+                ref var bounds = ref engine.World.Get<SpatialBounds>(entity);
+                bounds.LocalCenterYCm = localCenterYCm;
+                return;
+            }
+
+            engine.World.Add(entity, new SpatialBounds
+            {
+                Kind = SpatialBoundsKind.Point,
+                LocalCenterYCm = localCenterYCm,
+            });
+        }
+
+        private static Vector2 ProjectEntityBySimulationPose(GameEngine engine, IScreenProjector projector, Entity entity)
+        {
+            Assert.That(
+                SpatialBoundsUtility.TryProjectScreenBounds(engine.World, entity, projector, out ScreenRect bounds),
+                Is.True,
+                $"Entity #{entity.Id} must project from WorldPositionCm.");
+            return new Vector2((bounds.MinX + bounds.MaxX) * 0.5f, (bounds.MinY + bounds.MaxY) * 0.5f);
         }
 
         private static void UpdateHeadlessCamera(GameEngine engine)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# 概要

- 变更目标：谁能被选中、谁能收指令，只读模拟状态。相机裁掉的单位仍然能被点到、能收指令。
- 影响范围：点选 / Tab 循环 / 空间投影读位；分层文档补三个跨层组件的写所有者；架构守卫禁止模拟相读裁剪与视觉变换。

# SSOT 落点

- 正式规则：无
- 正式架构：`gitbook/architecture/entity-simulation-layering.md` §5.1；`gitbook/architecture/gas-order-input-runtime-contract.md` 一行
- 正式查表或操作：无
- 仓库深度材料：无
- 审计或提案：`docs/audits/gas_graph_architecture_fix_plan.md` §S10（#942）

# 设计与挂靠点

- 挂靠点：`CommandSourceAcquisitionSystem` / `CommandSourcePointerHitResolver` / `TabTargetCycleSystem` / `SpatialBoundsUtility`
- 复用清单：`WorldPositionCm`、`CommandSourceSelectableTag`、`CommandSourceEligibility` → `KnowledgeProjectionStore`
- 新增清单：分层文档 owner 表；守卫「模拟相不得读 VisualTransform / CullState」

# 选中改用的模拟真相

- 位置：`WorldPositionCm`（`SpatialBoundsUtility` 用它加可选 `FacingDirection` 做屏幕投影；不再读 `VisualTransform`）
- 可选中性：玩法组件 `CommandSourceSelectableTag`
- 玩法可见性：已有 `CommandSourceEligibility` → Knowledge live inspect
- 不再使用：相机 `CullState.IsVisible`、表现层 `VisualTransform`

# 三个跨层组件的 owner

| 组件 | write owner | 读方 |
|------|-------------|------|
| `PresentationStableId` | 模拟侧分配器与 spawn/lifecycle | 表现侧消费 |
| `PresentationDestroyPending` | 模拟侧 lifecycle | 表现侧消费并 finalize |
| `CullState` | `CameraCullingSystem` | 仅表现侧；不得用来做选中 |

# CI

验收页相对链接补了 `../`（主线预存红灯；本票改了 `gitbook/` 所以会跑文档治理）。

# 验证证据

```
ArchitectureTests filter ArchitectureGuardTests|Rfc0065|PerformContracts: Passed 83
GasTests filter OrderBufferSystem|CommandSource: Passed 47
Extra SelectionKnowledge/TabTarget/culled: Passed 8
```

# 文档同步

- [x] 行为变更已同步更新 `gitbook/` 正式文档
- [x] 所属目录 `README.md` 或 `SUMMARY.md` 已同步 —— 分层页内部增补，不改导航
- [x] 若影响入口或导航，`README.md` / `README_CN.md` / `AGENTS.md` / `CLAUDE.md` 已同步 —— 不影响

GAS 组合闸门：`artifacts/gas-composition-gate.md` — 交付物 A，PASS，无新 Layer 0 op。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88eeeec8-f8e7-44e7-bfea-db2b5c012489?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88eeeec8-f8e7-44e7-bfea-db2b5c012489&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

