### PR TITLE
docs(audits): #942 全票落地后独立架构审计

### DIFF
--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -27,6 +27,7 @@
 * [S14 分层物理化设计（第一阶段 · 只出设计）](s14_layering_physicalization_design.md)
 * [S 第二批 + S9 架构审计（#951 / #952 / #950 / #948 / #953）](s_batch2_s9_architecture_audit.md)
 * [GAS + Graph 修复计划落地后审计需求（#942 全票合入）](s_plan_landed_audit_handoff.md)
+* [GAS + Graph 修复计划落地后架构审计（SSOT）](s_plan_landed_architecture_audit.md)
 
 ## 2 使用边界
 

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -26,6 +26,7 @@
 * [S 第一批架构审计（#944 / #946 / #943 / #945）](s_batch1_architecture_audit.md)
 * [S14 分层物理化设计（第一阶段 · 只出设计）](s14_layering_physicalization_design.md)
 * [S 第二批 + S9 架构审计（#951 / #952 / #950 / #948 / #953）](s_batch2_s9_architecture_audit.md)
+* [GAS + Graph 修复计划落地后审计需求（#942 全票合入）](s_plan_landed_audit_handoff.md)
 
 ## 2 使用边界
 

--- a/docs/audits/s_plan_landed_architecture_audit.md
+++ b/docs/audits/s_plan_landed_architecture_audit.md
@@ -1,0 +1,364 @@
+# GAS + Graph 修复计划落地后架构审计（#942 全票合入）
+
+**审计对象：** `origin/main` @ `46fcd9dcda`（#960 合入后）  
+**需求正本：** [`s_plan_landed_audit_handoff.md`](s_plan_landed_audit_handoff.md)  
+**计划正本：** [`gas_graph_architecture_fix_plan.md`](gas_graph_architecture_fix_plan.md)（[#942](https://github.com/MightyBubble/Ludots/pull/942)）  
+**合同：** `gitbook/architecture/graph-funclib-actionlib-contract.md`（状态仍是**修复中**）  
+**前序（输入，不是结论）：** [`s_batch1_architecture_audit.md`](s_batch1_architecture_audit.md)、[`s_batch2_s9_architecture_audit.md`](s_batch2_s9_architecture_audit.md)、[`pr932_graph_landed_architecture_audit.md`](pr932_graph_landed_architecture_audit.md)  
+**方法：** 对照源码与指定过滤器证伪；零生产代码。  
+**刻意不审：** UI 面板（#886 / #893）、#723 GraphScore、#947 Pi、删八家族 Mod、S14 第 2–6 波搬家。
+
+---
+
+## 1. 概述
+
+### 1.1 Verdict
+
+**FIX-FORWARD。**
+
+玩家能感觉到的主故障，在这棵树上已经关上门：自己调自己不会把游戏弄没；写进去的数不会自己变回去；查询图不能偷偷绑一张会等一拍的动作；划掉的家族展厅没有可复制的启动命令；「派事件改血」打到零不会无声回满；被镜头挡住的人还能点到。作者也能用配置写巡逻树，哨兵机挂「等一拍」会在加载时失败。
+
+不能写成「计划已落地、合同改回已落地」。三件事还开着：
+
+1. **分层墙还在纸上和棘轮上。** S14 整体不得关单。Core 仍是一个程序集，这是本波预期，不是缺陷。
+2. **后票踩坏了一批夹具。** S8 的假防线没有回来（断言还在、门槛没放宽），但点名过滤器在 squash 后有 8 条红；S4 那条「后面一步失败必须整单回滚」的图用例登记不上。这是夹具没跟上新合同，不是玩家门重新打开。
+3. **验收页过时。** 查询口已经关了，UAT 页还写「本树未合入查询口收口」。合同必须继续写「修复中」。
+
+没有新的阻断项。没有「一行配置杀死进程」或「退役门又能点进去」这种 P0 回潮。
+
+### 1.2 玩家一句话
+
+进游戏：划掉的房间进不去；这一刀该掉的血会掉、掉到零不会偷偷回满；山坡后的人仍能点到。写技能：自己调自己当场被拒；查询图不能绑巡逻动作。写行为：巡逻树可以写在配置里，但默认「看见敌人 / 进入射程」这两片叶子还要 C# 喂一个数字。维护者：分层怎么切已经写清，工程没有假装拆完。
+
+### 1.3 逐票关单表
+
+| 任务 | 合入 | 本轮 | 关单 |
+|------|------|------|------|
+| S1 自己调自己会杀进程 | #944 | 复验：登记拒环，运行期超深抛错 | **可关** |
+| S2 写进去的数会变回去 | #946 | 第一批 M1 已收口：守卫扫 Core+展厅，缺 DLL 失败关闭；已扫程序集无裸写 | **可关**（扫描名单手工枚举，记债） |
+| S3 查询口偷跑可挂起动作 | #941 | **首次独立审。** 查询 `InvokeScript.graphId` 编译失败，诊断与线性方言同一套 | **可关** |
+| S4 回滚自己会抛 / 提交对齐写入面 | #959 | 第一批 M2 已收口：提交逐属性走正式写入面；事务类已移出白名单。回滚整块恢复快照是回滚语义，不是违规 | **可关**（点名回滚图用例被 S9 踩红，记 Major） |
+| S5 容量到顶不说话 | #945 | 复验：满了就抛；假计数未回 | **可关**（事件总线旁系死计数仍是已知债） |
+| S6 退役门没锁 | #941 | **首次独立审。** 八条 `binding`/`preset` 为空；启动器卡片不给命令；生产 bootstrap 不再清图号 | **可关**（Mod 列表仍能勾选家族 Mod，记债） |
+| S7 血条演戏 | #941 | **首次独立审。** 静默回卷已删；喝茶不写生命；「派事件改血」走图内正式加减 | **可关**（Clamp/Mul/Sub 简介仍像真结算，记 Major） |
+| S8 假防线 | #951 | 复验：断言还在、门槛没放宽。点名过滤器 8 红 / 26 绿，是后票踩夹具，不是假防线回来 | **可关**（夹具对齐另开，不要重开 S8） |
+| S9 图执行走同一道门 | #953 | 复验：七个生产宿主走 `GraphExecutor` | **可关**（typed 图号、展厅内部入口仍是已知缺口） |
+| S10 选中读裁剪 | #952 | 复验：点选/Tab 读战场坐标；镜头外仍可选；守卫仍禁模拟相读裁剪 | **可关** |
+| S11 覆盖表假绿 | #950 | 复验：`covered` 可解析；生成器 `--strict` 零漂移 | **可关** |
+| S12 格子与前门同一张表 | #956 | **首次独立审。** 临时格走分配器；前门 ⊆ 策略为空集；32 上限未改 | **可关**（双钉同格、`PatchFuncLib` 非幂等记债） |
+| S13 数据写行为 | #960 | **首次独立审。** 巡逻树来自 JSON；HFSM/关卡挂 Yield 加载失败；叶子自读能力已开，默认发货图未换 | **可关**（默认感知叶不得写成已关） |
+| S14 分层 | #954 设计 + #957 Wave 1 | **首次独立审。** 六问有书面答案；Wave 1 立了顺序墙和棘轮；**没有拆程序集** | **不关单** |
+| S15 验收页一份 | #948 | 复验：仍一个 H1。查询口段落与已落地代码矛盾 | **可关**（页要改写成「已关」，不要再写「未合入」） |
+
+---
+
+## 2. 结构
+
+```text
+阶段 0  对齐计划 / 合同 / 前序审计
+阶段 1  三条闸门（从未审）：S3 查询口 / S6 退役门 / S7 血条
+阶段 2  属性权威收口：S2 / S4（第一批当时不让关）
+阶段 3  作者地基（从未审）：S12 格子与前门 / S13 数据写行为
+阶段 4  分层第一波：S14 设计六问 + Wave 1 棘轮（不审搬家）
+阶段 5  前序可关单复验：S1 / S5 / S8 / S9 / S10 / S11 / S15
+阶段 6  本页合成
+```
+
+| 领域 | 一句话 | 对应 |
+|------|--------|------|
+| I | 纯查询能不能直绑一张会等一拍的图 | S3 |
+| J | 划掉的卡还能不能点进去，会不会清图号 | S6 |
+| K | 这一刀是真打还是演戏，打到零会不会偷偷回满 | S7 |
+| O | 展厅还能不能裸写；提交是不是正式写入面 | S2 / S4 |
+| L | 两个节点会不会抢同一格；文档能写的是否真写得出 | S12 |
+| M | JSON 树是否真在跑；叶子是否还靠 C# 喂数 | S13 |
+| N | 设计有没有答完六问；有没有假装拆完程序集 | S14 |
+| P | 已可关单的票在 squash 之后有没有被后票踩坏 | S1 / S5 / S8 / S9 / S10 / S11 / S15 |
+
+---
+
+## 3. 详情
+
+### 3.1 从未审的票
+
+#### S3 · 查询口 — 可关
+
+查询图的 `InvokeScript` 只给图号、不给函数名，编译失败。诊断码与线性方言同一套：缺函数名是 `MissingNodeRef`，带了 `graphId` 是 `TypeMismatch`，文案都是「linear FuncLib authoring」。`FrontDoor_LinearKindsInvokeScriptGraphId_FailClosed` 已带 `Query` 与 `Effect`。`assets/` / `mods/` 里没有 `kind=Query` 且带 `graphId` 的图。用清单函数名调用仍然允许。
+
+没有改合同措辞来代替编译期拒绝。合同 §3.4 仍只写 Effect 禁 `graphId`，Query 收口在代码里做了、合同投影不完整——记 Minor，不挡关单。
+
+运行期 `HandleInvokeScript` 仍只验「是 Script、不含 Yield」，不验是不是 FuncLib。作者 JSON 路径已关；绕过前门的 bytecode 仍能登记。这是纵深，不是今天作者能写进查询图的口。
+
+#### S6 · 退役门 — 可关
+
+八条 `capability_standard_graph_ops_*` 都是 `binding: null`、`preset: null`、`status: retired`。启动器配置和预设列表里没有对应名字。`launchHint` 对退役条目返回空，卡片写「已退役，不能启动」，没有复制按钮。`validate-registry.py` 错误 0。
+
+五个生产 bootstrap 不再调用 `GraphIdRegistry.Clear()`。Rel / Query 的 GameStart 不再对活引擎 `BindStandaloneFromModAssets`。有清表的家族验收夹具都标了 `NonParallelizable`。八个家族 Mod 目录还在——本票禁止删，还在不是缺陷。
+
+退役 `binding=null` 能过双向校验，靠的是脚本把空值静默排除，不是书面规则。启动器仍递归扫描 `mods/`，家族 Mod 还能在勾选列表里被手动打开。这两条不影响玩家门，记债。
+
+#### S7 · 血条 — 可关
+
+「派事件改血 / 扇出 / 读配置效果号」三张图里都有 `ModifyAttributeAdd`（−18），驱动只从世界把血读回来。全画廊搜不到 `if (next <= 0) next = opening`。喝茶只写字幕里的水位，不写生命；简介已改成「水位示意，不是血量」。知识披露 / 头顶条那一侧没有被顺手改坏。
+
+演戏和真结算要分开看：
+
+| 玩家点进去 | 条上的数从哪来 | 算不算这一刀 |
+|------------|----------------|--------------|
+| 派事件改血、扇出、读配置效果号 | 图里正式加减属性，驱动只回读 | 是（扇出模板本身不承担伤害，扣在显式目标上） |
+| 加减乘钳一类算式 | 驱动把算式结果画到条上 | 否。`AddFloat` 已写明「示意，不是结算」；`ClampFloat` / `MulFloat` / `SubFloat` 仍写「血条按…掉」 |
+| 喝茶 | 条不动，字幕涨水位 | 否。文案说条示水位，条实际不跟茶水走 |
+
+静默回卷这个主故障已经不在。文案批次不一致是 Major，不是阻断。
+
+#### S12 · 格子与前门 — 可关
+
+`TargetListGet` 与 `SnapToNearestInCollection` 的有效位不再写死 B[31]，都走 `AllocScratch()`。先分配再钉格会报冲突。存在 `GraphOpDescriptorTable`；「前门 ⊆ 策略」测试在本 SHA 上空集（六种 kind 都是 0）。`Patch()` 第二次是空操作。32 格上限未改。
+
+还没收干净的：先钉后分配只是跳过已占格、不报冲突；双钉同一格没有诊断；`PatchFuncLib` 没有幂等守卫；编译 emit / 符号补丁仍是大 switch，没有完全由 descriptor 驱动。这些不够把「两个节点抢同一格」的主故障重开。
+
+#### S13 · 数据写行为 — 可关，感知叶不关
+
+巡逻-追击-攻击树来自 `assets/Configs/AI/behavior_trees.json`。Core 里已经没有 `CreatePatrolChaseAttackTree`。11 个脚本名只活在 `action_lib.json`。行为树叶子经帧调用 FuncLib（`demo.const.seven`）能返回 7。含 Yield 的巡逻叶跨拍续跑。HFSM / 关卡挂含 Yield 的动作在加载期失败关闭，与合同「HFSM 禁止 Yield」同一裁决。
+
+默认 `bt.seeEnemy` / `bt.inAttackRange` 仍是 `HaltReturnInt` + `I[0]`。展厅 C# 仍往 `ints[0]` 里喂「看见 / 进入射程」。引擎已经允许叶子自己 `LoadAttribute`，专项测试也证明不必先喂数字——**发货内容还没换**。实现方自报的这条缺口核实成立，不得写成「叶子感知已关单」。
+
+#### S14 · 分层 — 不关单
+
+设计回答了计划里的六个问题：程序集切法、注册表实例化、Mod 可见面、跨层组件、SystemGroup 单一数据源、分波迁移。设计仍写「评审通过之前不搬生产代码」。`Ludots.Core.csproj` 仍是单一大程序集——这是本波预期。gitbook 没有把分层改成「已落地」。
+
+Wave 1：`SystemGroupOrder.All` 就是枚举声明顺序；合作仿真不再另藏一张阶段表；`GetEngine` 已标过时；棘轮只许下降。S8 的阶段顺序交叉校验没有被删成空断言，换成了「运行时表 = 枚举」加「禁止第二张表」。
+
+棘轮实测：`GetEngine` 205 / 未声明 `RegisterSystem` 100 / 引用门面 136 三项顶格；生产静态 `Clear` 10（上限 15）、mods `GraphIdRegistry.Clear` 0（上限 5）。低于上限来自 S6，不是 Wave 1 主动收口，**不得写成 S14 已关**。第 2–6 波未开工。
+
+### 3.2 第一批当时不让关的收口
+
+| 第一批 | @ `46fcd9dcda` | 本轮 |
+|--------|----------------|------|
+| M1 守卫只扫 Core；展厅裸写；文档缩到 Core | 守卫硬编码 11 个程序集（1 Core + 10 展厅/基准）；缺 DLL `Assert.Fail`；GoldMarket 补金走 `AttributeMutationOps.SetCurrent`；文档写 Core+展厅 | **关闭** |
+| M2 提交整块赋值缓冲；事务类在白名单 | `Commit` 按属性走 `AttributeMutationOps.SetBase` / `SetCurrent`；事务类已移出白名单；回滚仍整块恢复快照 | **关闭** |
+
+新债：扫描名单漏了画廊与行为公共程序集（当前源码合规，回归裸写不会被扫到）；`PrepareCommitState` 与正式写入面对脏标记仍有双轨；缺「多目标扇出中途销毁再回滚」的集成测试。
+
+### 3.3 前序可关单复验
+
+| 项 | 还成立吗 | 现在的路径 / 测试 |
+|----|----------|-------------------|
+| S1 | **仍成立** | `GraphProgramRegistry.EnsureNoInvokeCycle`；`GraphInvokeCycleTests` 在本轮 100 条绿集里 |
+| S5 | **仍成立** | `DeferredTriggerQueue` / `EffectRequestQueue` 满了抛；假计数未回。`GameplayEventBus.DroppedEventsLastUpdate` 仍恒 0，不是回归 |
+| S8 | **关单条件仍成立；过滤器红** | 门槛字面量未放宽（`<=64` / `<15ms` / `<5ms` / `<50ms`）。8 条红是 S9 要显式结束、S5 容量到顶、S2 当前值不再被聚合改写——夹具没改 |
+| S9 | **仍成立** | 七宿主走 `GraphExecutor`。typed 图号仍是 `int`；展厅内部仍走 `Execute` / `ExecuteSlice`。核实存在，不当新发现，也不当已收口 |
+| S10 | **仍成立** | 点选/Tab 读 `WorldPositionCm`；`CameraCulledEntity_RemainsSelectableAndReceivesOrders` 绿；守卫 51/51 |
+| S11 | **仍成立** | 覆盖表 120 条 `covered`；生成器 `--strict` 后覆盖表与登记表零漂移 |
+| S15 | **一份 H1 仍成立；正文过时** | 仍一个一级标题。第 81 行仍写查询口未合、过滤器不含 Query——与本树代码相反 |
+
+S8 不得写成「假防线回归」。断言有牙齿，所以夹具合同一变就红。另开夹具对齐票，不要为了变绿放宽 64，也不要重开 S8。
+
+### 3.4 阻断 / Major / Minor / 债务
+
+**阻断：** 无。
+
+| # | 级 | 项 | 证据 |
+|---|----|----|------|
+| M-A | Major | S8 点名过滤器 squash 后 8 红 | `DurationEffectTick` 期望 107 实得 100（S2 恢复当前值）；6 条 `MissingHalt` / `PcOutOfRange`（S9）；`Benchmark_DeferredTriggerQueue_Enqueue` 一次塞 10000 条，容量 1024+1024（S5） |
+| M-B | Major | S4 点名回滚图用例登记失败 | `InstantGraph_WhenLaterOperationFails_RollsBackAllStagedSideEffects` → `MissingHalt`。实现仍在，夹具手写图没有 `HaltReturnInt` |
+| M-C | Major | 验收页仍写查询口未关 | `gitbook/acceptance/graph-funclib-actionlib-uat.md` 第 81 行 vs `GraphControlFlowCompiler.Query.cs` 与已带 Query 的过滤器 |
+| M-D | Major | Clamp / Mul / Sub 简介仍像真结算 | `showcase.registry.json`：`血条按钳住后的数掉` / `按放大后的数往下掉` / `按剩下的数掉`；实现与已披露的 `AddFloat` 一样是示意条 |
+| M-E | Major | 退役 `binding=null` 没有书面规则 | `validate-registry.py` 用非空过滤跳过，不是「改规则」或「补豁免」 |
+| m1 | Minor | 守卫扫描名单手工枚举，漏画廊与行为公共程序集 | `CollectAttributeBufferWriteScanAssemblies` |
+| m2 | Minor | 合同未显式写 Query 禁 `graphId` | `graph-funclib-actionlib-contract.md` §3.4 |
+| m3 | Minor | 双钉同格、`PatchFuncLib` 非幂等 | `GraphRegisterFile.Pin`；`GraphProgramSymbolPatcher.PatchFuncLib` |
+| m4 | Minor | 测试仍手写一份 `DesignedSystemGroupOrder` | `ArchitectureGuardTests.cs`；运行时 SSOT 已是枚举 |
+| m5 | Minor | Rel/Query 家族 Mod 手动勾选后半残 | GameStart 只挂引擎，不绑注册表 |
+| d1 | 债 | 默认 `bt.seeEnemy` / `bt.inAttackRange` 仍吃 `I[0]` | 实现方自报，核实。不得当新发现，也不得当已关 |
+| d2 | 债 | typed 图号仍是 `int`；展厅内部入口仍在 | 第二批已知缺口 |
+| d3 | 债 | `GameplayEventBus` 旁系死计数恒 0 | 第一批已知债 |
+| d4 | 债 | S14 Wave 2–6 未开工 | 设计明文。发现大搬家才是越界 |
+| d5 | 债 | `BehaviorTreeFactory` 骨架树、`LevelBlueprintFactory.CreateTwoPhaseTrial` 仍是 C# | 实现方自报，核实：不是巡逻树 SSOT |
+
+---
+
+## 4. 场景
+
+1. **自己调自己。** 登记失败，游戏还在。复验仍成立。
+2. **不夹上限的属性写下当前值。** 重算之后数还在。S2 自己的 21 条测试全绿。
+3. **查询图填巡逻动作的图号。** 编译失败，理由与线性方言一致。作者今天写不进去。
+4. **启动器翻到已划掉的家族大杂烩。** 没有可复制的启动命令，顶栏预设也没有。Mod 勾选列表里目录还在，那是另一扇侧门。
+5. **点进「派事件改血」。** 木桩从 100 到 82，数从图里来。打到零不会被代码改回满血。加减乘钳那几间仍是示意条，其中三间简介还没说清楚。
+6. **镜头抬高、单位被挡住。** 仍能点到、能下令。
+7. **配置里写巡逻-追击-攻击树。** 代理按树走，不用改 Core 工厂。
+8. **叶子要看目标还剩多少血。** 引擎允许它自己读。默认那两片「看见 / 进入射程」还要有人先把 0/1 塞进来。
+9. **把含「等一拍」的动作挂到哨兵机上。** 加载就失败。
+10. **打开分层设计。** 六问都有答案。打开工程，Core 仍是一个程序集，没有假装拆完。
+
+---
+
+## 5. 边界
+
+**做了：** 证伪 `main@46fcd9dcda` 上计划全票的声称；从未审的票读源码；已可关单的票做回归抽查；对照合同与前三份审计写清仍开的债。
+
+**没做：** 改生产代码；审 UI 面板 / #723 / #947；审 S14 搬家；把 typed 图号或删家族 Mod 升成本次唯一目标；把合同改成「已落地」。
+
+**已裁决、不再争：** Duration/Period 在效果壳上；FuncLib 纯、ActionLib 可挂起；图节点玩家门是单节点展厅；选中读战场坐标；缺清单/空表/成环失败关闭；S14 禁止一周拆完。
+
+**已知已知（核实，不当新发现）：** 合同「修复中」；第一批/第二批对照的是旧 tip 上的 PR head；#943 已被 #959 取代；GetEngine 过时警告是 Wave 1 故意的；八家族 Mod 还在是 S6 要求。
+
+---
+
+## 6. UAT
+
+对照需求 §6。过 / 未过 / 无法测：
+
+```gherkin
+Feature: 一张图不能把游戏弄没了
+  Scenario: 自己调自己必须被拒绝
+    状态: 过
+    证据: GraphInvokeCycleTests；登记拒环，运行期超深抛错
+
+Feature: 写进去的数还在
+  Scenario: 不夹上限的属性也能保住写入
+    状态: 过
+    证据: AttributeAggregatorTests 21/21，含 UnconstrainedAttribute_DirectCurrentWriteSurvivesActiveAggregation
+    注: 展厅已扫程序集无裸写；名单外程序集是债，不是本场景未过
+
+Feature: 纯查询里不能偷偷跑起会等一拍的动作
+  Scenario: 查询图直绑图号必须被拒绝
+    状态: 过
+    证据: FrontDoor_LinearKindsInvokeScriptGraphId_FailClosed("Query")；Query.cs 与 Linear.cs 同一套诊断
+
+Feature: 划掉的门要真的锁上
+  Scenario: 退役展厅不再给出可点的入口
+    状态: 过
+    证据: launchHint 对 retired 返回 null；八条 binding/preset 为空；validate-registry 错误 0
+    注: Mod 勾选列表仍能看见家族目录，不是本场景的启动命令
+
+Feature: 血条要么代表真被打掉的血，要么别装成那样
+  Scenario: 打到零不许偷偷回满
+    状态: 过
+    证据: 画廊无 next<=0 回卷；SendEvent 100→82
+  Scenario: 喝茶不是掉血
+    状态: 过（条不跟茶水走，简介已不再承诺按茶水掉）
+    注: 文案说条示水位，条实际钉在开局，玩家若只看条会误解
+
+Feature: 被挡住的人还能点到
+  Scenario: 看不见也能下令
+    状态: 过
+    证据: CommandSourceAcquisitionSystem_CameraCulledEntity_RemainsSelectableAndReceivesOrders
+
+Feature: 行为可以用数据写，不必改引擎
+  Scenario: Mod 定义自己的行为树
+    状态: 过
+    证据: behavior_trees.json 的 bt.patrolChaseAttack；Core 无 CreatePatrolChaseAttackTree
+  Scenario: 叶子自己能感知
+    状态: 未过（能力过、发货未过）
+    证据: ScriptDialectL2AuthoringTests 证明 LoadAttribute 可行；默认 bt.seeEnemy / bt.inAttackRange 仍 HaltReturnInt+I[0]
+  Scenario: 哨兵机不能挂会等一拍的动作
+    状态: 过
+    证据: GraphActionCatalogLoaderTests 含 Yield 的 HFSM/关卡动作加载期失败关闭
+
+Feature: 层与层之间的墙还没假装砌完
+  Scenario: 设计能回答边界问题
+    状态: 过（设计 + Wave 1 墙；整票不关单）
+    证据: s14_layering_physicalization_design.md 六问；Ludots.Core.csproj 仍单一程序集；SystemGroupOrder.All = 枚举
+```
+
+合同 §3 / §4.4 / §5 / §6：查询禁直绑图号在实现里已立，合同正文没写全；HFSM 禁 Yield 合同与实现同一裁决；分层未落地。**合同状态必须继续「修复中」。**
+
+---
+
+## 附录 A — 测试证据
+
+对象：`/tmp/s-audit/main46` @ `46fcd9dcda`。独立工作区，不改生产。
+
+| 过滤器 / 命令 | 结果 |
+|---------------|------|
+| ArchitectureTests：`AttributeWriteAuthorityGuardTests` + S14 棘轮 + SystemGroup/PhaseOrder + 选中守卫 | 11 / 11 |
+| ArchitectureTests：`ArchitectureGuardTests` 全类 | 51 / 51 |
+| GasTests：作者前门 / 查询 / 合同 / 自递归 / 同一道门 / 覆盖表 / 寄存器 | 100 / 100 |
+| GasTests：AI + ActionLib + Script 方言 + 沙盒 / 行为展厅 | 40 / 40 |
+| GasTests：画廊 + Rel/Query/Attr/Spatial/Event 家族验收 | 112 / 112 |
+| GasTests：`AttributeAggregatorTests` | 21 / 21 |
+| GasTests：`LiveGasEditPipelineTests` | 14 / 14 |
+| GasTests：点选 / 命令源 / 指令缓冲 | 55 / 55 |
+| GasTests：`InstantEffectTransactionTests` | **14 / 16**（2 红：`MissingHalt`） |
+| GasTests：Allocation / GraphPerf / GasBenchmark / EffectPhaseStress / GraphFailFast | **26 / 34**（8 红，见 §3.4 M-A） |
+| `python3 scripts/validate-registry.py` | 错误 0，警告 23（T1 缺截图） |
+| `python3 scripts/generate-graph-op-node-galleries.py --strict` 后覆盖表/登记表 | 零漂移 |
+
+完整失败原文见产物 `s_plan_landed_audit_test_evidence.log`。
+
+---
+
+## 附录 B — 给后续 Agent 的最短提示词
+
+按票拆。不要合成一条巨提示词。不要改合同落地状态。不要重开 Duration/Yield 产品争论。
+
+### B.1 夹具对齐（S9 Halt + S5 容量 + S2 当前值）— 不要重开 S8 / S4
+
+```text
+对照 docs/audits/s_plan_landed_architecture_audit.md M-A / M-B。
+对象：手写 GraphInstruction[] 的测试，以及 DeferredTrigger 基准。
+要做：每张手写图末尾加 HaltReturnInt；DurationEffectTick 改断言 current 仍为写入值、cap 为 107，不要把聚合器改回覆盖 current；DeferredTrigger 基准按容量塞满再 Clear，不要为了变绿把容量调大，也不要放宽 64 字节门槛。
+禁止：重开 S8；改 GraphVmLimits 32；改 S2 直写存活语义。
+该跑：InstantEffectTransactionTests；AllocationTests.DurationEffectTick*；GraphPerfTests.Benchmark_GraphExecutor_SmallProgram；GasBenchmarkTests.Benchmark_DeferredTriggerQueue_Enqueue；EffectPhaseStressTests 里三条零分配；GraphFailFastAndCapacityTests.RelationshipQuery_AllowTruncated*
+```
+
+### B.2 验收页按实改写（S15 正文，不是重开 S15）
+
+```text
+对照 gitbook/acceptance/graph-funclib-actionlib-uat.md 第 81 行。
+查询方言 InvokeScript.graphId 已在 GraphControlFlowCompiler.Query.cs 拒绝；
+FrontDoor_LinearKindsInvokeScriptGraphId_FailClosed 已含 Query。
+把「本树未合入查询口收口」改成已覆盖，并指向上述测试。
+不要把 InvokeAction 原文场景写成已覆盖（全仓仍无该节点）。
+保持一个 H1。不要改合同落地状态。
+该跑：pwsh ./scripts/validate-docs.ps1
+```
+
+### B.3 默认感知叶换发货图（S13 已知缺口）
+
+```text
+对照 docs/audits/s_plan_landed_architecture_audit.md d1。
+bt.seeEnemy / bt.inAttackRange 仍是 HaltReturnInt + I[0]。
+把这两张图改成自己 LoadAttribute / Query，去掉展厅 WriteSensors 对这两 id 的喂数。
+BehaviorTreeFactory 骨架树可以留着给压测。
+禁止：把 I[0] 旁路写成「已关单」却不改资产；发明新 opcode。
+该跑：ScriptDialectL2AuthoringTests；BehaviorTreeRuntimeTests；GraphBehaviorSeparatedShowcaseAcceptanceTests
+```
+
+### B.4 S14 Wave 2（只做这一波）
+
+```text
+对照 docs/audits/s14_layering_physicalization_design.md §3.6 Wave 2。
+只做 ModRegistrySet 实例化设计落地的那一波：注册表从进程静态变成实例状态。
+禁止：拆 csproj；删 GetEngine；一周搬完；把 gitbook 改成分层已落地。
+棘轮常量只许下降。mods GraphIdRegistry.Clear 已是 0，把上限从 5 降到 0。
+该跑：S14LayeringRatchetTests；ArchitectureGuardTests.RuntimeSystemGroupOrder*
+```
+
+### B.5 typed 图号（S9 已知缺口，独立票）
+
+```text
+对照第二批审计与本报告 d2。
+生产宿主与 GraphExecutor 入口的图号仍是 int。
+本票只做类型化图号，不要顺手改展厅 InternalsVisibleTo。
+禁止：放宽 kind；拓宽 Script。
+```
+
+### B.6 删八个家族 Mod（S6 关门之后的独立票）
+
+```text
+S6 已经锁上玩家门。本票才允许删 CapabilityStandardGraphOps{Rel,Query,Attr,Spatial,Event,Float,Script,Blackboard}Mod。
+先从 launcher scanRoots / 默认 Mod 集拿掉，再删目录。
+禁止：在本票重开退役 binding 规则之前先删；动单节点画廊。
+该跑：python3 scripts/validate-registry.py；GraphOpsNodeGallery*
+```
+
+### B.7 简介对齐示意条（S7 文案）
+
+```text
+对照 showcase.registry.json 的 ClampFloat / MulFloat / SubFloat。
+按 AddFloat 的句式写明「是把算式结果画上去的示意，不是结算出来的伤」。
+不要改 LinearNodeDriver 的示意路径，那是算式展厅的既定语义。
+该跑：python3 scripts/validate-registry.py
+```

--- a/docs/audits/s_plan_landed_audit_handoff.md
+++ b/docs/audits/s_plan_landed_audit_handoff.md
@@ -1,0 +1,544 @@
+# 审计需求：GAS + Graph 修复计划落地后（#942 全票合入）
+
+**给审计 / 接手 Agent。**  
+这是一次**独立架构审计请求**。对象是已经 squash 进 `main` 的 [#942](https://github.com/MightyBubble/Ludots/pull/942) 计划全票，不是某一张还开着的 PR tip。  
+不要只扫 diff 文件名；必须对照计划任务书与玩家/作者会撞到的事，问「说的和进游戏看到的是不是同一件事」。
+
+本文件**不含结论**。结论另开一份 SSOT 报告。禁止借本需求夹带实现修复。
+
+**刻意不审：** UI 面板图（#886 / #893）、[#723](https://github.com/MightyBubble/Ludots/pull/723) GraphScore、[#947](https://github.com/MightyBubble/Ludots/pull/947) Pi、表现层改名/客户端座椅、删掉八个家族 Mod（S6 关门之后的独立票）、S14 第 2–6 波搬家（尚未开工）。
+
+---
+
+## 1. 概述
+
+计划从「审查里点名的洞」走到「任务书上的票都进了主线」。产品要确认的不是「PR 数字变绿了」，而是：
+
+1. 自己调自己的图不能把游戏弄没了。  
+2. 写进属性的数不会自己变回去；结算提交和回滚各走该走的路。  
+3. 纯查询不能偷偷跑起会等一拍的动作。  
+4. 划掉的展厅门是真锁上的；进一间展厅不会弄坏别的展厅的图编号。  
+5. 血条要么代表真被打掉的血，要么别装成那样。  
+6. 所有图执行走同一道门；选中看战场坐标，不看镜头裁剪。  
+7. 覆盖表说覆盖了就要真跑；验收页只剩一份。  
+8. 格子只由分配器发放；行为树和状态机可以用数据写。  
+9. 分层墙还在纸上和棘轮上，没有假装已经拆完程序集。  
+10. 合同若仍写「修复中」，报告里不得把它当成「已落地」。
+
+| 对象 | 值 |
+|------|-----|
+| 被审 tip | `origin/main` @ `46fcd9dcda`（#960 合入后） |
+| 计划正本 | [`gas_graph_architecture_fix_plan.md`](gas_graph_architecture_fix_plan.md)（[#942](https://github.com/MightyBubble/Ludots/pull/942)） |
+| 审查正本 | [`gas_graph_architecture_review.md`](gas_graph_architecture_review.md) |
+| 合同 | `gitbook/architecture/graph-funclib-actionlib-contract.md`（状态：**修复中**） |
+| 分层 | `gitbook/architecture/graph-layering-flow-and-behavior.md` |
+| 属性写入 | `gitbook/architecture/attribute-write-authority.md` |
+| 跨层所有权 | `gitbook/architecture/entity-simulation-layering.md` §5.1 |
+| 验收页 | `gitbook/acceptance/graph-funclib-actionlib-uat.md` |
+| 前序审计（输入，不是结论） | [`s_batch1_architecture_audit.md`](s_batch1_architecture_audit.md)、[`s_batch2_s9_architecture_audit.md`](s_batch2_s9_architecture_audit.md)、[`pr932_graph_landed_architecture_audit.md`](pr932_graph_landed_architecture_audit.md) |
+| S14 设计 | [`s14_layering_physicalization_design.md`](s14_layering_physicalization_design.md) |
+
+实现方声称已合入（请逐项证伪，不要把 PR 标题当证据）：
+
+| 任务 | 合入 PR | 实现方声称 | 前序审计怎么说 |
+|------|---------|------------|----------------|
+| S1 自己调自己会杀进程 | [#944](https://github.com/MightyBubble/Ludots/pull/944) | 登记拒环；漏到运行期抛错，不崩进程 | 第一批：**可关单**。本轮只复验 squash 后是否仍成立 |
+| S2 写进去的数会变回去 | [#946](https://github.com/MightyBubble/Ludots/pull/946) | 直写永远存活；展厅也扫；裸写 CI 红 | 第一批当时：**合入，不关单**（只扫 Core）。声称收口已进 #946 |
+| S3 查询口偷跑可挂起动作 | [#941](https://github.com/MightyBubble/Ludots/pull/941) | 查询 `InvokeScript` 只许函数名，拒 `graphId` | **从未独立审过** |
+| S4 回滚自己会抛 | [#959](https://github.com/MightyBubble/Ludots/pull/959)（#943 已关） | 回滚走完；提交按属性走正式写入面 | 第一批当时：**合入，不关单**。声称收口已进 #959 |
+| S5 容量到顶不说话 | [#945](https://github.com/MightyBubble/Ludots/pull/945) | 满了就抛；假计数整套删掉 | 第一批：**可关单**。旁系死计数是已知债 |
+| S6 退役门没锁 | [#941](https://github.com/MightyBubble/Ludots/pull/941) | 退役不再给启动命令；生产 mod 不再 `GraphIdRegistry.Clear` | **从未独立审过** |
+| S7 血条演戏 | [#941](https://github.com/MightyBubble/Ludots/pull/941) | 真结算走图；驱动只回读世界血；茶水不当血 | **从未独立审过** |
+| S8 假防线 | [#951](https://github.com/MightyBubble/Ludots/pull/951) | 只打印的补成真断言 | 第二批：**可关单** |
+| S9 图执行走同一道门 | [#953](https://github.com/MightyBubble/Ludots/pull/953) | 七宿主走 `GraphExecutor` | 第二批：**可关单**（typed 图号、展厅内部入口是已知缺口） |
+| S10 选中读裁剪 | [#952](https://github.com/MightyBubble/Ludots/pull/952) | 点选/Tab 读模拟位置 | 第二批：**可关单** |
+| S11 覆盖表假绿 | [#950](https://github.com/MightyBubble/Ludots/pull/950) | 错指针先修；生成器失败关闭 | 第二批：**可关单** |
+| S12 格子与前门同一张表 | [#956](https://github.com/MightyBubble/Ludots/pull/956) | 分配器发放格子；前门 ⊆ 策略 | **从未独立审过** |
+| S13 数据写行为 | [#960](https://github.com/MightyBubble/Ludots/pull/960) | JSON 树/机；叶子自己读血；HFSM 禁 Yield | **从未独立审过** |
+| S14 分层 | [#954](https://github.com/MightyBubble/Ludots/pull/954) 设计 + [#957](https://github.com/MightyBubble/Ludots/pull/957) Wave 1 | 设计答六问；顺序只认枚举；拿引擎标过时；**不搬家** | 设计未审；Wave 1 未审。第 2–6 波不在范围 |
+| S15 验收页一份 | [#948](https://github.com/MightyBubble/Ludots/pull/948) | 一个 H1；没做的写成没做 | 第二批：**可关单** |
+
+---
+
+## 2. 结构
+
+```text
+阶段 0  对齐：读计划、合同、前序审计，禁止重开已裁决争论
+阶段 1  三条闸门（从未审）：查询口 / 退役门 / 血条
+阶段 2  属性权威收口：第一批当时不让关的 S2 / S4
+阶段 3  作者地基（从未审）：S12 格子与前门、S13 数据写行为
+阶段 4  分层第一波：设计六问 + Wave 1 棘轮（不审搬家）
+阶段 5  前序可关单复验：S1 / S5 / S8 / S9 / S10 / S11 / S15
+阶段 6  合成：一份 Verdict，禁止平行结论
+```
+
+领域（可并行，阶段 6 必须合成）：
+
+| 领域 | 一句话 | 对应任务 |
+|------|--------|----------|
+| I 查询口 | 纯查询能不能直绑一张会等一拍的图 | S3 |
+| J 退役门 | 划掉的卡还能不能点进去，进去会不会清图号 | S6 |
+| K 血条 | 这一刀是真打还是演戏，打到零会不会偷偷回满 | S7 |
+| O 属性收口 | 展厅还能不能裸写；提交是不是正式写入面 | S2 / S4 |
+| L 格子与前门 | 两个节点会不会抢同一格；文档能写的是否真写得出 | S12 |
+| M 数据写行为 | JSON 树是否真在跑；叶子是否还靠 C# 喂数 | S13 |
+| N 分层第一波 | 设计有没有答完六问；Wave 1 有没有假装拆完程序集 | S14 |
+| P 前序复验 | 已可关单的票在 squash 之后有没有被后票踩坏 | S1 / S5 / S8 / S9 / S10 / S11 / S15 |
+
+交叉审计可用多个子 Agent，**最终只留一份**报告：
+
+`docs/audits/s_plan_landed_architecture_audit.md`
+
+---
+
+## 3. 详情
+
+### 3.1 产品共识（勿再争）
+
+1. Duration / Period 在效果壳上；Effect 图内不用 Yield 冒充时间轴。  
+2. FuncLib = 纯（无 Yield）；ActionLib = 可挂起；同名跨库失败关闭。  
+3. Effect 可分支 + 调 FuncLib；不得调 ActionLib。查询方言与线性方言同一条红线。  
+4. 一种作者边模型 + 一台 VM；禁止平行编译器、平行程序宇宙。  
+5. 图节点玩家门是**单节点展厅**；八个家族大杂烩退役，不是第二套玩家入口。  
+6. 人从地图刷；血条走 WorldHud / 生命披露；禁止 C# 改血演戏驱动 HUD。  
+7. 选中、点选、下达命令读战场坐标与情报，不读镜头裁剪。  
+8. NO FALLBACK：缺清单、空表、未知符号、引擎空、容量满、调用成环，全部失败关闭。  
+9. 合同在计划点名的红线收完之前，不得改回「已落地」。  
+10. S14 禁止一周全切完；Wave 1 只立墙和棘轮，不搬家。
+
+### 3.2 阶段 × 领域：给审计 Agent 的提示词
+
+下面每块都可以**单独另开一个审计员**。纪律对所有块生效：只读自己工作区；先读 `gitbook/contributing/ai-assisted-development.md` 任务执行决策规范；NO FALLBACK / SSOT / 禁止发明 opcode；证据要有路径；不要重开产品争论；不要把前序审计的「可关单」直接抄成结论。
+
+---
+
+#### 阶段 0 — 所有人先贴（短对齐，不写结论）
+
+```text
+你是只读审计员。对象：Ludots origin/main @ 46fcd9dcda（#942 计划全票已合）。
+先读并复述（各三句以内，禁止开始改代码）：
+1) docs/audits/gas_graph_architecture_fix_plan.md 依赖图与「不在本计划内」
+2) gitbook/architecture/graph-funclib-actionlib-contract.md 首页状态与三条边界
+3) docs/audits/s_plan_landed_audit_handoff.md 阶段划分：哪些从未审、哪些只复验
+刻意不审：#886/#893 UI 面板、#723 GraphScore、#947 Pi、S14 第 2–6 波、删八家族 Mod。
+完成后停，等阶段任务。
+```
+
+---
+
+#### 阶段 1 — 三条闸门（从未审）
+
+**领域 I · S3 查询口**
+
+```text
+阶段 1 / 领域 I。只审查询方言能不能直绑可挂起动作。
+对象：origin/main @ 46fcd9dcda。
+计划任务书：gas_graph_architecture_fix_plan.md §S3。
+必读：src/Core/NodeLibraries/GASGraph/GraphControlFlowCompiler.Query.cs、
+同目录 GraphControlFlowCompiler.Linear.cs 的 InvokeScript 分支、
+src/Tests/GasTests/Graph/GraphEffectAuthoringExpressivenessTests.cs、
+gitbook/architecture/graph-funclib-actionlib-contract.md §3.4。
+证伪：
+1) 查询图 InvokeScript 只给 graphId、不给 functionName，编译是否失败？诊断是否与线性方言同一套，而不是新错误体系？
+2) FrontDoor_LinearKindsInvokeScriptGraphId_FailClosed（或等价）是否覆盖 Query 与 Effect？不要只看 Score/Validation/Derived。
+3) assets/ 与 mods/ 下是否还有 kind=Query 且带 graphId 的图被放行？
+4) 用清单函数名调用是否仍然允许？
+5) 有没有用「改合同措辞」或「只拦运行期」代替编译期拒绝？
+该跑：--filter "FullyQualifiedName~GraphEffectAuthoringExpressivenessTests|FullyQualifiedName~GraphQueryControlFlowTests|FullyQualifiedName~GraphContractTests"
+产出：阻断/Major/Minor，每条给路径。不要写总 Verdict。
+```
+
+**领域 J · S6 退役门**
+
+```text
+阶段 1 / 领域 J。只审划掉的门和清图号。
+对象：origin/main @ 46fcd9dcda。
+计划任务书：gas_graph_architecture_fix_plan.md §S6。
+必读：showcase.registry.json 八条 capability_standard_graph_ops_*、
+launcher.config.json、src/Tools/Ludots.Launcher.React/src/lib/showcase.ts、
+ShowcasePanel.tsx、scripts/validate-registry.py、
+CapabilityStandardGraphOps{Rel,Query,Attr,Spatial,Event}* 的 Entry/Bootstrap。
+证伪：
+1) 八条退役条目 binding 是否为 null？启动器 launchHint / 预设列表是否仍吐可复制命令？
+2) 登记表 binding 与 launcher binding 是否双向一致？retired 允许 binding=null 是改了规则还是留了静默特例？
+3) 五个生产 bootstrap 是否还调用 GraphIdRegistry.Clear()？Rel/Query 是否还在 GameStart 对活引擎 BindStandaloneFromModAssets？
+4) 测试夹具清表是否标了 NonParallelizable？不要把测试清表当成生产清表。
+5) 八个家族 Mod 目录是否还在？（应该还在。本票禁止删 Mod；还在不是缺陷。）
+该跑：python3 scripts/validate-registry.py；
+--filter "FullyQualifiedName~GraphOpsRelShowcaseAcceptanceTests|FullyQualifiedName~GraphOpsQueryShowcaseAcceptanceTests|FullyQualifiedName~GraphOpsAttrShowcaseAcceptanceTests|FullyQualifiedName~GraphOpsSpatialShowcaseAcceptanceTests|FullyQualifiedName~GraphOpsEventShowcaseAcceptanceTests|FullyQualifiedName~GraphOpsNodeGallery"
+产出：残留表。家族场缺陷若不影响玩家门，标 Major/债务，不要自动升阻断。不要写总 Verdict。
+```
+
+**领域 K · S7 血条**
+
+```text
+阶段 1 / 领域 K。只审玩家看见的血条是不是它声称的东西。
+对象：origin/main @ 46fcd9dcda。
+计划任务书：gas_graph_architecture_fix_plan.md §S7。
+必读：CapabilityStandardGraphOpsNodeGalleryMod/Runtime/Drivers/{Event,Blackboard,Sandbox,Script,Linear}NodeDriver.cs、
+同 Mod assets/GAS/graphs/SendEvent.json、FanOutDispatchEffect*.json、LoadConfigEffectId.json、
+showcase.registry.json 相关简介、GraphOpsNodeGallery* 测试。
+证伪：
+1) SendEvent / FanOutDispatch* / LoadConfigEffectId 是否在图里 ModifyAttributeAdd（或等价正式结算），驱动是否只 SyncActorHealthFromWorld？
+2) Linear/Event 驱动里是否还留 if (next <= 0) next = opening 这类静默回卷？
+3) Script 喝茶是否还把茶水写进 ActorHealth？简介是否还承诺「血条按茶水掉」？
+4) 纯算式展厅（AddFloat 等）简介是否还让玩家以为血条是被真打掉的？
+5) 知识披露 / 头顶条那一侧有没有被顺手改坏？（计划禁止动那一侧。）
+该跑：--filter "FullyQualifiedName~GraphOpsNodeGallery"；python3 scripts/validate-registry.py
+产出：把「演戏」和「真结算」分开写。不要写总 Verdict。
+```
+
+---
+
+#### 阶段 2 — 属性权威收口
+
+**领域 O · S2 / S4**
+
+```text
+阶段 2 / 领域 O。只审第一批当时不让关的两处收口现在是否成立。
+对象：origin/main @ 46fcd9dcda。
+计划任务书：gas_graph_architecture_fix_plan.md §S2 / §S4。
+前序：docs/audits/s_batch1_architecture_audit.md 的 M1 / M2。
+必读：gitbook/architecture/attribute-write-authority.md、
+src/Tests/ArchitectureTests/Governance/ArchitectureGuardTests.cs
+（AttributeBufferWrites_MustComeFromWhitelistedCallers、CollectAttributeBufferWriteScanAssemblies）、
+AttributeMutationOps、EffectPhaseSideEffectTransaction、EffectModifierOps、
+效果阶段事务的 Commit / Rollback。
+证伪：
+1) 守卫是否同时扫 Core 和展厅程序集？缺 DLL 是失败关闭还是静默只扫 Core？
+2) 展厅（含 GoldMarket 运行时补货）是否还对 AttributeBuffer 裸 SetBase/SetCurrent？
+3) EffectPhaseSideEffectTransaction 是否仍在写入白名单？（声称已移出。）
+4) 提交路径是否按属性走 AttributeMutationOps.SetBase/SetCurrent，而不是整块赋值缓冲？
+5) 回滚是否仍整块恢复事务开始时的缓冲？这是回滚，不是玩法写入——不要把它误判成 S2 违规。
+6) 回滚中途缺服务 / 目标被销毁是否仍失败关闭或按任务书选定语义走完，而不是装成零目标？
+不要把「聚合过程中当前值短暂被改写」自动升成阻断；第一批已记录为中间态。本轮要看收口项，不是重打第一批主故障。
+产出：M1/M2 是否关闭、新债表。不要写总 Verdict。
+```
+
+---
+
+#### 阶段 3 — 作者地基（从未审）
+
+**领域 L · S12 格子与前门**
+
+```text
+阶段 3 / 领域 L。只审寄存器归属和 kind×opcode 单一数据源。
+对象：origin/main @ 46fcd9dcda。
+计划任务书：gas_graph_architecture_fix_plan.md §S12。
+必读：GraphRegisterFile（或等价分配器）、GraphOpDescriptorTable*、
+GraphKindOperationPolicy、GraphProgramAuthoringFrontDoor、
+GraphProgramSymbolPatcher、GraphControlFlowConfigCoverageTests。
+证伪：
+1) TargetListGet 与 SnapToNearestInCollection 的 valid 位是否还写死 B[31]？所有 scratch 是否走 AllocScratch()？
+2) PinRegister 与已分配格子冲突时是否编译失败，而不是静默别名？
+3) 是否存在一张 descriptor 表，前门矩阵、端口、authorableKinds、策略例外都由它投影？
+4) 是否有「前门 ⊆ 策略」的一致性断言？Score/Validation/Derived 的「前门能写、策略拒」是否变成作者能看懂的诊断？
+5) GraphProgramSymbolPatcher.Patch 第二次跑会不会把已解析 id 再当符号索引（热改错绑）？
+6) 有没有顺手改 32 容量上限？（计划禁止。）
+该跑：--filter "FullyQualifiedName~GraphControlFlowConfigCoverageTests|FullyQualifiedName~GraphContractTests|FullyQualifiedName~GraphEffectAuthoringExpressivenessTests|FullyQualifiedName~GraphQueryControlFlowTests|FullyQualifiedName~GraphNodeOpCoverageRegistryTests|FullyQualifiedName~LiveGasEditPipelineTests"
+产出：格子冲突表 + 前门/策略缺口表。不要写总 Verdict。
+```
+
+**领域 M · S13 数据写行为**
+
+```text
+阶段 3 / 领域 M。只审「行为能不能用数据写」。
+对象：origin/main @ 46fcd9dcda。
+计划任务书：gas_graph_architecture_fix_plan.md §S13。
+必读：assets/Configs/AI/behavior_trees.json、hfsm.json 及 schema、
+GraphBehaviorDefinitionLoader、GraphBehaviorCatalog、
+assets/Configs/GAS/action_lib.json、GraphActionCatalogLoader 的 host/Yield 策略、
+ScriptDialectL2AuthoringTests、BehaviorTreeWorld / GraphProgramHfsmHost。
+证伪：
+1) 巡逻-追击-攻击树是否来自 JSON，而不是 BehaviorTreeFactory.CreatePatrolChaseAttackTree 仍当玩法 SSOT？
+2) 叶子读目标血量是否真走 LoadAttribute，不必 C# 先喂 I[0]？默认 bt.seeEnemy / bt.inAttackRange 若仍是 HaltReturnInt+I[0]，记已知缺口，不要自动升阻断，但不得写成「叶子感知已关单」。
+3) ActionLib 叶子经帧调 FuncLib（如 demo.const.seven）是否真返回，而不是 Programs 为 null 必抛？
+4) 11 个脚本键是否只活在 action_lib.json？Core 里是否还留第二份名字表当玩法 SSOT？
+5) HFSM / 关卡 RunScript 挂含 Yield 的动作，是否在加载期失败关闭？合同 §4.4 与实现是否同一裁决（实现方声称：HFSM 禁止 Yield）？
+6) 含 Yield 的行为树叶子跨拍是否续跑，而不是每波从根重来？（实现方修过「数据写的巡逻树」Running vs Success。）
+7) 手写沙盒图 Dst=255 这类非寄存器口，是否还被当成寄存器越界？（实现方修过 AbilityGraphSandbox_CastArc_UnderBudget。）
+该跑：--filter "FullyQualifiedName~Ludots.Tests.Gas.AI|FullyQualifiedName~GraphActionCatalogLoaderTests|FullyQualifiedName~ScriptDialectL2AuthoringTests|FullyQualifiedName~AbilityGraphSandbox_CastArc|FullyQualifiedName~ScriptFlowSandboxShowcaseAcceptanceTests|FullyQualifiedName~GraphBehaviorSeparatedShowcaseAcceptanceTests"
+产出：作者面符合性 + 实现方自报缺口核实。不要写总 Verdict。
+```
+
+---
+
+#### 阶段 4 — 分层第一波
+
+**领域 N · S14 设计 + Wave 1**
+
+```text
+阶段 4 / 领域 N。只审「墙有没有立住」，不审搬家。
+对象：origin/main @ 46fcd9dcda。
+计划任务书：gas_graph_architecture_fix_plan.md §S14。
+必读：docs/audits/s14_layering_physicalization_design.md、
+src/Core/Engine/SystemGroupOrder.cs、
+src/Core/Engine/Pacemaker/PhaseOrderedCooperativeSimulation.cs、
+src/Core/Scripting/ScriptContextExtensions.cs、
+src/Tests/ArchitectureTests/Governance/S14LayeringRatchetTests.cs、
+ArchitectureGuardTests 里 SystemGroup / PhaseOrder 相关测试。
+证伪：
+1) 设计是否回答计划里的六个问题（程序集切法、注册表实例化、Mod 可见面、跨层组件、SystemGroup SSOT、分波迁移）？缺一问记 Major。
+2) 设计是否仍写「评审通过之前不搬生产代码」？main 上 src/Core/Ludots.Core.csproj 是否仍是单一大程序集？（仍是单一程序集不是缺陷；若已经大搬家，那是超范围，记阻断。）
+3) SystemGroupOrder.All 是否就是 Enum.GetValues<SystemGroup>()？PhaseOrderedCooperativeSimulation 是否还有第二份 PhaseOrder 数组？
+4) GetEngine 是否标 Obsolete？棘轮数字（声称 GetEngine 205 / 未声明 RegisterSystem 100 / 生产 Registry.Clear 15 / 引用 Facade 136 / mods GraphIdRegistry.Clear 5）是否只降不升？S6 之后 mods Clear 可能已是 0——不要把「低于上限」写成「S14 已关单」。
+5) S8 的阶段顺序交叉校验有没有被 Wave 1 删成空断言？设计文档交叉校验（enum 名表）是否还在？
+6) 有没有把 gitbook 合同改成「分层已落地」？
+该跑：--filter "FullyQualifiedName~S14LayeringRatchetTests|FullyQualifiedName~ArchitectureGuardTests.RuntimeSystemGroupOrder|FullyQualifiedName~ArchitectureGuardTests.PhaseOrdered|FullyQualifiedName~ArchitectureGuardTests.SystemGroup_MustMatch"
+产出：设计符合性 + Wave 1 棘轮表。明确写：S14 整体不得关单。不要写总 Verdict。
+```
+
+---
+
+#### 阶段 5 — 前序可关单复验
+
+**领域 P · 抽查，不重做整份旧报告**
+
+```text
+阶段 5 / 领域 P。只复验第一批/第二批当时可关单的票，在 46fcd9dcda 上有没有被后票踩坏。
+对象：origin/main @ 46fcd9dcda。
+前序报告：s_batch1_architecture_audit.md、s_batch2_s9_architecture_audit.md。
+不要重写那两份报告。只回答「还成立吗」。
+抽查清单（每条给现在的路径或测试名）：
+S1  自递归 / A→B→A 登记失败；深度超限抛错而不是杀进程
+S5  点名队列满了抛；被删的假计数没有回来（事件总线旁系死计数仍是已知债）
+S8  以前只打印的基准现在仍有会失败的断言；门槛数字没有被后票放宽
+S9  七个生产宿主不直连内部 Execute/ExecuteSlice；typed 图号仍是 int、展厅内部入口仍在——核实存在，不当新发现，也不当已收口
+S10 点选/Tab 仍读 WorldPositionCm；镜头外 IsVisible=false 仍可选；守卫仍禁模拟相读 VisualTransform/CullState
+S11 覆盖表 covered ⇒ 测试可解析；生成器找不到专属测试仍退出
+S15 验收页只有一个 H1；查询 graphId 直绑不得写成合同原文已覆盖
+若 squash 后某条主故障回归，升阻断并点名后票。若只是注释/路径漂移，记 Minor。
+产出：七行「仍成立 / 回归 / 无法测」表。不要写总 Verdict。
+```
+
+---
+
+#### 阶段 6 — 合成（只允许一个 Agent）
+
+```text
+阶段 6。你是唯一合成员。收集阶段 1–5 各领域表，只写一份报告：
+docs/audits/s_plan_landed_architecture_audit.md
+并在 docs/audits/README.md 加目录链接。
+
+报告必须有：
+1) Verdict：HOLD MAIN / FIX-FORWARD / REGRESS（禁止用 MERGE，因为已经在 main）
+2) 逐票关单表：可关 / 合入不关 / 回归。S14 整体必须显式写「不关单」
+3) 阻断 / Major / Minor / 债务表（路径 + 证据）
+4) 玩家/作者先写：查询口、退役门、血条、数据写的树，进游戏会看见什么
+5) 合同 §3/§4.4/§5/§6 符合性；合同状态该不该继续「修复中」
+6) 与第一批 / 第二批 / #932 审计的衔接：哪些已关、哪些仍开、哪些是新债
+7) 给后续 Agent 的最短提示词（按票拆：S14 Wave 2+、typed 图号、默认叶子感知、删家族 Mod——不要一条巨提示词）
+
+禁止：多份平行结论；夹带实现；重开产品争论；把 UI 面板/#723/#947/S14 搬家写进阻断。
+纪律：NO FALLBACK、SSOT、说人话写场景证据。
+```
+
+### 3.3 建议报告骨架
+
+```text
+# 1. 概述（Verdict + 玩家一句话 + 逐票关单表）
+# 2. 结构（阶段/领域对照）
+# 3. 详情（从未审的票先写，复验表后写）
+# 4. 场景（玩家看见什么 vs 实际）
+# 5. 边界（不审项、已裁决共识）
+# 6. UAT（对照下面 §6，标过/未过/无法测）
+附录 A 测试证据
+附录 B 给后续 Agent 的最短提示词
+```
+
+### 3.4 实现方自报、核实即可的缺口
+
+这些是落地时自己写下的，**不要当成新发现**，但也不能写成已经关单：
+
+| 项 | 谁说的 | 怎么核实 |
+|----|--------|----------|
+| typed 图号仍是 `int` | 第二批 S9 | 生产宿主与 `GraphExecutor` 入口类型 |
+| 展厅内部仍走 `Execute` / `ExecuteSlice` | 第二批 S9 | `CapabilityStandardGraphOps*Mod` 与画廊 driver |
+| 默认 `bt.seeEnemy` / `bt.inAttackRange` 仍是 `HaltReturnInt` + 可选 `I[0]` | S13 实现方 | `action_lib.json` 与对应图 |
+| `BehaviorTreeFactory` 仍留 AlwaysSuccess / HoldRunning / 骨架树 | S13 实现方 | 是否还被玩法树引用，还是只供拓扑/性能 |
+| `LevelBlueprintFactory.CreateTwoPhaseTrial` 仍是 C# 关卡骨架 | S13 实现方 | 相位图 id 是否来自 ActionLib |
+| Script 查询列表沿用 Effect 隐式 TargetList | S13 实现方 | Query* 是否另开 script `list` 端口 |
+| `GraphActionCatalog` 加载后不持久化 `host` | S13 实现方 | 宿主 Yield 策略是否只在装载期跑一次 |
+| S5 事件总线旁系死计数恒为 0 | 第一批 | 不要当 S5 回归 |
+| S14 第 2–6 波未开工 | 设计明文 | 发现大搬家才是越界 |
+
+---
+
+## 4. 场景
+
+审计时用玩家/作者眼睛，不要用架构名词当场景。
+
+1. 我写了一张只会调用自己的图：登记必须当场失败，游戏还在。  
+2. 我给一个不夹上限的属性写了当前值：过几拍再看，数还在。  
+3. 我在查询图里填了一个巡逻动作的图号：编译失败，不能靠查询偷偷等一拍。  
+4. 启动器里翻到已划掉的家族大杂烩：没有可复制的启动命令。  
+5. 我点进「派事件改血」那一类短剧：血条跟结算走；打到零不会无声回满。  
+6. 镜头抬高、单位被挡住：我仍然能点到他、能下令。  
+7. 我在配置里写了一棵巡逻-追击-攻击树：代理按树走，我不用改引擎 C#。  
+8. 叶子要看目标还剩多少血：它自己读，不必先有人把数字塞进来。  
+9. 我把含「等一拍」的动作挂到哨兵状态机上：加载就失败，而不是跑到一半炸。  
+10. 维护者打开分层设计：能看见六波怎么切；打开工程，Core 仍是一个程序集，没有假装拆完。
+
+---
+
+## 5. 边界
+
+**做**
+
+- 证伪 `main@46fcd9dcda` 上计划全票的声称  
+- 从未审过的票（S3 / S6 / S7 / S12 / S13 / S14 设计与 Wave 1 / S2·S4 收口）必须读源码，不能只读 PR 说明  
+- 已可关单的票做回归抽查  
+- 对照合同与前三份审计，写清仍开的债  
+- 一份 SSOT 报告
+
+**不做**
+
+- 改生产代码、顺手修 UI 面板、重开 Duration/Yield 产品争论  
+- 把 S14 第 2–6 波、删八家族 Mod、typed 图号、#723、#947 升成本次唯一目标  
+- 用「合同缩编」或改测试门槛掩盖  
+- 发明新 graph op / profile enum / 第二套加载器  
+- 把第一批/第二批报告复制粘贴改个日期交差
+
+**已知已知（核实，勿当新发现）**
+
+| 项 | 说明 |
+|----|------|
+| 合同「修复中」 | S13 明确未改落地状态；报告不得写成已落地 |
+| 前序审计基线是旧 tip | 第一批/第二批对照的是 `82ddb3322` 上的 PR head；本轮对照 squash 后的 main |
+| #943 已关 | 被 #959 取代，不要按 #943 tip 复读 |
+| #939 / #955 已关 | 旧审计需求与重复审计，内容分别进了 #941 与 #958 |
+| GetEngine 过时警告 | Wave 1 故意标过时，205 处警告不是回归 |
+| 八家族 Mod 还在 | S6 禁止删除 |
+
+---
+
+## 6. UAT
+
+```gherkin
+Feature: 一张图不能把游戏弄没了
+  作为技能作者
+  我希望自己调自己的图在登记时就被拒绝
+  以便游戏还能打开
+
+  Scenario: 自己调自己必须被拒绝
+    Given 我写了一张脚本图，它唯一做的事就是调用自己
+    When 这张图被登记进图注册表
+    Then 登记必须失败并告诉我这里有一个调用环
+    And 游戏不应该能带着这张图启动
+
+Feature: 写进去的数还在
+  作为数值作者
+  我希望正式接口写进去的当前值过几拍还在
+  以便我不靠「夹不夹上限」碰运气
+
+  Scenario: 不夹上限的属性也能保住写入
+    Given 我通过正式写入面给一个不夹上限的属性写下当前值
+    When 属性重算跑完
+    Then 我写下的数还在
+    And 展厅里的裸写如果还在，守卫必须红
+
+Feature: 纯查询里不能偷偷跑起会等一拍的动作
+  作为技能作者
+  我希望查询图不能直绑巡逻动作的图号
+  以便结算不会做到一半停住
+
+  Scenario: 查询图直绑图号必须被拒绝
+    Given 我在一张查询图里写了一个调用，直接指向某个巡逻动作的图号
+    When 这张图通过作者前门编译
+    Then 编译必须失败，理由与线性方言一致
+
+Feature: 划掉的门要真的锁上
+  作为玩家
+  我希望退役展厅不能再被点进去
+  以便我不会走进一间会弄坏别的展厅的房间
+
+  Scenario: 退役展厅不再给出可点的入口
+    Given 登记表里某个家族展厅已经标成退役
+    When 我在启动器里翻到它
+    Then 卡片上不得出现可复制的启动命令
+    And 顶栏的预设列表里也翻不到它
+
+Feature: 血条要么代表真被打掉的血，要么别装成那样
+  作为新玩家
+  我希望点进「派事件改血」时看见的掉血是真的
+  以便我看懂这一刀
+
+  Scenario: 打到零不许偷偷回满
+    Given 一间展厅里这一刀足以把木桩的血打到零
+    When 这一刀结算
+    Then 结果必须由数据决定，而不是被代码悄悄改回满血
+
+  Scenario: 喝茶不是掉血
+    Given 脚本短剧里角色在喝茶
+    When 我看血条和简介
+    Then 茶水不得被写成生命值
+    And 简介不得让我以为血条是被茶水打掉的
+
+Feature: 被挡住的人还能点到
+  作为玩家
+  我希望镜头抬高之后仍能点到山坡后的人
+  以便我不是在跟摄像机下棋
+
+  Scenario: 看不见也能下令
+    Given 场上有一个单位被镜头裁掉
+    When 我点他并下达命令
+    Then 命令应当落到这个单位上
+    And 游戏不得因为他现在画不出来就当他不存在
+
+Feature: 行为可以用数据写，不必改引擎
+  作为玩法作者
+  我希望在配置里写巡逻树
+  以便换一棵树不用改 Core
+
+  Scenario: Mod 定义自己的行为树
+    Given 我在配置里写了一棵巡逻-追击-攻击的树
+    When 游戏加载这些数据
+    Then 代理应当按我写的树行动
+    And 我不需要改 Core 的任何玩法 C# 工厂
+
+  Scenario: 叶子自己能感知
+    Given 一个行为树叶子需要读取目标的血量来决定是否撤退
+    When 它执行
+    Then 它应当能直接读到血量
+    And 不需要 C# 侧先把结果喂进来
+
+  Scenario: 哨兵机不能挂会等一拍的动作
+    Given 我把一个含「等一拍」的动作挂到状态机的心跳上
+    When 游戏加载这份配置
+    Then 加载必须失败并说明这个宿主不许挂起
+
+Feature: 层与层之间的墙还没假装砌完
+  作为维护者
+  我希望分层设计能回答怎么切，并且工程还没被一周拆烂
+  以便后面可以一波一波搬
+
+  Scenario: 设计能回答边界问题
+    Given 一份分层物理化设计已经在仓库里
+    When 我按计划里的六个问题核对
+    Then 每个问题都有书面答案
+    And 工程里的 Core 仍是一个程序集
+    And 阶段顺序只认枚举声明，不再另藏一张表
+```
+
+---
+
+## 7. 必读（最短）
+
+- 本文件  
+- `docs/audits/gas_graph_architecture_fix_plan.md`  
+- `docs/audits/gas_graph_architecture_review.md`  
+- `docs/audits/s_batch1_architecture_audit.md`  
+- `docs/audits/s_batch2_s9_architecture_audit.md`  
+- `docs/audits/s14_layering_physicalization_design.md`  
+- `gitbook/architecture/graph-funclib-actionlib-contract.md`  
+- `gitbook/architecture/attribute-write-authority.md`  
+- `gitbook/acceptance/graph-funclib-actionlib-uat.md`  
+- `gitbook/contributing/ai-assisted-development.md`（任务执行决策规范）
+
+---
+
+## 8. 本需求文档的范围
+
+- **包含**：上下文、阶段/领域提示词、产出格式、UAT。  
+- **不包含**：审计结论、实现修复。  
+- **禁止**：多份平行报告；把提示词合成一条让一个人同时审所有领域。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# 概要

- 变更目标：对照 `docs/audits/s_plan_landed_audit_handoff.md`，对 `origin/main` @ `46fcd9dcda` 做独立架构审计。零生产代码。
- 影响范围：只新增 SSOT 报告 `docs/audits/s_plan_landed_architecture_audit.md`，并在 `docs/audits/README.md` 加目录链接。

# SSOT 落点

- 正式规则：无
- 正式架构：无（合同继续「修复中」，本 PR 不改合同）
- 正式查表或操作：无
- 仓库深度材料：无
- 审计或提案：`docs/audits/s_plan_landed_architecture_audit.md`（结论）；需求正本 `docs/audits/s_plan_landed_audit_handoff.md`

# 设计与挂靠点

- 挂靠点：#942 计划全票已 squash 进 main；需求在 #961
- 复用清单：第一批 / 第二批 / #932 审计作输入，不抄结论
- 新增清单：一份落地后审计报告

# 验证证据

- 编译/测试命令：在独立工作区 `/tmp/s-audit/main46` @ `46fcd9dcda` 跑交接点名的过滤器
- 结果摘要：
  - **Verdict：FIX-FORWARD。** 没有新的阻断项。S14 整体不关单。
  - 可关：S1 / S2 / S3 / S4 / S5 / S6 / S7 / S8 / S9 / S10 / S11 / S12 / S13 / S15
  - 不关：S14
  - 绿：ArchitectureGuard 51/51；作者前门/查询/自递归/覆盖表 100/100；AI+ActionLib 40/40；画廊+家族 112/112；属性聚合 21/21；点选 55/55
  - 红（夹具没跟上后票，不是玩家门回开）：`InstantEffectTransactionTests` 14/16；Allocation/Perf/Benchmark 26/34
- 相关日志：[s_plan_landed_audit_test_evidence.log](https://cursor.com/agents/bc-07dacb7d-d6e0-4fcb-9604-8bc6b046d131/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fs_plan_landed_audit_test_evidence.log)

# 文档同步

- [x] 所属目录 `docs/audits/README.md` 已同步
- [ ] 行为变更已同步更新 `gitbook/` 正式文档（本 PR 不改正式文档；报告要求另开票改 UAT 第 81 行）
- [ ] 入口导航：无

玩家能感觉到的主故障已经关上门。合同不得改回「已落地」。S8 假防线没有回来；点名过滤器变红要另开夹具对齐，不要重开 S8。

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07dacb7d-d6e0-4fcb-9604-8bc6b046d131?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07dacb7d-d6e0-4fcb-9604-8bc6b046d131&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

