### PR TITLE
fix(gallery): 窗口重建后 Skia 字体纹理跨 GL 上下文失效致场景黑屏

### DIFF
--- a/src/Apps/Raylib/Ludots.App.RaylibEngineGallery/GalleryFont.cs
+++ b/src/Apps/Raylib/Ludots.App.RaylibEngineGallery/GalleryFont.cs
@@ -38,6 +38,19 @@ namespace Ludots.App.RaylibEngineGallery
             canvas.DrawText(text, x, y + (size * BaselineOffsetFactor), font, paint);
         }
 
+        public static void Reset()
+        {
+            if (!Instance.IsValueCreated)
+            {
+                return;
+            }
+
+            GalleryFont self = Instance.Value;
+            self._renderer?.Dispose();
+            self._renderer = null;
+            self._frameBegun = false;
+        }
+
         public static void Flush()
         {
             if (!Instance.IsValueCreated)

--- a/src/Apps/Raylib/Ludots.App.RaylibEngineGallery/Program.cs
+++ b/src/Apps/Raylib/Ludots.App.RaylibEngineGallery/Program.cs
@@ -51,6 +51,7 @@ namespace Ludots.App.RaylibEngineGallery
                 Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(screenshotPath!))!);
             }
 
+            GalleryFont.Reset();
             Rl.InitWindow(WindowWidth, WindowHeight, $"Ludots Engine Gallery — {scene.Id}");
             Rl.SetTargetFPS(60);
 
@@ -118,6 +119,7 @@ namespace Ludots.App.RaylibEngineGallery
 
         private static int RunMenu()
         {
+            GalleryFont.Reset();
             Rl.InitWindow(WindowWidth, WindowHeight, "Ludots Engine Gallery");
             Rl.SetTargetFPS(60);
 
@@ -156,6 +158,7 @@ namespace Ludots.App.RaylibEngineGallery
 
         private static int RunSceneInteractive(IEngineScene scene)
         {
+            GalleryFont.Reset();
             Rl.InitWindow(WindowWidth, WindowHeight, $"Ludots Engine Gallery — {scene.Title}");
             Rl.SetTargetFPS(60);
             var camera = new EngineOrbitCamera();
@@ -184,6 +187,7 @@ namespace Ludots.App.RaylibEngineGallery
             scene.Dispose();
             Rl.CloseWindow();
 
+            GalleryFont.Reset();
             Rl.InitWindow(WindowWidth, WindowHeight, "Ludots Engine Gallery");
             Rl.SetTargetFPS(60);
             int back = RunMenu();


### PR DESCRIPTION
菜单→场景（或场景→菜单）切换时 CloseWindow/InitWindow 重建 GL 上下文，GalleryFont 单例持有的 RaylibSkiaRenderer 纹理 ID 在新上下文失效，全屏四边形以无效纹理绘制盖黑一切。修复：每次 InitWindow 前 GalleryFont.Reset() 重建渲染器（4 处窗口生命周期挂钩）。复现路径：启动画廊菜单（文字正常）→ 按 H Enter 进图元群体场景 → 整屏黑。验证：修复后该路径正常渲染；批量截图模式不受影响。