### PR TITLE
feat(agent-bridge): 空间探针 + NavMesh 四工具（24 个）——直走生产查询链路

### DIFF
--- a/docs/rfcs/RFC-0066-agent-debug-bridge.md
+++ b/docs/rfcs/RFC-0066-agent-debug-bridge.md
@@ -83,7 +83,7 @@ Ludots 进程:  AgentBridgeHttpServer (后台线程, 仅绑 127.0.0.1)
 - `GET /tools` → 工具目录（name / description / inputSchema JSON Schema），供 Agent 发现
 - `GET /` → 人读说明 + 发现文件路径
 
-内置工具（20，v1 13 个 + v2 帧捕获与窗口层输入 4 个 + v3 相机/日志/事件 3 个）：
+内置工具（24，v1 13 个 + v2 帧捕获与窗口层输入 4 个 + v3 相机/日志/事件 3 个 + v4 空间探针与导航 4 个）：
 
 | 工具 | 说明 |
 |------|------|
@@ -105,6 +105,9 @@ Ludots 进程:  AgentBridgeHttpServer (后台线程, 仅绑 127.0.0.1)
 | `ludots.camera.control` | 相机读/控：`get` / `set`（部分姿态，经 `CameraManager.ApplyPose` 持久进活动虚拟相机）/ `follow {entityId}`（实体跟随目标）/ `unfollow` |
 | `ludots.logs.tail` | 进程内日志环形缓冲（`AgentLogRingBackend` 经 `Log.AddBackend` 挂入，不动宿主级别配置）；`count/minLevel/channel/contains` 过滤 |
 | `ludots.events.fire` | 经 `TriggerManager.FireEventAsync` 发送任意事件键（与引擎生命周期事件同分发路径），响应带本次 `triggerErrors` |
+| `ludots.entities.pick` | 屏幕坐标 → 实体（复用生产点选解析器 `CommandSourcePointerHitResolver`：selectable 标签 + 知识门控 + 投影包围盒决胜） |
+| `ludots.spatial.query` | 空间探针：radius / aabb / cone / rect / line 五形（直走 `ISpatialQueryService` 生产查询层，与技能/自动索敌同一分区后端） |
+| `ludots.nav.project` / `ludots.nav.findPath` | NavMesh 探针：世界点投影到可行走三角形；A→B 寻路（`NavQueryService` 稳定读 + portal A*，状态 NotReady/NotReachable 显式上报） |
 
 错误协议：JSON-RPC error，`-32602` 参数错，`-32601` 未知工具，`-32000` 域错误并带 `data.code`（`AgentBridgeErrorCodes`：`invalid.params` / `service.unavailable` / `entity.not_found` / `capability.unavailable` / `tool.failed` / `bridge.timeout`，另有工具自带码如 `ui.node_not_found`、`ui.scene_not_mounted`）。
 

--- a/gitbook/agent-bridge.md
+++ b/gitbook/agent-bridge.md
@@ -1,6 +1,6 @@
 # Agent Bridge
 
-> 面向 AI coding agent 的 Ludots 运行时操控与取证通道：环回 HTTP JSON-RPC，20 个自描述工具，零多模态依赖——看画面、点 UI、放技能、查状态、抓证据，全部用结构化 JSON 完成，取代 screenshot + computer-use 的脆弱路径。
+> 面向 AI coding agent 的 Ludots 运行时操控与取证通道：环回 HTTP JSON-RPC，24 个自描述工具，零多模态依赖——看画面、点 UI、放技能、查状态、抓证据，全部用结构化 JSON 完成，取代 screenshot + computer-use 的脆弱路径。
 >
 > 设计 SSOT：[RFC-0066](https://github.com/mightyBubble/Ludots/blob/main/docs/rfcs/RFC-0066-agent-debug-bridge.md)；工具域参考手册：[架构页 · Agent 调试桥](architecture/agent-debug-bridge.md)。**本页是任务视角的实操指南**，所有请求/响应示例来自真实验证会话（`raylib.agent-demo` · ChampionSkillSandbox）。
 
@@ -48,6 +48,9 @@ curl -s -X POST http://127.0.0.1:47921/rpc \
 |-----------|--------|---------------|
 | 确认游戏活着、-loaded 了哪些 mod | `ludots.session.info` | 无参；tick 在涨=循环活着 |
 | 找一个实体（敌人/英雄/召唤物） | `ludots.entities.query` | `nameFilter`（大小写不敏感子串）、`onScreenOnly:true` 只看镜头内的；返回 `screenCoverage`（占屏比）判断"看得清吗" |
+| 屏幕某点下面是哪个实体 | `ludots.entities.pick` | `{x, y, radiusPixels?=24}`；与点击选中同一条生产解析链（selectable + 知识门控），未命中返回 `hit:false` |
+| 一片区域里有谁（半径/扇形/直线） | `ludots.spatial.query` | `shape: radius/aabb/cone/rect/line` + 中心与尺寸参数；直走生产空间查询服务（技能/自动索敌同层），带 `distanceCmToCenter` 与 `dropped` 诊断 |
+| 某点可不可走 / A→B 怎么走 | `ludots.nav.project` / `ludots.nav.findPath` | project 命中可行走三角形；findPath 返回 `status`（NotReady=瓦片未就绪）+ 路径点 + `travelCostCm` |
 | 看某实体的血量/属性/技能槽 | `ludots.gas.entity` | `{entityId}`；tags 名称已解析、attributes 只列非零 |
 | 看面板/按钮长什么样 | `ludots.ui.tree` / `ludots.ui.query` | tree 全量；query 用 CSS 选择器——**实测注意**：选择器按 tag/`#id`/`.class` 匹配，本仓 UI 多用 tag（`selector:"button"` 命中 10 个，`.button` 命中 0 个，因为节点没有 class） |
 | 点一个按钮 | `ludots.ui.click` | `{elementId}` 或裸坐标 `{x,y}`；返回 `handled:true/false` + 命中节点的 rect/pseudoState——点到容器会 `handled:false`，换 elementId |

--- a/gitbook/architecture/agent-debug-bridge.md
+++ b/gitbook/architecture/agent-debug-bridge.md
@@ -36,7 +36,7 @@ MCP 客户端（Claude Code、pi 等）另配零依赖 stdio 适配器 `src/Tool
 - `GET /tools` → 自描述工具目录（name / description / inputSchema）
 - `POST /rpc` → JSON-RPC 2.0：`{"jsonrpc":"2.0","id":1,"method":"ludots.session.info","params":{}}`
 
-## 内置工具（20）
+## 内置工具（24）
 
 | 域 | 工具 | 能力 |
 |----|------|------|
@@ -45,6 +45,8 @@ MCP 客户端（Claude Code、pi 等）另配零依赖 stdio 适配器 `src/Tool
 | 相机 | `ludots.camera.control` | `get` 姿态与活动虚拟相机；`set` 部分姿态（经 `ApplyPose` 持久）；`follow {entityId}` / `unfollow` 实体跟随 |
 | 日志 | `ludots.logs.tail` | 进程内日志环形缓冲（激活时经 `Log.AddBackend` 挂入）；`count/minLevel/channel/contains` 过滤 |
 | 事件 | `ludots.events.fire` | 经 `TriggerManager.FireEventAsync` 发送任意事件键，响应带本次 `triggerErrors` |
+| 空间 | `ludots.entities.pick` · `ludots.spatial.query` | 屏幕点选实体（生产 `CommandSourcePointerHitResolver` 同算法）；radius/aabb/cone/rect/line 探针（生产 `ISpatialQueryService`） |
+| 导航 | `ludots.nav.project` · `ludots.nav.findPath` | 世界点 → 可行走三角形投影；A→B 寻路 + 路径点 + 代价（生产 `NavQueryService`） |
 | 实体 | `ludots.entities.query` | 世界坐标→屏幕投影 rect、**屏幕占比**、可见性；`offset/limit/nameFilter/onScreenOnly` |
 | UI | `ludots.ui.tree` · `ludots.ui.query` · `ludots.ui.click` | 统一 UiScene 遍历（markup / composite / reactive 三写法归一，browser canvas 节点有标注）；CSS 选择器；elementId 或坐标点击 |
 | GAS | `ludots.gas.entity` · `ludots.gas.diagnostics` | tags（名称解析）/ attributes / active effects / ability 槽位；诊断事件缓冲转储 |

--- a/mods/AgentBridgeMod/AgentBridgeModEntry.cs
+++ b/mods/AgentBridgeMod/AgentBridgeModEntry.cs
@@ -91,6 +91,10 @@ namespace AgentBridgeMod
             tools.Register(new CameraControlTool());
             tools.Register(new LogsTailTool(_logRing));
             tools.Register(new EventsFireTool());
+            tools.Register(new EntitiesPickTool());
+            tools.Register(new SpatialQueryTool());
+            tools.Register(new NavProjectTool());
+            tools.Register(new NavFindPathTool());
 
             engine.SetService(ToolRegistryKey, tools);
 

--- a/src/Libraries/Ludots.AgentBridge/Tools/NavTools.cs
+++ b/src/Libraries/Ludots.AgentBridge/Tools/NavTools.cs
@@ -1,0 +1,129 @@
+using System.Text.Json.Nodes;
+using Ludots.Core.Navigation.NavMesh;
+using Ludots.Core.Scripting;
+
+namespace Ludots.AgentBridge.Tools
+{
+    /// <summary>
+    /// NavMesh probes over the production NavQueryService (tile store + Detour
+    /// query engine) — the same service movement orders path through.
+    /// </summary>
+    public sealed class NavProjectTool : IAgentTool
+    {
+        public string Name => "ludots.nav.project";
+
+        public string Description =>
+            "Project a world position onto the navmesh (nearest walkable triangle) via the production NavQueryService. " +
+            "Params: {worldXCm: int, worldYCm: int, layer?=0, profile?=0}. " +
+            "hit:false means no loaded nav tile covers the point or no walkable triangle nearby.";
+
+        public JsonObject? InputSchema => new JsonObject
+        {
+            ["type"] = "object",
+            ["properties"] = new JsonObject
+            {
+                ["worldXCm"] = new JsonObject { ["type"] = "integer" },
+                ["worldYCm"] = new JsonObject { ["type"] = "integer" },
+                ["layer"] = new JsonObject { ["type"] = "integer", ["default"] = 0 },
+                ["profile"] = new JsonObject { ["type"] = "integer", ["default"] = 0 },
+            },
+            ["required"] = new JsonArray("worldXCm", "worldYCm"),
+        };
+
+        public JsonNode? Execute(JsonObject? args, AgentToolContext context)
+        {
+            int x = AgentToolContext.RequireInt(args, "worldXCm");
+            int y = AgentToolContext.RequireInt(args, "worldYCm");
+            NavQueryService service = ResolveService(args, context);
+
+            if (!service.TryProject(x, y, out NavLocation loc))
+            {
+                return new JsonObject
+                {
+                    ["hit"] = false,
+                    ["worldCm"] = new JsonObject { ["x"] = x, ["y"] = y },
+                    ["reason"] = "No loaded nav tile covers the point or no walkable triangle found.",
+                };
+            }
+
+            return new JsonObject
+            {
+                ["hit"] = true,
+                ["worldCm"] = new JsonObject { ["x"] = x, ["y"] = y },
+                ["tileId"] = loc.TileId.ToString(),
+                ["tileVersion"] = loc.TileVersion,
+                ["triangleId"] = loc.TriangleId,
+                ["localCm"] = new JsonObject { ["x"] = loc.LocalXcm, ["y"] = loc.LocalZcm },
+            };
+        }
+
+        internal static NavQueryService ResolveService(JsonObject? args, AgentToolContext context)
+        {
+            int layer = AgentToolContext.OptionalInt(args, "layer", 0);
+            int profile = AgentToolContext.OptionalInt(args, "profile", 0);
+            var registry = context.RequireService(CoreServiceKeys.NavQueryServices);
+            if (!registry.TryCreateQuery(layer, profile, null!, out NavQueryService service))
+            {
+                throw new AgentToolException(
+                    AgentBridgeErrorCodes.ServiceUnavailable,
+                    $"No nav tile store for layer={layer} profile={profile}. Check the map's navmesh bake output and NavMeshProfiles.");
+            }
+
+            return service;
+        }
+    }
+
+    public sealed class NavFindPathTool : IAgentTool
+    {
+        public string Name => "ludots.nav.findPath";
+
+        public string Description =>
+            "Find a navmesh path between two world positions via the production NavQueryService (stable-read, portal A*). " +
+            "Params: {startXCm, startYCm, goalXCm, goalYCm, layer?=0, profile?=0, maxPortals?=256}. " +
+            "status: Ok | NotReady (tiles still baking/loading) | NotReachable | InvalidInput; waypoints in world cm; travelCostCm from the area cost table.";
+
+        public JsonObject? InputSchema => new JsonObject
+        {
+            ["type"] = "object",
+            ["properties"] = new JsonObject
+            {
+                ["startXCm"] = new JsonObject { ["type"] = "integer" },
+                ["startYCm"] = new JsonObject { ["type"] = "integer" },
+                ["goalXCm"] = new JsonObject { ["type"] = "integer" },
+                ["goalYCm"] = new JsonObject { ["type"] = "integer" },
+                ["layer"] = new JsonObject { ["type"] = "integer", ["default"] = 0 },
+                ["profile"] = new JsonObject { ["type"] = "integer", ["default"] = 0 },
+                ["maxPortals"] = new JsonObject { ["type"] = "integer", ["minimum"] = 1, ["maximum"] = 4096, ["default"] = 256 },
+            },
+            ["required"] = new JsonArray("startXCm", "startYCm", "goalXCm", "goalYCm"),
+        };
+
+        public JsonNode? Execute(JsonObject? args, AgentToolContext context)
+        {
+            int sx = AgentToolContext.RequireInt(args, "startXCm");
+            int sy = AgentToolContext.RequireInt(args, "startYCm");
+            int gx = AgentToolContext.RequireInt(args, "goalXCm");
+            int gy = AgentToolContext.RequireInt(args, "goalYCm");
+            int maxPortals = Math.Clamp(AgentToolContext.OptionalInt(args, "maxPortals", 256), 1, 4096);
+            NavQueryService service = NavProjectTool.ResolveService(args, context);
+
+            NavPathResult path = service.TryFindPath(sx, sy, gx, gy, maxPortals);
+
+            var waypoints = new JsonArray();
+            int count = Math.Min(path.PathXcm.Length, path.PathZcm.Length);
+            for (int i = 0; i < count; i++)
+            {
+                waypoints.Add(new JsonObject { ["x"] = path.PathXcm[i], ["y"] = path.PathZcm[i] });
+            }
+
+            return new JsonObject
+            {
+                ["status"] = path.Status.ToString(),
+                ["ok"] = path.Status == NavPathStatus.Ok,
+                ["waypointCount"] = count,
+                ["travelCostCm"] = path.TravelCost.ToFloat(),
+                ["waypoints"] = waypoints,
+            };
+        }
+    }
+}

--- a/src/Libraries/Ludots.AgentBridge/Tools/SpatialProbeTools.cs
+++ b/src/Libraries/Ludots.AgentBridge/Tools/SpatialProbeTools.cs
@@ -1,0 +1,232 @@
+using System.Numerics;
+using System.Text.Json.Nodes;
+using Arch.Core;
+using Ludots.Core.Components;
+using Ludots.Core.Input.CommandSources;
+using Ludots.Core.Mathematics;
+using Ludots.Core.Scripting;
+using Ludots.Core.Spatial;
+using Ludots.Platform.Abstractions;
+
+namespace Ludots.AgentBridge.Tools
+{
+    /// <summary>
+    /// Screen-point entity picking via the production command-source hit
+    /// resolver (same algorithm as click selection: selectable tag, knowledge
+    /// gate, projected-bounds tiebreak).
+    /// </summary>
+    public sealed class EntitiesPickTool : IAgentTool
+    {
+        public string Name => "ludots.entities.pick";
+
+        public string Description =>
+            "Pick the entity under a screen point — the same resolution the game uses for click selection " +
+            "(CommandSourceSelectableTag + knowledge-gated inspectability + projected-bounds tiebreak). " +
+            "Params: {x: number, y: number, radiusPixels?=24}. Only selectable entities are candidates; " +
+            "use ludots.entities.query for the unfiltered feed.";
+
+        public JsonObject? InputSchema => new JsonObject
+        {
+            ["type"] = "object",
+            ["properties"] = new JsonObject
+            {
+                ["x"] = new JsonObject { ["type"] = "number" },
+                ["y"] = new JsonObject { ["type"] = "number" },
+                ["radiusPixels"] = new JsonObject { ["type"] = "number", ["default"] = 24 },
+            },
+            ["required"] = new JsonArray("x", "y"),
+        };
+
+        public JsonNode? Execute(JsonObject? args, AgentToolContext context)
+        {
+            float x = RequireFloat(args, "x");
+            float y = RequireFloat(args, "y");
+            float radius = args?["radiusPixels"] is JsonValue r && r.TryGetValue(out double rd) ? (float)rd : 24f;
+            if (radius <= 0f || radius > 500f)
+            {
+                throw new AgentToolException(AgentBridgeErrorCodes.InvalidParams, "radiusPixels must be in (0, 500].");
+            }
+
+            var engine = context.Engine;
+            if (!Ludots.Core.Client.ClientLocalSeatAccess.TryGetSolePossessedRep(engine, out Entity owner) ||
+                !engine.World.IsAlive(owner))
+            {
+                throw new AgentToolException(
+                    AgentBridgeErrorCodes.ServiceUnavailable,
+                    "No sole possessed local seat entity; picking requires the local command-source owner for knowledge gating.");
+            }
+
+            Entity hit = CommandSourcePointerHitResolver.FindNearestInspectableEntity(
+                engine.World, engine.GlobalContext, owner, new Vector2(x, y), radius);
+
+            if (hit == Entity.Null || !engine.World.IsAlive(hit))
+            {
+                return new JsonObject { ["hit"] = false, ["x"] = x, ["y"] = y, ["radiusPixels"] = radius };
+            }
+
+            var projector = context.RequireService(CoreServiceKeys.ScreenProjector);
+            var result = new JsonObject
+            {
+                ["hit"] = true,
+                ["entityId"] = hit.Id,
+                ["name"] = engine.World.Has<Name>(hit) ? engine.World.Get<Name>(hit).Value : null,
+            };
+
+            if (engine.World.TryGet(hit, out WorldPositionCm pos))
+            {
+                result["worldCm"] = new JsonObject { ["x"] = pos.Value.X.ToFloat(), ["y"] = pos.Value.Y.ToFloat() };
+            }
+
+            if (SpatialBoundsUtility.TryProjectScreenBounds(engine.World, hit, projector, out ScreenRect rect))
+            {
+                result["screenRect"] = new JsonObject
+                {
+                    ["x"] = MathF.Round(rect.MinX, 1),
+                    ["y"] = MathF.Round(rect.MinY, 1),
+                    ["w"] = MathF.Round(Math.Max(0f, rect.MaxX - rect.MinX), 1),
+                    ["h"] = MathF.Round(Math.Max(0f, rect.MaxY - rect.MinY), 1),
+                };
+            }
+
+            return result;
+        }
+
+        private static float RequireFloat(JsonObject? args, string name)
+        {
+            if (args?[name] is JsonValue node && node.TryGetValue(out double d)) return (float)d;
+            throw new AgentToolException(AgentBridgeErrorCodes.InvalidParams, $"Parameter '{name}' (number) is required.");
+        }
+    }
+
+    /// <summary>
+    /// Spatial probes over the production ISpatialQueryService (grid/chunked
+    /// partition backends) — the same query layer abilities and auto-targeting
+    /// use. Never scans the Arch world directly.
+    /// </summary>
+    public sealed class SpatialQueryTool : IAgentTool
+    {
+        private const int BufferCapacity = 512;
+
+        public string Name => "ludots.spatial.query";
+
+        public string Description =>
+            "Probe the world with the production spatial query service (same layer as ability/auto-target queries). " +
+            "Params: {shape: 'radius'|'aabb'|'cone'|'rect'|'line', centerXCm, centerYCm, " +
+            "radiusCm? (radius), halfWidthCm?/halfHeightCm? (aabb/rect), rotationDeg? (rect), " +
+            "directionDeg?/halfAngleDeg?/rangeCm? (cone), directionDeg?/lengthCm?/halfWidthCm? (line), limit?=100}. " +
+            "Rows: entityId/name/worldCm/distanceCmToCenter; dropped>0 means the backend buffer overflowed.";
+
+        public JsonObject? InputSchema => new JsonObject
+        {
+            ["type"] = "object",
+            ["properties"] = new JsonObject
+            {
+                ["shape"] = new JsonObject { ["type"] = "string", ["enum"] = new JsonArray("radius", "aabb", "cone", "rect", "line") },
+                ["centerXCm"] = new JsonObject { ["type"] = "integer" },
+                ["centerYCm"] = new JsonObject { ["type"] = "integer" },
+                ["radiusCm"] = new JsonObject { ["type"] = "integer" },
+                ["halfWidthCm"] = new JsonObject { ["type"] = "integer" },
+                ["halfHeightCm"] = new JsonObject { ["type"] = "integer" },
+                ["rotationDeg"] = new JsonObject { ["type"] = "integer" },
+                ["directionDeg"] = new JsonObject { ["type"] = "integer", ["description"] = "heading, 0=+X 90=+Y" },
+                ["halfAngleDeg"] = new JsonObject { ["type"] = "integer" },
+                ["rangeCm"] = new JsonObject { ["type"] = "integer" },
+                ["lengthCm"] = new JsonObject { ["type"] = "integer" },
+                ["limit"] = new JsonObject { ["type"] = "integer", ["minimum"] = 1, ["maximum"] = 512, ["default"] = 100 },
+            },
+            ["required"] = new JsonArray("shape", "centerXCm", "centerYCm"),
+        };
+
+        public JsonNode? Execute(JsonObject? args, AgentToolContext context)
+        {
+            string shape = AgentToolContext.RequireString(args, "shape");
+            int cx = AgentToolContext.RequireInt(args, "centerXCm");
+            int cy = AgentToolContext.RequireInt(args, "centerYCm");
+            int limit = Math.Clamp(AgentToolContext.OptionalInt(args, "limit", 100), 1, BufferCapacity);
+
+            var spatial = context.RequireService(CoreServiceKeys.SpatialQueryService);
+            var center = new WorldCmInt2(cx, cy);
+            var buffer = new Entity[BufferCapacity];
+
+            SpatialQueryResult result = shape switch
+            {
+                "radius" => spatial.QueryRadius(center, RequirePositiveInt(args, "radiusCm"), buffer),
+                "aabb" => spatial.QueryAabb(
+                    new WorldAabbCm(
+                        cx - RequirePositiveInt(args, "halfWidthCm"),
+                        cy - RequirePositiveInt(args, "halfHeightCm"),
+                        RequirePositiveInt(args, "halfWidthCm") * 2,
+                        RequirePositiveInt(args, "halfHeightCm") * 2),
+                    buffer),
+                "cone" => spatial.QueryCone(
+                    center,
+                    AgentToolContext.OptionalInt(args, "directionDeg", 0),
+                    RequirePositiveInt(args, "halfAngleDeg"),
+                    RequirePositiveInt(args, "rangeCm"),
+                    buffer),
+                "rect" => spatial.QueryRectangle(
+                    center,
+                    RequirePositiveInt(args, "halfWidthCm"),
+                    RequirePositiveInt(args, "halfHeightCm"),
+                    AgentToolContext.OptionalInt(args, "rotationDeg", 0),
+                    buffer),
+                "line" => spatial.QueryLine(
+                    center,
+                    AgentToolContext.OptionalInt(args, "directionDeg", 0),
+                    RequirePositiveInt(args, "lengthCm"),
+                    RequirePositiveInt(args, "halfWidthCm"),
+                    buffer),
+                _ => throw new AgentToolException(
+                    AgentBridgeErrorCodes.InvalidParams,
+                    $"Unknown shape '{shape}'. Expected radius | aabb | cone | rect | line."),
+            };
+
+            var world = context.Engine.World;
+            var entities = new JsonArray();
+            int returned = 0;
+            for (int i = 0; i < result.Count && returned < limit; i++)
+            {
+                Entity e = buffer[i];
+                if (!world.IsAlive(e)) continue;
+
+                var item = new JsonObject
+                {
+                    ["entityId"] = e.Id,
+                    ["name"] = world.Has<Name>(e) ? world.Get<Name>(e).Value : null,
+                };
+
+                if (world.TryGet(e, out WorldPositionCm pos))
+                {
+                    float px = pos.Value.X.ToFloat();
+                    float py = pos.Value.Y.ToFloat();
+                    item["worldCm"] = new JsonObject { ["x"] = MathF.Round(px, 1), ["y"] = MathF.Round(py, 1) };
+                    item["distanceCmToCenter"] = MathF.Round(Vector2.Distance(new Vector2(px, py), new Vector2(cx, cy)), 1);
+                }
+
+                entities.Add(item);
+                returned++;
+            }
+
+            return new JsonObject
+            {
+                ["shape"] = shape,
+                ["centerCm"] = new JsonObject { ["x"] = cx, ["y"] = cy },
+                ["matched"] = result.Count,
+                ["returned"] = returned,
+                ["dropped"] = result.Dropped + (result.Count - returned),
+                ["entities"] = entities,
+            };
+        }
+
+        private static int RequirePositiveInt(JsonObject? args, string name)
+        {
+            int value = AgentToolContext.RequireInt(args, name);
+            if (value <= 0)
+            {
+                throw new AgentToolException(AgentBridgeErrorCodes.InvalidParams, $"Parameter '{name}' must be positive.");
+            }
+
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
## 概述

空间探针 + NavMesh 切片：工具 20 → 24。全部走生产查询链路，无旁路实现。

## 新工具（4）

| 工具 | 能力 | 生产链路 |
|------|------|----------|
| `ludots.entities.pick` | 屏幕坐标 → 实体（`{x, y, radiusPixels?=24}`） | `CommandSourcePointerHitResolver.FindNearestInspectableEntity`——与点击选中同一算法：selectable 标签 + 知识门控（owner 取 sole possessed rep）+ 投影包围盒决胜 |
| `ludots.spatial.query` | radius / aabb / cone / rect / line 五形空间探针 | `ISpatialQueryService`（`CoreServiceKeys.SpatialQueryService`）——技能/自动索敌（`ContextScoredOrderResolver`、`AutoTargetResolver`）同一分区后端；带 `distanceCmToCenter` 与 `dropped` 溢出诊断 |
| `ludots.nav.project` | 世界点 → 最近可行走三角形（tile/version/triangleId） | `NavQueryServiceRegistry` → `NavQueryService.TryProject` |
| `ludots.nav.findPath` | A→B 寻路：status / 路径点 / `travelCostCm` | `NavQueryService.TryFindPath`（稳定读 + portal A*）；`NotReady/NotReachable/InvalidInput` 显式上报 |

注：仓库无 EQS 系统——`ISpatialQueryService` 就是环境查询层，`spatial.query` 是它的桥接暴露，未新建任何平行查询设施。

## 动机

非多模态 agent 的"场景视觉"补全：v1 已有屏幕投影正查（entities.query），本切片补齐反查（pick）、区域探针（spatial）与可行走性/寻路（nav），覆盖"点这里会选中谁 / 这片区域有谁 / 这里能不能走、怎么走"三类调试问答。

## 验证

- `mods/AgentBridgeMod` 构建 0 错误（仅存量 warning）
- 文档治理校验（validate-docs.ps1）通过
- 全部新引用（`FindNearestInspectableEntity` / `ISpatialQueryService` 五形签名 / `NavQueryServiceRegistry.TryCreateQuery` / `NavPathResult` / `WorldAabbCm` 等）逐一对照源码确认

## 已知边界

- 运行时冒烟未做（建议 raylib.agent-demo 实测 pick 与 findPath）
- hex 两形（QueryHexRange/Ring）未暴露（依赖 HexMetrics，后续按需加）
