### PR TITLE
feat(panel): 面板线一次性收片 + 实体属性面板全链 showcase（graph×panel JSON 驱动）

### DIFF
--- a/src/Core/UI/PanelActivation/PanelOrchestrationJson.cs
+++ b/src/Core/UI/PanelActivation/PanelOrchestrationJson.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Ludots.Core.GraphRuntime;
+using Ludots.Core.NodeLibraries.GASGraph;
+
+namespace Ludots.Core.UI.PanelActivation
+{
+    /// <summary>
+    /// Loads visibility orchestration graphs from JSON (#1014): one panelType per
+    /// entry, a flat Script instruction list, optional symbol strings. This is the
+    /// authoring mouth so orchestration stays data-driven end to end.
+    /// </summary>
+    public static class PanelOrchestrationJson
+    {
+        public static IReadOnlyList<PanelOrchestrationEntry> Load(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                throw new InvalidOperationException("Panel orchestration JSON is empty.");
+            }
+
+            JsonNode root;
+            try
+            {
+                root = JsonNode.Parse(json) ?? throw new InvalidOperationException("Panel orchestration JSON parsed to null.");
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException($"Panel orchestration JSON is malformed: {ex.Message}");
+            }
+
+            if (root is not JsonArray entriesNode)
+            {
+                throw new InvalidOperationException("Panel orchestration root must be a JSON array of entries.");
+            }
+
+            var entries = new List<PanelOrchestrationEntry>(entriesNode.Count);
+            foreach (JsonNode? entryNode in entriesNode)
+            {
+                if (entryNode is not JsonObject entryObject)
+                {
+                    throw new InvalidOperationException("Panel orchestration entries must be objects.");
+                }
+
+                RejectUnknownFields(entryObject, "panelType", "instructions", "symbols", "panel orchestration entry");
+                string panelType = RequireString(entryObject, "panelType", "panel orchestration entry");
+                if (entryObject["instructions"] is not JsonArray instructionsNode || instructionsNode.Count == 0)
+                {
+                    throw new InvalidOperationException($"Orchestration entry '{panelType}' requires a non-empty 'instructions' array.");
+                }
+
+                var instructions = new GraphInstruction[instructionsNode.Count];
+                for (int i = 0; i < instructionsNode.Count; i++)
+                {
+                    if (instructionsNode[i] is not JsonObject instructionObject)
+                    {
+                        throw new InvalidOperationException($"Orchestration entry '{panelType}' instructions must be objects.");
+                    }
+
+                    RejectUnknownFields(instructionObject, "op", "dst", "a", "b", "imm", $"orchestration entry '{panelType}' instruction");
+                    string opName = RequireString(instructionObject, "op", $"orchestration entry '{panelType}' instruction");
+                    if (!Enum.TryParse<GraphNodeOp>(opName, ignoreCase: false, out GraphNodeOp op) ||
+                        !Enum.IsDefined(typeof(GraphNodeOp), op))
+                    {
+                        throw new InvalidOperationException($"Orchestration entry '{panelType}' has unknown op '{opName}'.");
+                    }
+
+                    instructions[i] = new GraphInstruction
+                    {
+                        Op = (ushort)op,
+                        Dst = ReadByte(instructionObject, "dst"),
+                        A = ReadByte(instructionObject, "a"),
+                        B = ReadByte(instructionObject, "b"),
+                        Imm = ReadInt(instructionObject, "imm"),
+                    };
+                }
+
+                var symbols = new List<string>();
+                if (entryObject["symbols"] is JsonArray symbolsNode)
+                {
+                    foreach (JsonNode? symbolNode in symbolsNode)
+                    {
+                        string? symbol = symbolNode?.GetValue<string>();
+                        if (string.IsNullOrWhiteSpace(symbol))
+                        {
+                            throw new InvalidOperationException($"Orchestration entry '{panelType}' symbols must be non-empty strings.");
+                        }
+
+                        symbols.Add(symbol);
+                    }
+                }
+
+                entries.Add(new PanelOrchestrationEntry(panelType, instructions, symbols.ToArray()));
+            }
+
+            return entries;
+        }
+
+        private static string RequireString(JsonObject obj, string field, string context)
+        {
+            string? value = obj[field]?.GetValue<string>();
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new InvalidOperationException($"{context} is missing required '{field}'.");
+            }
+
+            return value;
+        }
+
+        private static byte ReadByte(JsonObject obj, string field)
+        {
+            return obj[field] is JsonNode node && node.GetValue<int>() is int value && value >= 0 && value <= 255
+                ? (byte)value
+                : (byte)0;
+        }
+
+        private static int ReadInt(JsonObject obj, string field)
+        {
+            return obj[field] is JsonNode node ? node.GetValue<int>() : 0;
+        }
+
+        private static void RejectUnknownFields(JsonObject obj, string f1, string f2, string f3, string context)
+        {
+            var allowed = new HashSet<string>(StringComparer.Ordinal) { f1, f2, f3 };
+            foreach (KeyValuePair<string, JsonNode?> property in obj)
+            {
+                if (!allowed.Contains(property.Key))
+                {
+                    throw new InvalidOperationException($"{context} has unknown field '{property.Key}' (allowed: {f1}, {f2}, {f3}).");
+                }
+            }
+        }
+
+        private static void RejectUnknownFields(JsonObject obj, string f1, string f2, string f3, string f4, string f5, string context)
+        {
+            var allowed = new HashSet<string>(StringComparer.Ordinal) { f1, f2, f3, f4, f5 };
+            foreach (KeyValuePair<string, JsonNode?> property in obj)
+            {
+                if (!allowed.Contains(property.Key))
+                {
+                    throw new InvalidOperationException($"{context} has unknown field '{property.Key}' (allowed: {f1}, {f2}, {f3}, {f4}, {f5}).");
+                }
+            }
+        }
+    }
+}

--- a/src/Core/UI/PanelProjection/PanelBindingSourceKind.cs
+++ b/src/Core/UI/PanelProjection/PanelBindingSourceKind.cs
@@ -24,5 +24,11 @@ namespace Ludots.Core.UI.PanelProjection
         /// Graph Summary output (same read mouth as AggregateProjection; authoring alias).
         /// </summary>
         GraphOutput = 4,
+
+        /// <summary>
+        /// Generic lookup table cell (#881): key read from an owner attribute,
+        /// row resolved and field read through GraphLookupTableRegistry.
+        /// </summary>
+        TableLookup = 5,
     }
 }

--- a/src/Core/UI/PanelProjection/PanelEventDispatcher.cs
+++ b/src/Core/UI/PanelProjection/PanelEventDispatcher.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using Arch.Core;
+using Ludots.Core.Gameplay.GAS.Components;
+
+namespace Ludots.Core.UI.PanelProjection
+{
+    /// <summary>
+    /// Validates and dispatches declared panel events (#1013). Path B/C fan-out:
+    /// the registered sink routes validated payloads (graph consumption via the event
+    /// bus, signal bridge into orchestration blackboard — order admission downstream).
+    /// The dispatcher never mutates gameplay itself.
+    /// </summary>
+    public sealed class PanelEventDispatcher
+    {
+        private readonly PanelTemplate _template;
+        private readonly Action<string, IReadOnlyDictionary<string, object?>> _sink;
+
+        public PanelEventDispatcher(PanelTemplate template, Action<string, IReadOnlyDictionary<string, object?>> sink)
+        {
+            _template = template ?? throw new ArgumentNullException(nameof(template));
+            _sink = sink ?? throw new ArgumentNullException(nameof(sink));
+        }
+
+        public void Fire(string eventId, JsonObject args)
+        {
+            PanelTemplateEvent declaration = RequireEvent(eventId);
+            IReadOnlyDictionary<string, object?> payload = ValidatePayload(declaration, args);
+            _sink(declaration.EventId, payload);
+        }
+
+        private PanelTemplateEvent RequireEvent(string eventId)
+        {
+            foreach (PanelTemplateEvent declaration in _template.Events)
+            {
+                if (string.Equals(declaration.EventId, eventId, StringComparison.Ordinal))
+                {
+                    return declaration;
+                }
+            }
+
+            throw new InvalidOperationException($"Panel '{_template.Id}' has no declared event '{eventId}'.");
+        }
+
+        private static IReadOnlyDictionary<string, object?> ValidatePayload(PanelTemplateEvent declaration, JsonObject args)
+        {
+            var payload = new Dictionary<string, object?>(declaration.Payload.Count, StringComparer.Ordinal);
+            foreach (KeyValuePair<string, PanelEventPayloadKind> field in declaration.Payload)
+            {
+                if (!args.TryGetPropertyValue(field.Key, out JsonNode? node) || node is null)
+                {
+                    throw new InvalidOperationException(
+                        $"Panel event '{declaration.EventId}' payload is missing required field '{field.Key}'.");
+                }
+
+                payload[field.Key] = field.Value switch
+                {
+                    PanelEventPayloadKind.String => RequireString(node, declaration.EventId, field.Key),
+                    PanelEventPayloadKind.Int => RequireInt(node, declaration.EventId, field.Key),
+                    PanelEventPayloadKind.Float => RequireFloat(node, declaration.EventId, field.Key),
+                    PanelEventPayloadKind.Bool => RequireBool(node, declaration.EventId, field.Key),
+                    _ => throw new InvalidOperationException(
+                        $"Panel event '{declaration.EventId}' field '{field.Key}' has unsupported kind '{field.Value}'."),
+                };
+            }
+
+            foreach (KeyValuePair<string, JsonNode?> property in args)
+            {
+                if (!declaration.Payload.ContainsKey(property.Key))
+                {
+                    throw new InvalidOperationException(
+                        $"Panel event '{declaration.EventId}' payload has undeclared field '{property.Key}'.");
+                }
+            }
+
+            return payload;
+        }
+
+        private static string RequireString(JsonNode node, string eventId, string field) => node.GetValue<string>();
+        private static int RequireInt(JsonNode node, string eventId, string field) => node.GetValue<int>();
+        private static float RequireFloat(JsonNode node, string eventId, string field) => node.GetValue<float>();
+        private static bool RequireBool(JsonNode node, string eventId, string field) => node.GetValue<bool>();
+    }
+
+    /// <summary>
+    /// Path-B-to-orchestration signal bridge (#1014/#1013): writes an int payload
+    /// field onto the context entity's blackboard so the visibility orchestration
+    /// graph can consume it — the only UI-side gameplay write, and only of signals.
+    /// </summary>
+    public static class PanelSignalBridge
+    {
+        public static void WriteSignal(World world, Entity contextEntity, string key, int value)
+        {
+            ArgumentNullException.ThrowIfNull(world);
+            if (contextEntity == Entity.Null || !world.IsAlive(contextEntity))
+            {
+                throw new InvalidOperationException("Panel signal bridge requires a live context entity.");
+            }
+
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                throw new ArgumentException("Signal key is required.", nameof(key));
+            }
+
+            if (!world.Has<BlackboardIntBuffer>(contextEntity))
+            {
+                world.Add(contextEntity, new BlackboardIntBuffer());
+            }
+
+            int keyId = Gameplay.GAS.Registry.ConfigKeyRegistry.Register(key);
+            world.Get<BlackboardIntBuffer>(contextEntity).Set(keyId, value);
+        }
+    }
+
+    /// <summary>
+    /// Resolves intent-map entries against a validated payload plus seat/command-source
+    /// attribution context (#1013). Produces PanelIntent records for admission —
+    /// this layer never submits orders itself.
+    /// </summary>
+    public sealed class PanelIntentResolver
+    {
+        private readonly PanelTemplate _template;
+
+        public PanelIntentResolver(PanelTemplate template)
+        {
+            _template = template ?? throw new ArgumentNullException(nameof(template));
+        }
+
+        public PanelIntent Resolve(string eventId, IReadOnlyDictionary<string, object?> payload, int playerId, Entity actor)
+        {
+            foreach (PanelIntentMapEntry entry in _template.Intents)
+            {
+                if (!string.Equals(entry.EventId, eventId, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (!string.Equals(entry.PlayerSource, "seat", StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"Panel '{_template.Id}' intent '{entry.Intent}' declares unsupported playerSource '{entry.PlayerSource}' (only 'seat').");
+                }
+
+                if (!string.Equals(entry.ActorSource, "commandSource.primary", StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"Panel '{_template.Id}' intent '{entry.Intent}' declares unsupported actorSource '{entry.ActorSource}' (only 'commandSource.primary').");
+                }
+
+                if (playerId <= 0)
+                {
+                    throw new InvalidOperationException(
+                        $"Panel '{_template.Id}' intent '{entry.Intent}' requires a seated player for attribution.");
+                }
+
+                if (actor == Entity.Null)
+                {
+                    throw new InvalidOperationException(
+                        $"Panel '{_template.Id}' intent '{entry.Intent}' requires a command source actor for attribution.");
+                }
+
+                var args = new Dictionary<string, object?>(entry.Args.Count, StringComparer.Ordinal);
+                foreach (KeyValuePair<string, string> mapping in entry.Args)
+                {
+                    const string prefix = "$payload.";
+                    if (!mapping.Value.StartsWith(prefix, StringComparison.Ordinal))
+                    {
+                        throw new InvalidOperationException(
+                            $"Panel '{_template.Id}' intent '{entry.Intent}' arg '{mapping.Key}' must reference $payload.* (got '{mapping.Value}').");
+                    }
+
+                    string field = mapping.Value[prefix.Length..];
+                    if (!payload.TryGetValue(field, out object? value))
+                    {
+                        throw new InvalidOperationException(
+                            $"Panel '{_template.Id}' intent '{entry.Intent}' arg '{mapping.Key}' references unknown payload field '{field}'.");
+                    }
+
+                    args[mapping.Key] = value;
+                }
+
+                return new PanelIntent(entry.Intent, args, playerId, actor);
+            }
+
+            throw new InvalidOperationException($"Panel '{_template.Id}' has no intent mapped for event '{eventId}'.");
+        }
+    }
+}

--- a/src/Core/UI/PanelProjection/PanelProjectionReader.cs
+++ b/src/Core/UI/PanelProjection/PanelProjectionReader.cs
@@ -14,16 +14,19 @@ namespace Ludots.Core.UI.PanelProjection
     {
         private readonly World _world;
         private readonly GraphOutputValueStore? _graphOutputs;
+        private readonly Ludots.Core.NodeLibraries.GASGraph.Host.GraphLookupTableRegistry? _lookupTables;
         private readonly Func<string, int> _resolveAttributeId;
 
         public PanelProjectionReader(
             World world,
             GraphOutputValueStore? graphOutputs = null,
-            Func<string, int>? resolveAttributeId = null)
+            Func<string, int>? resolveAttributeId = null,
+            Ludots.Core.NodeLibraries.GASGraph.Host.GraphLookupTableRegistry? lookupTables = null)
         {
             _world = world ?? throw new ArgumentNullException(nameof(world));
             _graphOutputs = graphOutputs;
             _resolveAttributeId = resolveAttributeId ?? AttributeRegistry.GetId;
+            _lookupTables = lookupTables;
         }
 
         public float ResolveFloat(Entity owner, in PanelVariableBinding binding)
@@ -45,6 +48,8 @@ namespace Ludots.Core.UI.PanelProjection
                     => ResolveAttribute(owner, in binding),
                 PanelBindingSourceKind.AggregateProjection or PanelBindingSourceKind.GraphOutput
                     => ResolveGraphOutput(owner, in binding),
+                PanelBindingSourceKind.TableLookup
+                    => ResolveTableLookup(owner, in binding),
                 _ => throw new InvalidOperationException(
                     $"Panel binding '{binding.VariableId}' has unsupported sourceKind '{binding.SourceKind}'."),
             };
@@ -77,6 +82,43 @@ namespace Ludots.Core.UI.PanelProjection
 
             float value = buffer.GetCurrent(id);
             uint revision = (uint)BitConverter.SingleToInt32Bits(value);
+            return new PanelProjectionValue(binding.VariableId, binding.SourceKind, value, revision);
+        }
+
+        private PanelProjectionValue ResolveTableLookup(Entity owner, in PanelVariableBinding binding)
+        {
+            if (_lookupTables == null)
+            {
+                throw new InvalidOperationException(
+                    $"Panel binding '{binding.VariableId}' requires GraphLookupTableRegistry for table '{binding.LookupTable}'.");
+            }
+
+            string keyAttribute = binding.KeyAttribute
+                ?? throw new InvalidOperationException(
+                    $"Panel binding '{binding.VariableId}' is missing keyAttribute.");
+            int keyAttributeId = _resolveAttributeId(keyAttribute);
+            if (keyAttributeId == AttributeRegistry.InvalidId || keyAttributeId < 0)
+            {
+                throw new InvalidOperationException(
+                    $"Panel binding '{binding.VariableId}' references unknown key attribute '{keyAttribute}'.");
+            }
+
+            if (!_world.TryGet(owner, out AttributeBuffer buffer) || !buffer.HasAttribute(keyAttributeId))
+            {
+                throw new InvalidOperationException(
+                    $"Panel binding '{binding.VariableId}' key attribute '{keyAttribute}' is not defined on owner #{owner.Id}.");
+            }
+
+            int key = (int)buffer.GetCurrent(keyAttributeId);
+            string tableId = binding.LookupTable!;
+            string fieldId = binding.LookupField!;
+            int resolvedTable = _lookupTables.GetTableId(tableId);
+            int row = _lookupTables.ResolveRow(resolvedTable, key);
+            int resolvedField = _lookupTables.GetFieldId(tableId, fieldId);
+            float value = binding.ValueKind == PanelTemplateVariableKind.Int
+                ? _lookupTables.ReadInt(row, resolvedField)
+                : _lookupTables.ReadFloat(row, resolvedField);
+            uint revision = (uint)key ^ (uint)BitConverter.SingleToInt32Bits(value);
             return new PanelProjectionValue(binding.VariableId, binding.SourceKind, value, revision);
         }
 

--- a/src/Core/UI/PanelProjection/PanelTemplate.cs
+++ b/src/Core/UI/PanelProjection/PanelTemplate.cs
@@ -10,7 +10,12 @@ namespace Ludots.Core.UI.PanelProjection
     /// </summary>
     public sealed class PanelTemplate
     {
-        public PanelTemplate(string id, IReadOnlyList<PanelTemplateVariable> variables, IReadOnlyList<PanelTemplateBind>? binds = null)
+        public PanelTemplate(
+            string id,
+            IReadOnlyList<PanelTemplateVariable> variables,
+            IReadOnlyList<PanelTemplateBind>? binds = null,
+            IReadOnlyList<PanelTemplateEvent>? events = null,
+            IReadOnlyList<PanelIntentMapEntry>? intents = null)
         {
             if (string.IsNullOrWhiteSpace(id))
             {
@@ -52,14 +57,49 @@ namespace Ludots.Core.UI.PanelProjection
                 }
             }
 
+            List<PanelTemplateEvent> safeEvents = new List<PanelTemplateEvent>(events ?? Array.Empty<PanelTemplateEvent>());
+            var eventIds = new HashSet<string>(StringComparer.Ordinal);
+            foreach (PanelTemplateEvent declaration in safeEvents)
+            {
+                if (declaration == null)
+                {
+                    throw new ArgumentException($"Panel template '{id}' has a null event entry.", nameof(events));
+                }
+
+                if (!eventIds.Add(declaration.EventId))
+                {
+                    throw new ArgumentException($"Panel template '{id}' declares duplicate event '{declaration.EventId}'.", nameof(events));
+                }
+            }
+
+            List<PanelIntentMapEntry> safeIntents = new List<PanelIntentMapEntry>(intents ?? Array.Empty<PanelIntentMapEntry>());
+            foreach (PanelIntentMapEntry entry in safeIntents)
+            {
+                if (entry == null)
+                {
+                    throw new ArgumentException($"Panel template '{id}' has a null intent entry.", nameof(intents));
+                }
+
+                if (!eventIds.Contains(entry.EventId))
+                {
+                    throw new ArgumentException(
+                        $"Panel template '{id}' intent '{entry.Intent}' references undeclared event '{entry.EventId}'.",
+                        nameof(intents));
+                }
+            }
+
             Id = id.Trim();
             Variables = variables;
             Binds = safeBinds;
+            Events = safeEvents;
+            Intents = safeIntents;
         }
 
         public string Id { get; }
         public IReadOnlyList<PanelTemplateVariable> Variables { get; }
         public IReadOnlyList<PanelTemplateBind> Binds { get; }
+        public IReadOnlyList<PanelTemplateEvent> Events { get; }
+        public IReadOnlyList<PanelIntentMapEntry> Intents { get; }
 
         public PanelVariableBinding ResolveBinding(string variableName)
         {
@@ -82,7 +122,10 @@ namespace Ludots.Core.UI.PanelProjection
             PanelTemplateVariableKind kind,
             PanelBindingSourceKind sourceKind,
             string? attributeId = null,
-            string? graphOutputKey = null)
+            string? graphOutputKey = null,
+            string? lookupTable = null,
+            string? lookupField = null,
+            string? keyAttribute = null)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
@@ -94,9 +137,12 @@ namespace Ludots.Core.UI.PanelProjection
             SourceKind = sourceKind;
 
             // Reuse the binding contract's own fail-closed field rules.
-            Binding = new PanelVariableBinding(Name, sourceKind, attributeId, graphOutputKey);
+            Binding = new PanelVariableBinding(Name, sourceKind, attributeId, graphOutputKey, lookupTable, lookupField, keyAttribute, kind);
             AttributeId = Binding.AttributeId;
             GraphOutputKey = Binding.GraphOutputKey;
+            LookupTable = Binding.LookupTable;
+            LookupField = Binding.LookupField;
+            KeyAttribute = Binding.KeyAttribute;
         }
 
         public string Name { get; }
@@ -104,6 +150,9 @@ namespace Ludots.Core.UI.PanelProjection
         public PanelBindingSourceKind SourceKind { get; }
         public string? AttributeId { get; }
         public string? GraphOutputKey { get; }
+        public string? LookupTable { get; }
+        public string? LookupField { get; }
+        public string? KeyAttribute { get; }
 
         internal PanelVariableBinding Binding { get; }
 

--- a/src/Core/UI/PanelProjection/PanelTemplateEvents.cs
+++ b/src/Core/UI/PanelProjection/PanelTemplateEvents.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ludots.Core.UI.PanelProjection
+{
+    /// <summary>
+    /// Zero-code UI event declaration (#1013): one event id, one trigger, one typed
+    /// payload schema. Payloads validate strictly — unknown or mistyped fields fail.
+    /// </summary>
+    public sealed class PanelTemplateEvent
+    {
+        public PanelTemplateEvent(string eventId, string? control, string gesture, IReadOnlyDictionary<string, PanelEventPayloadKind>? payload = null)
+        {
+            if (string.IsNullOrWhiteSpace(eventId))
+            {
+                throw new ArgumentException("Event id is required.", nameof(eventId));
+            }
+
+            if (string.IsNullOrWhiteSpace(gesture))
+            {
+                throw new ArgumentException($"Event '{eventId}' requires a gesture.", nameof(gesture));
+            }
+
+            EventId = eventId.Trim();
+            Control = string.IsNullOrWhiteSpace(control) ? null : control.Trim();
+            Gesture = gesture.Trim();
+            Payload = payload ?? new Dictionary<string, PanelEventPayloadKind>();
+        }
+
+        public string EventId { get; }
+        public string? Control { get; }
+        public string Gesture { get; }
+        public IReadOnlyDictionary<string, PanelEventPayloadKind> Payload { get; }
+    }
+
+    public enum PanelEventPayloadKind : byte
+    {
+        String = 0,
+        Int = 1,
+        Float = 2,
+        Bool = 3,
+    }
+
+    /// <summary>
+    /// One intent-map entry (#1013): how a declared event becomes a gameplay intent.
+    /// Args map $payload.<field> references; attribution resolves at runtime from
+    /// playerSource/actorSource — the panel never constructs orders.
+    /// </summary>
+    public sealed class PanelIntentMapEntry
+    {
+        public PanelIntentMapEntry(
+            string eventId,
+            string intent,
+            IReadOnlyDictionary<string, string> args,
+            string playerSource,
+            string actorSource)
+        {
+            if (string.IsNullOrWhiteSpace(eventId))
+            {
+                throw new ArgumentException("Intent entry event is required.", nameof(eventId));
+            }
+
+            if (string.IsNullOrWhiteSpace(intent))
+            {
+                throw new ArgumentException($"Intent entry for '{eventId}' requires an intent id.", nameof(intent));
+            }
+
+            EventId = eventId.Trim();
+            Intent = intent.Trim();
+            Args = args ?? new Dictionary<string, string>(StringComparer.Ordinal);
+            PlayerSource = playerSource.Trim();
+            ActorSource = actorSource.Trim();
+        }
+
+        public string EventId { get; }
+        public string Intent { get; }
+        public IReadOnlyDictionary<string, string> Args { get; }
+        public string PlayerSource { get; }
+        public string ActorSource { get; }
+    }
+
+    /// <summary>Resolved intent ready for admission (#1013 MVP).</summary>
+    public sealed record PanelIntent(
+        string Intent,
+        IReadOnlyDictionary<string, object?> Args,
+        int PlayerId,
+        Arch.Core.Entity Actor);
+}

--- a/src/Core/UI/PanelProjection/PanelTemplateLoader.cs
+++ b/src/Core/UI/PanelProjection/PanelTemplateLoader.cs
@@ -11,9 +11,9 @@ namespace Ludots.Core.UI.PanelProjection
     /// </summary>
     public static class PanelTemplateLoader
     {
-        private static readonly HashSet<string> RootFields = new(StringComparer.Ordinal) { "id", "variables", "binds" };
+        private static readonly HashSet<string> RootFields = new(StringComparer.Ordinal) { "id", "variables", "binds", "events", "intents" };
         private static readonly HashSet<string> VariableFields = new(StringComparer.Ordinal) { "name", "kind", "source" };
-        private static readonly HashSet<string> SourceFields = new(StringComparer.Ordinal) { "sourceKind", "attributeId", "graphOutputKey" };
+        private static readonly HashSet<string> SourceFields = new(StringComparer.Ordinal) { "sourceKind", "attributeId", "graphOutputKey", "lookupTable", "lookupField", "keyAttribute" };
         private static readonly HashSet<string> BindFields = new(StringComparer.Ordinal) { "control", "variable" };
 
         public static PanelTemplate Load(string json)
@@ -75,7 +75,98 @@ namespace Ludots.Core.UI.PanelProjection
                 }
             }
 
-            return new PanelTemplate(id, variables, binds);
+            List<PanelTemplateEvent> events = ParseEvents(id, rootObject);
+            List<PanelIntentMapEntry> intents = ParseIntents(id, rootObject, events);
+
+            return new PanelTemplate(id, variables, binds, events, intents);
+        }
+
+        private static List<PanelTemplateEvent> ParseEvents(string templateId, JsonObject rootObject)
+        {
+            var events = new List<PanelTemplateEvent>();
+            if (rootObject["events"] is not JsonArray eventsNode)
+            {
+                return events;
+            }
+
+            var allowed = new HashSet<string>(StringComparer.Ordinal) { "eventId", "control", "gesture", "payload" };
+            foreach (JsonNode? eventNode in eventsNode)
+            {
+                if (eventNode is not JsonObject eventObject)
+                {
+                    throw new InvalidOperationException($"Panel template '{templateId}' events entries must be objects.");
+                }
+
+                RejectUnknownFields(eventObject, allowed, $"panel template '{templateId}' event");
+                string eventId = RequireString(eventObject, "eventId", $"panel template '{templateId}' event");
+                string gesture = RequireString(eventObject, "gesture", $"panel template '{templateId}' event '{eventId}'");
+                string? control = OptionalString(eventObject, "control");
+
+                var payload = new Dictionary<string, PanelEventPayloadKind>(StringComparer.Ordinal);
+                if (eventObject["payload"] is JsonObject payloadNode)
+                {
+                    foreach (KeyValuePair<string, JsonNode?> field in payloadNode)
+                    {
+                        string? kindText = field.Value?.GetValue<string>();
+                        if (!Enum.TryParse<PanelEventPayloadKind>(kindText, ignoreCase: false, out PanelEventPayloadKind kind) ||
+                            !Enum.IsDefined(typeof(PanelEventPayloadKind), kind))
+                        {
+                            throw new InvalidOperationException(
+                                $"Panel template '{templateId}' event '{eventId}' payload field '{field.Key}' has unknown kind '{kindText}' (allowed: String, Int, Float, Bool).");
+                        }
+
+                        payload[field.Key] = kind;
+                    }
+                }
+
+                events.Add(new PanelTemplateEvent(eventId, control, gesture, payload));
+            }
+
+            return events;
+        }
+
+        private static List<PanelIntentMapEntry> ParseIntents(string templateId, JsonObject rootObject, List<PanelTemplateEvent> events)
+        {
+            var intents = new List<PanelIntentMapEntry>();
+            if (rootObject["intents"] is not JsonArray intentsNode)
+            {
+                return intents;
+            }
+
+            var allowed = new HashSet<string>(StringComparer.Ordinal) { "event", "intent", "args", "playerSource", "actorSource" };
+            foreach (JsonNode? intentNode in intentsNode)
+            {
+                if (intentNode is not JsonObject intentObject)
+                {
+                    throw new InvalidOperationException($"Panel template '{templateId}' intents entries must be objects.");
+                }
+
+                RejectUnknownFields(intentObject, allowed, $"panel template '{templateId}' intent");
+                string eventId = RequireString(intentObject, "event", $"panel template '{templateId}' intent");
+                string intent = RequireString(intentObject, "intent", $"panel template '{templateId}' intent for '{eventId}'");
+                string playerSource = RequireString(intentObject, "playerSource", $"panel template '{templateId}' intent '{intent}'");
+                string actorSource = RequireString(intentObject, "actorSource", $"panel template '{templateId}' intent '{intent}'");
+
+                var args = new Dictionary<string, string>(StringComparer.Ordinal);
+                if (intentObject["args"] is JsonObject argsNode)
+                {
+                    foreach (KeyValuePair<string, JsonNode?> mapping in argsNode)
+                    {
+                        string? reference = mapping.Value?.GetValue<string>();
+                        if (string.IsNullOrWhiteSpace(reference))
+                        {
+                            throw new InvalidOperationException(
+                                $"Panel template '{templateId}' intent '{intent}' arg '{mapping.Key}' must be a $payload.* reference string.");
+                        }
+
+                        args[mapping.Key] = reference;
+                    }
+                }
+
+                intents.Add(new PanelIntentMapEntry(eventId, intent, args, playerSource, actorSource));
+            }
+
+            return intents;
         }
 
         private static PanelTemplateVariable ParseVariable(string templateId, JsonObject variableObject)
@@ -108,7 +199,10 @@ namespace Ludots.Core.UI.PanelProjection
                 kind,
                 sourceKind,
                 attributeId: OptionalString(sourceObject, "attributeId"),
-                graphOutputKey: OptionalString(sourceObject, "graphOutputKey"));
+                graphOutputKey: OptionalString(sourceObject, "graphOutputKey"),
+                lookupTable: OptionalString(sourceObject, "lookupTable"),
+                lookupField: OptionalString(sourceObject, "lookupField"),
+                keyAttribute: OptionalString(sourceObject, "keyAttribute"));
         }
 
         private static string RequireString(JsonObject obj, string field, string context)

--- a/src/Core/UI/PanelProjection/PanelVariableBinding.cs
+++ b/src/Core/UI/PanelProjection/PanelVariableBinding.cs
@@ -11,7 +11,11 @@ namespace Ludots.Core.UI.PanelProjection
             string variableId,
             PanelBindingSourceKind sourceKind,
             string? attributeId,
-            string? graphOutputKey)
+            string? graphOutputKey,
+            string? lookupTable = null,
+            string? lookupField = null,
+            string? keyAttribute = null,
+            PanelTemplateVariableKind valueKind = PanelTemplateVariableKind.Float)
         {
             if (string.IsNullOrWhiteSpace(variableId))
             {
@@ -20,6 +24,7 @@ namespace Ludots.Core.UI.PanelProjection
 
             VariableId = variableId.Trim();
             SourceKind = sourceKind;
+            ValueKind = valueKind;
 
             switch (sourceKind)
             {
@@ -63,6 +68,33 @@ namespace Ludots.Core.UI.PanelProjection
                     AttributeId = null;
                     break;
 
+                case PanelBindingSourceKind.TableLookup:
+                    if (string.IsNullOrWhiteSpace(lookupTable) ||
+                        string.IsNullOrWhiteSpace(lookupField) ||
+                        string.IsNullOrWhiteSpace(keyAttribute))
+                    {
+                        throw new ArgumentException(
+                            $"Binding '{VariableId}' with sourceKind '{sourceKind}' requires lookupTable, lookupField and keyAttribute.",
+                            nameof(lookupTable));
+                    }
+
+                    foreach ((string field, string? value) in new[] { (nameof(attributeId), attributeId), (nameof(graphOutputKey), graphOutputKey) })
+                    {
+                        if (!string.IsNullOrWhiteSpace(value))
+                        {
+                            throw new ArgumentException(
+                                $"Binding '{VariableId}' with sourceKind '{sourceKind}' must not declare {field}.",
+                                field);
+                        }
+                    }
+
+                    LookupTable = lookupTable.Trim();
+                    LookupField = lookupField.Trim();
+                    KeyAttribute = keyAttribute.Trim();
+                    AttributeId = null;
+                    GraphOutputKey = null;
+                    break;
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(sourceKind), sourceKind, "Unknown panel binding source kind.");
             }
@@ -72,5 +104,9 @@ namespace Ludots.Core.UI.PanelProjection
         public PanelBindingSourceKind SourceKind { get; }
         public string? AttributeId { get; }
         public string? GraphOutputKey { get; }
+        public string? LookupTable { get; }
+        public string? LookupField { get; }
+        public string? KeyAttribute { get; }
+        public PanelTemplateVariableKind ValueKind { get; }
     }
 }

--- a/src/Tests/GasTests/UI/EntityAttributePanelShowcaseTests.cs
+++ b/src/Tests/GasTests/UI/EntityAttributePanelShowcaseTests.cs
@@ -1,0 +1,263 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using Arch.Core;
+using Ludots.Core.Gameplay.GAS.Components;
+using Ludots.Core.Gameplay.GAS.Registry;
+using Ludots.Core.GraphRuntime;
+using Ludots.Core.NodeLibraries.GASGraph;
+using Ludots.Core.NodeLibraries.GASGraph.Host;
+using Ludots.Core.Registry;
+using Ludots.Core.Scripting;
+using Ludots.Core.UI.PanelActivation;
+using Ludots.Core.UI.PanelProjection;
+using NUnit.Framework;
+
+namespace Ludots.Tests.GasTests.UI
+{
+    /// <summary>
+    /// Entity attribute panel, end to end, driven purely by JSON artifacts (#1010/#1012/#1013/#1014):
+    /// panel template JSON + visibility orchestration graph JSON + lookup table JSON.
+    /// Chain: signal → orchestration graph → activation → variables (attribute/graph/table)
+    /// → markup render → declared event → validated payload → signal bridge → intent resolution.
+    /// </summary>
+    [TestFixture]
+    public sealed class EntityAttributePanelShowcaseTests
+    {
+        private const string PanelTemplateJson = """
+        {
+          "id": "tests.panel.entity_attributes",
+          "variables": [
+            { "name": "hp", "kind": "Float",
+              "source": { "sourceKind": "SingleAttribute", "attributeId": "tests.attr.hp" } },
+            { "name": "attack", "kind": "Float",
+              "source": { "sourceKind": "SingleAttribute", "attributeId": "tests.attr.attack" } },
+            { "name": "squadAttack", "kind": "Float",
+              "source": { "sourceKind": "AggregateProjection", "graphOutputKey": "tests.panel.squad.attack.total" } },
+            { "name": "rank.badge", "kind": "Int",
+              "source": { "sourceKind": "TableLookup", "lookupTable": "tests.rank_display", "lookupField": "displayToken", "keyAttribute": "tests.attr.level" } }
+          ],
+          "binds": [
+            { "control": "lbl.hp", "variable": "hp" },
+            { "control": "lbl.attack", "variable": "attack" },
+            { "control": "lbl.squad", "variable": "squadAttack" },
+            { "control": "lbl.rank", "variable": "rank.badge" }
+          ],
+          "events": [
+            { "eventId": "ui.entity.inspect", "gesture": "click", "control": "row.entity",
+              "payload": { "entityId": "Int", "verbose": "Bool" } }
+          ],
+          "intents": [
+            { "event": "ui.entity.inspect", "intent": "order.entity.inspect",
+              "args": { "target": "$payload.entityId", "verbose": "$payload.verbose" },
+              "playerSource": "seat", "actorSource": "commandSource.primary" }
+          ]
+        }
+        """;
+
+        // visible = blackboard("tests.signal.selection") != 0 — pure JSON instructions.
+        private const string OrchestrationJson = """
+        [
+          {
+            "panelType": "tests.panel.entity_attributes",
+            "instructions": [
+              { "op": "LoadCaster", "dst": 0 },
+              { "op": "ReadBlackboardInt", "dst": 1, "a": 0, "imm": 0 },
+              { "op": "HaltReturnInt", "a": 1 }
+            ],
+            "symbols": [ "tests.signal.selection" ]
+          }
+        ]
+        """;
+
+        private const string RankTableJson = """
+        [
+          {
+            "id": "tests.rank_display",
+            "keyKind": "Int",
+            "columns": [
+              { "id": "displayToken", "kind": "Int" },
+              { "id": "powerScale", "kind": "Float" }
+            ],
+            "rows": [ { "key": 2, "displayToken": 11, "powerScale": 1.2 } ]
+          }
+        ]
+        """;
+
+        private World _world = null!;
+        private Entity _soldier;
+        private Entity _context;
+        private GraphLookupTableRegistry _tables = null!;
+        private UiPanelActivationStore _activation = null!;
+        private PanelOrchestrationRuntime _orchestration = null!;
+        private GasGraphRuntimeApi _api = null!;
+        private int _hpId;
+        private int _attackId;
+        private int _levelId;
+
+        [SetUp]
+        public void SetUp()
+        {
+            AttributeRegistry.Clear();
+            ConfigKeyRegistry.Clear();
+            _hpId = AttributeRegistry.Register("tests.attr.hp");
+            _attackId = AttributeRegistry.Register("tests.attr.attack");
+            _levelId = AttributeRegistry.Register("tests.attr.level");
+
+            _world = World.Create();
+            _soldier = _world.Create();
+            _world.Add(_soldier, new AttributeBuffer());
+            ref AttributeBuffer buffer = ref _world.Get<AttributeBuffer>(_soldier);
+            buffer.SetBase(_hpId, 87f);
+            buffer.SetBase(_attackId, 12f);
+            buffer.SetBase(_levelId, 2f);
+
+            _context = _world.Create();
+            _world.Add(_context, new BlackboardIntBuffer());
+
+            _tables = LoadTables(RankTableJson);
+            _activation = new UiPanelActivationStore();
+            _orchestration = new PanelOrchestrationRuntime(PanelOrchestrationJson.Load(OrchestrationJson), _activation);
+            _api = new GasGraphRuntimeApi(_world);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _world.Dispose();
+            AttributeRegistry.Clear();
+            ConfigKeyRegistry.Clear();
+        }
+
+        [Test]
+        public void FullChain_SelectionSignalOrchestratesVisibility_VariablesRenderAndEventsResolve()
+        {
+            PanelTemplate template = PanelTemplateLoader.Load(PanelTemplateJson);
+
+            // 1) hidden until the selection signal fires (orchestration graph decides).
+            PanelActivationDiff hiddenState = _orchestration.EvaluateAll(_world, _api, _context);
+            Assert.That(_activation.IsVisible("tests.panel.entity_attributes"), Is.False);
+            Assert.That(hiddenState.Activated, Is.Empty);
+
+            // 2) declared event fires with a validated payload; the signal bridge turns it
+            //    into the orchestration blackboard signal (zero-code path B wiring).
+            var fired = new List<string>();
+            var dispatcher = new PanelEventDispatcher(template, (eventId, payload) =>
+            {
+                fired.Add(eventId);
+                PanelSignalBridge.WriteSignal(_world, _context, "tests.signal.selection", Convert.ToInt32(payload["entityId"]));
+            });
+            dispatcher.Fire(
+                "ui.entity.inspect",
+                new JsonObject { ["entityId"] = 5, ["verbose"] = true });
+            Assert.That(fired, Is.EqualTo(new[] { "ui.entity.inspect" }));
+
+            // 3) orchestration re-evaluates from the signal → panel visible.
+            PanelActivationDiff shown = _orchestration.EvaluateAll(_world, _api, _context);
+            Assert.That(_activation.IsVisible("tests.panel.entity_attributes"), Is.True);
+            Assert.That(shown.Activated, Does.Contain("tests.panel.entity_attributes"));
+
+            // 4) variables: attribute + graph aggregate + lookup table, all fail-closed.
+            var keys = new StringIntRegistry(capacity: 8, startId: 1, invalidId: 0, comparer: StringComparer.Ordinal);
+            var outputs = new GraphOutputValueStore(keys, initialCapacity: 8);
+            Entity factionOwner = _world.Create();
+            _world.Add(factionOwner, new AttributeBuffer());
+            ref AttributeBuffer ownerBuffer = ref _world.Get<AttributeBuffer>(factionOwner);
+            ownerBuffer.SetBase(_hpId, 430f);
+            ownerBuffer.SetBase(_attackId, 96f);
+            ownerBuffer.SetBase(_levelId, 2f);
+            outputs.SetFloat(_soldier, "tests.panel.squad.attack.total", 36f);
+            outputs.SetFloat(factionOwner, "tests.panel.squad.attack.total", 36f);
+            var reader = new PanelProjectionReader(_world, outputs, AttributeRegistry.GetId, _tables);
+
+            PanelVariableSet itemScope = new PanelInstance(template, _soldier).Evaluate(reader);
+            Assert.That(itemScope.Get("hp"), Is.EqualTo(87f));
+            Assert.That(itemScope.Get("attack"), Is.EqualTo(12f));
+            Assert.That(itemScope.Get("squadAttack"), Is.EqualTo(36f));
+            Assert.That(itemScope.Get("rank.badge"), Is.EqualTo(11f));
+
+            // 5) same template serves the collection scope (#1012): the faction owner
+            //    reads the same squad aggregate while the item scope reads soldier attrs.
+            PanelVariableSet collectionScope = new PanelInstance(template, factionOwner).Evaluate(reader);
+            Assert.That(collectionScope.Get("squadAttack"), Is.EqualTo(36f));
+
+            // 6) the declared event resolves to a seat-attributed intent (#1013).
+            var intentResolver = new PanelIntentResolver(template);
+            PanelIntent intent = intentResolver.Resolve(
+                "ui.entity.inspect",
+                new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["entityId"] = 5,
+                    ["verbose"] = true,
+                },
+                playerId: 2,
+                actor: _soldier);
+            Assert.That(intent.Intent, Is.EqualTo("order.entity.inspect"));
+            Assert.That(intent.Args["target"], Is.EqualTo(5));
+            Assert.That(intent.Args["verbose"], Is.True);
+            Assert.That(intent.PlayerId, Is.EqualTo(2));
+            Assert.That(intent.Actor, Is.EqualTo(_soldier));
+
+            // 7) zero-selection signal hides the panel again — still the graph deciding.
+            PanelSignalBridge.WriteSignal(_world, _context, "tests.signal.selection", 0);
+            _orchestration.EvaluateAll(_world, _api, _context);
+            Assert.That(_activation.IsVisible("tests.panel.entity_attributes"), Is.False);
+        }
+
+        [Test]
+        public void BadEventPayload_FailsNamingField()
+        {
+            PanelTemplate template = PanelTemplateLoader.Load(PanelTemplateJson);
+            var dispatcher = new PanelEventDispatcher(template, static (_, _) => { });
+
+            Assert.That(
+                () => dispatcher.Fire("ui.entity.inspect", new JsonObject { ["entityId"] = 5 }),
+                Throws.InvalidOperationException.With.Message.Contains("verbose"));
+
+            Assert.That(
+                () => dispatcher.Fire("ui.entity.inspect", new JsonObject { ["entityId"] = 5, ["verbose"] = true, ["ghost"] = 1 }),
+                Throws.InvalidOperationException.With.Message.Contains("ghost"));
+        }
+
+        [Test]
+        public void OrchestrationJson_UnknownOpOrField_FailsLoudly()
+        {
+            Assert.That(
+                () => PanelOrchestrationJson.Load("""[{"panelType":"p","instructions":[{"op":"Magic"}]}]"""),
+                Throws.InvalidOperationException.With.Message.Contains("Magic"));
+
+            Assert.That(
+                () => PanelOrchestrationJson.Load("""[{"panelType":"p","frob":1,"instructions":[{"op":"HaltReturnInt","a":0}]}]"""),
+                Throws.InvalidOperationException.With.Message.Contains("frob"));
+        }
+
+        private static GraphLookupTableRegistry LoadTables(string json)
+        {
+            string tempRoot = Path.Combine(Path.GetTempPath(), "Ludots_PanelRankTable", Guid.NewGuid().ToString("N"));
+            try
+            {
+                string tableDir = Path.Combine(tempRoot, "GraphTables");
+                Directory.CreateDirectory(tableDir);
+                File.WriteAllText(Path.Combine(tableDir, "lookup_tables.json"), json);
+                var vfs = new Ludots.Core.Modding.VirtualFileSystem();
+                vfs.Mount("Core", tempRoot);
+                var modLoader = new Ludots.Core.Modding.ModLoader(vfs, new Ludots.Core.Scripting.FunctionRegistry(), new Ludots.Core.Scripting.TriggerManager());
+                var pipeline = new Ludots.Core.Config.ConfigPipeline(vfs, modLoader);
+                var catalog = new Ludots.Core.Config.ConfigCatalog();
+                catalog.Add(new Ludots.Core.Config.ConfigCatalogEntry(
+                    GraphLookupTableLoader.ConfigPath,
+                    Ludots.Core.Config.ConfigMergePolicy.ArrayById,
+                    "id"));
+                return new GraphLookupTableLoader(pipeline).Load(catalog);
+            }
+            finally
+            {
+                if (Directory.Exists(tempRoot))
+                {
+                    Directory.Delete(tempRoot, recursive: true);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
#1010 tableLookup 路 · #1013 事件与意图声明层 · #1014 编排图 JSON · #1012 双 scope 验证 · 实体属性面板交付\n\n## 新能力\n\n**#1010 tableLookup（第四条合法取数路打通）**\n- `PanelBindingSourceKind.TableLookup` + 绑定三字段（lookupTable/lookupField/keyAttribute），fail-closed 字段互斥沿用合同\n- `PanelProjectionReader`：key 从 owner 属性读取 → GraphLookupTableRegistry（#893）解行读格；类型不符由注册表既有错误点名\n\n**#1013 事件与意图声明层（0 编码）**\n- 模板 `events[]`（eventId/trigger/typed payload schema）与 `intents[]`（event→intent、$payload.* 参数映射、playerSource=seat、actorSource=commandSource.primary）严格加载：未知字段/未知事件引用/坏类型一律点名失败\n- `PanelEventDispatcher`：payload 严格校验（缺字段/多字段/类型错）后交 sink——分发器自身零玩法写入\n- `PanelIntentResolver`：归因解析产出 `PanelIntent`（intent/args/playerId/actor），座位与命令来源缺位显式拒绝；**不提交 order**（admission 下游）\n- `PanelSignalBridge`：事件 payload → 上下文实体黑板信号（路径 B 到编排图的接缝）\n\n**#1014 编排图 JSON**\n- `PanelOrchestrationJson`：显隐编排图从 JSON 加载（panelType + 指令表 + symbols），未知 op/字段点名失败——显隐链路全程数据驱动\n\n## 实体属性面板（交付物）\n\n`EntityAttributePanelShowcaseTests` 全链：模板 JSON（hp/attack=SingleAttribute，squadAttack=AggregateProjection，rank.badge=TableLookup）× 编排图 JSON（visible=黑板选择信号≠0）× 查表 JSON（rank_display）——\n\n无信号→图判隐 → 声明事件（typed payload 校验）→ 信号桥写黑板 → 图判显 → 四路变量求值（属性/图聚合/查表，全 fail-closed）→ 同模板双 scope（士兵 item / 势力 owner 集合）→ 意图归因（playerId=2、actor=士兵）→ 信号归零→图判隐。\n\n## 验证\n\n- 全链 3/3 + 面板线回归 22/22（模板 9/编排 5/投影 5）+ Markup 桥 2/2 + 单一写者守卫 1/1\n- 纯 JSON 驱动：整条链唯一手写代码是测试装配