### PR TITLE
feat(agent-bridge): 相机/日志/事件三工具 + 多会话重入修复 + RFC-0066 回填

### DIFF
--- a/docs/rfcs/RFC-0066-agent-debug-bridge.md
+++ b/docs/rfcs/RFC-0066-agent-debug-bridge.md
@@ -1,6 +1,6 @@
 # RFC-0066 Agent Debug Bridge（Ludots Harness for AI Agents）
 
-Status: Draft (implementation in progress on branch `feat/agent-debug-bridge`)
+Status: Implemented（已合入 main，PR #1001；2026-08-17 验收通过，见 §8）
 
 ## 1 背景与目标
 
@@ -58,10 +58,10 @@ Ludots 进程:  AgentBridgeHttpServer (后台线程, 仅绑 127.0.0.1)
 | UI 表面所有权 | `UiSurfaceHost`（lease/segment 模型，`RFC-0055`）；Browser surface 经 `IBrowserRuntime` 枚举，`UiNode.CanvasContent` 标记浏览器嵌入点 |
 | 时间控制 | `IPacemaker` / `TurnBasedPacemaker` / `engine.Pacemaker`（`DiagnosticsOverlaySystem` 的 F8 模式） |
 | 输入注入 | `PlayerInputHandler.InjectAction` / `InjectButtonPress` / `InjectButtonRelease`（已存在）；UI 键盘注入 `RaylibSyntheticKeyboardInput` |
-| 订单下发 | `OrderSubmitter.Submit` + `OrderTypeRegistry`（正式订单准入管线，含规则校验与 terminal result） |
+| 订单下发 | `OrderQueue.Submit`（`CoreServiceKeys.OrderQueue`）+ `OrderTypeRegistry`（正式订单准入管线，含规则校验与 terminal result） |
 | GAS 诊断 | `GasDiagnosticEventBuffer`（已注册为 CoreServiceKeys 服务） |
-| 系统挂载 | `SystemFactoryRegistry.Register` + `TryActivate`（`DiagnosticsOverlayMod` 模式） |
-| Mod 扩展 | `IModContext.Extensions`（`ModExtensionHub`）供其他 Mod 注册自定义工具 |
+| 系统挂载 | `SystemFactoryRegistry.RegisterPresentation` + `TryActivate`（`DiagnosticsOverlayMod` 模式；presentation 组保证 pause 下桥仍然泵） |
+| Mod 扩展 | `AgentBridgeModEntry.ToolRegistryKey`（`ServiceKey<AgentToolRegistry>`）：激活时经 `engine.SetService` 挂到 GlobalContext，其他 Mod 取注册表注册自己的 `IAgentTool`，即刻出现在 `/tools` 与 MCP 目录 |
 
 ## 4 组件划分
 
@@ -79,11 +79,11 @@ Ludots 进程:  AgentBridgeHttpServer (后台线程, 仅绑 127.0.0.1)
 
 自描述端点：
 
-- `GET /health` → `{ ok, pid, tick, uptimeMs }`
+- `GET /health` → `{ ok, pid, port, pendingRequests, pumpCount, lastPumpUtc }`（`pumpCount` 不涨说明游戏主循环停了）
 - `GET /tools` → 工具目录（name / description / inputSchema JSON Schema），供 Agent 发现
 - `GET /` → 人读说明 + 发现文件路径
 
-内置工具（v1）：
+内置工具（20，v1 13 个 + v2 帧捕获与窗口层输入 4 个 + v3 相机/日志/事件 3 个）：
 
 | 工具 | 说明 |
 |------|------|
@@ -96,14 +96,17 @@ Ludots 进程:  AgentBridgeHttpServer (后台线程, 仅绑 127.0.0.1)
 | `ludots.gas.entity` | 实体 GAS 状态：tags（名称解析）、attributes（base/current）、active effects、当前/排队订单 |
 | `ludots.gas.diagnostics` | `GasDiagnosticEventBuffer` 转储（系统/指标/容量/计数） |
 | `ludots.orders.inspect` | 指定实体 OrderBuffer 明细 + 全局 OrderAdmission/Terminal 结果缓冲 |
-| `ludots.orders.issue` | 经 `OrderSubmitter.Submit` 下发订单（走正式准入规则，返回 `OrderSubmitResult`） |
+| `ludots.orders.issue` | 经 `OrderQueue.Submit` 下发订单（走正式准入规则，返回 `OrderSubmitResult`） |
 | `ludots.input.state` | 输入上下文栈、动作清单、指针快照、UI 捕获状态、窗口层虚拟设备状态 |
 | `ludots.input.inject` | **语义动作层**：`press` / `release` / `action {value}`（复用 `PlayerInputHandler.Inject*`） |
 | `ludots.input.raw` | **窗口原始层**：`pointerMove/pointerDown/pointerUp/click/scroll/keyDown/keyUp/press/type/releaseAll`（经 `SyntheticInputDevice` 进入宿主轮询点，与物理输入同管线——UI 命中、捕获、绑定全部生效） |
 | `ludots.screenshot` | 经 `IHostFrameCapture` 端口抓下一呈现帧 PNG 到 `artifacts/agent-bridge/shots/`；暂停下可用 |
 | `ludots.recording.start` / `ludots.recording.stop` | 录屏为 PNG 序列（`intervalMs/maxFrames`），stop 写 `manifest.json`；agent 可按需抽帧阅读 |
+| `ludots.camera.control` | 相机读/控：`get` / `set`（部分姿态，经 `CameraManager.ApplyPose` 持久进活动虚拟相机）/ `follow {entityId}`（实体跟随目标）/ `unfollow` |
+| `ludots.logs.tail` | 进程内日志环形缓冲（`AgentLogRingBackend` 经 `Log.AddBackend` 挂入，不动宿主级别配置）；`count/minLevel/channel/contains` 过滤 |
+| `ludots.events.fire` | 经 `TriggerManager.FireEventAsync` 发送任意事件键（与引擎生命周期事件同分发路径），响应带本次 `triggerErrors` |
 
-错误协议：JSON-RPC error，`-32602` 参数错，`-32601` 未知工具，`-32000` 域错误并带 `data.code`（如 `entity.not_found`、`service.unavailable:<key>`、`capability.unavailable:<name>`）。
+错误协议：JSON-RPC error，`-32602` 参数错，`-32601` 未知工具，`-32000` 域错误并带 `data.code`（`AgentBridgeErrorCodes`：`invalid.params` / `service.unavailable` / `entity.not_found` / `capability.unavailable` / `tool.failed` / `bridge.timeout`，另有工具自带码如 `ui.node_not_found`、`ui.scene_not_mounted`）。
 
 ### 六边形端口（host 能力）
 
@@ -120,7 +123,7 @@ Ludots 进程:  AgentBridgeHttpServer (后台线程, 仅绑 127.0.0.1)
 
 ## 6 启用方式
 
-`game.*.json` 的 `ModPaths` 加入 `mods/AgentBridgeMod` 即启用。配置经环境变量/桥接配置节：
+启动配置的 Mod 集合加入 `AgentBridgeMod` 即启用（参考 `src/Apps/Raylib/Ludots.App.Raylib/raylib.agent-demo.launch.graph.json` 的 `orderedModIds`）。桥本体挂 presentation 系统，在 `GameStart` 时经 `SystemFactoryRegistry.TryActivate` 激活（同一 engine 内幂等）。配置经环境变量：
 
 - `LUDOTS_AGENT_BRIDGE=0` 强制关闭（即使 Mod 已加载）
 - `LUDOTS_AGENT_BRIDGE_PORT=<port>` 覆盖端口（默认 47921；占用时自动 +1 重试最多 16 次并写入发现文件）

--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -2,6 +2,7 @@
 
 - [Ludots 文档](README.md)
 - [快速开始](quick-start.md)
+- [Agent Bridge](agent-bridge.md)
 - [贡献与开发](contributing/README.md)
   - [编码标准](contributing/coding-standards.md)
   - [Feature 开发工作流](contributing/feature-development-workflow.md)

--- a/gitbook/agent-bridge.md
+++ b/gitbook/agent-bridge.md
@@ -24,7 +24,7 @@ curl -s -X POST http://127.0.0.1:47921/rpc \
   -d '{"jsonrpc":"2.0","id":1,"method":"ludots.session.info","params":{}}'
 ```
 
-环境变量：`LUDOTS_AGENT_BRIDGE=0` 强制关闭；`LUDOTS_AGENT_BRIDGE_PORT` 换端口（默认 47921，占用自动 +1）；`artifacts/agent-bridge/session.json` 是发现文件（含 port/pid/完整工具目录），进程退出即删。仅绑定 127.0.0.1，无鉴权调试接口。
+环境变量：`LUDOTS_AGENT_BRIDGE=0` 强制关闭；`LUDOTS_AGENT_BRIDGE_PORT` 换端口（默认 47921，占用自动 +1）；发现文件是 artifacts/agent-bridge/session.json（运行时生成、不入库，含 port/pid/完整工具目录），进程退出即删。仅绑定 127.0.0.1，无鉴权调试接口。
 
 ## Agent 标准工作循环：观察 → 驱动 → 验证
 

--- a/gitbook/agent-bridge.md
+++ b/gitbook/agent-bridge.md
@@ -1,0 +1,129 @@
+# Agent Bridge
+
+> 面向 AI coding agent 的 Ludots 运行时操控与取证通道：环回 HTTP JSON-RPC，20 个自描述工具，零多模态依赖——看画面、点 UI、放技能、查状态、抓证据，全部用结构化 JSON 完成，取代 screenshot + computer-use 的脆弱路径。
+>
+> 设计 SSOT：[RFC-0066](https://github.com/mightyBubble/Ludots/blob/main/docs/rfcs/RFC-0066-agent-debug-bridge.md)；工具域参考手册：[架构页 · Agent 调试桥](architecture/agent-debug-bridge.md)。**本页是任务视角的实操指南**，所有请求/响应示例来自真实验证会话（`raylib.agent-demo` · ChampionSkillSandbox）。
+
+## 60 秒上手
+
+```bash
+# 1. 构建（app + 图中各 mod）
+dotnet build src/Apps/Raylib/Ludots.App.Raylib/Ludots.App.Raylib.csproj -c Debug
+dotnet build mods/AgentBridgeMod/AgentBridgeMod.csproj -c Debug   # 其余 mod 同理
+
+# 2. 启动（launch graph 的 orderedModIds 含 AgentBridgeMod 即启用）
+cd src/Apps/Raylib/Ludots.App.Raylib/bin/Debug/net8.0
+dotnet Ludots.App.Raylib.dll launcher.agent-demo.runtime.json
+
+# 3. 判活 + 发现工具
+curl -s http://127.0.0.1:47921/health   # {"ok":true,"pid":...,"pumpCount":41,...}
+curl -s http://127.0.0.1:47921/tools    # 20 个工具的 name/description/inputSchema
+
+# 4. 第一个调用（JSON-RPC 2.0）
+curl -s -X POST http://127.0.0.1:47921/rpc \
+  -d '{"jsonrpc":"2.0","id":1,"method":"ludots.session.info","params":{}}'
+```
+
+环境变量：`LUDOTS_AGENT_BRIDGE=0` 强制关闭；`LUDOTS_AGENT_BRIDGE_PORT` 换端口（默认 47921，占用自动 +1）；`artifacts/agent-bridge/session.json` 是发现文件（含 port/pid/完整工具目录），进程退出即删。仅绑定 127.0.0.1，无鉴权调试接口。
+
+## Agent 标准工作循环：观察 → 驱动 → 验证
+
+每次调试会话都走这个闭环，工具选择自然浮现：
+
+```text
+/health 判活 ──▶ session.info（tick/mods）──▶ entities.query（找目标，看 screenCoverage 是否在镜头内）
+      │                                                    │
+      ▼                                                    ▼
+  驱动：orders.issue / input.inject / camera.follow / events.fire / ui.click
+      │
+      ▼
+  验证：gas.entity（属性变了？）/ ui.tree（面板亮了？）/ screenshot（画面对了？）/ logs.tail（日志说了什么？）
+```
+
+**判活要领**：`/health` 的 `pumpCount` 必须在涨——不涨说明游戏主循环卡死/暂停，后续一切调用都不可信。
+
+## 按任务查工具（不按域）
+
+| 你想做什么 | 用什么 | 关键参数/要领 |
+|-----------|--------|---------------|
+| 确认游戏活着、-loaded 了哪些 mod | `ludots.session.info` | 无参；tick 在涨=循环活着 |
+| 找一个实体（敌人/英雄/召唤物） | `ludots.entities.query` | `nameFilter`（大小写不敏感子串）、`onScreenOnly:true` 只看镜头内的；返回 `screenCoverage`（占屏比）判断"看得清吗" |
+| 看某实体的血量/属性/技能槽 | `ludots.gas.entity` | `{entityId}`；tags 名称已解析、attributes 只列非零 |
+| 看面板/按钮长什么样 | `ludots.ui.tree` / `ludots.ui.query` | tree 全量；query 用 CSS 选择器——**实测注意**：选择器按 tag/`#id`/`.class` 匹配，本仓 UI 多用 tag（`selector:"button"` 命中 10 个，`.button` 命中 0 个，因为节点没有 class） |
+| 点一个按钮 | `ludots.ui.click` | `{elementId}` 或裸坐标 `{x,y}`；返回 `handled:true/false` + 命中节点的 rect/pseudoState——点到容器会 `handled:false`，换 elementId |
+| 让实体做一件事（移动/施法/攻击） | `ludots.orders.issue` | `orderType` 是**字符串键或数字 id**；合法键在 `mods/LudotsCoreMod/assets/GAS/order_types.json`：实测 `castAbility` / `moveTo` / `attackTarget` / `stop` / `chainPass` 等；`targetEntityId` 或 `worldXCm/worldYCm` 按订单类型二选一 |
+| 模拟按键（放技能） | `ludots.input.inject` | `{actionId, mode:"press"|"release"|"set"}`——语义层，走游戏输入绑定表；**press 后记得 release** |
+| 模拟真实鼠标键盘（验证 UI 交互） | `ludots.input.raw` | `{op:"pointerMove"|...,"x","y"}`——窗口层，UI 命中/指针捕获全生效；下一帧才应用 |
+| 查输入管线状态 | `ludots.input.state` | 看 `uiCaptured`（UI 是否吃掉了输入）再决定用哪层注入 |
+| 冻结世界逐步看 | `ludots.time.control` | `pause` → `step {steps:N}`（响应带 `targetTick`）→ `resume`；pause 后 screenshot 依然可用 |
+| 把镜头对准目标 | `ludots.camera.control` | `follow {entityId}` 实体跟随；`set {yaw,pitch,distanceCm}` 部分姿态（持久）；`unfollow` 解除 |
+| 截一张图做证据 | `ludots.screenshot` | `{name?}`；PNG 落 `artifacts/agent-bridge/shots/`；帧末履行，pause 时也能截 |
+| 录一段过程 | `ludots.recording.start` / `.stop` | PNG 序列 + manifest.json 落 `artifacts/agent-bridge/recordings/<时间戳>/`，agent 可抽帧阅读 |
+| 看引擎日志 | `ludots.logs.tail` | `count/minLevel/channel/contains` 过滤；**只捕获桥激活之后的日志**；`totalWritten/capacity` 看旋转 |
+| 触发一个游戏事件 | `ludots.events.fire` | `{event:"GameStart"}` 等；与引擎生命周期同分发路径；返回 `triggerErrors` 计数——**配 logs.tail 组成"发事件→看反应"闭环** |
+| 看订单管线吞吐 | `ludots.orders.inspect` | 准入/终态缓冲、单实体 OrderBuffer；响应附 `orderTypes` 合法键清单（id/key/label） |
+| 看 GAS 诊断事件 | `ludots.gas.diagnostics` | 当帧 system/metric/count 转储 |
+
+## 实测会话摘录（agent-demo · 可直接复制的形状）
+
+```jsonc
+// 找实体 → 拿到 entityId
+{"method":"ludots.entities.query","params":{"limit":20}}
+// → {"entities":[{"entityId":9,"name":"Ezreal Alpha","worldCm":{"x":1180,"y":720},"onScreen":false},...],"totalMatched":16}
+
+// 用键名下单（字符串键）
+{"method":"ludots.orders.issue","params":{"entityId":9,"orderType":"castAbility","targetEntityId":9}}
+// → {"entityId":9,"orderTypeId":100,"result":"Queued","accepted":true}
+
+// 语义按键：按下并释放
+{"method":"ludots.input.inject","params":{"actionId":"SkillQ","mode":"press"}}   // → {"injected":true}
+{"method":"ludots.input.inject","params":{"actionId":"SkillQ","mode":"release"}}
+
+// 镜头跟随 → 摘证据 → 看日志
+{"method":"ludots.camera.control","params":{"action":"follow","entityId":9}}    // → 响应含 followingEntityId:9
+{"method":"ludots.screenshot","params":{"name":"after-fix.png"}}                // → {"path":"…shots/after-fix.png","bytes":82000}
+{"method":"ludots.logs.tail","params":{"count":5,"minLevel":"Info"}}            // → entries 按时间正序
+```
+
+## 踩坑清单（全部实测踩过）
+
+1. **`orderType` 键源**：合法键在 `mods/LudotsCoreMod/assets/GAS/order_types.json`（`castAbility`/`moveTo`/`attackTarget`/`stop`…）；`ludots.orders.inspect` 响应的 `orderTypes` 字段也带键清单（id/key/label），`orders.issue` 键名报错时会指向这两个来源。
+2. **CSS 选择器按属性匹配**：`.button` 匹配的是 `class="button"`，本仓多数按钮只有 tag——用 `selector:"button"` 或 `#elementId`。
+3. **`ui.click` 的 `handled:false` 不是故障**：命中了容器节点但无点击处理器；用 `ui.query` 拿真实按钮的 `elementId` 再点。
+4. **`input.inject` 的 press 是"按住"语义**：press 之后必须 release，否则按键悬挂。
+5. **`logs.tail` 只有激活后的日志**：想看启动期日志要靠 `game.log` 文件重定向，环里没有。
+6. **`pumpCount` 停涨** = 主循环停了（真死或被 pause 卡住），先 `/health` 再谈别的。
+7. **截图/录像路径**固定在仓库根 `artifacts/agent-bridge/`（从 AppBase 向上找 `global.json` 定位仓库根）。
+
+## MCP 接入（把桥挂进你的 agent 客户端）
+
+```bash
+# 零依赖 stdio 适配器；桥地址解析：argv > LUDOTS_AGENT_BRIDGE_URL > 发现文件 > 47921
+dotnet build src/Tools/Ludots.AgentBridge.Mcp/Ludots.AgentBridge.Mcp.csproj -c Release
+dotnet exec src/Tools/Ludots.AgentBridge.Mcp/bin/Release/net8.0/Ludots.AgentBridge.Mcp.dll http://127.0.0.1:47921
+```
+
+MCP 客户端配置片段（Claude Code / pi 等 stdio server 通用）：
+
+```json
+{
+  "mcpServers": {
+    "ludots": {
+      "command": "dotnet",
+      "args": ["exec", "<仓库>/src/Tools/Ludots.AgentBridge.Mcp/bin/Release/net8.0/Ludots.AgentBridge.Mcp.dll"]
+    }
+  }
+}
+```
+
+不配 MCP 也完全够用：`POST /rpc` 的 method 就是工具名，任何能发 HTTP 的 agent 都能驱动。
+
+## 错误协议
+
+| code | 含义 | 典型场景 |
+|------|------|----------|
+| `-32601` | 未知工具 | method 拼错 |
+| `-32602` | 参数错 | 缺必填/键名拼错/`orderType` 键不存在；`data.code=invalid.params` |
+| `-32000` | 域错误 | `entity.not_found`、`ui.node_not_found`、`bridge.timeout`、`capability.unavailable`（宿主未实现端口） |
+
+错误信息自带下一步指引；改参数前先读 `data.code` 与 message。

--- a/gitbook/architecture/agent-debug-bridge.md
+++ b/gitbook/architecture/agent-debug-bridge.md
@@ -36,12 +36,15 @@ MCP 客户端（Claude Code、pi 等）另配零依赖 stdio 适配器 `src/Tool
 - `GET /tools` → 自描述工具目录（name / description / inputSchema）
 - `POST /rpc` → JSON-RPC 2.0：`{"jsonrpc":"2.0","id":1,"method":"ludots.session.info","params":{}}`
 
-## 内置工具（17）
+## 内置工具（20）
 
 | 域 | 工具 | 能力 |
 |----|------|------|
 | 会话 | `ludots.session.info` | tick / 地图 / Mod 清单 / 相机 / 分辨率 |
 | 时间 | `ludots.time.get` · `ludots.time.control` | pause（换绑 TurnBasedPacemaker）/ step N（响应带 `targetTick`）/ resume |
+| 相机 | `ludots.camera.control` | `get` 姿态与活动虚拟相机；`set` 部分姿态（经 `ApplyPose` 持久）；`follow {entityId}` / `unfollow` 实体跟随 |
+| 日志 | `ludots.logs.tail` | 进程内日志环形缓冲（激活时经 `Log.AddBackend` 挂入）；`count/minLevel/channel/contains` 过滤 |
+| 事件 | `ludots.events.fire` | 经 `TriggerManager.FireEventAsync` 发送任意事件键，响应带本次 `triggerErrors` |
 | 实体 | `ludots.entities.query` | 世界坐标→屏幕投影 rect、**屏幕占比**、可见性；`offset/limit/nameFilter/onScreenOnly` |
 | UI | `ludots.ui.tree` · `ludots.ui.query` · `ludots.ui.click` | 统一 UiScene 遍历（markup / composite / reactive 三写法归一，browser canvas 节点有标注）；CSS 选择器；elementId 或坐标点击 |
 | GAS | `ludots.gas.entity` · `ludots.gas.diagnostics` | tags（名称解析）/ attributes / active effects / ability 槽位；诊断事件缓冲转储 |

--- a/mods/AgentBridgeMod/AgentBridgeModEntry.cs
+++ b/mods/AgentBridgeMod/AgentBridgeModEntry.cs
@@ -1,5 +1,7 @@
 using Ludots.AgentBridge;
 using Ludots.AgentBridge.Tools;
+using Ludots.Core.Diagnostics;
+using Ludots.Core.Engine;
 using Ludots.Core.Modding;
 using Ludots.Core.Scripting;
 
@@ -13,6 +15,8 @@ namespace AgentBridgeMod
     public sealed class AgentBridgeModEntry : IMod
     {
         private AgentBridgeHttpServer? _server;
+        private readonly AgentLogRingBackend _logRing = new();
+        private bool _logRingInstalled;
 
         public static ServiceKey<AgentToolRegistry> ToolRegistryKey { get; } = new("AgentToolRegistry");
 
@@ -25,45 +29,11 @@ namespace AgentBridgeMod
                 return;
             }
 
-            var tools = new AgentToolRegistry();
-            var time = new AgentTimeController();
-            var recording = new RecordingController();
-
             context.SystemFactoryRegistry.RegisterPresentation("AgentBridge", scriptCtx =>
             {
                 var engine = scriptCtx.GetEngine();
                 if (engine == null) return null!;
-
-                string discoveryDir = AgentBridgeConfig.ResolveDiscoveryDirectory(AppContext.BaseDirectory);
-                var runtime = new AgentBridgeRuntime(engine, tools) { ArtifactsRoot = discoveryDir };
-                runtime.FrameTick += recording.Tick;
-
-                tools.Register(new SessionInfoTool(runtime));
-                tools.Register(new TimeGetTool(time));
-                tools.Register(new TimeControlTool(time));
-                tools.Register(new EntitiesQueryTool());
-                tools.Register(new UiTreeTool());
-                tools.Register(new UiQueryTool());
-                tools.Register(new UiClickTool());
-                tools.Register(new GasEntityTool());
-                tools.Register(new GasDiagnosticsTool());
-                tools.Register(new OrdersInspectTool());
-                tools.Register(new OrdersIssueTool());
-                tools.Register(new InputStateTool());
-                tools.Register(new InputInjectTool());
-                tools.Register(new InputRawTool());
-                tools.Register(new ScreenshotTool(runtime));
-                tools.Register(new RecordingStartTool(recording, runtime));
-                tools.Register(new RecordingStopTool(recording));
-
-                engine.SetService(ToolRegistryKey, tools);
-
-                var server = new AgentBridgeHttpServer(runtime, config, discoveryDir);
-                server.Start();
-                _server = server;
-
-                context.Log($"[AgentBridgeMod] Agent bridge active: http://127.0.0.1:{server.Port}/ ({tools.Tools.Count} tools)");
-                return new AgentBridgeSystem(runtime);
+                return Activate(engine, config, context);
             });
 
             context.OnEvent(GameEvents.GameStart, ctx =>
@@ -76,6 +46,60 @@ namespace AgentBridgeMod
 
                 return System.Threading.Tasks.Task.CompletedTask;
             });
+        }
+
+        private AgentBridgeSystem Activate(GameEngine engine, AgentBridgeConfig config, IModContext context)
+        {
+            // Registry, runtime, and controllers are per-activation state: they
+            // capture the engine. Rebuild them on every activation and tear
+            // down any previous listener first, so a re-activated entry never
+            // double-registers tools or leaks a zombie port.
+            _server?.Dispose();
+
+            var tools = new AgentToolRegistry();
+            var time = new AgentTimeController();
+            var recording = new RecordingController();
+
+            string discoveryDir = AgentBridgeConfig.ResolveDiscoveryDirectory(AppContext.BaseDirectory);
+            var runtime = new AgentBridgeRuntime(engine, tools) { ArtifactsRoot = discoveryDir };
+            runtime.FrameTick += recording.Tick;
+
+            // Process-wide ring survives re-activation; wrap the host backend once.
+            if (!_logRingInstalled)
+            {
+                Log.AddBackend(_logRing);
+                _logRingInstalled = true;
+            }
+
+            tools.Register(new SessionInfoTool(runtime));
+            tools.Register(new TimeGetTool(time));
+            tools.Register(new TimeControlTool(time));
+            tools.Register(new EntitiesQueryTool());
+            tools.Register(new UiTreeTool());
+            tools.Register(new UiQueryTool());
+            tools.Register(new UiClickTool());
+            tools.Register(new GasEntityTool());
+            tools.Register(new GasDiagnosticsTool());
+            tools.Register(new OrdersInspectTool());
+            tools.Register(new OrdersIssueTool());
+            tools.Register(new InputStateTool());
+            tools.Register(new InputInjectTool());
+            tools.Register(new InputRawTool());
+            tools.Register(new ScreenshotTool(runtime));
+            tools.Register(new RecordingStartTool(recording, runtime));
+            tools.Register(new RecordingStopTool(recording));
+            tools.Register(new CameraControlTool());
+            tools.Register(new LogsTailTool(_logRing));
+            tools.Register(new EventsFireTool());
+
+            engine.SetService(ToolRegistryKey, tools);
+
+            var server = new AgentBridgeHttpServer(runtime, config, discoveryDir);
+            server.Start();
+            _server = server;
+
+            context.Log($"[AgentBridgeMod] Agent bridge active: http://127.0.0.1:{server.Port}/ ({tools.Tools.Count} tools)");
+            return new AgentBridgeSystem(runtime);
         }
 
         public void OnUnload()

--- a/src/Apps/Raylib/Ludots.App.Raylib/Ludots.App.Raylib.csproj
+++ b/src/Apps/Raylib/Ludots.App.Raylib/Ludots.App.Raylib.csproj
@@ -106,11 +106,11 @@
       <Link>postprocess.fs</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="..\..\..\Client\Ludots.Client.Raylib\Resources\ambient_day_ramp.json">
+    <None Include="..\..\..\Client\Ludots.Raylib.Render\Resources\ambient_day_ramp.json">
       <Link>ambient_day_ramp.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="..\..\..\Client\Ludots.Client.Raylib\Resources\distance_fog.json">
+    <None Include="..\..\..\Client\Ludots.Raylib.Render\Resources\distance_fog.json">
       <Link>distance_fog.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Core/Diagnostics/Log.cs
+++ b/src/Core/Diagnostics/Log.cs
@@ -151,6 +151,16 @@ namespace Ludots.Core.Diagnostics
         }
 
         /// <summary>
+        /// Adds a backend alongside the current one. Unlike <see cref="Initialize"/>,
+        /// channel level configuration is preserved.
+        /// </summary>
+        public static void AddBackend(ILogBackend backend)
+        {
+            ArgumentNullException.ThrowIfNull(backend);
+            _backend = _backend is NullLogBackend ? backend : new MultiLogBackend(_backend, backend);
+        }
+
+        /// <summary>
         /// Reset all state. For testing only.
         /// </summary>
         internal static void Reset()

--- a/src/Libraries/Ludots.AgentBridge/AgentLogRingBackend.cs
+++ b/src/Libraries/Ludots.AgentBridge/AgentLogRingBackend.cs
@@ -1,0 +1,72 @@
+using Ludots.Core.Diagnostics;
+
+namespace Ludots.AgentBridge
+{
+    /// <summary>
+    /// Bounded in-memory log ring backing ludots.logs.tail. Installed via
+    /// Log.AddBackend so the host's configured backend and levels are untouched.
+    /// </summary>
+    public sealed class AgentLogRingBackend : ILogBackend
+    {
+        public readonly struct Entry
+        {
+            public Entry(DateTime utc, LogLevel level, string channel, string message)
+            {
+                Utc = utc;
+                Level = level;
+                Channel = channel;
+                Message = message;
+            }
+
+            public DateTime Utc { get; }
+            public LogLevel Level { get; }
+            public string Channel { get; }
+            public string Message { get; }
+        }
+
+        private readonly object _gate = new();
+        private readonly Entry[] _ring;
+        private int _next;
+
+        public AgentLogRingBackend(int capacity = 2048)
+        {
+            if (capacity <= 0) throw new ArgumentOutOfRangeException(nameof(capacity));
+            _ring = new Entry[capacity];
+        }
+
+        public int Capacity => _ring.Length;
+        public int Count { get; private set; }
+        public long TotalWritten { get; private set; }
+
+        public void Write(LogLevel level, in LogChannel channel, string message)
+        {
+            lock (_gate)
+            {
+                _ring[_next] = new Entry(DateTime.UtcNow, level, channel.Name, message);
+                _next = (_next + 1) % _ring.Length;
+                if (Count < _ring.Length) Count++;
+                TotalWritten++;
+            }
+        }
+
+        /// <summary>Most recent entries in chronological order.</summary>
+        public List<Entry> Snapshot(int count)
+        {
+            lock (_gate)
+            {
+                int take = Math.Min(count, Count);
+                var result = new List<Entry>(take);
+                int start = (_next - take + _ring.Length) % _ring.Length;
+                for (int i = 0; i < take; i++)
+                {
+                    result.Add(_ring[(start + i) % _ring.Length]);
+                }
+
+                return result;
+            }
+        }
+
+        public void Flush() { }
+        public void Dispose() { }
+    }
+}

--- a/src/Libraries/Ludots.AgentBridge/Tools/CameraTools.cs
+++ b/src/Libraries/Ludots.AgentBridge/Tools/CameraTools.cs
@@ -1,0 +1,191 @@
+using System.Numerics;
+using System.Text.Json.Nodes;
+using Arch.Core;
+using Ludots.Core.Components;
+using Ludots.Core.Gameplay.Camera;
+using Ludots.Core.Presentation.Camera;
+
+namespace Ludots.AgentBridge.Tools
+{
+    /// <summary>
+    /// Entity follow target for the debug bridge: resolves a live entity's
+    /// world position (and facing) every camera tick. Unlike the config-driven
+    /// follow targets it binds the entity directly — no global-key indirection.
+    /// </summary>
+    internal sealed class AgentEntityFollowTarget : ICameraFollowTarget
+    {
+        private readonly World _world;
+        private readonly Entity _entity;
+
+        public AgentEntityFollowTarget(World world, Entity entity)
+        {
+            _world = world;
+            _entity = entity;
+        }
+
+        public bool TryGetTransform(out CameraTargetTransformSnapshot transform)
+        {
+            transform = default;
+            if (!_world.IsAlive(_entity) || !_world.Has<WorldPositionCm>(_entity))
+            {
+                return false;
+            }
+
+            Vector2 position = _world.Get<WorldPositionCm>(_entity).Value.ToVector2();
+            bool hasFacing = _world.TryGet(_entity, out FacingDirection facing);
+            transform = new CameraTargetTransformSnapshot(
+                position,
+                hasFacingYawRad: hasFacing,
+                facingYawRad: hasFacing ? facing.AngleRad : 0f);
+            return true;
+        }
+    }
+
+    public sealed class CameraControlTool : IAgentTool
+    {
+        public string Name => "ludots.camera.control";
+
+        public string Description =>
+            "Inspect or drive the authority camera. Params: {action: 'get'|'set'|'follow'|'unfollow', " +
+            "entityId?: int (follow), targetXCm/targetYCm?: number, yaw?/pitch?/distanceCm?: number (set)}. " +
+            "'set' applies a partial pose through CameraManager.ApplyPose (persists into the active virtual camera); " +
+            "'follow' attaches the entity as follow target of the active virtual camera; 'unfollow' clears it.";
+
+        public JsonObject? InputSchema => new JsonObject
+        {
+            ["type"] = "object",
+            ["properties"] = new JsonObject
+            {
+                ["action"] = new JsonObject { ["type"] = "string", ["enum"] = new JsonArray("get", "set", "follow", "unfollow") },
+                ["entityId"] = new JsonObject { ["type"] = "integer", ["description"] = "required for action=follow" },
+                ["targetXCm"] = new JsonObject { ["type"] = "number", ["description"] = "set: both targetXCm and targetYCm required" },
+                ["targetYCm"] = new JsonObject { ["type"] = "number" },
+                ["yaw"] = new JsonObject { ["type"] = "number" },
+                ["pitch"] = new JsonObject { ["type"] = "number" },
+                ["distanceCm"] = new JsonObject { ["type"] = "number" },
+            },
+            ["required"] = new JsonArray("action"),
+        };
+
+        public JsonNode? Execute(JsonObject? args, AgentToolContext context)
+        {
+            string action = AgentToolContext.RequireString(args, "action");
+            CameraManager camera = Ludots.Core.Client.ClientLocalSeatAccess.ResolveAuthorityCamera(context.Engine);
+
+            switch (action)
+            {
+                case "get":
+                    return Status(camera);
+
+                case "set":
+                {
+                    var request = new CameraPoseRequest
+                    {
+                        VirtualCameraId = camera.VirtualCameraBrain?.ActiveCameraId ?? string.Empty,
+                        Yaw = OptionalFloat(args, "yaw"),
+                        Pitch = OptionalFloat(args, "pitch"),
+                        DistanceCm = OptionalFloat(args, "distanceCm"),
+                    };
+
+                    float? x = OptionalFloat(args, "targetXCm");
+                    float? y = OptionalFloat(args, "targetYCm");
+                    if (x.HasValue != y.HasValue)
+                    {
+                        throw new AgentToolException(
+                            AgentBridgeErrorCodes.InvalidParams,
+                            "targetXCm and targetYCm must be provided together.");
+                    }
+
+                    if (x.HasValue)
+                    {
+                        request.TargetCm = new Vector2(x.Value, y!.Value);
+                    }
+
+                    if (request.TargetCm == null && !request.Yaw.HasValue && !request.Pitch.HasValue && !request.DistanceCm.HasValue)
+                    {
+                        throw new AgentToolException(
+                            AgentBridgeErrorCodes.InvalidParams,
+                            "action=set requires at least one of targetXCm/targetYCm, yaw, pitch, distanceCm.");
+                    }
+
+                    camera.ApplyPose(request);
+                    return Status(camera);
+                }
+
+                case "follow":
+                {
+                    int entityId = AgentToolContext.RequireInt(args, "entityId");
+                    Entity entity = context.ResolveEntity(entityId);
+                    VirtualCameraBrain brain = RequireBrain(camera);
+                    if (!camera.SetFollowTarget(brain.ActiveCameraId, new AgentEntityFollowTarget(context.Engine.World, entity)))
+                    {
+                        throw new AgentToolException(
+                            AgentBridgeErrorCodes.ToolFailed,
+                            $"Active virtual camera '{brain.ActiveCameraId}' rejected the follow target.");
+                    }
+
+                    var result = Status(camera);
+                    result["followingEntityId"] = entityId;
+                    return result;
+                }
+
+                case "unfollow":
+                {
+                    VirtualCameraBrain brain = RequireBrain(camera);
+                    camera.SetFollowTarget(brain.ActiveCameraId, null);
+                    return Status(camera);
+                }
+
+                default:
+                    throw new AgentToolException(
+                        AgentBridgeErrorCodes.InvalidParams,
+                        $"Unknown action '{action}'. Expected get | set | follow | unfollow.");
+            }
+        }
+
+        private static VirtualCameraBrain RequireBrain(CameraManager camera)
+        {
+            VirtualCameraBrain? brain = camera.VirtualCameraBrain;
+            if (brain == null || !brain.HasActiveCamera)
+            {
+                throw new AgentToolException(
+                    AgentBridgeErrorCodes.CapabilityUnavailable,
+                    "No active virtual camera. follow/unfollow require a virtual camera; use action=set for a direct pose instead.");
+            }
+
+            return brain;
+        }
+
+        private static JsonObject Status(CameraManager camera)
+        {
+            CameraState state = camera.State;
+            var result = new JsonObject
+            {
+                ["targetCm"] = new JsonObject { ["x"] = state.TargetCm.X, ["y"] = state.TargetCm.Y },
+                ["targetHeightCm"] = state.TargetHeightCm,
+                ["yaw"] = state.Yaw,
+                ["pitch"] = state.Pitch,
+                ["distanceCm"] = state.DistanceCm,
+            };
+
+            VirtualCameraBrain? brain = camera.VirtualCameraBrain;
+            result["activeCameraId"] = brain != null && brain.HasActiveCamera ? brain.ActiveCameraId : null;
+            if (brain != null && brain.HasActiveCamera)
+            {
+                result["isBlending"] = brain.IsBlending;
+                Vector2? follow = brain.ActiveFollowTargetPositionCm;
+                result["followTargetCm"] = follow.HasValue
+                    ? new JsonObject { ["x"] = follow.Value.X, ["y"] = follow.Value.Y }
+                    : null;
+            }
+
+            return result;
+        }
+
+        private static float? OptionalFloat(JsonObject? args, string name)
+        {
+            if (args?[name] is JsonValue node && node.TryGetValue(out double d)) return (float)d;
+            return null;
+        }
+    }
+}

--- a/src/Libraries/Ludots.AgentBridge/Tools/CaptureTools.cs
+++ b/src/Libraries/Ludots.AgentBridge/Tools/CaptureTools.cs
@@ -17,7 +17,8 @@ namespace Ludots.AgentBridge.Tools
         private int _intervalMs;
         private int _maxFrames;
         private int _frameCount;
-        private bool _captureInFlight;
+        // Cleared on threadpool continuations, read on the game thread.
+        private volatile bool _captureInFlight;
         private DateTime _startedUtc;
         private DateTime _nextDueUtc;
 

--- a/src/Libraries/Ludots.AgentBridge/Tools/EventTools.cs
+++ b/src/Libraries/Ludots.AgentBridge/Tools/EventTools.cs
@@ -1,0 +1,48 @@
+using System.Text.Json.Nodes;
+using Ludots.Core.Scripting;
+
+namespace Ludots.AgentBridge.Tools
+{
+    public sealed class EventsFireTool : IAgentTool
+    {
+        public string Name => "ludots.events.fire";
+
+        public string Description =>
+            "Fire a game event through TriggerManager — the same dispatch path as engine lifecycle events (GameStart etc.), " +
+            "so mod EventHandlers and event-keyed triggers all run. Params: {event: string}. " +
+            "Response carries triggerErrors (handler failures during this fire). " +
+            "Discover event keys in mod configs/code; pair with ludots.logs.tail to observe handler output.";
+
+        public JsonObject? InputSchema => new JsonObject
+        {
+            ["type"] = "object",
+            ["properties"] = new JsonObject
+            {
+                ["event"] = new JsonObject { ["type"] = "string", ["description"] = "event key, e.g. 'GameStart' or a mod-defined key" },
+            },
+            ["required"] = new JsonArray("event"),
+        };
+
+        public JsonNode? Execute(JsonObject? args, AgentToolContext context)
+        {
+            string eventKey = AgentToolContext.RequireString(args, "event");
+            var engine = context.Engine;
+
+            int errorsBefore = engine.TriggerManager.Errors.Count;
+            // Consistent with the engine's own lifecycle dispatch: handlers are
+            // expected to complete synchronously; the bridge timeout bounds a
+            // misbehaving handler.
+            engine.TriggerManager
+                .FireEventAsync(new EventKey(eventKey), engine.CreateContext())
+                .GetAwaiter()
+                .GetResult();
+
+            return new JsonObject
+            {
+                ["event"] = eventKey,
+                ["fired"] = true,
+                ["triggerErrors"] = engine.TriggerManager.Errors.Count - errorsBefore,
+            };
+        }
+    }
+}

--- a/src/Libraries/Ludots.AgentBridge/Tools/LogTools.cs
+++ b/src/Libraries/Ludots.AgentBridge/Tools/LogTools.cs
@@ -1,0 +1,77 @@
+using System.Text.Json.Nodes;
+using Ludots.Core.Diagnostics;
+
+namespace Ludots.AgentBridge.Tools
+{
+    public sealed class LogsTailTool : IAgentTool
+    {
+        private readonly AgentLogRingBackend _ring;
+
+        public LogsTailTool(AgentLogRingBackend ring) => _ring = ring;
+
+        public string Name => "ludots.logs.tail";
+
+        public string Description =>
+            "Read recent engine log entries from the in-memory ring (installed when the bridge activates; entries before activation are not captured). " +
+            "Params: {count?=50 (max 500), minLevel?='Trace'|'Debug'|'Info'|'Warning'|'Error', channel?=substring, contains?=substring}. " +
+            "Entries are chronological; totalWritten/capacity indicate how much history was rotated out.";
+
+        public JsonObject? InputSchema => new JsonObject
+        {
+            ["type"] = "object",
+            ["properties"] = new JsonObject
+            {
+                ["count"] = new JsonObject { ["type"] = "integer", ["minimum"] = 1, ["maximum"] = 500, ["default"] = 50 },
+                ["minLevel"] = new JsonObject { ["type"] = "string", ["enum"] = new JsonArray("Trace", "Debug", "Info", "Warning", "Error") },
+                ["channel"] = new JsonObject { ["type"] = "string", ["description"] = "case-insensitive substring on channel name, e.g. 'GAS'" },
+                ["contains"] = new JsonObject { ["type"] = "string", ["description"] = "case-insensitive substring on message" },
+            },
+        };
+
+        public JsonNode? Execute(JsonObject? args, AgentToolContext context)
+        {
+            int count = Math.Clamp(AgentToolContext.OptionalInt(args, "count", 50), 1, 500);
+            string? channelFilter = AgentToolContext.OptionalString(args, "channel");
+            string? contains = AgentToolContext.OptionalString(args, "contains");
+
+            LogLevel minLevel = LogLevel.Trace;
+            string? minLevelArg = AgentToolContext.OptionalString(args, "minLevel");
+            if (minLevelArg != null && !Enum.TryParse(minLevelArg, ignoreCase: true, out minLevel))
+            {
+                throw new AgentToolException(
+                    AgentBridgeErrorCodes.InvalidParams,
+                    $"Unknown minLevel '{minLevelArg}'. Expected Trace | Debug | Info | Warning | Error.");
+            }
+
+            // Over-fetch so post-filter results can still reach `count`.
+            var snapshot = _ring.Snapshot(_ring.Count);
+            var entries = new JsonArray();
+            int matched = 0;
+            for (int i = snapshot.Count - 1; i >= 0 && matched < count; i--)
+            {
+                AgentLogRingBackend.Entry e = snapshot[i];
+                if (e.Level < minLevel) continue;
+                if (channelFilter != null && !e.Channel.Contains(channelFilter, StringComparison.OrdinalIgnoreCase)) continue;
+                if (contains != null && !e.Message.Contains(contains, StringComparison.OrdinalIgnoreCase)) continue;
+
+                matched++;
+                entries.Insert(0, new JsonObject
+                {
+                    ["utc"] = e.Utc.ToString("O"),
+                    ["level"] = e.Level.ToString(),
+                    ["channel"] = e.Channel,
+                    ["message"] = e.Message,
+                });
+            }
+
+            return new JsonObject
+            {
+                ["returned"] = matched,
+                ["ringCount"] = _ring.Count,
+                ["capacity"] = _ring.Capacity,
+                ["totalWritten"] = _ring.TotalWritten,
+                ["entries"] = entries,
+            };
+        }
+    }
+}

--- a/src/Libraries/Ludots.AgentBridge/Tools/OrderTools.cs
+++ b/src/Libraries/Ludots.AgentBridge/Tools/OrderTools.cs
@@ -14,7 +14,7 @@ namespace Ludots.AgentBridge.Tools
         public string Description =>
             "Inspect order pipeline state. Params: {entityId?: int, recent?: int (default 20)}. " +
             "With entityId: that entity's OrderBuffer (active order, queued orders with priority). " +
-            "Always includes global admission/terminal result buffers (most recent first).";
+            "Always includes global admission/terminal result buffers (most recent first) and the orderTypes key catalog (valid keys for ludots.orders.issue).";
 
         public JsonObject? InputSchema => new JsonObject
         {
@@ -85,6 +85,25 @@ namespace Ludots.AgentBridge.Tools
                     ["count"] = terminal.Count,
                     ["recent"] = terminalArray,
                 };
+            }
+
+            if (context.TryGetService(CoreServiceKeys.OrderTypeRegistry, out var orderTypes))
+            {
+                var typeArray = new JsonArray();
+                foreach (int typeId in orderTypes.GetRegisteredIds())
+                {
+                    if (orderTypes.TryGet(typeId, out var config))
+                    {
+                        typeArray.Add(new JsonObject
+                        {
+                            ["id"] = typeId,
+                            ["key"] = config.Key,
+                            ["label"] = config.Label,
+                        });
+                    }
+                }
+
+                result["orderTypes"] = typeArray;
             }
 
             return result;
@@ -194,7 +213,7 @@ namespace Ludots.AgentBridge.Tools
                 {
                     throw new AgentToolException(
                         AgentBridgeErrorCodes.InvalidParams,
-                        $"Unknown order type key '{key}'. Use ludots.orders.inspect or config to discover valid keys.");
+                        $"Unknown order type key '{key}'. Discover valid keys via ludots.orders.inspect (orderTypes field) or the order_types.json config.");
                 }
             }
             else


### PR DESCRIPTION
## 概述

Agent Debug Bridge 审计后的落地切片：工具 17 → 20，修掉多会话重入隐患，并把 RFC-0066 正本回填到与实现一致。

## 新工具（3）

| 工具 | 能力 | 复用锚点 |
|------|------|----------|
| `ludots.camera.control` | `get` / `set`（部分姿态）/ `follow {entityId}` / `unfollow` | `CameraManager.ApplyPose`（持久进 VirtualCameraBrain，不会被控制器冲掉）、`SetFollowTarget` + 薄适配器 `AgentEntityFollowTarget`（直接绑实体，不走 global-key 间接路径） |
| `ludots.logs.tail` | 进程内日志环形缓冲读取，`count/minLevel/channel/contains` 过滤，带 totalWritten/capacity 旋转诊断 | `AgentLogRingBackend`（2048 槽）经 Core 新增 `Log.AddBackend` 挂入——不重置通道级别，宿主日志行为零影响 |
| `ludots.events.fire` | 发送任意事件键，响应带本次 `triggerErrors` 增量 | `TriggerManager.FireEventAsync`，与引擎生命周期事件同分发路径；与 logs.tail 构成"发事件→看日志"闭环 |

动机：v1 验收里 agent 要靠 `ui.click` 点"Follow selection"才能转镜头（相机只能读不能控），且看不到进程内日志、无法主动触发事件。

## 修复

- **多会话重入**：`AgentBridgeModEntry` 的注册表/运行时/控制器原本在 `OnLoad` 外层只建一次却捕获 engine，改为每次激活重建，重入先 `Dispose` 旧 listener——杜绝重复注册异常与僵尸端口。日志环挂 entry 字段，跨激活只 `AddBackend` 一次，历史不丢、不套娃。
- **数据竞争**：`RecordingController._captureInFlight` 游戏线程读、线程池 continuation 写，补 `volatile`。

## 文档回填（RFC-0066）

状态 → Implemented；`/health` 契约（`pumpCount/lastPumpUtc`）；`OrderQueue.Submit`；`ToolRegistryKey` 扩展机制（原写 ModExtensionHub）；错误码全清单；启用方式对齐 launch graph；工具数 17→20。gitbook `agent-debug-bridge.md` 同步。

## 验证

- `mods/AgentBridgeMod`（含 `Ludots.AgentBridge`、`Ludots.Core` 改动面）构建 0 错误（仅存量 warning）
- 全部新增 API 引用（`ApplyPose`/`SetFollowTarget`/`CameraPoseRequest`/`FireEventAsync`/`Log.AddBackend` 等）逐一对照源码确认存在

## 已知边界

- 运行时冒烟（起 raylib.agent-demo + curl /tools 看 20 个工具）尚未做，建议合并前跑一次
- HTTP 层无并发上限（loopback 调试接口，后续可加）
- 桥仍无自动化测试，注册表/配置/MCP framing 纯逻辑可补单测（后续切片）
