### PR TITLE
feat(panel): PANEL-1 最小 MVP——面板数据合同（variables[]）与 Markup 皮渲染桥（#1010）

### DIFF
--- a/mods/UiShowcaseCoreMod/Showcase/PanelTemplateMarkupRenderer.cs
+++ b/mods/UiShowcaseCoreMod/Showcase/PanelTemplateMarkupRenderer.cs
@@ -1,0 +1,47 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Ludots.Core.UI.PanelProjection;
+using Ludots.UI;
+using Ludots.UI.HtmlEngine.Markup;
+using Ludots.UI.Runtime;
+
+namespace UiShowcaseCoreMod.Showcase;
+
+/// <summary>
+/// Markup surface adapter (#1010 MVP / #1011): renders a panel template's HTML with
+/// {variable} tokens substituted from the evaluated <see cref="PanelVariableSet"/>.
+/// The adapter only consumes variables; it never fetches graph/attribute data.
+/// </summary>
+public static class PanelTemplateMarkupRenderer
+{
+    private static readonly Regex TokenPattern = new(@"\{([A-Za-z0-9_.]+)\}", RegexOptions.Compiled);
+
+    public static UiScene Render(
+        string html,
+        string css,
+        PanelVariableSet variables,
+        IUiTextMeasurer textMeasurer,
+        IUiImageSizeProvider imageSizeProvider)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+        {
+            throw new System.ArgumentException("Panel markup HTML is required.", nameof(html));
+        }
+
+        ArgumentNullException.ThrowIfNull(variables);
+
+        string resolved = TokenPattern.Replace(html, match =>
+        {
+            string name = match.Groups[1].Value;
+            if (!variables.TryGet(name, out float value))
+            {
+                throw new System.InvalidOperationException(
+                    $"Panel '{variables.TemplateId}' markup references unknown variable '{name}'.");
+            }
+
+            return value.ToString("0.##", CultureInfo.InvariantCulture);
+        });
+
+        return new UiMarkupLoader().LoadScene(textMeasurer, imageSizeProvider, resolved, css);
+    }
+}

--- a/src/Core/UI/PanelProjection/PanelInstance.cs
+++ b/src/Core/UI/PanelProjection/PanelInstance.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using Arch.Core;
+
+namespace Ludots.Core.UI.PanelProjection
+{
+    /// <summary>
+    /// One live panel: a template bound to a scope (#1010 MVP: the owner entity).
+    /// Evaluation goes exclusively through <see cref="PanelProjectionReader"/>.
+    /// </summary>
+    public sealed class PanelInstance
+    {
+        public PanelInstance(PanelTemplate template, Entity scope)
+        {
+            Template = template ?? throw new ArgumentNullException(nameof(template));
+            Scope = scope;
+        }
+
+        public PanelTemplate Template { get; }
+        public Entity Scope { get; }
+
+        public PanelVariableSet Evaluate(PanelProjectionReader reader)
+        {
+            ArgumentNullException.ThrowIfNull(reader);
+
+            var values = new Dictionary<string, float>(Template.Variables.Count, StringComparer.Ordinal);
+            uint revision = 0;
+            foreach (PanelTemplateVariable variable in Template.Variables)
+            {
+                PanelProjectionValue value = reader.Resolve(Scope, variable.ToBinding());
+                values[variable.Name] = value.FloatValue;
+                revision ^= value.Revision;
+            }
+
+            return new PanelVariableSet(Template.Id, values, revision);
+        }
+    }
+
+    /// <summary>
+    /// Evaluated variables for one instance. Reads of unknown names fail loudly;
+    /// there is no silent zero.
+    /// </summary>
+    public sealed class PanelVariableSet
+    {
+        private readonly IReadOnlyDictionary<string, float> _values;
+
+        public PanelVariableSet(string templateId, IReadOnlyDictionary<string, float> values, uint revision)
+        {
+            TemplateId = templateId;
+            _values = values;
+            Revision = revision;
+        }
+
+        public string TemplateId { get; }
+        public uint Revision { get; }
+        public int Count => _values.Count;
+        public IEnumerable<string> Names => _values.Keys;
+
+        public float Get(string variableName)
+        {
+            if (!_values.TryGetValue(variableName, out float value))
+            {
+                throw new InvalidOperationException($"Panel '{TemplateId}' has no evaluated variable '{variableName}'.");
+            }
+
+            return value;
+        }
+
+        public bool TryGet(string variableName, out float value) => _values.TryGetValue(variableName, out value);
+    }
+}

--- a/src/Core/UI/PanelProjection/PanelTemplate.cs
+++ b/src/Core/UI/PanelProjection/PanelTemplate.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ludots.Core.UI.PanelProjection
+{
+    /// <summary>
+    /// Author-facing panel contract (#1010): declared variables plus control binds.
+    /// Each variable maps onto a <see cref="PanelVariableBinding"/>; every value flows
+    /// through <see cref="PanelProjectionReader"/> — surfaces never fetch data themselves.
+    /// </summary>
+    public sealed class PanelTemplate
+    {
+        public PanelTemplate(string id, IReadOnlyList<PanelTemplateVariable> variables, IReadOnlyList<PanelTemplateBind>? binds = null)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentException("Panel template id is required.", nameof(id));
+            }
+
+            if (variables == null || variables.Count == 0)
+            {
+                throw new ArgumentException($"Panel template '{id}' must declare at least one variable.", nameof(variables));
+            }
+
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (PanelTemplateVariable variable in variables)
+            {
+                if (variable == null)
+                {
+                    throw new ArgumentException($"Panel template '{id}' has a null variable entry.", nameof(variables));
+                }
+
+                if (!seen.Add(variable.Name))
+                {
+                    throw new ArgumentException($"Panel template '{id}' declares duplicate variable '{variable.Name}'.", nameof(variables));
+                }
+            }
+
+            List<PanelTemplateBind> safeBinds = new List<PanelTemplateBind>(binds ?? Array.Empty<PanelTemplateBind>());
+            foreach (PanelTemplateBind bind in safeBinds)
+            {
+                if (bind == null)
+                {
+                    throw new ArgumentException($"Panel template '{id}' has a null bind entry.", nameof(binds));
+                }
+
+                if (!seen.Contains(bind.Variable))
+                {
+                    throw new ArgumentException(
+                        $"Panel template '{id}' bind '{bind.Control}' references undeclared variable '{bind.Variable}'.",
+                        nameof(binds));
+                }
+            }
+
+            Id = id.Trim();
+            Variables = variables;
+            Binds = safeBinds;
+        }
+
+        public string Id { get; }
+        public IReadOnlyList<PanelTemplateVariable> Variables { get; }
+        public IReadOnlyList<PanelTemplateBind> Binds { get; }
+
+        public PanelVariableBinding ResolveBinding(string variableName)
+        {
+            foreach (PanelTemplateVariable variable in Variables)
+            {
+                if (string.Equals(variable.Name, variableName, StringComparison.Ordinal))
+                {
+                    return variable.ToBinding();
+                }
+            }
+
+            throw new InvalidOperationException($"Panel template '{Id}' has no variable '{variableName}'.");
+        }
+    }
+
+    public sealed class PanelTemplateVariable
+    {
+        public PanelTemplateVariable(
+            string name,
+            PanelTemplateVariableKind kind,
+            PanelBindingSourceKind sourceKind,
+            string? attributeId = null,
+            string? graphOutputKey = null)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("Variable name is required.", nameof(name));
+            }
+
+            Name = name.Trim();
+            Kind = kind;
+            SourceKind = sourceKind;
+
+            // Reuse the binding contract's own fail-closed field rules.
+            Binding = new PanelVariableBinding(Name, sourceKind, attributeId, graphOutputKey);
+            AttributeId = Binding.AttributeId;
+            GraphOutputKey = Binding.GraphOutputKey;
+        }
+
+        public string Name { get; }
+        public PanelTemplateVariableKind Kind { get; }
+        public PanelBindingSourceKind SourceKind { get; }
+        public string? AttributeId { get; }
+        public string? GraphOutputKey { get; }
+
+        internal PanelVariableBinding Binding { get; }
+
+        public PanelVariableBinding ToBinding() => Binding;
+    }
+
+    public enum PanelTemplateVariableKind : byte
+    {
+        Float = 0,
+        Int = 1,
+    }
+
+    public sealed class PanelTemplateBind
+    {
+        public PanelTemplateBind(string control, string variable)
+        {
+            if (string.IsNullOrWhiteSpace(control))
+            {
+                throw new ArgumentException("Bind control id is required.", nameof(control));
+            }
+
+            if (string.IsNullOrWhiteSpace(variable))
+            {
+                throw new ArgumentException($"Bind '{control}' requires a variable name.", nameof(variable));
+            }
+
+            Control = control.Trim();
+            Variable = variable.Trim();
+        }
+
+        public string Control { get; }
+        public string Variable { get; }
+    }
+}

--- a/src/Core/UI/PanelProjection/PanelTemplateLoader.cs
+++ b/src/Core/UI/PanelProjection/PanelTemplateLoader.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Ludots.Core.UI.PanelProjection
+{
+    /// <summary>
+    /// Strict JSON loader for panel templates (#1010). Unknown fields, unknown source
+    /// kinds, and cross-field violations fail at load time with the offending id named.
+    /// </summary>
+    public static class PanelTemplateLoader
+    {
+        private static readonly HashSet<string> RootFields = new(StringComparer.Ordinal) { "id", "variables", "binds" };
+        private static readonly HashSet<string> VariableFields = new(StringComparer.Ordinal) { "name", "kind", "source" };
+        private static readonly HashSet<string> SourceFields = new(StringComparer.Ordinal) { "sourceKind", "attributeId", "graphOutputKey" };
+        private static readonly HashSet<string> BindFields = new(StringComparer.Ordinal) { "control", "variable" };
+
+        public static PanelTemplate Load(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                throw new InvalidOperationException("Panel template JSON is empty.");
+            }
+
+            JsonNode root;
+            try
+            {
+                root = JsonNode.Parse(json) ?? throw new InvalidOperationException("Panel template JSON parsed to null.");
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException($"Panel template JSON is malformed: {ex.Message}");
+            }
+
+            if (root is not JsonObject rootObject)
+            {
+                throw new InvalidOperationException("Panel template root must be a JSON object.");
+            }
+
+            RejectUnknownFields(rootObject, RootFields, "panel template root");
+
+            string id = RequireString(rootObject, "id", "panel template");
+            if (rootObject["variables"] is not JsonArray variablesNode || variablesNode.Count == 0)
+            {
+                throw new InvalidOperationException($"Panel template '{id}' must declare a non-empty 'variables' array.");
+            }
+
+            var variables = new List<PanelTemplateVariable>(variablesNode.Count);
+            foreach (JsonNode? variableNode in variablesNode)
+            {
+                if (variableNode is not JsonObject variableObject)
+                {
+                    throw new InvalidOperationException($"Panel template '{id}' variables entries must be objects.");
+                }
+
+                RejectUnknownFields(variableObject, VariableFields, $"panel template '{id}' variable");
+                variables.Add(ParseVariable(id, variableObject));
+            }
+
+            var binds = new List<PanelTemplateBind>();
+            if (rootObject["binds"] is JsonArray bindsNode)
+            {
+                foreach (JsonNode? bindNode in bindsNode)
+                {
+                    if (bindNode is not JsonObject bindObject)
+                    {
+                        throw new InvalidOperationException($"Panel template '{id}' binds entries must be objects.");
+                    }
+
+                    RejectUnknownFields(bindObject, BindFields, $"panel template '{id}' bind");
+                    binds.Add(new PanelTemplateBind(
+                        RequireString(bindObject, "control", $"panel template '{id}' bind"),
+                        RequireString(bindObject, "variable", $"panel template '{id}' bind")));
+                }
+            }
+
+            return new PanelTemplate(id, variables, binds);
+        }
+
+        private static PanelTemplateVariable ParseVariable(string templateId, JsonObject variableObject)
+        {
+            string name = RequireString(variableObject, "name", $"panel template '{templateId}' variable");
+            string kindText = RequireString(variableObject, "kind", $"panel template '{templateId}' variable '{name}'");
+            if (!Enum.TryParse<PanelTemplateVariableKind>(kindText, ignoreCase: false, out PanelTemplateVariableKind kind) ||
+                !Enum.IsDefined(typeof(PanelTemplateVariableKind), kind))
+            {
+                throw new InvalidOperationException(
+                    $"Panel template '{templateId}' variable '{name}' has unknown kind '{kindText}' (allowed: Float, Int).");
+            }
+
+            if (variableObject["source"] is not JsonObject sourceObject)
+            {
+                throw new InvalidOperationException($"Panel template '{templateId}' variable '{name}' requires a 'source' object.");
+            }
+
+            RejectUnknownFields(sourceObject, SourceFields, $"panel template '{templateId}' variable '{name}' source");
+            string sourceKindText = RequireString(sourceObject, "sourceKind", $"panel template '{templateId}' variable '{name}' source");
+            if (!Enum.TryParse<PanelBindingSourceKind>(sourceKindText, ignoreCase: false, out PanelBindingSourceKind sourceKind) ||
+                !Enum.IsDefined(typeof(PanelBindingSourceKind), sourceKind))
+            {
+                throw new InvalidOperationException(
+                    $"Panel template '{templateId}' variable '{name}' has unknown sourceKind '{sourceKindText}'.");
+            }
+
+            return new PanelTemplateVariable(
+                name,
+                kind,
+                sourceKind,
+                attributeId: OptionalString(sourceObject, "attributeId"),
+                graphOutputKey: OptionalString(sourceObject, "graphOutputKey"));
+        }
+
+        private static string RequireString(JsonObject obj, string field, string context)
+        {
+            string? value = obj[field]?.GetValue<string>();
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new InvalidOperationException($"{context} is missing required '{field}'.");
+            }
+
+            return value;
+        }
+
+        private static string? OptionalString(JsonObject obj, string field)
+        {
+            return obj[field]?.GetValue<string>();
+        }
+
+        private static void RejectUnknownFields(JsonObject obj, HashSet<string> allowed, string context)
+        {
+            foreach (KeyValuePair<string, JsonNode?> property in obj)
+            {
+                if (!allowed.Contains(property.Key))
+                {
+                    throw new InvalidOperationException($"{context} has unknown field '{property.Key}' (allowed: {string.Join(", ", allowed)}).");
+                }
+            }
+        }
+    }
+}

--- a/src/Tests/GasTests/UI/PanelTemplateTests.cs
+++ b/src/Tests/GasTests/UI/PanelTemplateTests.cs
@@ -1,0 +1,204 @@
+using System;
+using Arch.Core;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.NodeLibraries.GASGraph;
+using Ludots.Core.Registry;
+using Ludots.Core.UI.PanelProjection;
+using NUnit.Framework;
+
+namespace Ludots.Tests.GasTests.UI
+{
+    [TestFixture]
+    public sealed class PanelTemplateTests
+    {
+        private const string AggregateTemplateJson = """
+        {
+          "id": "tests.panel.resource_bar",
+          "variables": [
+            { "name": "ore.total", "kind": "Float",
+              "source": { "sourceKind": "AggregateProjection", "graphOutputKey": "tests.panel.ore.total" } },
+            { "name": "gas.total", "kind": "Float",
+              "source": { "sourceKind": "AggregateProjection", "graphOutputKey": "tests.panel.gas.total" } }
+          ],
+          "binds": [
+            { "control": "lbl.ore", "variable": "ore.total" },
+            { "control": "lbl.gas", "variable": "gas.total" }
+          ]
+        }
+        """;
+
+        [Test]
+        public void Load_ValidTemplate_CarriesVariablesAndBinds()
+        {
+            PanelTemplate template = PanelTemplateLoader.Load(AggregateTemplateJson);
+
+            Assert.That(template.Id, Is.EqualTo("tests.panel.resource_bar"));
+            Assert.That(template.Variables, Has.Count.EqualTo(2));
+            Assert.That(template.Binds, Has.Count.EqualTo(2));
+            Assert.That(template.ResolveBinding("ore.total").GraphOutputKey, Is.EqualTo("tests.panel.ore.total"));
+        }
+
+        [Test]
+        public void Load_MissingGraphOutputKey_FailsNamingVariable()
+        {
+            const string json = """
+            {
+              "id": "tests.panel.bad",
+              "variables": [
+                { "name": "ore", "kind": "Float", "source": { "sourceKind": "AggregateProjection" } }
+              ]
+            }
+            """;
+
+            Assert.That(
+                () => PanelTemplateLoader.Load(json),
+                Throws.Exception.With.Message.Contains("ore"));
+        }
+
+        [Test]
+        public void Load_UnknownSourceKind_FailsNamingKind()
+        {
+            const string json = """
+            {
+              "id": "tests.panel.bad",
+              "variables": [
+                { "name": "ore", "kind": "Float", "source": { "sourceKind": "Magic" } }
+              ]
+            }
+            """;
+
+            Assert.That(
+                () => PanelTemplateLoader.Load(json),
+                Throws.InvalidOperationException.With.Message.Contains("Magic"));
+        }
+
+        [Test]
+        public void Load_UnknownRootField_FailsNamingField()
+        {
+            const string json = """
+            {
+              "id": "tests.panel.bad",
+              "frobnicate": true,
+              "variables": [
+                { "name": "ore", "kind": "Float", "source": { "sourceKind": "SingleAttribute", "attributeId": "a" } }
+              ]
+            }
+            """;
+
+            Assert.That(
+                () => PanelTemplateLoader.Load(json),
+                Throws.InvalidOperationException.With.Message.Contains("frobnicate"));
+        }
+
+        [Test]
+        public void Load_BindToUndeclaredVariable_FailsNamingBind()
+        {
+            const string json = """
+            {
+              "id": "tests.panel.bad",
+              "variables": [
+                { "name": "ore", "kind": "Float", "source": { "sourceKind": "AggregateProjection", "graphOutputKey": "k" } }
+              ],
+              "binds": [ { "control": "lbl.x", "variable": "ghost" } ]
+            }
+            """;
+
+            Assert.That(
+                () => PanelTemplateLoader.Load(json),
+                Throws.ArgumentException.With.Message.Contains("ghost"));
+        }
+
+        [Test]
+        public void Evaluate_AggregateProjection_EqualsGraphOutput()
+        {
+            PanelTemplate template = PanelTemplateLoader.Load(AggregateTemplateJson);
+            using World world = World.Create();
+            Entity owner = world.Create();
+
+            var keys = new StringIntRegistry(capacity: 8, startId: 1, invalidId: 0, comparer: StringComparer.Ordinal);
+            var outputs = new GraphOutputValueStore(keys, initialCapacity: 8);
+            outputs.SetFloat(owner, "tests.panel.ore.total", 1200f);
+            outputs.SetFloat(owner, "tests.panel.gas.total", 450.5f);
+
+            var reader = new PanelProjectionReader(world, outputs);
+            PanelVariableSet result = new PanelInstance(template, owner).Evaluate(reader);
+
+            Assert.That(result.Get("ore.total"), Is.EqualTo(1200f));
+            Assert.That(result.Get("gas.total"), Is.EqualTo(450.5f).Within(0.0001f));
+        }
+
+        [Test]
+        public void Evaluate_MissingGraphOutput_FailsNoSilentZero()
+        {
+            PanelTemplate template = PanelTemplateLoader.Load(AggregateTemplateJson);
+            using World world = World.Create();
+            Entity owner = world.Create();
+
+            var keys = new StringIntRegistry(capacity: 8, startId: 1, invalidId: 0, comparer: StringComparer.Ordinal);
+            var outputs = new GraphOutputValueStore(keys, initialCapacity: 8);
+
+            var reader = new PanelProjectionReader(world, outputs);
+
+            Assert.That(
+                () => new PanelInstance(template, owner).Evaluate(reader),
+                Throws.InvalidOperationException.With.Message.Contains("tests.panel.ore.total"));
+        }
+
+        [Test]
+        public void Evaluate_TwoInstancesSameTemplate_IndependentScopes()
+        {
+            PanelTemplate template = PanelTemplateLoader.Load(AggregateTemplateJson);
+            using World world = World.Create();
+            Entity ownerA = world.Create();
+            Entity ownerB = world.Create();
+
+            var keys = new StringIntRegistry(capacity: 8, startId: 1, invalidId: 0, comparer: StringComparer.Ordinal);
+            var outputs = new GraphOutputValueStore(keys, initialCapacity: 8);
+            outputs.SetFloat(ownerA, "tests.panel.ore.total", 100f);
+            outputs.SetFloat(ownerA, "tests.panel.gas.total", 10f);
+            outputs.SetFloat(ownerB, "tests.panel.ore.total", 900f);
+            outputs.SetFloat(ownerB, "tests.panel.gas.total", 90f);
+
+            var reader = new PanelProjectionReader(world, outputs);
+            PanelVariableSet setA = new PanelInstance(template, ownerA).Evaluate(reader);
+            PanelVariableSet setB = new PanelInstance(template, ownerB).Evaluate(reader);
+
+            Assert.That(setA.Get("ore.total"), Is.EqualTo(100f));
+            Assert.That(setB.Get("ore.total"), Is.EqualTo(900f));
+        }
+
+        [Test]
+        public void Evaluate_SingleAttribute_ReadsOwnerBuffer()
+        {
+            AttributeRegistry.Clear();
+            int attrId = AttributeRegistry.Register("tests.panel.queue");
+            try
+            {
+                const string json = """
+                {
+                  "id": "tests.panel.queue_card",
+                  "variables": [
+                    { "name": "queue.length", "kind": "Float",
+                      "source": { "sourceKind": "SingleAttribute", "attributeId": "tests.panel.queue" } }
+                  ]
+                }
+                """;
+                PanelTemplate template = PanelTemplateLoader.Load(json);
+                using World world = World.Create();
+                Entity owner = world.Create();
+                world.Add(owner, new AttributeBuffer());
+                world.Get<AttributeBuffer>(owner).SetBase(attrId, 3f);
+
+                var reader = new PanelProjectionReader(world);
+                PanelVariableSet result = new PanelInstance(template, owner).Evaluate(reader);
+
+                Assert.That(result.Get("queue.length"), Is.EqualTo(3f));
+            }
+            finally
+            {
+                AttributeRegistry.Clear();
+            }
+        }
+    }
+}

--- a/src/Tests/UiShowcaseTests/PanelTemplateMarkupRendererTests.cs
+++ b/src/Tests/UiShowcaseTests/PanelTemplateMarkupRendererTests.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using Ludots.Core.UI.PanelProjection;
+using Ludots.UI.Skia;
+using NUnit.Framework;
+using UiShowcaseCoreMod.Showcase;
+
+namespace Ludots.Tests.UiShowcase;
+
+[TestFixture]
+public sealed class PanelTemplateMarkupRendererTests
+{
+    [Test]
+    public void Render_SubstitutesVariablesIntoMarkup()
+    {
+        var variables = new PanelVariableSet(
+            "tests.panel.resource_bar",
+            new Dictionary<string, float>(StringComparer.Ordinal)
+            {
+                ["ore.total"] = 1200f,
+                ["gas.total"] = 450.5f,
+            },
+            revision: 7);
+
+        var scene = PanelTemplateMarkupRenderer.Render(
+            "<div id=\"bar\">矿 {ore.total} 气 {gas.total}</div>",
+            "#bar { width: 200px; }",
+            variables,
+            new SkiaTextMeasurer(),
+            new SkiaImageSizeProvider());
+
+        Ludots.UI.Runtime.UiNode bar = scene.FindByElementId("bar");
+        Assert.That(bar, Is.Not.Null);
+        Assert.That(bar.TextContent, Does.Contain("1200"));
+        Assert.That(bar.TextContent, Does.Contain("450.5"));
+    }
+
+    [Test]
+    public void Render_UnknownToken_FailsNamingVariable()
+    {
+        var variables = new PanelVariableSet(
+            "tests.panel.resource_bar",
+            new Dictionary<string, float>(StringComparer.Ordinal) { ["ore.total"] = 1f },
+            revision: 1);
+
+        Assert.That(
+            () => PanelTemplateMarkupRenderer.Render(
+                "<div>{ghost}</div>",
+                "",
+                variables,
+                new SkiaTextMeasurer(),
+                new SkiaImageSizeProvider()),
+            Throws.InvalidOperationException.With.Message.Contains("ghost"));
+    }
+}


### PR DESCRIPTION
#1010 MVP 切片 / 宪法 #858（PANEL-0）\n\n## 交付\n\n**Core（src/Core/UI/PanelProjection/，与既有 PanelVariableBinding/PanelProjectionReader 同居）**\n- `PanelTemplate`：id + `variables[]`（name/kind/source）+ `binds[]`；变量构造复用 PanelVariableBinding 的 fail-closed 字段规则（attribute/graphKey 互斥与必填）\n- `PanelTemplateLoader`：严格 JSON——未知字段/未知 sourceKind/未知 kind/缺字段一律点名失败；binds 引用未声明变量拒绝；变量名查重\n- `PanelInstance` + `PanelVariableSet`：模板 × scope 实例，求值**只走 PanelProjectionReader**（四条合法路之三已通：SingleAttribute/DerivedAttribute/AggregateProjection；tableLookup 待接 #893 查表）；未知变量读取抛错，无静默零\n\n**Markup 皮适配（mods/UiShowcaseCoreMod/Showcase/）**\n- `PanelTemplateMarkupRenderer`：HTML 中 `{var}` token 由求值结果代换后经 UiMarkupLoader 成景；未知 token 点名失败；适配器**零取数**（只消费 PanelVariableSet）\n\n## 验证\n\n- GasTests `PanelTemplateTests` 9/9：加载 fail-fast ×4（缺 key/坏 sourceKind/未知字段/幽灵 bind）、求值 == GraphOutputValueStore、缺输出无静默零、双实例 scope 独立、SingleAttribute 读 AttributeBuffer\n- UiShowcaseTests `PanelTemplateMarkupRendererTests` 2/2：token 代换进 DOM、未知 token 失败\n- 回归：PanelProjectionReader 5/5、UiShowcaseTests 全量 88/88、ArchitectureGuard 53/53\n\n## 边界（按宪法）\n\n- 不新增 Graph VM / 取数旁路；求值路径无手写跨实体求和\n- Compose/Reactive/Web 三皮适配（#1011）、tableLookup 变量路、目录登记（#841）为后续切片