### PR TITLE
docs(raylib): 引擎能力门户一级 tab + 光照指南同步最终态

### DIFF
--- a/docs/raylib-engine.html
+++ b/docs/raylib-engine.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Raylib 引擎能力 — Ludots</title>
+<meta name="description" content="Ludots Raylib 桌面引擎适配器能力总览：车道化渲染、材质实例与 shaderKey、方向光阴影、split-sum IBL、数据驱动昼夜，20 个引擎画廊场景一键验收。">
+<link rel="stylesheet" href="site-assets/site.css">
+<style>
+  .docs-view {
+    background: var(--card); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: 36px 44px; min-height: 400px;
+    max-width: 100%; overflow-x: hidden;
+  }
+  .docs-view .doc-path { font-size: 12.5px; color: var(--faint); margin-bottom: 18px; font-family: var(--mono); }
+  .md-body h1 { font-size: 26px; border-bottom: 2px solid var(--border); padding-bottom: 10px; margin: 0 0 18px; }
+  .md-body h2 { font-size: 21px; margin-top: 34px; border-bottom: 1px solid var(--border); padding-bottom: 7px; }
+  .md-body h3 { font-size: 17px; margin-top: 26px; }
+  .md-body p { margin: 12px 0; }
+  .md-body ul, .md-body ol { margin: 12px 0; padding-left: 24px; }
+  .md-body li { margin: 4px 0; }
+  .md-body table { width: 100%; border-collapse: collapse; margin: 16px 0; font-size: 13.5px; display: block; overflow-x: auto; }
+  .md-body th, .md-body td { border: 1px solid var(--border); padding: 7px 12px; text-align: left; }
+  .md-body th { background: var(--bg-soft); font-weight: 600; }
+  .md-body blockquote {
+    border-left: 3px solid var(--accent); margin: 16px 0;
+    padding: 8px 16px; background: var(--bg-soft); color: var(--muted);
+  }
+  .md-body pre { background: var(--bg-soft); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 14px 16px; overflow-x: auto; font-size: 13px; }
+  .md-body code { font-family: var(--mono); font-size: 0.92em; background: var(--bg-soft); border-radius: 4px; padding: 1px 5px; }
+  .md-body pre code { background: none; padding: 0; }
+  .md-body img { max-width: 100%; border: 1px solid var(--border); border-radius: var(--radius-sm); margin: 14px 0; }
+  .md-body hr { border: none; border-top: 1px solid var(--border); margin: 24px 0; }
+  .docs-loading { color: var(--faint); padding: 40px 0; text-align: center; }
+  .engine-actions { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 22px; }
+</style>
+</head>
+<body data-page="raylibengine">
+<header id="topbar"></header>
+
+<main class="page">
+  <div class="engine-actions" style="margin-top: 22px;">
+    <a class="btn btn-primary" href="gallery.html">Showcase 画廊 →</a>
+    <a class="btn btn-ghost" href="index.html#docs/architecture/render-lighting-guide.md">渲染光照栈指南</a>
+    <a class="btn btn-ghost" href="index.html#docs/architecture/engine-capability-showcases.md">能力标准化 Showcase</a>
+    <a class="btn btn-ghost" href="tests.html">测试与验收 →</a>
+  </div>
+  <article class="docs-view">
+    <div class="doc-path">写作源 gitbook/architecture/raylib-engine-capabilities.md</div>
+    <div class="md-body" id="doc-body">
+      <div class="docs-loading">文档加载中…</div>
+    </div>
+  </article>
+</main>
+
+<footer class="site-footer">
+  <div class="inner">
+    <span>Ludots Raylib 引擎能力 · 写作源 gitbook/architecture/raylib-engine-capabilities.md</span>
+    <span>发布于 GitHub Pages</span>
+  </div>
+</footer>
+
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="site-assets/site.js"></script>
+<script>
+(function () {
+  "use strict";
+  if (window.marked && marked.setOptions) {
+    marked.setOptions({ gfm: true, breaks: false, headerIds: true, mangle: false });
+  }
+
+  fetch(LudotsSite.SITE_BASE + "gitbook/architecture/raylib-engine-capabilities.md")
+    .then(function (r) {
+      if (!r.ok) throw new Error("HTTP " + r.status);
+      return r.text();
+    })
+    .then(function (md) {
+      document.getElementById("doc-body").innerHTML = marked.parse(md);
+    })
+    .catch(function (err) {
+      document.getElementById("doc-body").innerHTML =
+        '<div class="docs-loading">文档加载失败：' + LudotsSite.esc(String(err)) + "</div>";
+    });
+})();
+</script>
+</body>
+</html>

--- a/docs/site-assets/site.js
+++ b/docs/site-assets/site.js
@@ -28,6 +28,7 @@
   var NAV_ITEMS = [
     { href: "index.html", label: "门户", page: "home" },
     { href: "index.html#docs", label: "文档", page: "home", hash: "#docs" },
+    { href: "raylib-engine.html", label: "Raylib 引擎", page: "raylibengine" },
     { href: "graph-op-wiki.html", label: "Graph 节点画廊", page: "graphop" },
     { href: "agent-bridge.html", label: "Agent 调试桥", page: "agentbridge" },
     { href: "gallery.html", label: "Showcase 画廊", page: "gallery" },

--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -43,6 +43,7 @@
   - [Core Field2D](architecture/core-field2d.md)
   - [Global Field Rendering](architecture/global-field-rendering.md)
   - [Raylib 引擎能力标准化 Showcase](architecture/engine-capability-showcases.md)
+  - [Raylib 最小引擎能力总览](architecture/raylib-engine-capabilities.md)
   - [渲染光照栈与下游使用指南](architecture/render-lighting-guide.md)
   - [MassNavigation 数值域与确定性边界](architecture/mass-navigation-numeric-domain.md)
   - [Prefab Grounding 与 Visual Height](architecture/prefab-grounding-and-visual-height.md)

--- a/gitbook/architecture/raylib-engine-capabilities.md
+++ b/gitbook/architecture/raylib-engine-capabilities.md
@@ -1,0 +1,91 @@
+# Raylib 最小引擎能力总览
+
+Ludots 的 Raylib 桌面引擎适配器（`src/Client/Ludots.Raylib.Render` + `src/Client/Ludots.Client.Raylib`）是一套**最小但完整**的商业引擎式渲染基建：车道化渲染、材质实例、方向光阴影、split-sum IBL、数据驱动昼夜。全部作者面走 JSON 配置与注册表，合同 fail-loud，无静默降级、无 fallback 分支。
+
+## 渲染车道矩阵
+
+| 车道 | 用途 | shader | 入口 |
+|---|---|---|---|
+| 静态实例化合批（ISM） | 大量静态网格（植被、道具群） | `instancing.vs/fs` | `PrimitiveDrawItem` → `RaylibPrimitiveRenderer` |
+| GPU 骨骼蒙皮实例化 | 人群/军队同模型动画 | `skinning_instanced` | `ISkinnedVisualBatchSnapshot` → `RaylibGpuSkinnedBatchRenderer` |
+| 单物体带光照 | 少量模型、编辑器道具 | `model_lit` | `RaylibLitModel` |
+| 地形 | 高度图 / 平面 surface | `terrain.fs` | `RaylibVisualHeightmapRenderer` / `RaylibTerrainRenderer` |
+| 植被 billboard | 镂空贴图植物 | `vegetation_cutout` | `MeshAssetType.Billboard` + Cutout 材质 |
+| 投影贴花 | 脚印、弹坑、标记 | `decal_project` | `AssetKind.Decal` → `RaylibDecalProjectorRenderer` |
+| 天空 | 昼夜渐变 / 程序化天空盒 | `sky_daynight` / `skybox` | `RaylibSkyEnvironment` / `RaylibSkyboxRenderer` |
+| 其他 | 水体 / 后处理 / 调试绘制 / ribbon / Skia 覆盖层 / 粒子 VFX | `water` / `postprocess` / … | 各专用渲染器 |
+
+两条主光照车道（合批 + 单物体）合同词汇一致：**Cook-Torrance GGX 单灯 metallic-roughness + split-sum 天空 IBL**，光照总线 `RaylibFrameLighting`（光向/环境/光色/强度/雾/视点）。
+
+## 材质系统
+
+三轴正交、全部数据驱动（`Presentation/materials.json` + `MaterialAssetDescriptor`）：
+
+- **换贴图 / 改参数**：材质实例链 `ParentKey`，子材质只写差异字段，`MaterialAssetResolver` 沿链合并；
+- **改着色行为**：`ShaderKey` + `RaylibShaderCatalog` 注册表分派到实例化车道；非实例化车道遇自定义 key fail-loud；
+- **命名参数**：`FloatParams`/`ColorParams` 按键名直推 shader uniform；
+- **标量 PBR**：无贴图材质 `roughness`/`metalness` 直达 `uRoughness`/`uMetallic`；贴图优先。
+
+宿主侧统一材质装订库 `RaylibMaterialLibrary` 经 `IRenderMaterialAssets.TryResolve` 消费解析后视图，重注册不丢标量参数。
+
+## 光照与 IBL
+
+- **方向光 + 环境**：`RaylibFrameLighting` 从环境配置装载，昼夜相位驱动；
+- **split-sum 天空 IBL**：`RaylibSkyIbl` CPU 烘焙 6×64² 环境立方图（mip 链按粗糙度 GGX 预滤波）+ 512² BRDF LUT（Hammersley 256 采样数值积分），两车道 `ambientSpecular` 同合同；相位步进节流重烘，GPU 端零额外 pass；
+- **雾与天空**：`distance_fog.json`、天空环境 JSON、环境光 ramp，全配置文件驱动。
+
+## 方向光阴影
+
+`RaylibDirectionalShadowMap`：深度打包 RGB24 颜色 RT + 3×3 PCF 接收；四接收 shader 经 `// ludo:include shadow_sampling.glsl.inc` 共享唯一采样源（`RaylibShaderLoader` 运行时展开，禁内联 + 逐字一致双合同）。
+
+投影资格矩阵：
+
+| 材质 blend | 投影 | 形态 |
+|---|---|---|
+| Opaque | ✓ | 实体深度 |
+| Cutout | ✓ | alpha 打孔（树冠影斑驳，非实心矩形） |
+| AlphaBlend / Additive | ✗ | 覆盖/发光语义不构成遮挡体 |
+| VFX / Decal | ✗ | 条目级跳过 |
+
+阴影参数走环境配置树 `RaylibShadowConfig(MapSize, ReceiverBiasWorld)`，无魔法数硬编码。
+
+## 配置与资产
+
+- 资产注册：`host_assets.json`（mesh/材质/贴图行）→ `RaylibMaterialLibrary` / mesh 注册表；
+- 环境配置：天空环境、雾、阴影、环境光 ramp 各自 JSON，装载期严格校验；
+- 太阳盘/光晕四参数（`RaylibSkyboxConfig`）双天空 shader 共享 `sun_disk.glsl.inc`。
+
+## 引擎画廊：20 场景一键验收
+
+```powershell
+.\scripts\run-mod-launcher.cmd cli launch preset:engine_raylib_lighting --adapter raylib
+```
+
+| preset | 演示点 |
+|---|---|
+| `engine_raylib_primitives` | 图元车道基线 |
+| `engine_raylib_instancing` | 静态实例化合批 |
+| `engine_raylib_gpu_skinning` | GPU 蒙皮实例化 |
+| `engine_raylib_crowd_anim` | 4096 动画实例人群合批 |
+| `engine_raylib_lighting` | 光照全效：GGX 粗糙度×金属度梯度球阵 + IBL + 阴影 |
+| `engine_raylib_frame_lighting` | 光照总线昼夜 |
+| `engine_raylib_material_binding` | 材质库/实例链/shaderKey 自发光 |
+| `engine_raylib_vegetation_cutout` | 镂空植被 + alpha 打孔影 |
+| `engine_raylib_decal_projection` | 地形投影贴花 |
+| `engine_raylib_terrain_surface` / `engine_raylib_terrain_heightmap` | 地形两车道 |
+| `engine_raylib_skybox` / `engine_raylib_sky_daynight` | 天空两车道 |
+| `engine_raylib_water` / `engine_raylib_atmosphere_fog` / `engine_raylib_postprocess` | 水体/雾/后处理 |
+| `engine_raylib_particles` / `engine_raylib_ribbon_overlay` / `engine_raylib_skia_overlay` / `engine_raylib_debug_draw` | 粒子/ribbon/Skia/调试绘制 |
+
+每场景有验收六件套证据（截图 + stats），见「测试与验收」页。
+
+## 质量门
+
+- 合同测试锁 shader 接线（`RaylibShaderContractTests`：深度打包一致性、接收端采样块逐字一致、镂空/投影资格）；
+- 场景截图回归基线（静态场景像素级比对）；
+- 新增 shader 强制走 `RaylibShaderLoader` include 展开与 fail-loud uniform 校验。
+
+## 深读
+
+- [渲染光照栈与下游使用指南](render-lighting-guide.md)——车道接线、IBL 实现细节、材质合同；
+- [Raylib 引擎能力标准化 Showcase](engine-capability-showcases.md)——能力矩阵与验收登记。

--- a/gitbook/architecture/render-lighting-guide.md
+++ b/gitbook/architecture/render-lighting-guide.md
@@ -29,20 +29,32 @@ Rl.DrawModelEx(model, position, axis, angle, scale, color);
 
 画廊范式：`GalleryLitProps`（共享立方体/球 + 单实例）与 `GpuSkinningScene`（自有实例）。
 
-## 平面投影阴影：RaylibPlanarShadows
+## 方向光 Shadow Map：RaylibDirectionalShadowMap
+
+平面投影阴影（`RaylibPlanarShadows`）已退役，全场景统一走方向光 shadow map 车道：
 
 ```csharp
-var shadows = new RaylibPlanarShadows(alpha: 110);
-shadows.GroundY = 0.21f;                   // 接收平面高度（必须高于地面几何顶面）
-
-// 模型：换装默认着色器 → planar 矩阵 → 还原
-shadows.DrawModelShadow(model, position, rotationAngleY, scale, lighting.SunDirectionToward);
-
-// mesh：
-shadows.DrawMeshShadow(mesh, modelTransform, lighting.SunDirectionToward);
+var shadow = new RaylibDirectionalShadowMap();   // 配置走环境配置树 RaylibShadowConfig(MapSize, ReceiverBiasWorld)
+shadow.BeginFrame(lighting.SunDirectionToward, sceneCenter, sceneRadius);
+// 各车道把投影体灌进深度 pass：
+primitiveRenderer.DrawShadow(snapshot, shadow, meshes, camera);   // 图元/模型/billboard
+primitiveRenderer.DrawShadow(skinnedBatch, shadow, meshes);       // GPU 蒙皮合批
+shadow.EndFrame();
 ```
 
-限制：接收面为水平面（`GroundY`）；重叠投影会加深。非平面接收需等 native 升级后的 shadow map 车道。
+- **深度编码**：硬件深度打包进 RGBA 颜色 RT（RGB 24 位进位），接收端经 `uLightSpaceMatrix` 投影 + 3×3 PCF；RT 点采样 + 钳制包裹（bilinear 解码打包深度在数学上是错的）。
+- **shader 单一来源**：四个接收 shader（`model_lit.fs` / `instancing.fs` / `skinning_instanced.fs` / `terrain.fs`）经 `// ludo:include shadow_sampling.glsl.inc` 共享同一块采样代码，`RaylibShaderLoader` 运行时展开（递归 ≤4、fail-loud、防路径穿越）；合同测试断言"禁内联 + 展开后逐字一致"双守卫。
+- **投影资格**（收口于 `DrawShadowLeafAsset` 单点，`RaylibMaterialDrawState.CastsShadow`）：
+
+| 材质 blend | 是否投影 | 说明 |
+|---|---|---|
+| Opaque | 是 | 实体深度 |
+| Cutout | 是 | `shadow_depth_cutout` 采样 albedo alpha 打孔（阈值 `DefaultVegetationAlphaCutoff`），树冠影呈斑驳形态而非实心矩形 |
+| AlphaBlend / Additive | 否 | alpha 是发光/覆盖语义，不构成遮挡体 |
+| VFX / Decal | 否 | 条目级跳过 |
+
+- **深度 pass shader 族**：`shadow_depth`（实体）、`shadow_depth_instanced`（ISM 合批）、`shadow_depth_skinning_instanced`（蒙皮合批）、`shadow_depth_cutout`（镂空 billboard）；镂空与实体打包编码逐字一致，合同测试锁定。
+- 无 `1/2048` 之类的硬编码：`uShadowMapTexel` 由 `RaylibShadowConfig.MapSize` 推导。
 
 ## 材质标量 PBR 合同
 
@@ -55,6 +67,16 @@ shadows.DrawMeshShadow(mesh, modelTransform, lighting.SunDirectionToward);
 - 有贴图 → 贴图优先（标量忽略）；无贴图 → 标量直达 `uRoughness`/`uMetallic`。
 - 越界（非 [0,1] / 非数字）装载期 fail-loud。
 - 合批管线与单物体通道同一合同（`MaterialAssetDescriptor.Roughness/Metalness`）。
+
+## 材质实例与 shaderKey（对齐商业引擎心智）
+
+材质是三轴正交的作者面，均数据驱动、解析期 fail-loud：
+
+- **材质实例链**：`MaterialAssetDescriptor.ParentKey` 指向父材质，`MaterialAssetResolver` 沿链合并——子材质只写差异字段（换贴图、改 roughness/metalness、改 blend flags），未写字段继承父级；`IRenderMaterialAssets.TryResolve` 给解析后视图。
+- **自定义着色行为**：`ShaderKey`（默认 `lit`）+ `RaylibShaderCatalog` 注册表分派。`RaylibLaneShader` 接线契约挂在实例化合批车道（`RegisterInstancingShader(key, lane)`）；非实例化车道遇非默认 shaderKey 一律 fail-loud，不静默降级。
+- **命名参数直推 uniform**：`FloatParams` / `ColorParams` 字典按键名直达 shader uniform（如 emissive 强度/颜色），实例材质改参数即生效。
+
+范式见引擎画廊 `material_binding` 场景：`[iron] 基础金属 → [rusty] 实例覆盖 albedo+roughness`、`[emissive] shaderKey=emissive 自发光车道 → [hot] 实例参数覆盖`。
 
 ## split-sum 天空 IBL（预滤波环境立方图 + BRDF LUT）
 


### PR DESCRIPTION
## 内容

- **Pages 新增一级 tab「Raylib 引擎」**：`docs/raylib-engine.html` 壳页（与 agent-bridge 同构 marked 渲染）+ `site.js` NAV_ITEMS 登记；写作源 `gitbook/architecture/raylib-engine-capabilities.md`——车道矩阵（ISM/GPU 蒙皮/单物体/地形/billboard/贴花/天空等）、材质三轴（实例链/shaderKey/命名参数）、split-sum IBL、阴影投影资格矩阵、20 引擎画廊场景表与质量门。
- **render-lighting-guide.md 同步最终态**：过期的平面投影阴影章节（`RaylibPlanarShadows` 已随 #1022 退役）重写为方向光 shadow map 车道全链文档（RGB24 打包、`ludo:include` 单源、投影资格矩阵、cutout alpha 打孔）；补材质实例链与 shaderKey 章节。
- `gitbook/SUMMARY.md` 导航挂新页。

## 验证

- `python scripts/build-site.py` 本地构建 0 告警，_site 含新页与写作源 md；
- 文档所有类型名/字段名对最新 main 代码逐一核对（`RaylibMaterialLibrary`/`RegisterInstancingShader`/`CastsShadow` 等）。

Refs #1032 #1038