### PR TITLE
fix(raylib-render): 审计跟进——诊断 IO 归口 + ShaderCatalog 行为测试 + 指南政策明文

### DIFF
--- a/gitbook/architecture/render-lighting-guide.md
+++ b/gitbook/architecture/render-lighting-guide.md
@@ -67,6 +67,7 @@ shadow.EndFrame();
 - 有贴图 → 贴图优先（标量忽略）；无贴图 → 标量直达 `uRoughness`/`uMetallic`。
 - 越界（非 [0,1] / 非数字）装载期 fail-loud。
 - 合批管线与单物体通道同一合同（`MaterialAssetDescriptor.Roughness/Metalness`）。
+- 可选字段的默认值是合同的一部分：新增或修改默认值必须配合同合同测试守卫（参照环境配置太阳盘四参数的 S3.5 守卫），不允许"顺手改默认值"静默通过。
 
 ## 材质实例与 shaderKey（对齐商业引擎心智）
 
@@ -98,6 +99,11 @@ shadow.EndFrame();
 | `SHADER_UNIFORM_VEC4` 通道不稳 | vec4 uniform 不生效 | 着色器矩阵列用 vec3 语义（`model_lit` 不依赖 vec4 uniform） |
 
 新增着色器时遵守：矩阵不进 uniform、模型 mesh 不按值过边界。
+
+## 渲染期资产缺失政策与诊断出口
+
+- **渲染期资产缺失**（模型/贴图运行期解析不到）：`RenderDiagnostics.Warn` warn-once + 跳过该条目绘制，**不画占位体**——缺失资产属于数据问题，由宿主日志与验收兜住，渲染器不造替代形。装载期错误（越界标量、shader 合同缺 uniform、JSON 解析失败）仍是 fail-loud，两者不要混。
+- **诊断出口**：`RenderDiagnostics.InfoSink/WarnSink` 由宿主启动时接线到正式日志，未接线静默（画廊可独立运行）。文件细节诊断（逐资产纹理加载、billboard 绘制参数）经环境变量 `LUDOTS_RAYLIB_DIAGNOSTIC_PATH` 开启、默认关闭，按 (category, key) 去重；热路径调用方先判 `RenderDiagnostics.FileSinkEnabled` 再构造消息，关闭时零分配。
 
 ## 宿主接入（表现 showcase 侧）
 

--- a/src/Client/Ludots.Raylib.Render/Rendering/RaylibPrimitiveRenderer.cs
+++ b/src/Client/Ludots.Raylib.Render/Rendering/RaylibPrimitiveRenderer.cs
@@ -29,7 +29,6 @@ namespace Ludots.Raylib.Render
         private readonly IRenderAssetPathResolver? _vfs;
         private readonly IRenderMaterialAssets? _materials;
         private readonly RaylibMaterialLibrary? _materialLibrary;
-        private readonly string? _diagnosticPath;
         private const int DefaultMaxModelInstancesPerDraw = 32768;
         private const int HardMaxModelInstancesPerDraw = 131072;
 
@@ -76,8 +75,6 @@ namespace Ludots.Raylib.Render
         private readonly Dictionary<int, CachedModel> _modelCache = new Dictionary<int, CachedModel>();
         private readonly Dictionary<int, CachedProceduralMesh> _proceduralMeshCache = new Dictionary<int, CachedProceduralMesh>();
         private readonly Dictionary<int, CachedTexture> _textureCache = new Dictionary<int, CachedTexture>();
-        private readonly HashSet<int> _loggedTextureDiagnostics = new HashSet<int>();
-        private readonly HashSet<int> _loggedBillboardDrawDiagnostics = new HashSet<int>();
         private readonly HashSet<int> _reportedMissingModelDraws = new HashSet<int>();
         private Material _proceduralMeshMaterial;
         private bool _proceduralMeshMaterialLoaded;
@@ -204,7 +201,6 @@ namespace Ludots.Raylib.Render
             _materialLibrary = vfs != null && materials != null
                 ? new RaylibMaterialLibrary(vfs, materials)
                 : null;
-            _diagnosticPath = Environment.GetEnvironmentVariable("LUDOTS_RAYLIB_DIAGNOSTIC_PATH");
             _maxModelInstancesPerDraw = ResolveMaxModelInstancesPerDraw();
             _gpuSkinnedModelCache = new RaylibGpuSkinnedModelCache(vfs);
             _materialPipeline = new RaylibInstancedMaterialPipeline(_materialLibrary);
@@ -1286,9 +1282,13 @@ namespace Ludots.Raylib.Render
                 Clamp01ToByte(litRgb.Z),
                 alpha);
             bool doubleSided = IsMaterialDoubleSided(materialId);
-            LogBillboardDrawDiagnostic(
-                meshAssetId,
-                $"billboard-draw pos=({billboardPosition.X:F2},{billboardPosition.Y:F2},{billboardPosition.Z:F2}) scale=({scale.X:F2},{scale.Y:F2},{scale.Z:F2}) size=({width:F2}x{height:F2}) alpha={alpha} blend={blendMode} materialId={materialId} cameraPos=({camera.position.X:F2},{camera.position.Y:F2},{camera.position.Z:F2}) cameraTarget=({camera.target.X:F2},{camera.target.Y:F2},{camera.target.Z:F2})");
+            if (RenderDiagnostics.FileSinkEnabled)
+            {
+                RenderDiagnostics.Detail(
+                    "billboard-draw",
+                    meshAssetId,
+                    $"pos=({billboardPosition.X:F2},{billboardPosition.Y:F2},{billboardPosition.Z:F2}) scale=({scale.X:F2},{scale.Y:F2},{scale.Z:F2}) size=({width:F2}x{height:F2}) alpha={alpha} blend={blendMode} materialId={materialId} cameraPos=({camera.position.X:F2},{camera.position.Y:F2},{camera.position.Z:F2}) cameraTarget=({camera.target.X:F2},{camera.target.Y:F2},{camera.target.Z:F2})");
+            }
 
             if (doubleSided)
             {
@@ -1585,7 +1585,7 @@ namespace Ludots.Raylib.Render
 
             if (_vfs == null || desc.SourceUris == null || desc.SourceUris.Length == 0)
             {
-                LogTextureDiagnostic(meshAssetId, $"texture-load skipped; vfsMissing={_vfs == null}; uriCount={desc.SourceUris?.Length ?? 0}");
+                RenderDiagnostics.Detail("texture", meshAssetId, $"texture-load skipped; vfsMissing={_vfs == null}; uriCount={desc.SourceUris?.Length ?? 0}");
                 _textureCache[meshAssetId] = cached;
                 return false;
             }
@@ -1597,13 +1597,13 @@ namespace Ludots.Raylib.Render
 
                 if (!_vfs.TryResolveFullPath(uri, out string fullPath))
                 {
-                    LogTextureDiagnostic(meshAssetId, $"texture-resolve failed; uri={uri}");
+                    RenderDiagnostics.Detail("texture", meshAssetId, $"texture-resolve failed; uri={uri}");
                     continue;
                 }
 
                 if (!File.Exists(fullPath))
                 {
-                    LogTextureDiagnostic(meshAssetId, $"texture-file missing; uri={uri}; fullPath={fullPath}");
+                    RenderDiagnostics.Detail("texture", meshAssetId, $"texture-file missing; uri={uri}; fullPath={fullPath}");
                     continue;
                 }
 
@@ -1617,11 +1617,11 @@ namespace Ludots.Raylib.Render
                         AspectRatio = texture.height > 0 ? (float)texture.width / texture.height : 1f,
                     };
                     _textureCache[meshAssetId] = cached;
-                    LogTextureDiagnostic(meshAssetId, $"texture-load success; uri={uri}; fullPath={fullPath}; size={texture.width}x{texture.height}");
+                    RenderDiagnostics.Detail("texture", meshAssetId, $"texture-load success; uri={uri}; fullPath={fullPath}; size={texture.width}x{texture.height}");
                     return true;
                 }
 
-                LogTextureDiagnostic(meshAssetId, $"texture-load failed; uri={uri}; fullPath={fullPath}; textureId={texture.id}; size={texture.width}x{texture.height}");
+                RenderDiagnostics.Detail("texture", meshAssetId, $"texture-load failed; uri={uri}; fullPath={fullPath}; textureId={texture.id}; size={texture.width}x{texture.height}");
 
                 if (texture.id != 0)
                     Rl.UnloadTexture(texture);
@@ -1631,43 +1631,11 @@ namespace Ludots.Raylib.Render
             return false;
         }
 
-        private void LogTextureDiagnostic(int meshAssetId, string message)
-        {
-            if (string.IsNullOrWhiteSpace(_diagnosticPath))
-                return;
-
-            if (!_loggedTextureDiagnostics.Add(meshAssetId))
-                return;
-
-            string fullPath = Path.GetFullPath(_diagnosticPath);
-            string? directory = Path.GetDirectoryName(fullPath);
-            if (!string.IsNullOrWhiteSpace(directory))
-                Directory.CreateDirectory(directory);
-
-            File.AppendAllText(fullPath, $"[{DateTime.UtcNow:O}] meshAssetId={meshAssetId} {message}{Environment.NewLine}");
-        }
-
         private static string FormatSourceUris(string[]? sourceUris)
         {
             return sourceUris == null || sourceUris.Length == 0
                 ? "(none)"
                 : string.Join("|", sourceUris);
-        }
-
-        private void LogBillboardDrawDiagnostic(int meshAssetId, string message)
-        {
-            if (string.IsNullOrWhiteSpace(_diagnosticPath))
-                return;
-
-            if (!_loggedBillboardDrawDiagnostics.Add(meshAssetId))
-                return;
-
-            string fullPath = Path.GetFullPath(_diagnosticPath);
-            string? directory = Path.GetDirectoryName(fullPath);
-            if (!string.IsNullOrWhiteSpace(directory))
-                Directory.CreateDirectory(directory);
-
-            File.AppendAllText(fullPath, $"[{DateTime.UtcNow:O}] meshAssetId={meshAssetId} {message}{Environment.NewLine}");
         }
 
         private void WarnMissingModelSkipped(int meshAssetId, int stableId, string path)

--- a/src/Client/Ludots.Raylib.Render/Rendering/RenderDiagnostics.cs
+++ b/src/Client/Ludots.Raylib.Render/Rendering/RenderDiagnostics.cs
@@ -2,14 +2,47 @@ namespace Ludots.Raylib.Render
 {
     /// <summary>
     /// 渲染程序集诊断出口；宿主启动时接线到正式日志，未接线时静默（画廊可独立运行）。
+    /// 文件诊断是低频调查工具，经 LUDOTS_RAYLIB_DIAGNOSTIC_PATH 开启，默认关闭。
     /// </summary>
     public static class RenderDiagnostics
     {
         public static System.Action<string>? InfoSink;
         public static System.Action<string>? WarnSink;
 
+        private static readonly System.Lazy<string?> s_filePath =
+            new(() => System.Environment.GetEnvironmentVariable("LUDOTS_RAYLIB_DIAGNOSTIC_PATH"));
+        private static readonly System.Collections.Generic.HashSet<(string Category, int Key)> s_reportedFileDetails = new();
+
+        public static bool FileSinkEnabled => !string.IsNullOrWhiteSpace(s_filePath.Value);
+
         public static void Info(string message) => InfoSink?.Invoke(message);
 
         public static void Warn(string message) => WarnSink?.Invoke(message);
+
+        /// <summary>
+        /// 按 (category, key) 去重的文件细节诊断。热路径调用方必须先用 <see cref="FileSinkEnabled"/>
+        /// 拦截再构造消息字符串，否则关闭诊断时仍按帧分配。
+        /// </summary>
+        public static void Detail(string category, int key, string message)
+        {
+            if (!FileSinkEnabled)
+            {
+                return;
+            }
+
+            if (!s_reportedFileDetails.Add((category, key)))
+            {
+                return;
+            }
+
+            string fullPath = System.IO.Path.GetFullPath(s_filePath.Value!);
+            string? directory = System.IO.Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                System.IO.Directory.CreateDirectory(directory);
+            }
+
+            System.IO.File.AppendAllText(fullPath, $"[{System.DateTime.UtcNow:O}] {category} key={key} {message}{System.Environment.NewLine}");
+        }
     }
 }

--- a/src/Tests/RaylibAdapterTests/RaylibShaderCatalogTests.cs
+++ b/src/Tests/RaylibAdapterTests/RaylibShaderCatalogTests.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+using Ludots.Raylib.Render;
+
+namespace Ludots.Tests.RaylibAdapter;
+
+[TestFixture]
+public sealed class RaylibShaderCatalogTests
+{
+    [Test]
+    public void RegisterInstancing_RejectsEmptyShaderKey()
+    {
+        var catalog = new RaylibShaderCatalog();
+
+        Assert.Throws<ArgumentException>(() => catalog.RegisterInstancing("", null!));
+        Assert.Throws<ArgumentException>(() => catalog.RegisterInstancing("   ", null!));
+    }
+
+    [Test]
+    public void RegisterInstancing_RejectsDuplicateShaderKey()
+    {
+        var catalog = new RaylibShaderCatalog();
+        catalog.RegisterInstancing("lit.custom", null!);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => catalog.RegisterInstancing("lit.custom", null!));
+        Assert.That(ex!.Message, Does.Contain("already registered"));
+        Assert.That(ex.Message, Does.Contain("lit.custom"));
+    }
+
+    [Test]
+    public void RequireInstancing_ThrowsForUnregisteredShaderKey()
+    {
+        var catalog = new RaylibShaderCatalog();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => catalog.RequireInstancing("lit.missing"));
+        Assert.That(ex!.Message, Does.Contain("lit.missing"));
+    }
+
+    [Test]
+    public void RequireInstancing_ReturnsRegisteredShader()
+    {
+        var catalog = new RaylibShaderCatalog();
+        catalog.RegisterInstancing("lit.custom", null!);
+
+        // RaylibLaneShader 构造函数私有且接线依赖 GL，注册表语义用 null 值占位验证存取闭环。
+        Assert.That(catalog.RequireInstancing("lit.custom"), Is.Null);
+        Assert.That(catalog.InstancingShaders.Count(), Is.EqualTo(1));
+    }
+}


### PR DESCRIPTION
## 背景

合并后复审（审计报告见 `artifacts/audit-render-lighting/audit-report-20260821-postmerge.md`，本地 artifacts 未入库）对 Raylib 引擎基建开出五条可修 finding，本 PR 一次修完：

- **P2-1 billboard 诊断热路径分配**：原 `DrawBillboard` 每帧先构造插值字符串、进 `LogBillboardDrawDiagnostic` 后才判空丢弃，诊断关闭时仍按帧分配。
- **P3-5 诊断 IO 混入渲染器**：环境变量读取、两组去重 HashSet、文件落盘散在 `RaylibPrimitiveRenderer` 内。

  → 两者合并修：诊断文件 IO 全部收口到 `RenderDiagnostics`（`FileSinkEnabled` + `Detail(category, key, message)` 按 (category, key) 去重），渲染器 5 处调用点同构改写，热路径以布尔守卫先行拦截，诊断关闭时零分配。不用 `Func<string>` 惰性求值——lambda 闭包同样每次分配。

- **P3-3 RaylibShaderCatalog 无行为测试**：新增 `RaylibShaderCatalogTests` 覆盖空 key 拒绝 / 重复 key fail-loud / 未注册 key fail-loud / 注册存取闭环（`RaylibLaneShader` 构造依赖 GL，注册表语义以 null 值占位验证）。

- **P3-2 warn-skip 政策未明文**：指南新增「渲染期资产缺失政策与诊断出口」一节——渲染期资产缺失 = `RenderDiagnostics.Warn` warn-once + 跳过绘制（不画占位体）；装载期错误仍 fail-loud。

- **P3-4 可选配置默认值守卫**：指南材质章节补明文——可选字段默认值是合同的一部分，改默认值须配合同合同测试（参照太阳盘四参数 S3.5 守卫）。

P3-1（PrimitiveRenderer 2692 行规模）已定案记录不动工，不在本 PR。

## 验证

- `RaylibAdapterTests`：73 通过 / 1 失败——唯一失败为 main 存量环境分配测试 `BuildTexturePlan_ReusesScratchAndAllocatesZeroAfterWarmup`，与本改动无关。
- `PresentationTests`（ProjectedDecalContract + Material 过滤）：31/31 通过。
- 诊断改动不影响渲染输出路径，无视觉回归面。

Refs #1032