### PR TITLE
feat(s14): 阶段顺序只认一张表，拿引擎的入口标过时

### DIFF
--- a/.github/workflows/solution-verify.yml
+++ b/.github/workflows/solution-verify.yml
@@ -102,6 +102,7 @@ jobs:
         run: |
           $guardFilter = @(
             'FullyQualifiedName~ArchitectureGuardTests',
+            'FullyQualifiedName~S14LayeringRatchetTests',
             'FullyQualifiedName~GasRuntimeStateContractTests',
             'FullyQualifiedName~GraphRuntimeArchitectureGuardTests'
           ) -join '|'

--- a/src/Core/Engine/Pacemaker/PhaseOrderedCooperativeSimulation.cs
+++ b/src/Core/Engine/Pacemaker/PhaseOrderedCooperativeSimulation.cs
@@ -9,21 +9,6 @@ namespace Ludots.Core.Engine.Pacemaker
 {
     public sealed class PhaseOrderedCooperativeSimulation : ICooperativeSimulation
     {
-        private static readonly SystemGroup[] PhaseOrder =
-        [
-            SystemGroup.SchemaUpdate,
-            SystemGroup.InputCollection,
-            SystemGroup.PostMovement,
-            SystemGroup.AbilityActivation,
-            SystemGroup.EffectProcessing,
-            SystemGroup.RuntimeEntityBinding,
-            SystemGroup.AttributeCalculation,
-            SystemGroup.DeferredTriggerCollection,
-            SystemGroup.Cleanup,
-            SystemGroup.EventDispatch,
-            SystemGroup.ClearPresentationFlags
-        ];
-
         private readonly Dictionary<SystemGroup, List<ISystem<float>>> _systemGroups;
         private readonly Action<float> _onStepCompleted;
         private readonly PresentationTimingDiagnostics? _timingDiagnostics;
@@ -55,9 +40,10 @@ namespace Ludots.Core.Engine.Pacemaker
             var start = System.Diagnostics.Stopwatch.GetTimestamp();
             long budgetTicks = timeBudgetMs * (System.Diagnostics.Stopwatch.Frequency / 1000);
 
-            while (_phaseIndex < PhaseOrder.Length)
+            IReadOnlyList<SystemGroup> phases = SystemGroupOrder.All;
+            while (_phaseIndex < phases.Count)
             {
-                var phase = PhaseOrder[_phaseIndex];
+                var phase = phases[_phaseIndex];
                 if (_systemGroups.TryGetValue(phase, out var systems))
                 {
                     for (int i = _systemIndex; i < systems.Count; i++)

--- a/src/Core/Engine/SystemGroupOrder.cs
+++ b/src/Core/Engine/SystemGroupOrder.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ludots.Core.Engine
+{
+    public static class SystemGroupOrder
+    {
+        public static IReadOnlyList<SystemGroup> All { get; } = Enum.GetValues<SystemGroup>();
+    }
+}

--- a/src/Core/Scripting/ScriptContextExtensions.cs
+++ b/src/Core/Scripting/ScriptContextExtensions.cs
@@ -7,6 +7,7 @@ namespace Ludots.Core.Scripting
 {
     public static class ScriptContextExtensions
     {
+        [Obsolete("Do not take the concrete GameEngine from ScriptContext. Use IModContext and existing ScriptContext ports (GetWorld, CoreServiceKeys). Do not add new call sites.")]
         public static GameEngine GetEngine(this ScriptContext ctx) => ctx.Get(CoreServiceKeys.Engine);
         public static World GetWorld(this ScriptContext ctx) => ctx.Get(CoreServiceKeys.World);
         public static MapSession GetMapSession(this ScriptContext ctx) => ctx.Get(CoreServiceKeys.MapSession);

--- a/src/Tests/ArchitectureTests/Governance/ArchitectureGuardTests.cs
+++ b/src/Tests/ArchitectureTests/Governance/ArchitectureGuardTests.cs
@@ -11,7 +11,6 @@ using Arch.System;
 using CoreInputMod.Systems;
 using Ludots.Core.Config;
 using Ludots.Core.Engine;
-using Ludots.Core.Engine.Pacemaker;
 using Ludots.Core.Gameplay.GAS;
 using Ludots.Core.Gameplay.GAS.Benchmarks;
 using Ludots.Core.Gameplay.GAS.Bindings;
@@ -61,17 +60,38 @@ namespace Ludots.Tests.Architecture.Governance
         }
 
         [Test]
-        public void SystemGroup_PhaseOrder_MustIncludeEveryEnumValueInDesignedOrder()
+        public void RuntimeSystemGroupOrder_EqualsEnumDeclarationOrder()
         {
-            string[] phaseOrderNames = Array.ConvertAll(ReadRuntimePhaseOrder(), group => group.ToString());
-            Assert.That(
-                phaseOrderNames,
-                Is.EqualTo(DesignedSystemGroupOrder),
-                "PhaseOrderedCooperativeSimulation.PhaseOrder must list every SystemGroup in designed order.");
-            Assert.That(
-                phaseOrderNames,
-                Is.EqualTo(Enum.GetNames<SystemGroup>()),
-                "A SystemGroup present on the enum but missing from PhaseOrder would silently skip registered systems.");
+            SystemGroup[] enumOrder = Enum.GetValues<SystemGroup>();
+            Assert.That(SystemGroupOrder.All, Is.EqualTo(enumOrder));
+            for (int i = 0; i < enumOrder.Length; i++)
+            {
+                Assert.That((int)enumOrder[i], Is.EqualTo(i));
+            }
+        }
+
+        [Test]
+        public void PhaseOrderedCooperativeSimulation_HasNoSecondPhaseOrderTable()
+        {
+            var repoRoot = FindRepoRoot();
+            string simulationSource = File.ReadAllText(Path.Combine(
+                repoRoot,
+                "src",
+                "Core",
+                "Engine",
+                "Pacemaker",
+                "PhaseOrderedCooperativeSimulation.cs"));
+            string orderSource = File.ReadAllText(Path.Combine(
+                repoRoot,
+                "src",
+                "Core",
+                "Engine",
+                "SystemGroupOrder.cs"));
+
+            Assert.That(simulationSource, Does.Not.Contain("PhaseOrder"));
+            Assert.That(simulationSource, Does.Contain("SystemGroupOrder.All"));
+            Assert.That(orderSource, Does.Contain("Enum.GetValues<SystemGroup>()"));
+            Assert.That(orderSource, Does.Not.Contain("SystemGroup."));
         }
 
         [Test]
@@ -2147,17 +2167,6 @@ namespace Ludots.Tests.Architecture.Governance
             string ArtifactFolder,
             string AcceptanceTestName,
             bool PurePhysics);
-
-        private static SystemGroup[] ReadRuntimePhaseOrder()
-        {
-            FieldInfo? field = typeof(PhaseOrderedCooperativeSimulation).GetField(
-                "PhaseOrder",
-                BindingFlags.Static | BindingFlags.NonPublic);
-            Assert.That(field, Is.Not.Null, "PhaseOrderedCooperativeSimulation.PhaseOrder is the runtime order table.");
-            var order = field!.GetValue(null) as SystemGroup[];
-            Assert.That(order, Is.Not.Null, "PhaseOrderedCooperativeSimulation.PhaseOrder must be a SystemGroup array.");
-            return order!;
-        }
 
         private static string FindRepoRoot()
         {

--- a/src/Tests/ArchitectureTests/Governance/ArchitectureGuardTests.cs
+++ b/src/Tests/ArchitectureTests/Governance/ArchitectureGuardTests.cs
@@ -88,7 +88,7 @@ namespace Ludots.Tests.Architecture.Governance
                 "Engine",
                 "SystemGroupOrder.cs"));
 
-            Assert.That(simulationSource, Does.Not.Contain("PhaseOrder"));
+            Assert.That(Regex.IsMatch(simulationSource, @"\bPhaseOrder\b"), Is.False);
             Assert.That(simulationSource, Does.Contain("SystemGroupOrder.All"));
             Assert.That(orderSource, Does.Contain("Enum.GetValues<SystemGroup>()"));
             Assert.That(orderSource, Does.Not.Contain("SystemGroup."));

--- a/src/Tests/ArchitectureTests/Governance/S14LayeringRatchetTests.cs
+++ b/src/Tests/ArchitectureTests/Governance/S14LayeringRatchetTests.cs
@@ -1,0 +1,196 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Ludots.Core.Scripting;
+using NUnit.Framework;
+
+namespace Ludots.Tests.Architecture.Governance;
+
+[Category("ci-gate")]
+[Category("arch-guard")]
+public sealed class S14LayeringRatchetTests
+{
+    public const int MaxGetEngineCalls = 205;
+    public const int MaxUndeclaredModRegisterSystemCalls = 100;
+    public const int MaxProductionStaticRegistryClearCalls = 15;
+    public const int MaxModProjectsReferencingFacadeGameEngine = 136;
+    public const int MaxModGraphIdRegistryClearCalls = 5;
+
+    private static readonly Regex GetEngineCall = new(@"\.GetEngine\s*\(", RegexOptions.Compiled);
+    private static readonly Regex RegisterSystemCall = new(@"\.RegisterSystem\s*\(", RegexOptions.Compiled);
+    private static readonly Regex CapabilityDeclaration = new(
+        @"SystemCapability\s*\(|capabilityId\s*:",
+        RegexOptions.Compiled);
+    private static readonly Regex StaticRegistryClear = new(
+        @"\b[A-Za-z][A-Za-z0-9]*Registry\.Clear\s*\(",
+        RegexOptions.Compiled);
+    private static readonly Regex GraphIdRegistryClear = new(
+        @"GraphIdRegistry\.Clear\s*\(",
+        RegexOptions.Compiled);
+
+    [Test]
+    public void GetEngine_IsObsolete_AndCallSitesDoNotIncrease()
+    {
+        MethodInfo? method = typeof(ScriptContextExtensions).GetMethod(
+            "GetEngine",
+            BindingFlags.Public | BindingFlags.Static);
+        Assert.That(method, Is.Not.Null);
+        Assert.That(Attribute.IsDefined(method!, typeof(ObsoleteAttribute)), Is.True);
+
+        int actual = CountMatches(EnumerateCsFiles("mods", "src"), GetEngineCall);
+        AssertRatchet(actual, MaxGetEngineCalls, ".GetEngine(");
+    }
+
+    [Test]
+    public void Mods_DirectRegisterSystemWithoutCapability_DoesNotIncrease()
+    {
+        int actual = 0;
+        foreach (string file in EnumerateCsFiles("mods"))
+        {
+            string text = File.ReadAllText(file);
+            foreach (Match match in RegisterSystemCall.Matches(text))
+            {
+                int lineStart = text.LastIndexOf('\n', match.Index) + 1;
+                int priorStart = lineStart;
+                for (int i = 0; i < 15 && priorStart > 0; i++)
+                {
+                    int previousBreak = text.LastIndexOf('\n', priorStart - 2);
+                    priorStart = previousBreak < 0 ? 0 : previousBreak + 1;
+                }
+
+                int invocationEnd = text.IndexOf(';', match.Index);
+                if (invocationEnd < 0)
+                {
+                    invocationEnd = Math.Min(text.Length, match.Index + 160);
+                }
+
+                string window = text[priorStart..invocationEnd];
+                if (!CapabilityDeclaration.IsMatch(window))
+                {
+                    actual++;
+                }
+            }
+        }
+
+        AssertRatchet(actual, MaxUndeclaredModRegisterSystemCalls, "mods undeclared RegisterSystem(");
+    }
+
+    [Test]
+    public void Production_StaticRegistryClear_DoesNotIncrease()
+    {
+        int actual = 0;
+        foreach (string file in EnumerateProductionCsFiles())
+        {
+            actual += StaticRegistryClear.Matches(File.ReadAllText(file)).Count;
+        }
+
+        AssertRatchet(actual, MaxProductionStaticRegistryClearCalls, "production *Registry.Clear(");
+    }
+
+    [Test]
+    public void Mods_GraphIdRegistryClear_DoesNotIncrease()
+    {
+        int actual = CountMatches(EnumerateCsFiles("mods"), GraphIdRegistryClear);
+        AssertRatchet(actual, MaxModGraphIdRegistryClearCalls, "mods GraphIdRegistry.Clear(");
+    }
+
+    [Test]
+    public void ModProjects_ReferencingFacadeGameEngine_DoNotIncrease()
+    {
+        string modsRoot = Path.Combine(FindRepoRoot(), "mods");
+        int actual = 0;
+        foreach (string projectPath in Directory.EnumerateFiles(modsRoot, "*.csproj", SearchOption.AllDirectories))
+        {
+            XDocument document = XDocument.Load(projectPath);
+            bool referencesFacade = document
+                .Descendants()
+                .Where(element => element.Name.LocalName == "ProjectReference")
+                .Select(element => element.Attribute("Include")?.Value)
+                .OfType<string>()
+                .Any(include =>
+                    include.Contains("Ludots.Core.csproj", StringComparison.Ordinal) ||
+                    include.Contains("Ludots.Engine", StringComparison.Ordinal));
+            if (referencesFacade)
+            {
+                actual++;
+            }
+        }
+
+        AssertRatchet(actual, MaxModProjectsReferencingFacadeGameEngine, "mod projects referencing facade GameEngine");
+    }
+
+    private static void AssertRatchet(int actual, int maximum, string label)
+    {
+        Assert.That(
+            actual,
+            Is.LessThanOrEqualTo(maximum),
+            $"{label} actual {actual} exceeded ratchet {maximum}. Constants may only decrease.");
+    }
+
+    private static int CountMatches(IEnumerable<string> files, Regex pattern)
+    {
+        int total = 0;
+        foreach (string file in files)
+        {
+            total += pattern.Matches(File.ReadAllText(file)).Count;
+        }
+
+        return total;
+    }
+
+    private static IEnumerable<string> EnumerateCsFiles(params string[] relativeRoots)
+    {
+        string repoRoot = FindRepoRoot();
+        foreach (string relativeRoot in relativeRoots)
+        {
+            string root = Path.Combine(repoRoot, relativeRoot);
+            if (!Directory.Exists(root))
+            {
+                continue;
+            }
+
+            foreach (string file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+            {
+                yield return file;
+            }
+        }
+    }
+
+    private static IEnumerable<string> EnumerateProductionCsFiles()
+    {
+        foreach (string file in EnumerateCsFiles("mods", "src"))
+        {
+            string relative = ToRepoRelativePath(FindRepoRoot(), file);
+            if (relative.StartsWith("src/Tests/", StringComparison.Ordinal) ||
+                relative.StartsWith("src/Libraries/", StringComparison.Ordinal) ||
+                relative.StartsWith("src/Tools/", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            yield return file;
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        for (int i = 0; i < 10 && dir != null; i++)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "src")) &&
+                Directory.Exists(Path.Combine(dir.FullName, "assets")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Failed to locate repository root from test output directory.");
+    }
+
+    private static string ToRepoRelativePath(string repoRoot, string absolutePath)
+    {
+        return Path.GetRelativePath(repoRoot, absolutePath).Replace('\\', '/');
+    }
+}

--- a/src/Tests/ArchitectureTests/Governance/S14LayeringRatchetTests.cs
+++ b/src/Tests/ArchitectureTests/Governance/S14LayeringRatchetTests.cs
@@ -22,7 +22,7 @@ public sealed class S14LayeringRatchetTests
         @"SystemCapability\s*\(|capabilityId\s*:",
         RegexOptions.Compiled);
     private static readonly Regex StaticRegistryClear = new(
-        @"\b[A-Za-z][A-Za-z0-9]*Registry\.Clear\s*\(",
+        @"\b[A-Z][A-Za-z0-9]*Registry\.Clear\s*\(",
         RegexOptions.Compiled);
     private static readonly Regex GraphIdRegistryClear = new(
         @"GraphIdRegistry\.Clear\s*\(",
@@ -37,8 +37,8 @@ public sealed class S14LayeringRatchetTests
         Assert.That(method, Is.Not.Null);
         Assert.That(Attribute.IsDefined(method!, typeof(ObsoleteAttribute)), Is.True);
 
-        int actual = CountMatches(EnumerateCsFiles("mods", "src"), GetEngineCall);
-        AssertRatchet(actual, MaxGetEngineCalls, ".GetEngine(");
+        int actual = CountMatches(EnumerateProductionAndModCsFiles(), GetEngineCall);
+        AssertRatchet(actual, MaxGetEngineCalls, "GetEngine invocations");
     }
 
     [Test]
@@ -72,7 +72,7 @@ public sealed class S14LayeringRatchetTests
             }
         }
 
-        AssertRatchet(actual, MaxUndeclaredModRegisterSystemCalls, "mods undeclared RegisterSystem(");
+        AssertRatchet(actual, MaxUndeclaredModRegisterSystemCalls, "mods undeclared RegisterSystem invocations");
     }
 
     [Test]
@@ -84,14 +84,14 @@ public sealed class S14LayeringRatchetTests
             actual += StaticRegistryClear.Matches(File.ReadAllText(file)).Count;
         }
 
-        AssertRatchet(actual, MaxProductionStaticRegistryClearCalls, "production *Registry.Clear(");
+        AssertRatchet(actual, MaxProductionStaticRegistryClearCalls, "production static Registry.Clear invocations");
     }
 
     [Test]
     public void Mods_GraphIdRegistryClear_DoesNotIncrease()
     {
         int actual = CountMatches(EnumerateCsFiles("mods"), GraphIdRegistryClear);
-        AssertRatchet(actual, MaxModGraphIdRegistryClearCalls, "mods GraphIdRegistry.Clear(");
+        AssertRatchet(actual, MaxModGraphIdRegistryClearCalls, "mods GraphIdRegistry.Clear invocations");
     }
 
     [Test]
@@ -151,8 +151,27 @@ public sealed class S14LayeringRatchetTests
 
             foreach (string file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
             {
+                if (IsIgnoredBuildArtifact(file))
+                {
+                    continue;
+                }
+
                 yield return file;
             }
+        }
+    }
+
+    private static IEnumerable<string> EnumerateProductionAndModCsFiles()
+    {
+        foreach (string file in EnumerateCsFiles("mods", "src"))
+        {
+            string relative = ToRepoRelativePath(FindRepoRoot(), file);
+            if (relative.StartsWith("src/Tests/", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            yield return file;
         }
     }
 
@@ -170,6 +189,20 @@ public sealed class S14LayeringRatchetTests
 
             yield return file;
         }
+    }
+
+    private static bool IsIgnoredBuildArtifact(string path)
+    {
+        string[] parts = path.Replace('\\', '/').Split('/');
+        for (int i = 0; i < parts.Length; i++)
+        {
+            if (parts[i] is "bin" or "obj")
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string FindRepoRoot()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# 概要

- 变更目标：S14 第一波。阶段顺序只认枚举本身；拿引擎的入口标过时但不删；调用次数只许下降。
- 影响范围：模拟阶段迭代改为读枚举；新增棘轮测试。不搬文件夹，不拆工程，不迁现有调用点。

设计正本：[#954](https://github.com/MightyBubble/Ludots/pull/954) §3.5–3.6 Wave 1。S8 尚未合入，本票直接做根治。

# SSOT 落点

- 正式规则：无
- 正式架构：无（不把合同改成「已落地」）
- 正式查表或操作：无
- 仓库深度材料：无
- 审计或提案：`docs/audits/s14_layering_physicalization_design.md` Wave 1

# 设计与挂靠点

- 挂靠点：`PhaseOrderedCooperativeSimulation`、`ScriptContext.GetEngine`、ArchitectureTests 棘轮
- 复用清单：`SystemGroup` 枚举声明顺序
- 新增清单：`SystemGroupOrder.All`；四条只降不升的计数守卫

# 验证证据

```
ArchitectureTests 守卫+棘轮：50 passed
GasTests ArchitectureGuardTests：38 passed
pacemaker / slicing：5 passed
```

棘轮常数等于本树实测：拿引擎 205、无能力声明登记 100、生产清空 15、引用门面的 Mod 136。展厅里清图表 5 次，只许下降。

# 文档同步

- [x] 行为变更已同步更新 `gitbook/` 正式文档 —— 无玩家可见行为变更
- [x] 所属目录 `README.md` 或 `SUMMARY.md` 已同步 —— 不需要
- [x] 若影响入口或导航，`README.md` / `README_CN.md` / `AGENTS.md` / `CLAUDE.md` 已同步 —— 不影响

# 不在本票

第二波到第六波：注册表实例化、迁走拿引擎、所有者分析器、剥程序集、删除旧门。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88eeeec8-f8e7-44e7-bfea-db2b5c012489?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88eeeec8-f8e7-44e7-bfea-db2b5c012489&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

