### PR TITLE
fix(gas): S4 结算提交走正式写入面，不再整块改属性

### DIFF
--- a/gitbook/architecture/attribute-write-authority.md
+++ b/gitbook/architecture/attribute-write-authority.md
@@ -32,13 +32,13 @@
 
 `AttributeBuffer.SetBase` / `SetCurrent` / `SetAggregatedCurrent` 不是玩法写入面。Core 与展厅程序集里只有白名单类型可以调用它们：
 
-- 结算：`AttributeMutationOps`、`EffectModifierOps`、`EffectPhaseSideEffectTransaction`
+- 结算：`AttributeMutationOps`、`EffectModifierOps`
 - 聚合与派生：`AttributeAggregatorSystem`、`GasGraphRuntimeApi`（仅派生暂存 buffer）
 - 装载物化：`ComponentRegistry`、`TemplateEntityBatchSpawner`、`QuestDefinitions`
 - 每帧脉冲消费：`ForceInput2DSink`、`CameraBehaviorInputSink`
 - 基准装配：`GasBenchmark`
 
-展厅运行时（含运行期补金、种子属性、基准装配）必须走 `AttributeMutationOps`，禁止裸写缓冲。`ArchitectureGuardTests.AttributeBufferWrites_MustComeFromWhitelistedCallers` 用 IL 扫描 Core 与展厅程序集强制这条名单；不在名单里的调用方必须让 CI 失败并点名。
+展厅运行时（含运行期补金、种子属性、基准装配）必须走 `AttributeMutationOps`，禁止裸写缓冲。`EffectPhaseSideEffectTransaction.Commit` 按变更的 attributeId 调用 `AttributeMutationOps` 写 current/base，不再整块赋值 `AttributeBuffer`，因此不在白名单里；暂存副本通过 `EffectModifierOps` 写入。`ArchitectureGuardTests.AttributeBufferWrites_MustComeFromWhitelistedCallers` 用 IL 扫描 Core 与展厅程序集强制这条名单；不在名单里的调用方必须让 CI 失败并点名。
 
 ## 非法编号失败关闭
 

--- a/src/Core/Gameplay/GAS/BuiltinHandlers.cs
+++ b/src/Core/Gameplay/GAS/BuiltinHandlers.cs
@@ -33,6 +33,12 @@ namespace Ludots.Core.Gameplay.GAS
             return attributeId != AttributeRegistry.InvalidId;
         }
 
+        public const string MissingHandlerRuntimeError = "GAS.BUILTIN.ERR.MissingHandlerRuntime";
+        public const string MissingSpatialQueriesError = "GAS.BUILTIN.ERR.MissingSpatialQueries";
+        public const string MissingFanOutBudgetError = "GAS.BUILTIN.ERR.MissingFanOutBudget";
+        public const string MissingFanOutCommandsError = "GAS.BUILTIN.ERR.MissingFanOutCommands";
+        public const string MissingResolverBufferError = "GAS.BUILTIN.ERR.MissingResolverBuffer";
+
         private static void RejectNonTransactionalPersistentSideEffect(string operation)
         {
             if (BuiltinHandlerRuntimeScope.Current?.EffectSideEffects?.IsActive == true)
@@ -40,6 +46,17 @@ namespace Ludots.Core.Gameplay.GAS
                 throw new InvalidOperationException(
                     $"{EffectPhaseSideEffectTransaction.UnsupportedSideEffectError}: operation={operation}.");
             }
+        }
+
+        private static BuiltinHandlerExecutionContext RequireHandlerRuntime()
+        {
+            BuiltinHandlerExecutionContext? runtime = BuiltinHandlerRuntimeScope.Current;
+            if (runtime == null)
+            {
+                throw new InvalidOperationException(MissingHandlerRuntimeError);
+            }
+
+            return runtime;
         }
 
         public static void RegisterAll(BuiltinHandlerRegistry registry)
@@ -137,10 +154,14 @@ namespace Ludots.Core.Gameplay.GAS
             in EffectConfigParams mergedParams,
             in EffectTemplateData templateData)
         {
-            var runtime = BuiltinHandlerRuntimeScope.Current;
-            if (runtime?.SpatialQueries == null || runtime.ResolverBuffer == null)
+            var runtime = RequireHandlerRuntime();
+            if (runtime.SpatialQueries == null)
             {
-                return;
+                throw new InvalidOperationException(MissingSpatialQueriesError);
+            }
+            if (runtime.ResolverBuffer == null)
+            {
+                throw new InvalidOperationException(MissingResolverBufferError);
             }
 
             int candidateCount = TargetResolverFanOutHelper.ResolveTargets(
@@ -161,10 +182,18 @@ namespace Ludots.Core.Gameplay.GAS
             in EffectConfigParams mergedParams,
             in EffectTemplateData templateData)
         {
-            var runtime = BuiltinHandlerRuntimeScope.Current;
-            if (runtime?.FanOutBudget == null || runtime.FanOutCommands == null || runtime.ResolverBuffer == null)
+            var runtime = RequireHandlerRuntime();
+            if (runtime.FanOutBudget == null)
             {
-                return;
+                throw new InvalidOperationException(MissingFanOutBudgetError);
+            }
+            if (runtime.FanOutCommands == null)
+            {
+                throw new InvalidOperationException(MissingFanOutCommandsError);
+            }
+            if (runtime.ResolverBuffer == null)
+            {
+                throw new InvalidOperationException(MissingResolverBufferError);
             }
 
             int candidateCount = runtime.ResolvedCandidateCount;
@@ -195,10 +224,22 @@ namespace Ludots.Core.Gameplay.GAS
             in EffectConfigParams mergedParams,
             in EffectTemplateData templateData)
         {
-            var runtime = BuiltinHandlerRuntimeScope.Current;
-            if (runtime?.SpatialQueries == null || runtime.FanOutBudget == null || runtime.FanOutCommands == null || runtime.ResolverBuffer == null)
+            var runtime = RequireHandlerRuntime();
+            if (runtime.SpatialQueries == null)
             {
-                return;
+                throw new InvalidOperationException(MissingSpatialQueriesError);
+            }
+            if (runtime.FanOutBudget == null)
+            {
+                throw new InvalidOperationException(MissingFanOutBudgetError);
+            }
+            if (runtime.FanOutCommands == null)
+            {
+                throw new InvalidOperationException(MissingFanOutCommandsError);
+            }
+            if (runtime.ResolverBuffer == null)
+            {
+                throw new InvalidOperationException(MissingResolverBufferError);
             }
 
             int candidateCount = TargetResolverFanOutHelper.ResolveTargets(

--- a/src/Core/Gameplay/GAS/EffectPhaseSideEffectTransaction.cs
+++ b/src/Core/Gameplay/GAS/EffectPhaseSideEffectTransaction.cs
@@ -351,15 +351,28 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
     public void StageAttributeAdd(Entity target, int attributeId, float delta)
     {
         int index = GetOrAddAttributeEntity(target);
-        float before = _attributeValues[index].GetCurrent(attributeId);
-        _attributeValues[index].SetCurrent(attributeId, before + delta);
+        var modifiers = new EffectModifiers();
+        if (!modifiers.Add(attributeId, ModifierOp.Add, delta))
+        {
+            throw new InvalidOperationException(
+                $"{CapacityExceededError}: destination=EffectModifiers, staged=1, capacity={EffectModifiers.CAPACITY}.");
+        }
+
+        EffectModifierOps.Apply(in modifiers, ref _attributeValues[index]);
         RefreshAttributeChanged(index, attributeId);
     }
 
     public void StageAttributeSet(Entity target, int attributeId, float value)
     {
         int index = GetOrAddAttributeEntity(target);
-        _attributeValues[index].SetCurrent(attributeId, value);
+        var modifiers = new EffectModifiers();
+        if (!modifiers.Add(attributeId, ModifierOp.Override, value))
+        {
+            throw new InvalidOperationException(
+                $"{CapacityExceededError}: destination=EffectModifiers, staged=1, capacity={EffectModifiers.CAPACITY}.");
+        }
+
+        EffectModifierOps.Apply(in modifiers, ref _attributeValues[index]);
         RefreshAttributeChanged(index, attributeId);
     }
 
@@ -850,6 +863,11 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
                 _structuralCommands.Playback(_world);
             }
 
+            if (_attributeCount > 0 && _tagOps == null)
+            {
+                throw new InvalidOperationException(TagOps.MissingTagOpsError);
+            }
+
             for (int i = 0; i < _attributeCount; i++)
             {
                 if (_attributeChangedMasks[i] == 0UL)
@@ -858,14 +876,25 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
                 }
 
                 Entity entity = _attributeEntities[i];
-                _world.Get<AttributeBuffer>(entity) = _attributeValues[i];
-                _world.Get<GameplayAttributeChangedBits>(entity) = _attributeChangedValues[i];
                 for (int attributeId = 0; attributeId < AttributeBuffer.MAX_ATTRS; attributeId++)
                 {
-                    if ((_attributeChangedMasks[i] & (1UL << attributeId)) != 0UL)
+                    if ((_attributeChangedMasks[i] & (1UL << attributeId)) == 0UL)
                     {
-                        _world.Get<DirtyFlags>(entity).MarkAttributeDirty(attributeId);
+                        continue;
                     }
+
+                    float stagedBase = ReadRawBase(ref _attributeValues[i], attributeId);
+                    if (stagedBase != ReadRawBase(ref _attributeOriginalValues[i], attributeId))
+                    {
+                        AttributeMutationOps.SetBase(_world, entity, attributeId, stagedBase, _tagOps!);
+                    }
+
+                    AttributeMutationOps.SetCurrent(
+                        _world,
+                        entity,
+                        attributeId,
+                        _attributeValues[i].GetCurrent(attributeId),
+                        _tagOps!);
                 }
             }
             for (int i = 0; i < _tagEntityCount; i++)
@@ -1193,8 +1222,11 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
             return;
         }
         ulong bit = 1UL << attributeId;
-        if (_attributeValues[index].GetCurrent(attributeId) !=
-            _attributeOriginalValues[index].GetCurrent(attributeId))
+        bool currentChanged = _attributeValues[index].GetCurrent(attributeId) !=
+            _attributeOriginalValues[index].GetCurrent(attributeId);
+        bool baseChanged = ReadRawBase(ref _attributeValues[index], attributeId) !=
+            ReadRawBase(ref _attributeOriginalValues[index], attributeId);
+        if (currentChanged || baseChanged)
         {
             _attributeChangedMasks[index] |= bit;
         }
@@ -1202,6 +1234,11 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
         {
             _attributeChangedMasks[index] &= ~bit;
         }
+    }
+
+    private static unsafe float ReadRawBase(ref AttributeBuffer buffer, int attributeId)
+    {
+        return buffer.BaseValues[attributeId];
     }
 
     private void ValidateCommit()

--- a/src/Core/Gameplay/GAS/EffectPhaseSideEffectTransaction.cs
+++ b/src/Core/Gameplay/GAS/EffectPhaseSideEffectTransaction.cs
@@ -21,6 +21,7 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
     public const string UnsupportedSideEffectError = "GAS.EFFECT_TRANSACTION.ERR.UnsupportedSideEffect";
     public const string AttributeTargetInvalidError = "GAS.EFFECT_TRANSACTION.ERR.AttributeTargetInvalid";
     public const string RelationTargetInvalidError = "GAS.EFFECT_TRANSACTION.ERR.RelationTargetInvalid";
+    public const string MissingPresentationEventBufferError = "GAS.GRAPH.ERR.MissingGasPresentationEventBuffer";
 
     private readonly World _world;
     private readonly TagOps? _tagOps;
@@ -428,7 +429,7 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
         RequireActive();
         if (_presentationEvents == null)
         {
-            return;
+            throw new InvalidOperationException(MissingPresentationEventBufferError);
         }
         if (_presentationEventCount >= _stagedPresentationEvents.Length ||
             _presentationEventCount >= _presentationEvents.AvailableCapacity)
@@ -497,6 +498,45 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
 
         hasTag = _tagOps.HasTag(ref _tagValues[index], tagId, TagSense.Effective);
         return true;
+    }
+
+    public void StageGrantedTagGrant(Entity target, in EffectGrantedTags grantedTags, int stackCount)
+    {
+        RequireActive();
+        if (!_world.IsAlive(target) || grantedTags.Count <= 0)
+        {
+            return;
+        }
+        if (_tagOps == null)
+        {
+            throw new InvalidOperationException(TagOps.MissingTagOpsError);
+        }
+
+        int index = GetOrAddTagEntity(target);
+        bool changed = false;
+        for (int grantIndex = 0; grantIndex < grantedTags.Count; grantIndex++)
+        {
+            TagContribution contribution = grantedTags.Get(grantIndex);
+            int amount = contribution.Compute(stackCount);
+            for (int repeat = 0; repeat < amount; repeat++)
+            {
+                if (!_tagOps.AddTag(
+                    ref _tagValues[index],
+                    ref _tagCountValues[index],
+                    contribution.TagId,
+                    ref _tagDirtyValues[index]))
+                {
+                    throw new InvalidOperationException(TagOps.RuleRejectedError);
+                }
+
+                changed = true;
+            }
+        }
+
+        if (changed)
+        {
+            StageDirtyEntity(target);
+        }
     }
 
     public void StageGrantedTagRevoke(Entity target, in EffectGrantedTags grantedTags, int stackCount)
@@ -799,10 +839,11 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
     {
         RequireActive();
         ValidateCommit();
-        PrepareCommitState();
 
+        int pendingDestroyCount = _destroyedEffectCount;
         try
         {
+            PrepareCommitState();
             _worldCommitStarted = true;
             if (_structuralCommands.Size > 0)
             {
@@ -907,25 +948,21 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
             {
                 _gameplayEventBus!.Publish(_stagedGameplayEvents[i]);
             }
-            for (int i = 0; i < _destroyedEffectCount; i++)
-            {
-                Entity effect = _destroyedEffects[i];
-                if (_world.IsAlive(effect))
-                {
-                    _world.Destroy(effect);
-                }
-            }
-
             if (_rootBudget != null)
             {
                 _rootBudget.CommitWrites(in _rootBudgetCheckpoint);
             }
 
             End();
+            LandStagedDestroys(pendingDestroyCount);
         }
         catch
         {
-            Rollback();
+            if (IsActive)
+            {
+                Rollback();
+            }
+
             throw;
         }
     }
@@ -1711,25 +1748,32 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
         }
         for (int i = 0; i < _blackboardFloatCount; i++)
         {
-            _world.Get<BlackboardFloatBuffer>(_blackboardFloatEntities[i]) = _blackboardFloatOriginalValues[i];
+            RestoreComponent(_blackboardFloatEntities[i], in _blackboardFloatOriginalValues[i]);
         }
         for (int i = 0; i < _blackboardIntCount; i++)
         {
-            _world.Get<BlackboardIntBuffer>(_blackboardIntEntities[i]) = _blackboardIntOriginalValues[i];
+            RestoreComponent(_blackboardIntEntities[i], in _blackboardIntOriginalValues[i]);
         }
         for (int i = 0; i < _blackboardEntityCount; i++)
         {
-            _world.Get<BlackboardEntityBuffer>(_blackboardEntityEntities[i]) = _blackboardEntityOriginalValues[i];
+            RestoreComponent(_blackboardEntityEntities[i], in _blackboardEntityOriginalValues[i]);
         }
         for (int i = 0; i < _cancelledEffectCount; i++)
         {
-            _world.Get<GameplayEffect>(_cancelledEffects[i]).CancelRequested = _cancelledEffectOriginalValues[i];
+            Entity entity = _cancelledEffects[i];
+            if (_world.IsAlive(entity) && _world.Has<GameplayEffect>(entity))
+            {
+                _world.Get<GameplayEffect>(entity).CancelRequested = _cancelledEffectOriginalValues[i];
+            }
         }
         for (int i = 0; i < _listenerEntityCount; i++)
         {
-            if (_listenerExisted[i] && _world.Has<EffectPhaseListenerBuffer>(_listenerEntities[i]))
+            Entity entity = _listenerEntities[i];
+            if (_listenerExisted[i] &&
+                _world.IsAlive(entity) &&
+                _world.Has<EffectPhaseListenerBuffer>(entity))
             {
-                _world.Get<EffectPhaseListenerBuffer>(_listenerEntities[i]) = _listenerOriginalValues[i];
+                _world.Get<EffectPhaseListenerBuffer>(entity) = _listenerOriginalValues[i];
             }
         }
         for (int i = 0; i < _relationParentCount; i++)
@@ -1980,6 +2024,28 @@ public sealed class EffectPhaseSideEffectTransaction : IDisposable
 
         position = default;
         return false;
+    }
+
+    private void RestoreComponent<T>(Entity entity, in T original)
+        where T : struct
+    {
+        if (_world.IsAlive(entity) && _world.Has<T>(entity))
+        {
+            _world.Get<T>(entity) = original;
+        }
+    }
+
+    private void LandStagedDestroys(int pendingDestroyCount)
+    {
+        // Destroy only after End(): the transaction can no longer fail or roll back.
+        for (int i = 0; i < pendingDestroyCount; i++)
+        {
+            Entity effect = _destroyedEffects[i];
+            if (_world.IsAlive(effect))
+            {
+                _world.Destroy(effect);
+            }
+        }
     }
 
     private void RequireActive()

--- a/src/Core/Gameplay/GAS/EffectTagContributionHelper.cs
+++ b/src/Core/Gameplay/GAS/EffectTagContributionHelper.cs
@@ -12,23 +12,6 @@ namespace Ludots.Core.Gameplay.GAS
     {
         public static void GrantToEntity(World world, Entity target, in EffectGrantedTags grantedTags, int stackCount, TagOps tagOps, GasBudget budget = null)
         {
-            GrantToEntityCore(world, target, in grantedTags, stackCount, tagOps, budget, trackDirtyEntity: true);
-        }
-
-        internal static void PrepareGrantToEntity(World world, Entity target, in EffectGrantedTags grantedTags, int stackCount, TagOps tagOps, GasBudget budget = null)
-        {
-            GrantToEntityCore(world, target, in grantedTags, stackCount, tagOps, budget, trackDirtyEntity: false);
-        }
-
-        private static void GrantToEntityCore(
-            World world,
-            Entity target,
-            in EffectGrantedTags grantedTags,
-            int stackCount,
-            TagOps tagOps,
-            GasBudget budget,
-            bool trackDirtyEntity)
-        {
             if (!world.IsAlive(target) || grantedTags.Count <= 0)
             {
                 return;
@@ -53,7 +36,7 @@ namespace Ludots.Core.Gameplay.GAS
                             throw new System.InvalidOperationException(TagOps.RuleRejectedError);
                     }
                 }
-                if (trackDirtyEntity && dirtyFlags.IsAnyTagDirty()) tagOps.MarkDirtyEntity(world, target);
+                if (dirtyFlags.IsAnyTagDirty()) tagOps.MarkDirtyEntity(world, target);
             }
             catch
             {

--- a/src/Core/Gameplay/GAS/Systems/EffectApplicationSystem.cs
+++ b/src/Core/Gameplay/GAS/Systems/EffectApplicationSystem.cs
@@ -81,7 +81,8 @@ namespace Ludots.Core.Gameplay.GAS.Systems
         public int LastSliceProcessed { get; private set; }
 
         /// <summary>
-        /// Time-sliced application stages for EffectApplicationSystem.
+        /// Time-sliced application stages. ProcessPending through AttachEffects
+        /// commit a visible attachment; ActivateEffects is the settlement transaction.
         /// </summary>
         private enum ApplicationStage : byte
         {
@@ -388,19 +389,14 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                             EffectContext context = World.Get<EffectContext>(e);
                             if (!IsEffectAttached(context.Target, e))
                             {
-                                RollbackPersistentAttachment(context.Target, e);
-                                ConsumeWork(ref workUnits);
-                                continue;
+                                throw new InvalidOperationException(
+                                    $"GAS.ACTIVE_EFFECT_CONTAINER.ERR.MissingAttachment: target={context.Target.Id}, effect={e.Id}.");
                             }
 
                             int templateId = World.Has<EffectTemplateRef>(e)
                                 ? World.Get<EffectTemplateRef>(e).TemplateId
                                 : 0;
 
-                            bool hasGrantedTagSnapshot = false;
-                            GameplayTagContainer tagsBefore = default;
-                            TagCountContainer tagCountsBefore = default;
-                            DirtyFlags dirtyFlagsBefore = default;
                             int fanOutCommandCountBefore = _fanOutCommands.Count;
                             int listenerRegistrationCountBefore = _pendingListenerRegistrations.Count;
                             bool graphTransactionBound = false;
@@ -418,16 +414,7 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                                 {
                                     EffectGrantedTags grantedTags = World.Get<EffectGrantedTags>(e);
                                     int stackCount = World.Has<EffectStack>(e) ? World.Get<EffectStack>(e).Count : 1;
-                                    TagOps.RequireTagState(World, context.Target);
-                                    tagsBefore = World.Get<GameplayTagContainer>(context.Target);
-                                    tagCountsBefore = World.Get<TagCountContainer>(context.Target);
-                                    dirtyFlagsBefore = World.Get<DirtyFlags>(context.Target);
-                                    hasGrantedTagSnapshot = true;
-                                    EffectTagContributionHelper.PrepareGrantToEntity(World, context.Target, in grantedTags, stackCount, _tagOps, _budget);
-                                    if (World.Get<DirtyFlags>(context.Target).IsAnyTagDirty())
-                                    {
-                                        _persistentPhaseTransaction.StageDirtyEntity(context.Target);
-                                    }
+                                    _persistentPhaseTransaction.StageGrantedTagGrant(context.Target, in grantedTags, stackCount);
                                 }
 
                                 ExecutePersistentPhases(e, in context, templateId);
@@ -459,13 +446,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
                                 _persistentPhaseTransaction.Rollback();
                                 _fanOutCommands.Truncate(fanOutCommandCountBefore);
                                 TrimTail(_pendingListenerRegistrations, listenerRegistrationCountBefore);
-                                if (hasGrantedTagSnapshot && World.IsAlive(context.Target))
-                                {
-                                    World.Get<GameplayTagContainer>(context.Target) = tagsBefore;
-                                    World.Get<TagCountContainer>(context.Target) = tagCountsBefore;
-                                    World.Get<DirtyFlags>(context.Target) = dirtyFlagsBefore;
-                                }
-                                RollbackPersistentAttachment(context.Target, e);
                                 throw;
                             }
                             finally
@@ -735,38 +715,6 @@ namespace Ludots.Core.Gameplay.GAS.Systems
             for (int i = 0; i < container.Count; i++)
             {
                 if (container.GetEntity(i) == effect)
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private void RollbackPersistentAttachment(Entity target, Entity effect)
-        {
-            bool removeCreatedContainer = false;
-            if (World.IsAlive(target) && World.Has<ActiveEffectContainer>(target))
-            {
-                ref ActiveEffectContainer container = ref World.Get<ActiveEffectContainer>(target);
-                container.Remove(effect);
-                removeCreatedContainer = container.Count == 0 && WasContainerCreatedThisPass(target);
-            }
-
-            if (removeCreatedContainer && World.IsAlive(target) && World.Has<ActiveEffectContainer>(target))
-            {
-                World.Remove<ActiveEffectContainer>(target);
-            }
-            if (World.IsAlive(effect))
-            {
-                World.Destroy(effect);
-            }
-        }
-
-        private bool WasContainerCreatedThisPass(Entity target)
-        {
-            for (int i = 0; i < _createdContainers.Count; i++)
-            {
-                if (_createdContainers[i] == target)
                 {
                     return true;
                 }

--- a/src/Tests/ArchitectureTests/Governance/ArchitectureGuardTests.cs
+++ b/src/Tests/ArchitectureTests/Governance/ArchitectureGuardTests.cs
@@ -985,7 +985,6 @@ namespace Ludots.Tests.Architecture.Governance
                 typeof(AttributeMutationOps),
                 typeof(AttributeAggregatorSystem),
                 typeof(EffectModifierOps),
-                typeof(EffectPhaseSideEffectTransaction),
                 typeof(GasGraphRuntimeApi),
                 typeof(Ludots.Core.Config.ComponentRegistry),
                 typeof(TemplateEntityBatchSpawner),

--- a/src/Tests/GasTests/Effect/InstantEffectTransactionTests.cs
+++ b/src/Tests/GasTests/Effect/InstantEffectTransactionTests.cs
@@ -397,6 +397,294 @@ public sealed class InstantEffectTransactionTests
         });
     }
 
+    [Test]
+    public unsafe void RollbackWorldWrites_WhenBlackboardHolderIsDestroyed_CompletesRemainingRestores()
+    {
+        using World world = World.Create();
+        int healthId = AttributeRegistry.Register("Test.S4.Rollback.Health");
+        var tagOps = new TagOps(new DirtyEntityQueue(8), new TagRuleRegistry());
+        Entity victim = world.Create(new BlackboardFloatBuffer());
+        Entity survivor = world.Create(new AttributeBuffer(), new DirtyFlags());
+        world.Get<AttributeBuffer>(survivor).SetBase(healthId, 100f);
+        Entity source = world.Create();
+        using var transaction = new EffectPhaseSideEffectTransaction(
+            world,
+            tagOps,
+            effectRequests: null,
+            spawnRequests: null,
+            presentationEvents: null,
+            attributeEntityCapacity: 8);
+        transaction.Begin();
+        transaction.StageBlackboardFloat(victim, keyId: 7, value: 3.5f);
+        transaction.StageAttributeAdd(survivor, healthId, -25f);
+        EffectPhaseListenerBuffer setup = default;
+        setup.Count = 1;
+        setup.Phases[0] = (byte)EffectPhaseId.OnApply;
+        setup.Scopes[0] = (byte)PhaseListenerScope.Target;
+        setup.ActionFlags[0] = (byte)PhaseListenerActionFlags.ExecuteGraph;
+        setup.GraphProgramIds[0] = 1;
+        var context = new EffectContext { Source = source, Target = survivor };
+        transaction.StageListenerRegistration(in context, in setup, ownerEffectId: 11);
+
+        Type transactionType = typeof(EffectPhaseSideEffectTransaction);
+        MethodInfo prepareCommitState = transactionType.GetMethod(
+            "PrepareCommitState",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        FieldInfo structuralCommandsField = transactionType.GetField(
+            "_structuralCommands",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        FieldInfo worldCommitStartedField = transactionType.GetField(
+            "_worldCommitStarted",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        FieldInfo attributeValuesField = transactionType.GetField(
+            "_attributeValues",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        prepareCommitState.Invoke(transaction, null);
+        worldCommitStartedField.SetValue(transaction, true);
+        ((CommandBuffer)structuralCommandsField.GetValue(transaction)!).Playback(world);
+        world.Get<AttributeBuffer>(survivor) = ((AttributeBuffer[])attributeValuesField.GetValue(transaction)!)[0];
+        world.Destroy(victim);
+
+        Assert.DoesNotThrow(() => transaction.Rollback());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(world.IsAlive(victim), Is.False);
+            Assert.That(world.Get<AttributeBuffer>(survivor).GetCurrent(healthId), Is.EqualTo(100f));
+            Assert.That(world.Has<EffectPhaseListenerBuffer>(survivor), Is.False);
+        });
+    }
+
+    [Test]
+    public void StagePresentationEvent_WhenBufferIsMissing_ThrowsNamedError()
+    {
+        using World world = World.Create();
+        using var transaction = new EffectPhaseSideEffectTransaction(
+            world,
+            tagOps: null,
+            effectRequests: null,
+            spawnRequests: null,
+            presentationEvents: null,
+            attributeEntityCapacity: 2);
+        transaction.Begin();
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() =>
+            transaction.StagePresentationEvent(new GasPresentationEvent
+            {
+                Kind = GasPresentationEventKind.EffectActivated,
+            }))!;
+
+        Assert.That(error.Message, Does.StartWith(EffectPhaseSideEffectTransaction.MissingPresentationEventBufferError));
+        transaction.Rollback();
+    }
+
+    [Test]
+    public void StageGrantedTagGrant_CommitsThroughTransactionAndRollsBackOnAbort()
+    {
+        using World world = World.Create();
+        const int tagId = 91;
+        var dirtyQueue = new DirtyEntityQueue(8);
+        var tagOps = new TagOps(dirtyQueue, new TagRuleRegistry());
+        Entity target = world.Create(new GameplayTagContainer(), new TagCountContainer(), new DirtyFlags());
+        var grantedTags = new EffectGrantedTags();
+        Assert.That(grantedTags.Add(new TagContribution
+        {
+            TagId = tagId,
+            Formula = TagContributionFormula.Fixed,
+            Amount = 1,
+        }), Is.True);
+        using var transaction = new EffectPhaseSideEffectTransaction(
+            world,
+            tagOps,
+            effectRequests: null,
+            spawnRequests: null,
+            presentationEvents: null,
+            attributeEntityCapacity: 4);
+
+        transaction.Begin();
+        transaction.StageGrantedTagGrant(target, in grantedTags, stackCount: 1);
+        Assert.That(world.Get<GameplayTagContainer>(target).HasTag(tagId), Is.False);
+        transaction.Rollback();
+        Assert.That(world.Get<GameplayTagContainer>(target).HasTag(tagId), Is.False);
+        Assert.That(dirtyQueue.Count, Is.Zero);
+
+        transaction.Begin();
+        transaction.StageGrantedTagGrant(target, in grantedTags, stackCount: 1);
+        transaction.Commit();
+
+        Assert.That(world.Get<GameplayTagContainer>(target).HasTag(tagId), Is.True);
+        Assert.That(world.Get<TagCountContainer>(target).GetCount(tagId), Is.EqualTo(1));
+        Assert.That(dirtyQueue.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void FanOutBuiltins_WhenRequiredServicesAreMissing_ThrowNamedErrors()
+    {
+        using World world = World.Create();
+        Entity source = world.Create();
+        Entity target = world.Create();
+        var context = new EffectContext { Source = source, Target = target };
+        EffectConfigParams mergedParams = default;
+        EffectTemplateData template = default;
+
+        using (BuiltinHandlerRuntimeScope.Push(new BuiltinHandlerExecutionContext()))
+        {
+            InvalidOperationException spatial = Assert.Throws<InvalidOperationException>(() =>
+                BuiltinHandlers.HandleSpatialQuery(world, default, ref context, in mergedParams, in template))!;
+            Assert.That(spatial.Message, Does.StartWith(BuiltinHandlers.MissingSpatialQueriesError));
+
+            InvalidOperationException dispatch = Assert.Throws<InvalidOperationException>(() =>
+                BuiltinHandlers.HandleDispatchPayload(world, default, ref context, in mergedParams, in template))!;
+            Assert.That(dispatch.Message, Does.StartWith(BuiltinHandlers.MissingFanOutBudgetError));
+
+            InvalidOperationException reresolve = Assert.Throws<InvalidOperationException>(() =>
+                BuiltinHandlers.HandleReResolveAndDispatch(world, default, ref context, in mergedParams, in template))!;
+            Assert.That(reresolve.Message, Does.StartWith(BuiltinHandlers.MissingSpatialQueriesError));
+        }
+
+        InvalidOperationException missingRuntime = Assert.Throws<InvalidOperationException>(() =>
+            BuiltinHandlers.HandleSpatialQuery(world, default, ref context, in mergedParams, in template))!;
+        Assert.That(missingRuntime.Message, Does.StartWith(BuiltinHandlers.MissingHandlerRuntimeError));
+    }
+
+    [Test]
+    public void EffectApplication_AttachIsVisibleIntermediateState_BeforeActivateSettlement()
+    {
+        using World world = World.Create();
+        Entity source = world.Create();
+        Entity target = world.Create(new ActiveEffectContainer());
+        Entity effect = GameplayEffectFactory.CreateEffect(
+            world,
+            rootId: 1,
+            source,
+            target,
+            durationTicks: 30,
+            lifetimeKind: EffectLifetimeKind.After);
+        var system = new EffectApplicationSystem(
+            world,
+            GasConstants.MAX_EFFECT_REQUESTS_PER_FRAME,
+            new DiscreteClock())
+        {
+            MaxWorkUnitsPerSlice = 1,
+        };
+
+        Assert.That(system.UpdateSlice(0f, int.MaxValue), Is.False);
+        Assert.That(world.IsAlive(effect), Is.True);
+        Assert.That(world.Get<ActiveEffectContainer>(target).Count, Is.EqualTo(1));
+        Assert.That(world.Get<GameplayEffect>(effect).State, Is.EqualTo(EffectState.Apply));
+
+        system.MaxWorkUnitsPerSlice = int.MaxValue;
+        int slices = 0;
+        while (!system.UpdateSlice(0f, int.MaxValue))
+        {
+            slices++;
+            Assert.That(slices, Is.LessThan(16));
+        }
+
+        Assert.That(world.Get<GameplayEffect>(effect).State, Is.EqualTo(EffectState.Committed));
+        Assert.That(world.Get<ActiveEffectContainer>(target).Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void EffectApplication_ActivateFailure_LeavesVisibleAttachment_AndResetSliceReclaimsIt()
+    {
+        using World world = World.Create();
+        const int templateId = 1942;
+        const int graphId = 1943;
+        var programs = new GraphProgramRegistry();
+        programs.Register(graphId,
+        [
+            new GraphInstruction { Op = (ushort)GraphNodeOp.WriteBlackboardFloat, A = 0, B = 0, Imm = 1 },
+        ], GraphKind.Effect);
+        EffectPhaseGraphBindings bindings = default;
+        Assert.That(bindings.TryAddStep(EffectPhaseId.OnApply, PhaseSlot.Main, graphId), Is.True);
+        var templates = new EffectTemplateRegistry();
+        templates.Register(templateId, new EffectTemplateData
+        {
+            LifetimeKind = EffectLifetimeKind.After,
+            DurationTicks = 30,
+            PhaseGraphBindings = bindings,
+        });
+        var presets = new PresetTypeRegistry();
+        var builtins = new BuiltinHandlerRegistry();
+        BuiltinHandlers.RegisterAll(builtins);
+        EffectExecutionPlanCompiler.FinalizeAll(
+            templates,
+            presets,
+            builtins,
+            programs,
+            GasGraphOpHandlerTable.Instance,
+            "Test/s4-attach-intermediate-effects.json");
+        var phaseExecutor = new EffectPhaseExecutor(
+            programs,
+            presets,
+            builtins,
+            GasGraphOpHandlerTable.Instance,
+            templates);
+        var graphApi = new GasGraphRuntimeApi(world);
+        Entity source = world.Create();
+        Entity target = world.Create(new ActiveEffectContainer());
+        Entity effect = GameplayEffectFactory.CreateEffect(
+            world,
+            rootId: 2,
+            source,
+            target,
+            durationTicks: 30,
+            lifetimeKind: EffectLifetimeKind.After);
+        world.Add(effect, new EffectTemplateRef { TemplateId = templateId });
+        var system = new EffectApplicationSystem(
+            world,
+            GasConstants.MAX_EFFECT_REQUESTS_PER_FRAME,
+            new DiscreteClock(),
+            templates: templates,
+            phaseExecutor: phaseExecutor,
+            graphApi: graphApi)
+        {
+            MaxWorkUnitsPerSlice = 1,
+        };
+
+        Assert.That(system.UpdateSlice(0f, int.MaxValue), Is.False);
+        Assert.That(world.Get<ActiveEffectContainer>(target).Count, Is.EqualTo(1));
+
+        system.MaxWorkUnitsPerSlice = int.MaxValue;
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() =>
+        {
+            while (!system.UpdateSlice(0f, int.MaxValue))
+            {
+            }
+        })!;
+
+        Assert.That(error.Message, Does.StartWith("GAS.EFFECT_TRANSACTION.ERR.MissingBlackboard"));
+        Assert.That(world.IsAlive(effect), Is.True);
+        Assert.That(world.Get<ActiveEffectContainer>(target).Count, Is.EqualTo(1));
+        Assert.That(world.Get<GameplayEffect>(effect).State, Is.EqualTo(EffectState.Apply));
+
+        system.ResetSlice();
+
+        Assert.That(world.IsAlive(effect), Is.False);
+        Assert.That(world.Get<ActiveEffectContainer>(target).Count, Is.Zero);
+    }
+
+    [Test]
+    public void StageEffectDestroy_LandsOnlyAfterSuccessfulCommit()
+    {
+        using World world = World.Create();
+        Entity effect = world.Create(new GameplayEffect());
+        using var transaction = new EffectPhaseSideEffectTransaction(
+            world,
+            tagOps: null,
+            effectRequests: null,
+            spawnRequests: null,
+            presentationEvents: null,
+            attributeEntityCapacity: 2);
+        transaction.Begin();
+        transaction.StageEffectDestroy(effect);
+        Assert.That(world.IsAlive(effect), Is.True);
+        transaction.Commit();
+        Assert.That(world.IsAlive(effect), Is.False);
+    }
+
     private static EffectProposalProcessingSystem CreateSetParentRuntime(
         World world,
         int templateId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# 概要

- 变更目标：结算提交按改过的属性走正式写入面。事务类不再直写属性缓冲，从白名单拿掉。
- 影响范围：`EffectPhaseSideEffectTransaction.Commit`；S2 守卫白名单。

叠在 [#946](https://github.com/MightyBubble/Ludots/pull/946) 上。#943 仍只带回滚必须走完，不要用本分支替换 #943。

# SSOT 落点

- 正式规则：无
- 正式架构：`gitbook/architecture/attribute-write-authority.md`
- 正式查表或操作：无
- 仓库深度材料：无
- 审计或提案：#949 附录 B.2

# 设计与挂靠点

- 挂靠点：S2 `AttributeMutationOps` / `EffectModifierOps`
- 复用清单：按 attributeId 的 `SetBase` / `SetCurrent`
- 新增清单：无平行写入面

# 已知取舍

回滚仍整块恢复原始缓冲。那是撤回，不是玩法写入。

# 验证证据

```
ArchitectureTests 守卫：3 passed（事务类已不在白名单，展厅仍被扫描）
GasTests EffectPhase / InstantTxn / Attribute：97 passed
```

# 文档同步

- [x] 行为变更已同步更新 `gitbook/` 正式文档 —— 写入面合同已在 #946
- [x] 所属目录 `README.md` 或 `SUMMARY.md` 已同步 —— 不需要
- [x] 若影响入口或导航，`README.md` / `README_CN.md` / `AGENTS.md` / `CLAUDE.md` 已同步 —— 不影响

#949 之后：回滚与提交都收完，**可以关单**（与 #943 一起看）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88eeeec8-f8e7-44e7-bfea-db2b5c012489?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88eeeec8-f8e7-44e7-bfea-db2b5c012489&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

