### PR TITLE
docs(panel): 面板目录设计与典型案例全设计——四道审计七轮收敛版

### DIFF
--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -17,6 +17,7 @@
   - [UIP-0：Template / Instance / Router 合同](architecture/ui-panel-template-instance-router.md)
   - [四皮面板：工程结构与换肤合同](architecture/panel-skins.md)
   - [面板目录设计：配置形状与线框](architecture/panel-catalog-designs.md)
+  - [面板典型案例全设计](architecture/panel-case-designs.md)
   - [Browser Runtime Provider Adapter Guide](architecture/browser-runtime-provider-adapter-guide.md)
   - [Mod 架构](architecture/mod-architecture.md)
   - [GAS 分层架构](architecture/gas-layered-architecture.md)

--- a/gitbook/SUMMARY.md
+++ b/gitbook/SUMMARY.md
@@ -16,6 +16,7 @@
   - [UI 面板作者形态（四种表面）](architecture/ui-panel-authoring-form.md)
   - [UIP-0：Template / Instance / Router 合同](architecture/ui-panel-template-instance-router.md)
   - [四皮面板：工程结构与换肤合同](architecture/panel-skins.md)
+  - [面板目录设计：配置形状与线框](architecture/panel-catalog-designs.md)
   - [Browser Runtime Provider Adapter Guide](architecture/browser-runtime-provider-adapter-guide.md)
   - [Mod 架构](architecture/mod-architecture.md)
   - [GAS 分层架构](architecture/gas-layered-architecture.md)

--- a/gitbook/architecture/panel-case-designs.md
+++ b/gitbook/architecture/panel-case-designs.md
@@ -63,13 +63,24 @@ screen.topLeft ┌────────────────────�
 ### A5 显隐编排
 常驻面板：地图装载图（TriggerGraph）`CreatePanel(panelAnchor: "screen.topLeft")` 后**不调** `ShowPanel` 之外的任何显隐逻辑——开局默认隐藏由激活商店语义决定（`IsVisible` 缺省 false），装载图随即 `ShowPanel("panel.player.aggregate")` 常亮。整局无再隐需求。
 
-### A6 验收断言
-- 自动化（headless）：装载地图 → 实例 1 个、变量初值正确；驱动经济图输出变化 → 面板变量同帧跟随（现有 PanelFireball 断言模式复用）。
-- 30 秒人验：`preset:panel_fullhud` 打开即见资源条；按 U 造兵 → 金掉/人口涨可见。
-- 边界（fail-closed）：`graphOutputKey` 写错 → 装载期抛错点名 key；缺图（Graph.Economy.Aggregate 未注册）→ 同上，无 0 兜底。
+### A6 验收（Gherkin）
+
+```gherkin
+Scenario: 资源条随经济同帧刷新
+  Given Full-HUD 验收场启动且 panel.player.aggregate 可见
+  When 玩家花费 200 金生产一队兵
+  Then gold 变量减少 200 且 popUsed 增加，与图输出 economy.gold 同帧
+
+Scenario: 溯源失败即拒
+  Given 模板引用未注册的 graphOutputKey
+  When 装载地图
+  Then 装载失败并点名该 key（无 0 兜底）
+```
+
+30 秒人验：打开即见资源条；按 U 造兵 → 金掉/人口涨肉眼可见。
 
 ### A7 依赖与边界
-依赖：**G3**（scope=global 实例语义，#1012 主战场）。明确不做：货币动画/溢出滚动（皮层自由实现，模板不承诺）；不读敌方经济（图输出仅己方 scope）。
+依赖：G3（scope=global，#1012）。明确不做：货币动画/溢出滚动（皮层自由实现，模板不承诺）；不读敌方经济（图输出仅己方 scope）。
 
 ---
 
@@ -100,10 +111,12 @@ screen.topLeft ┌────────────────────�
     { "eventId": "speed.set.3", "control": "btn.speed3", "gesture": "click" }
   ],
   "intents": [
-    { "eventId": "speed.set", "intent": "game.setSpeed",
-      "args": { "speed": "$payload.speed" },
-      "playerSource": "seat", "actorSource": "commandSource.primary" }
+    { "event": "speed.set.pause", "intent": "game.setSpeed", "args": { "speed": "0" }, "playerSource": "seat", "actorSource": "commandSource.primary" },
+    { "event": "speed.set.1", "intent": "game.setSpeed", "args": { "speed": "1" }, "playerSource": "seat", "actorSource": "commandSource.primary" },
+    { "event": "speed.set.2", "intent": "game.setSpeed", "args": { "speed": "2" }, "playerSource": "seat", "actorSource": "commandSource.primary" },
+    { "event": "speed.set.3", "intent": "game.setSpeed", "args": { "speed": "3" }, "playerSource": "seat", "actorSource": "commandSource.primary" }
   ]
+  // 装载器 intents 的事件字段名是 event:（非 eventId:）；四挡四独立事件各自映射，args 字面常量定挡位（语义规则 G8）
 }
 ```
 
@@ -123,7 +136,7 @@ screen.topRight 时间条右侧 ┌───────────────
       ▼
 PanelEventBus（声明层校验：eventId/控件/手势/载荷类型四对四）
       ▼
-IntentMap：speed.set → game.setSpeed，args={$payload.speed}
+IntentMap：speed.set.3 → game.setSpeed，args={speed:"3"}（字面常量定挡，语义规则 G8）
       │ 归因：playerSource=seat（座位 2 点的就是座位 2 的）
       ▼
 意图 admission 中间层（预算/合法性裁决——UI 不碰）
@@ -140,13 +153,30 @@ Order(game.setSpeed,3)                拒绝回执(reason)→面板显示
 ### B5 显隐编排
 常驻（同案 A）：装载图 CreatePanel + ShowPanel。暂停菜单打开时可选择 HidePanel（由暂停菜单的图决定，本面板不自理）。
 
-### B6 验收断言
-- 自动化：模拟事件 speed.set{3} → 意图入队且 args 归因正确；置 admission 预算 0 → 意图被拒、`clock.speed` 不变、面板回读不变（拒绝回执显示属 #1015 回执场景，此处只验状态一致）。
-- 30 秒人验：点 3x 游戏加速+按钮高亮；点暂停画面静止。
-- 边界：未声明 payload 字段被塞入 → 事件层校验拒绝；`$payload.speed` 拼错 → 装载期抛（意图 args 校验）。
+### B6 验收（Gherkin）
+
+```gherkin
+Scenario: 点挡加速且高亮回读
+  Given 游戏以 1x 运行且面板可见
+  When 玩家点击【3x】
+  Then game.setSpeed 意图以 args{speed:3} 入队并被 admission 放行
+  And clock.speed 输出变为 3 且【3x】进入高亮态
+
+Scenario: 拒绝时状态不漂移
+  Given admission 预算为 0
+  When 玩家点击【2x】
+  Then 意图被拒、clock.speed 不变、无按钮状态变化
+
+Scenario: 载荷校验 fail-closed
+  Given 事件携带未声明字段
+  When 事件分发
+  Then 事件层拒绝并点名字段
+```
+
+30 秒人验：点 3x 游戏明显加速+高亮；点暂停画面静止。
 
 ### B7 依赖与边界
-依赖：**G3** + **#1015 交互回调**（事件分发→意图→admission 链路本体）。不做：热键绑定（输入系统域，面板只管点击）；变速过渡动画（皮层）。
+依赖：G3、G8（args 常量）、#1015（事件分发→意图→admission 链路本体）。不做：热键绑定（输入系统域，面板只管点击）；变速过渡动画（皮层）。
 
 ---
 
@@ -206,13 +236,31 @@ Order(game.setSpeed,3)                拒绝回执(reason)→面板显示
 - 开：⚙ 入口的事件 `sub.open{sub:settings}` 走图（TriggerGraph 监听 UI 事件）调 `ShowPanel("panel.settings")` + 输入焦点捕获。
 - 关：`settings.close` 事件被同一张图消费 → `HidePanel` + 释放焦点。**纯 UI 事件不经意图层**——无 order 副作用的关闭动作在编排层终结。
 
-### C6 验收断言
-- 自动化：声明校验（gesture=change 合法手势表内）；显隐图驱动 Show/Hide 后激活商店真值正确；连续事件合流后仅一条 setVolume 意图入队。
-- 30 秒人验：⚙ 开浮层→拖滑条声音变→✕ 关闭恢复操作。
-- 边界：`actorSource: "none"` 合法性（无实体归因的设置类意图）；modal 锚点未实现时（G5 未落地）本面板配置装载即拒——不静默降级为角落面板。
+### C6 验收（Gherkin）
+
+```gherkin
+Scenario: 模态开合由图编排
+  Given panel.settings 已创建且未显示
+  When ⚙ 入口事件出现（G10 接线后）
+  Then 编排图调 ShowPanel 且输入焦点被浮层捕获
+  When 玩家点击【✕】
+  Then 编排图调 HidePanel 且焦点释放
+
+Scenario: 连续意图合流
+  Given 浮层打开且音量滑条存在
+  When 玩家连续拖动产生 10 个 change 事件
+  Then 仅一条 settings.setVolume 意图携带末值入队
+
+Scenario: 模态锚点未落地即拒
+  Given G5 未实现且配置使用 modal.center
+  When 装载
+  Then 装载失败，不静默降级为角落面板
+```
+
+30 秒人验：⚙ 开浮层→拖滑条声音变→✕ 关闭恢复。
 
 ### C7 依赖与边界
-依赖：**G5 模态锚点+焦点语义**（#840 前置小片）、**#1015**（change 手势+连续合流）。不做：热键 Esc 关闭（输入域）；设置持久化（存档域，仅回读已存值）。
+依赖：G5（模态锚点，#840 前置）、G8（change 手势+载荷值）、G9（actorSource none）、G10（开/关编排接线）、#1015。不做：热键 Esc 关闭（输入域）；设置持久化（存档域，仅回读已存值）。
 
 ---
 
@@ -265,13 +313,24 @@ screen.bottomCenter ┌───────────────────
 ### D5 显隐编排
 常驻。特殊编排需求：**指挥模式互斥**——当玩家进入其他命令模式（如建筑放置）时，指挥图调 `HidePanel`；退出模式恢复 Show。仍由图驱动，面板不自理。
 
-### D6 验收断言
-- 自动化：G6 落地后本配置装载通过；四事件各自意图入队断言；`args:{}` 无参意图合法。
-- 30 秒人验：选兵→点集结→光标变指定态；点全选→全军亮。
-- 边界：`variables: []` 在 G6 落地前装载即抛并提示"纯命令面板需 G6"——不静默塞假变量。
+### D6 验收（Gherkin）
+
+```gherkin
+Scenario: 零变量命令面板装载（G6 后）
+  Given G6 已放开零变量约束
+  When 装载本模板
+  Then 装载通过且无假变量被塞入
+
+Scenario: 命令直达意图
+  Given 玩家已框选一队兵
+  When 玩家点击【集结】
+  Then army.setRally 意图入队，光标进入指定目标模式
+```
+
+30 秒人验：选兵→点集结→光标变指定态；点全选→全军亮。边界：G6 落地前 `variables: []` 装载即抛并提示"纯命令面板需 G6"。
 
 ### D7 依赖与边界
-依赖：**G6**（零变量放开，小改）、**#1015**、**G3**。不做：按钮冷却是皮层自由实现（读 admission 状态），模板不承诺。
+依赖：G6（零变量）、G9、G10（互斥编排）、#1015、G3。不做：按钮冷却是皮层自由实现（读 admission 状态），模板不承诺。
 
 ---
 

--- a/gitbook/architecture/panel-case-designs.md
+++ b/gitbook/architecture/panel-case-designs.md
@@ -70,7 +70,8 @@ Scenario: 资源条随经济同帧刷新
   Given Full-HUD 验收场启动
   And panel.player.aggregate 可见
   When 玩家花费 200 金生产一队兵
-  Then gold 变量减少 200 且 popUsed 增加
+  Then gold 变量减少 200
+  And popUsed 增加
   And 与图输出 economy.gold 同帧
 
 Scenario: 溯源失败即拒

--- a/gitbook/architecture/panel-case-designs.md
+++ b/gitbook/architecture/panel-case-designs.md
@@ -2,11 +2,15 @@
 
 本页是 [面板目录设计](panel-catalog-designs.md) 的第一批**全设计案**：从分组一挑选四个最典型 case（覆盖纯展示、交互全链、模态浮层、零变量命令四种形态，踩中 G3/G5/G6 全部缺口），每案含：玩家旅程、完整配置、线框、数据流、事件-意图链、显隐编排、验收断言、依赖与边界。本批同时作为后续 31 类的设计范式模板。
 
+**状态分级契约（审稿产物）**：每案头部标装载状态——🟢 今日可装载（过 PanelTemplateLoader 即真）/ 🔴 目标态（依赖缺口，**今日装载会被拒**，是验收目标不是可抄配置）。判断依据只有一条：拿配置去碰 `PanelTemplateLoader` 的字段白名单与校验规则。目标态被拒的原因在案内逐条点名（哪个字段、哪条校验），缺口编号进 §1.5。
+
 **通用约定**（不再每案重复）：实例参数四级链（op > 模板 > game.json > default）；皮与主题正交（`panelSkin` × `panelTheme`），本页线框均为内容语义，视觉由主题决定；所有 JSON fail-closed——未知字段/未知读嘴/未知事件手势装载期即抛。
 
 ---
 
 ## 案 A：玩家信息聚合 `panel.player.aggregate` —— 纯展示 · global scope · 活状态中转
+
+> 🔴 **目标态**：`scope` 字段今日不在装载器白名单（G3）。落地前本配置装载即拒——拒因：unknown field 'scope'。
 
 ### A1 玩家旅程
 开局即见顶栏左角资源条；造一队兵花掉 200 金——金币数字掉、人口 8→10；再花光时人口变红提示超限。全程零交互，纯被动读取。
@@ -71,6 +75,8 @@ screen.topLeft ┌────────────────────�
 
 ## 案 B：时间控制 `panel.time.control` —— 交互全链 · 事件/意图/回读闭环
 
+> 🔴 **目标态**：拒因=① `scope`（G3）② intents 字段名用 `event:` 非 `eventId:`（本文已按真实 loader 修正）③ args 常量语义（{"speed":"3"}）未定义——引用 `$payload.x` 与字面常量的区分规则属 G8；④ 手势载荷值来源（按钮怎么把自己的挡位塞进事件）同属 G8。
+
 ### B1 玩家旅程
 游戏进行中，玩家点【3x】→ 游戏明显加速，【3x】按钮进入高亮态；再点【⏸】→ 游戏停，暂停键高亮。全程面板不知道"游戏速度"是什么——它只发事件、收回读。
 
@@ -87,11 +93,11 @@ screen.topLeft ┌────────────────────�
   "binds": [
     { "control": "lbl.speed", "variable": "speed" }               // 高亮态由皮按 speed 值决定
   ],
-  "events": [                                                     // 四挡合一事件，载荷区分
-    { "eventId": "speed.set", "control": "btn.pause", "gesture": "click", "payload": { "speed": "Int" } },
-    { "eventId": "speed.set", "control": "btn.speed1", "gesture": "click", "payload": { "speed": "Int" } },
-    { "eventId": "speed.set", "control": "btn.speed2", "gesture": "click", "payload": { "speed": "Int" } },
-    { "eventId": "speed.set", "control": "btn.speed3", "gesture": "click", "payload": { "speed": "Int" } }
+  "events": [                                                     // 四挡四事件（装载器拒重复 eventId）
+    { "eventId": "speed.set.pause", "control": "btn.pause", "gesture": "click" },
+    { "eventId": "speed.set.1", "control": "btn.speed1", "gesture": "click" },
+    { "eventId": "speed.set.2", "control": "btn.speed2", "gesture": "click" },
+    { "eventId": "speed.set.3", "control": "btn.speed3", "gesture": "click" }
   ],
   "intents": [
     { "eventId": "speed.set", "intent": "game.setSpeed",
@@ -112,7 +118,7 @@ screen.topRight 时间条右侧 ┌───────────────
 ### B4 事件-意图链（UI 永不直构 Order）
 
 ```text
-点击 btn.speed3 ──gesture:click──> 事件 speed.set {speed:3}
+点击 btn.speed3 ──gesture:click──> 事件 speed.set.3（挡位经 intent args 常量携带，G8）
       │（皮侧只声明，不实现）
       ▼
 PanelEventBus（声明层校验：eventId/控件/手势/载荷类型四对四）
@@ -146,6 +152,8 @@ Order(game.setSpeed,3)                拒绝回执(reason)→面板显示
 
 ## 案 C：设置 `panel.settings` —— 模态浮层 · 连续手势 · 全局副作用
 
+> 🔴 **目标态**：拒因=① `scope`（G3）② `actorSource:"none"` 值域（G9，解析器现拒）③ `gesture:"change"` 连续手势不在现有手势表（G8）④ C5 的"图消费 UI 事件→调 ShowPanel"整条接线不存在——触发器事件词典无 UI 域（G10，本页初稿"#1014 现有"系高估，审稿纠正）；⑤ modal.center 锚点（G5）。
+
 ### C1 玩家旅程
 玩家点右上角常驻【⚙】→ 模态浮层弹出（其余输入挂起）；拖音量滑条 → 音量实时变化；点【✕】或浮层外 → 关闭，输入恢复。点【退出到主菜单】→ 二次确认后退出。
 
@@ -169,10 +177,10 @@ Order(game.setSpeed,3)                拒绝回执(reason)→面板显示
     { "eventId": "settings.close", "control": "btn.close", "gesture": "click" }
   ],
   "intents": [
-    { "eventId": "settings.volume", "intent": "settings.setVolume",
+    { "event": "settings.volume", "intent": "settings.setVolume",
       "args": { "value": "$payload.value" }, "playerSource": "seat", "actorSource": "none" },
-    { "eventId": "settings.exit", "intent": "game.exitToMenu",
-      "args": {}, "playerSource": "seat", "actorSource": "none" }
+    { "event": "settings.exit", "intent": "game.exitToMenu",
+      "args": {}, "playerSource": "seat", "actorSource": "none" }  // actorSource none → G9
     // settings.close 无意图——纯 UI 事件，显隐编排层消费（见 C5）
   ]
 }
@@ -210,6 +218,8 @@ Order(game.setSpeed,3)                拒绝回执(reason)→面板显示
 
 ## 案 D：全局指令 `panel.command.global` —— 零变量纯命令 · G6 缺口样板
 
+> 🔴 **目标态**：拒因=① `scope`（G3）② `variables:[]`（G6）③ `actorSource:"none"`（G9）。D5 的模式互斥编排同样依赖 G10。
+
 ### D1 玩家旅程
 玩家框选一队兵后点底栏【集结】→ 进入指定目标模式，光标变化；点【全选】→ 场上己方作战单位全亮。按钮按下即命令，面板自身无任何状态显示。
 
@@ -228,13 +238,13 @@ Order(game.setSpeed,3)                拒绝回执(reason)→面板显示
     { "eventId": "army.retreat", "control": "btn.retreat", "gesture": "click" }
   ],
   "intents": [
-    { "eventId": "army.selectAll", "intent": "selection.allArmy", "args": {},
+    { "event": "army.selectAll", "intent": "selection.allArmy", "args": {},
       "playerSource": "seat", "actorSource": "commandSource.primary" },
-    { "eventId": "army.rally", "intent": "army.setRally", "args": {},
+    { "event": "army.rally", "intent": "army.setRally", "args": {},
       "playerSource": "seat", "actorSource": "commandSource.primary" },
-    { "eventId": "army.stop", "intent": "army.stopAll", "args": {},
+    { "event": "army.stop", "intent": "army.stopAll", "args": {},
       "playerSource": "seat", "actorSource": "commandSource.primary" },
-    { "eventId": "army.retreat", "intent": "army.retreat", "args": {},
+    { "event": "army.retreat", "intent": "army.retreat", "args": {},
       "playerSource": "seat", "actorSource": "commandSource.primary" }
   ]
 }
@@ -274,4 +284,7 @@ screen.bottomCenter ┌───────────────────
 | events/intents | 无 | click+载荷 | **change 连续+合流** | click 无载荷 |
 | 显隐 | 常驻 | 常驻 | **模态编排（开/关图）** | 互斥编排 |
 | 锚点 | topLeft | topRight | **modal.center（G5）** | bottomCenter |
+| 手势载荷/args 常量（G8） | — | ✅ | ✅(change) | — |
+| actorSource none（G9） | — | — | ✅ | ✅ |
+| 图消费 UI 事件（G10） | — | — | ✅(开/关编排) | ✅(互斥编排) |
 | 溯源形态 | 图聚合输出 | 图输出回读闭环 | 图输出+连续意图 | 纯意图 |

--- a/gitbook/architecture/panel-case-designs.md
+++ b/gitbook/architecture/panel-case-designs.md
@@ -1,0 +1,277 @@
+# 面板典型案例全设计——四个样板间的完整设计案
+
+本页是 [面板目录设计](panel-catalog-designs.md) 的第一批**全设计案**：从分组一挑选四个最典型 case（覆盖纯展示、交互全链、模态浮层、零变量命令四种形态，踩中 G3/G5/G6 全部缺口），每案含：玩家旅程、完整配置、线框、数据流、事件-意图链、显隐编排、验收断言、依赖与边界。本批同时作为后续 31 类的设计范式模板。
+
+**通用约定**（不再每案重复）：实例参数四级链（op > 模板 > game.json > default）；皮与主题正交（`panelSkin` × `panelTheme`），本页线框均为内容语义，视觉由主题决定；所有 JSON fail-closed——未知字段/未知读嘴/未知事件手势装载期即抛。
+
+---
+
+## 案 A：玩家信息聚合 `panel.player.aggregate` —— 纯展示 · global scope · 活状态中转
+
+### A1 玩家旅程
+开局即见顶栏左角资源条；造一队兵花掉 200 金——金币数字掉、人口 8→10；再花光时人口变红提示超限。全程零交互，纯被动读取。
+
+### A2 完整配置
+
+```jsonc
+{
+  "id": "panel.player.aggregate",
+  "scope": "global",                          // G3：无 scope 实体，地图级唯一实例
+  "variables": [
+    { "name": "gold", "kind": "Int", "realtime": true,
+      "source": { "sourceKind": "GraphOutput", "graphOutputKey": "economy.gold" } },
+    { "name": "popUsed", "kind": "Int", "realtime": true,
+      "source": { "sourceKind": "GraphOutput", "graphOutputKey": "pop.used" } },
+    { "name": "popCap", "kind": "Int", "realtime": true,
+      "source": { "sourceKind": "GraphOutput", "graphOutputKey": "pop.cap" } }
+  ],
+  "binds": [
+    { "control": "lbl.gold", "variable": "gold" },
+    { "control": "lbl.popUsed", "variable": "popUsed" },
+    { "control": "lbl.popCap", "variable": "popCap" }
+  ]
+  // 无 events / 无 intents —— 纯展示面板零交互面
+}
+```
+
+### A3 线框
+
+```text
+screen.topLeft ┌──────────────────────────────┐  panelZOrder 100（常驻最底）
+               │ ⛁ 1,240     👥 8/20          │  超 popCap 时皮层把 👥 行标红
+               └──────────────────────────────┘  （皮读双变量自行比较，模板不做逻辑）
+```
+
+### A4 数据流（溯源到图）
+
+```text
+经济系统(实体属性) ──┐
+人口系统(集合计数) ──┼→ Graph.Economy.Aggregate（Derived 图，心跳拍重算）
+地图变量(储备)    ──┘        │ graphOutputKey: economy.gold / pop.used / pop.cap
+                             ▼
+                 PanelProjectionReader(GraphOutput 读嘴, realtime 帧扫)
+                             ▼
+                 PanelVariableSet{gold,popUsed,popCap} ──binds──> 控件 lbl.*
+```
+
+要点：面板**不直读**地图变量/实体——一切活状态经图输出中转（完成核"数字溯源到图"）；图心跳拍重算，面板帧扫取值，两级节流天然存在。
+
+### A5 显隐编排
+常驻面板：地图装载图（TriggerGraph）`CreatePanel(panelAnchor: "screen.topLeft")` 后**不调** `ShowPanel` 之外的任何显隐逻辑——开局默认隐藏由激活商店语义决定（`IsVisible` 缺省 false），装载图随即 `ShowPanel("panel.player.aggregate")` 常亮。整局无再隐需求。
+
+### A6 验收断言
+- 自动化（headless）：装载地图 → 实例 1 个、变量初值正确；驱动经济图输出变化 → 面板变量同帧跟随（现有 PanelFireball 断言模式复用）。
+- 30 秒人验：`preset:panel_fullhud` 打开即见资源条；按 U 造兵 → 金掉/人口涨可见。
+- 边界（fail-closed）：`graphOutputKey` 写错 → 装载期抛错点名 key；缺图（Graph.Economy.Aggregate 未注册）→ 同上，无 0 兜底。
+
+### A7 依赖与边界
+依赖：**G3**（scope=global 实例语义，#1012 主战场）。明确不做：货币动画/溢出滚动（皮层自由实现，模板不承诺）；不读敌方经济（图输出仅己方 scope）。
+
+---
+
+## 案 B：时间控制 `panel.time.control` —— 交互全链 · 事件/意图/回读闭环
+
+### B1 玩家旅程
+游戏进行中，玩家点【3x】→ 游戏明显加速，【3x】按钮进入高亮态；再点【⏸】→ 游戏停，暂停键高亮。全程面板不知道"游戏速度"是什么——它只发事件、收回读。
+
+### B2 完整配置
+
+```jsonc
+{
+  "id": "panel.time.control",
+  "scope": "global",
+  "variables": [
+    { "name": "speed", "kind": "Int", "realtime": true,          // 回读：当前速度挡
+      "source": { "sourceKind": "GraphOutput", "graphOutputKey": "clock.speed" } }
+  ],
+  "binds": [
+    { "control": "lbl.speed", "variable": "speed" }               // 高亮态由皮按 speed 值决定
+  ],
+  "events": [                                                     // 四挡合一事件，载荷区分
+    { "eventId": "speed.set", "control": "btn.pause", "gesture": "click", "payload": { "speed": "Int" } },
+    { "eventId": "speed.set", "control": "btn.speed1", "gesture": "click", "payload": { "speed": "Int" } },
+    { "eventId": "speed.set", "control": "btn.speed2", "gesture": "click", "payload": { "speed": "Int" } },
+    { "eventId": "speed.set", "control": "btn.speed3", "gesture": "click", "payload": { "speed": "Int" } }
+  ],
+  "intents": [
+    { "eventId": "speed.set", "intent": "game.setSpeed",
+      "args": { "speed": "$payload.speed" },
+      "playerSource": "seat", "actorSource": "commandSource.primary" }
+  ]
+}
+```
+
+### B3 线框
+
+```text
+screen.topRight 时间条右侧 ┌───────────────────┐
+                           │ 【⏸】【1x】【2x】【3x】│  speed=0..3，皮层高亮 bind 到 lbl.speed
+                           └───────────────────┘
+```
+
+### B4 事件-意图链（UI 永不直构 Order）
+
+```text
+点击 btn.speed3 ──gesture:click──> 事件 speed.set {speed:3}
+      │（皮侧只声明，不实现）
+      ▼
+PanelEventBus（声明层校验：eventId/控件/手势/载荷类型四对四）
+      ▼
+IntentMap：speed.set → game.setSpeed，args={$payload.speed}
+      │ 归因：playerSource=seat（座位 2 点的就是座位 2 的）
+      ▼
+意图 admission 中间层（预算/合法性裁决——UI 不碰）
+      ▼ 通过                              ▼ 拒绝
+Order(game.setSpeed,3)                拒绝回执(reason)→面板显示
+      ▼
+时钟系统执行 → GraphOutput clock.speed=3
+      ▼
+面板 realtime 回读 → 【3x】高亮
+```
+
+要点：**回读闭环**——高亮不是点击直接置位，而是意图落地后经 `clock.speed` 图输出回流。暂停键点两下、网络延迟、admission 拒绝，面板状态永远与游戏真值一致。
+
+### B5 显隐编排
+常驻（同案 A）：装载图 CreatePanel + ShowPanel。暂停菜单打开时可选择 HidePanel（由暂停菜单的图决定，本面板不自理）。
+
+### B6 验收断言
+- 自动化：模拟事件 speed.set{3} → 意图入队且 args 归因正确；置 admission 预算 0 → 意图被拒、`clock.speed` 不变、面板回读不变（拒绝回执显示属 #1015 回执场景，此处只验状态一致）。
+- 30 秒人验：点 3x 游戏加速+按钮高亮；点暂停画面静止。
+- 边界：未声明 payload 字段被塞入 → 事件层校验拒绝；`$payload.speed` 拼错 → 装载期抛（意图 args 校验）。
+
+### B7 依赖与边界
+依赖：**G3** + **#1015 交互回调**（事件分发→意图→admission 链路本体）。不做：热键绑定（输入系统域，面板只管点击）；变速过渡动画（皮层）。
+
+---
+
+## 案 C：设置 `panel.settings` —— 模态浮层 · 连续手势 · 全局副作用
+
+### C1 玩家旅程
+玩家点右上角常驻【⚙】→ 模态浮层弹出（其余输入挂起）；拖音量滑条 → 音量实时变化；点【✕】或浮层外 → 关闭，输入恢复。点【退出到主菜单】→ 二次确认后退出。
+
+### C2 完整配置
+
+```jsonc
+{
+  "id": "panel.settings",
+  "scope": "global",
+  "variables": [
+    { "name": "volume", "kind": "Float", "realtime": true,
+      "source": { "sourceKind": "GraphOutput", "graphOutputKey": "settings.volume" } }
+  ],
+  "binds": [
+    { "control": "slider.volume", "variable": "volume" }          // 滑条位置=volume 回读
+  ],
+  "events": [
+    { "eventId": "settings.volume", "control": "slider.volume", "gesture": "change",
+      "payload": { "value": "Float" } },
+    { "eventId": "settings.exit", "control": "btn.exit", "gesture": "click" },
+    { "eventId": "settings.close", "control": "btn.close", "gesture": "click" }
+  ],
+  "intents": [
+    { "eventId": "settings.volume", "intent": "settings.setVolume",
+      "args": { "value": "$payload.value" }, "playerSource": "seat", "actorSource": "none" },
+    { "eventId": "settings.exit", "intent": "game.exitToMenu",
+      "args": {}, "playerSource": "seat", "actorSource": "none" }
+    // settings.close 无意图——纯 UI 事件，显隐编排层消费（见 C5）
+  ]
+}
+```
+
+### C3 线框
+
+```text
+模态锚点 modal.center（G5）   ┌──────────────────────┐ zOrder 500（浮层最高层）
+                              │ 设置            【✕】 │
+                              │ 音量 ▁▂▃▅▆▇ 【━━●━】 │ ← gesture:change 连续派发
+                              │ 【退出到主菜单】       │
+                              └──────────────────────┘
+   背景输入挂起（模态语义）；【⚙】入口按钮属 subsystem.entries（2.9），非本面板
+```
+
+### C4 数据流与事件链
+- 音量：滑条 change → settings.volume 事件（连续）→ 意图 settings.setVolume → 设置系统落值 → `settings.volume` 图输出 → 面板 realtime 回读（滑条跟随）。与案 B 同构，差别在 gesture=change 高频派发——**意图层须做合流**（admission 对连续意图只取末值，#1015 设计点）。
+- 退出：click → game.exitToMenu 意图（无载荷）→ 确认流程属玩法域。
+
+### C5 显隐编排（本案的灵魂）
+默认隐藏：装载图只 `CreatePanel(panelAnchor: "modal.center")` **不 Show**。
+- 开：⚙ 入口的事件 `sub.open{sub:settings}` 走图（TriggerGraph 监听 UI 事件）调 `ShowPanel("panel.settings")` + 输入焦点捕获。
+- 关：`settings.close` 事件被同一张图消费 → `HidePanel` + 释放焦点。**纯 UI 事件不经意图层**——无 order 副作用的关闭动作在编排层终结。
+
+### C6 验收断言
+- 自动化：声明校验（gesture=change 合法手势表内）；显隐图驱动 Show/Hide 后激活商店真值正确；连续事件合流后仅一条 setVolume 意图入队。
+- 30 秒人验：⚙ 开浮层→拖滑条声音变→✕ 关闭恢复操作。
+- 边界：`actorSource: "none"` 合法性（无实体归因的设置类意图）；modal 锚点未实现时（G5 未落地）本面板配置装载即拒——不静默降级为角落面板。
+
+### C7 依赖与边界
+依赖：**G5 模态锚点+焦点语义**（#840 前置小片）、**#1015**（change 手势+连续合流）。不做：热键 Esc 关闭（输入域）；设置持久化（存档域，仅回读已存值）。
+
+---
+
+## 案 D：全局指令 `panel.command.global` —— 零变量纯命令 · G6 缺口样板
+
+### D1 玩家旅程
+玩家框选一队兵后点底栏【集结】→ 进入指定目标模式，光标变化；点【全选】→ 场上己方作战单位全亮。按钮按下即命令，面板自身无任何状态显示。
+
+### D2 完整配置
+
+```jsonc
+{
+  "id": "panel.command.global",
+  "scope": "global",
+  "variables": [],                        // G6：现行装载器要求 ≥1 变量，纯命令面板需放开为 0
+  "binds": [],
+  "events": [
+    { "eventId": "army.selectAll", "control": "btn.selectAll", "gesture": "click" },
+    { "eventId": "army.rally", "control": "btn.rally", "gesture": "click" },
+    { "eventId": "army.stop", "control": "btn.stop", "gesture": "click" },
+    { "eventId": "army.retreat", "control": "btn.retreat", "gesture": "click" }
+  ],
+  "intents": [
+    { "eventId": "army.selectAll", "intent": "selection.allArmy", "args": {},
+      "playerSource": "seat", "actorSource": "commandSource.primary" },
+    { "eventId": "army.rally", "intent": "army.setRally", "args": {},
+      "playerSource": "seat", "actorSource": "commandSource.primary" },
+    { "eventId": "army.stop", "intent": "army.stopAll", "args": {},
+      "playerSource": "seat", "actorSource": "commandSource.primary" },
+    { "eventId": "army.retreat", "intent": "army.retreat", "args": {},
+      "playerSource": "seat", "actorSource": "commandSource.primary" }
+  ]
+}
+```
+
+### D3 线框
+
+```text
+screen.bottomCenter ┌────────────────────────────────┐
+                    │ 【全选】【集结】【停止】【撤退】 │  无状态显示：按钮永远不高亮
+                    └────────────────────────────────┘  （可用性态=灰，由皮读意图
+                                                          admission 状态渲染，非模板变量）
+```
+
+### D4 事件链
+与案 B 同构（click → 意图 → admission → order）。特点：**四事件零载荷零变量**——载荷/变量/binds 全部缺席，最小事件面板。`args: {}` 合法（无参意图）。
+
+### D5 显隐编排
+常驻。特殊编排需求：**指挥模式互斥**——当玩家进入其他命令模式（如建筑放置）时，指挥图调 `HidePanel`；退出模式恢复 Show。仍由图驱动，面板不自理。
+
+### D6 验收断言
+- 自动化：G6 落地后本配置装载通过；四事件各自意图入队断言；`args:{}` 无参意图合法。
+- 30 秒人验：选兵→点集结→光标变指定态；点全选→全军亮。
+- 边界：`variables: []` 在 G6 落地前装载即抛并提示"纯命令面板需 G6"——不静默塞假变量。
+
+### D7 依赖与边界
+依赖：**G6**（零变量放开，小改）、**#1015**、**G3**。不做：按钮冷却是皮层自由实现（读 admission 状态），模板不承诺。
+
+---
+
+## 四案覆盖矩阵
+
+| 维度 | A 聚合 | B 时间控制 | C 设置 | D 全局指令 |
+|---|---|---|---|---|
+| scope=global (G3) | ✅ | ✅ | ✅ | ✅ |
+| 变量/binds | 有+realtime | 有（回读） | 有（回读） | **无（G6）** |
+| events/intents | 无 | click+载荷 | **change 连续+合流** | click 无载荷 |
+| 显隐 | 常驻 | 常驻 | **模态编排（开/关图）** | 互斥编排 |
+| 锚点 | topLeft | topRight | **modal.center（G5）** | bottomCenter |
+| 溯源形态 | 图聚合输出 | 图输出回读闭环 | 图输出+连续意图 | 纯意图 |

--- a/gitbook/architecture/panel-case-designs.md
+++ b/gitbook/architecture/panel-case-designs.md
@@ -67,9 +67,11 @@ screen.topLeft ┌────────────────────�
 
 ```gherkin
 Scenario: 资源条随经济同帧刷新
-  Given Full-HUD 验收场启动且 panel.player.aggregate 可见
+  Given Full-HUD 验收场启动
+  And panel.player.aggregate 可见
   When 玩家花费 200 金生产一队兵
-  Then gold 变量减少 200 且 popUsed 增加，与图输出 economy.gold 同帧
+  Then gold 变量减少 200 且 popUsed 增加
+  And 与图输出 economy.gold 同帧
 
 Scenario: 溯源失败即拒
   Given 模板引用未注册的 graphOutputKey
@@ -157,15 +159,19 @@ Order(game.setSpeed,3)                拒绝回执(reason)→面板显示
 
 ```gherkin
 Scenario: 点挡加速且高亮回读
-  Given 游戏以 1x 运行且面板可见
+  Given 游戏以 1x 运行
+  And 面板可见
   When 玩家点击【3x】
   Then game.setSpeed 意图以 args{speed:3} 入队并被 admission 放行
-  And clock.speed 输出变为 3 且【3x】进入高亮态
+  And clock.speed 输出变为 3
+  And 【3x】进入高亮态
 
 Scenario: 拒绝时状态不漂移
   Given admission 预算为 0
   When 玩家点击【2x】
-  Then 意图被拒、clock.speed 不变、无按钮状态变化
+  Then 意图被拒
+  And clock.speed 不变
+  And 无按钮状态变化
 
 Scenario: 载荷校验 fail-closed
   Given 事件携带未声明字段
@@ -240,19 +246,24 @@ Scenario: 载荷校验 fail-closed
 
 ```gherkin
 Scenario: 模态开合由图编排
-  Given panel.settings 已创建且未显示
+  Given panel.settings 已创建
+  And 未显示
   When ⚙ 入口事件出现（G10 接线后）
-  Then 编排图调 ShowPanel 且输入焦点被浮层捕获
+  Then 编排图调 ShowPanel
+  And 输入焦点被浮层捕获
   When 玩家点击【✕】
-  Then 编排图调 HidePanel 且焦点释放
+  Then 编排图调 HidePanel
+  And 焦点释放
 
 Scenario: 连续意图合流
-  Given 浮层打开且音量滑条存在
+  Given 浮层打开
+  And 音量滑条存在
   When 玩家连续拖动产生 10 个 change 事件
   Then 仅一条 settings.setVolume 意图携带末值入队
 
 Scenario: 模态锚点未落地即拒
-  Given G5 未实现且配置使用 modal.center
+  Given G5 未实现
+  And 配置使用 modal.center
   When 装载
   Then 装载失败，不静默降级为角落面板
 ```
@@ -319,7 +330,8 @@ screen.bottomCenter ┌───────────────────
 Scenario: 零变量命令面板装载（G6 后）
   Given G6 已放开零变量约束
   When 装载本模板
-  Then 装载通过且无假变量被塞入
+  Then 装载通过
+  And 无假变量被塞入
 
 Scenario: 命令直达意图
   Given 玩家已框选一队兵

--- a/gitbook/architecture/panel-catalog-designs.md
+++ b/gitbook/architecture/panel-catalog-designs.md
@@ -26,10 +26,10 @@
 {
   "id": "panel.<域>.<名>",            // 顶点前缀 panel.，点分命名空间
   "skin": "markup",                    // 可选：本模板默认皮（实例 op 可覆盖）
-  "scope": "item",                     // item | collection | global —— 行为侧（§1.4）
+  // scope 不是今日 schema 字段（行为侧设计见 §1.4）——出现即被白名单拒绝
   "variables": [                       // 至少一条；kind 目前 Float|Int（缺口 G1: Bool|String）
     { "name": "gold", "kind": "Int", "realtime": true,
-      "source": {                      // 五路读嘴，fail-closed：
+      "source": {                      // 六路读嘴（真实枚举名），fail-closed：
         "sourceKind": "TableLookup",   //   六路读嘴（真实枚举名，fail-closed）：
                                        //   SingleAttribute / DerivedAttribute / AggregateProjection /
                                        //   GraphOutput / TableLookup / AttributeBase
@@ -61,7 +61,7 @@
 | TableLookup | ❌ | 查的是启动装载的静态表，结果不动；key 动态换行属例外，走显式 Refresh，不帧扫 |
 | DerivedAttribute | 随派生源 | 派生图绑定写入 AttributeBuffer |
 
-配套建模纪律：**活游戏状态（gold/人口/时钟）一律 GraphOutput 中转**——查表只放静态数据（税率/周期/文案表）。这同时满足完成核"数字溯源到图"。地图变量（MapVariableStore）不在五路读嘴内：全局状态经图输出中转是刻意设计；若实践中"每项全局状态开一张图"爆炸，再议第六读嘴（G7 候选，暂不立项）。
+配套建模纪律：**活游戏状态（gold/人口/时钟）一律 GraphOutput 中转**——查表只放静态数据（税率/周期/文案表）。这同时满足完成核"数字溯源到图"。地图变量（MapVariableStore）不在六路读嘴内：全局状态经图输出中转是刻意设计；若实践中"每项全局状态开一张图"爆炸，再议第七路读嘴（G7 候选，暂不立项）。
 
 ### 1.3 实例参数（四级链，已落地）
 
@@ -97,29 +97,18 @@
 
 ## 二、分组一：全局 HUD（9 类）
 
+> **单一配置源纪律**：本目录只留索引（id/线框/30 秒预期/依赖）；完整配置只住在案例页，分组内各类立案时逐案迁入。今日已立案四件（2.1/2.4/2.5/2.8 → 案 A/B/D/C）。
+
 约定：线框用锚点+尺寸语义描述；`【】`标交互控件（事件源）。
 
-### 2.1 玩家信息聚合 `panel.player.aggregate`
-
-```jsonc
-{ "id": "panel.player.aggregate", "scope": "global",
-  "variables": [
-    { "name": "gold", "kind": "Int", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "economy.gold" } },
-    { "name": "popUsed", "kind": "Int", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "pop.used" } },
-    { "name": "popCap", "kind": "Int", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "pop.cap" } } ],
-  "binds": [ { "control": "lbl.gold", "variable": "gold" }, { "control": "lbl.pop", "variable": "popUsed" } ] }
-// 注：gold/pop 是活状态 → GraphOutput 中转（§1.2.1 纪律）；economy 查表放静态（如
-// 每级人口上限 popCapByLevel），面板侧不标 realtime。初稿曾把活状态建模成查表+
-// realtime——用户审稿揪出的反例，规则因此入合同。
-```
+### 2.1 玩家信息聚合 `panel.player.aggregate` —— 配置唯一源：[全设计案 A](panel-case-designs.md)
 
 ```text
 screen.topLeft ┌────────────────────────────┐
                │ ⛁ 1,240   👥 8/20   ⚡ 65 │
                └────────────────────────────┘
 ```
-30 秒预期：顶栏左角资源条；花 200 金造兵 → 金数字掉、人口 +1，同帧刷新。
-依赖：G3（global scope）。现有读嘴即可，G1/G2 不需要。
+30 秒预期：花 200 金造兵 → 金掉、人口 +1 同帧。依赖 G3。
 
 ### 2.2 时间流逝 `panel.time.elapsed`
 
@@ -156,48 +145,23 @@ screen.topRight 区、信息聚合左侧 ┌──────────┐
 30 秒预期：过夜后日期 +1，季节图标换。
 依赖：G3；TableLookup 周期表（现有读嘴）。
 
-### 2.4 时间控制 `panel.time.control`
-
-```jsonc
-{ "id": "panel.time.control", "scope": "global",
-  "variables": [
-    { "name": "speed", "kind": "Int", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "clock.speed" } } ],
-  "binds": [ { "control": "lbl.speed", "variable": "speed" } ],
-  "events": [
-    { "eventId": "speed.set", "control": "btn.speed", "gesture": "click", "payload": { "speed": "Int" } } ],
-  "intents": [
-    { "eventId": "speed.set", "intent": "game.setSpeed",
-      "args": { "speed": "$payload.speed" }, "playerSource": "seat", "actorSource": "commandSource.primary" } ] }
-```
+### 2.4 时间控制 `panel.time.control` —— 配置唯一源：[全设计案 B](panel-case-designs.md)
 
 ```text
 时间条右侧 ┌───────────────────┐
-           │ 【⏸】【1x】【2x】【3x】│   ← 点击切挡，当前挡高亮（speed 变量回读）
+           │ 【⏸】【1x】【2x】【3x】│
            └───────────────────┘
 ```
-30 秒预期：点 3x 游戏明显加速，按钮高亮跟随。
-依赖：G3 + **#1015 交互回调**（事件/意图声明已落地，回调链路待建）。
+30 秒预期：点 3x 加速+高亮回读。依赖 G3/G8/#1015。
 
-### 2.5 全局指令 `panel.command.global`
+### 2.5 全局指令 `panel.command.global` —— 配置唯一源：[全设计案 D](panel-case-designs.md)
 
-```jsonc
-{ "id": "panel.command.global", "scope": "global",
-  "variables": [],
-  "events": [
-    { "eventId": "army.selectAll", "control": "btn.selectAll", "gesture": "click" },
-    { "eventId": "army.rally", "control": "btn.rally", "gesture": "click" } ],
-  "intents": [
-    { "eventId": "army.selectAll", "intent": "selection.all", "args": {}, "playerSource": "seat", "actorSource": "commandSource.primary" },
-    { "eventId": "army.rally", "intent": "army.setRally", "args": {}, "playerSource": "seat", "actorSource": "commandSource.primary" } ] }
-```
-注：variables 至少一条的现行约束（模板骨架）对纯命令面板需放开为 0 条（记 **G6**）。
 ```text
 底栏中央 ┌──────────────────────────────┐
          │ 【全选】【集结】【停止】【撤退】 │
          └──────────────────────────────┘
 ```
-30 秒预期：点全选 → 场上己方单位全亮；点集结 → 进入指定目标状态。
-依赖：G6 + #1015。
+30 秒预期：选兵点集结→光标变指定态。依赖 G3/G6/G9/G10/#1015。
 
 ### 2.6 全局功能 tab `panel.tabs.global`
 
@@ -238,30 +202,9 @@ screen.topCenter ┌────────────────────
 30 秒预期：敌军进区 → 横幅弹出红字；威胁解除 → 消失。
 依赖：G3；G1（String 变量）让文案直读，否则查表 id。显隐图 op 现有。
 
-### 2.8 设置 `panel.settings`
+### 2.8 设置 `panel.settings` —— 配置唯一源：[全设计案 C](panel-case-designs.md)
 
-```jsonc
-{ "id": "panel.settings", "scope": "global",
-  "variables": [
-    { "name": "volume", "kind": "Float", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "settings.volume" } } ],
-  "events": [
-    { "eventId": "settings.volume", "control": "slider.volume", "gesture": "change", "payload": { "value": "Float" } },
-    { "eventId": "settings.exit", "control": "btn.exit", "gesture": "click" } ],
-  "intents": [
-    { "eventId": "settings.volume", "intent": "settings.setVolume", "args": { "value": "$payload.value" }, "playerSource": "seat", "actorSource": "none" },
-    { "eventId": "settings.exit", "intent": "game.exitToMenu", "args": {}, "playerSource": "seat", "actorSource": "none" } ] }
-```
-
-```text
-模态浮层（G5 锚点） ┌──────────────────────┐
-                    │ 设置            【✕】 │
-                    │ 音量 ▁▁▂▃▅▆▇ 【滑条】│
-                    │ 【退出到主菜单】       │
-                    └──────────────────────┘
-                     入口齿轮常驻右上；点开模态，其余输入挂起
-```
-30 秒预期：齿轮点开浮层拖音量即生效；点外部或 ✕ 关闭。
-依赖：G5（模态锚点）+ #1015（gesture=change 的滑条输入）。
+模态浮层（⚙ 入口，音量滑条+退出）。30 秒预期：开浮层拖滑条声音变、✕ 关闭。依赖 G5/G8/G9/G10/#1015。
 
 ### 2.9 子系统入口 `panel.subsystem.entries`
 

--- a/gitbook/architecture/panel-catalog-designs.md
+++ b/gitbook/architecture/panel-catalog-designs.md
@@ -1,0 +1,274 @@
+# 面板目录设计——配置形状总合同与分组线框
+
+本页是 PANEL-6（#841 目录即数据）与 PANEL-7（#840 验收场）的**前置设计 SSOT**：先给全部面板类型定死配置形状与线框，再逐组登记、逐组过核。每组过完即锁组；本页产物直接成为 #841 的种子行与 #840 的对照物。
+
+## 用法
+
+1. 每个面板类型 = **一条目录行 + 一份配置草案 + 一张线框 + 一句 30 秒预期**；
+2. 设计发现的基建缺口回填对应子单（票号写在依赖栏），不在本页开实现；
+3. 归类修正（某行其实不是框、是机制或全屏效果）发生在本页，目录行数允许微调。
+
+## 一、共同骨架（总合同）
+
+### 1.1 一个面板类型的全部组成
+
+```text
+面板类型 = assets/Panels/panel_templates.json 里的一个条目（下述模板骨架）
+         + PanelThemes 目录（#841）里的一行（登记与完成核字段）
+         + 本页的一条线框与 30 秒预期
+实例参数 = 图 op（CreatePanel: panelType/panelAnchor/panelSkin/panelZOrder）
+         > 模板 skin 字段 > game.json panelSkin/panelTheme > default
+```
+
+### 1.2 模板骨架（真实 schema 的全字段注释版，非发明）
+
+```jsonc
+{
+  "id": "panel.<域>.<名>",            // 顶点前缀 panel.，点分命名空间
+  "skin": "markup",                    // 可选：本模板默认皮（实例 op 可覆盖）
+  "scope": "item",                     // item | collection | global —— 行为侧（§1.4）
+  "variables": [                       // 至少一条；kind 目前 Float|Int（缺口 G1: Bool|String）
+    { "name": "gold", "kind": "Int", "realtime": true,
+      "source": {                      // 五路读嘴，fail-closed：
+        "sourceKind": "TableLookup",   //   SingleAttribute / AttributeBase / Derived /
+        "lookupTable": "economy",      //   GraphOutput / TableLookup
+        "lookupField": "goldPerTick",
+        "keyAttribute": "TeamId" } } ],
+  "binds": [                           // 控件 ↔ 变量（皮侧按 control id 寻址）
+    { "control": "lbl.gold", "variable": "gold" } ],
+  "events": [                          // 0 编码事件（#1013 已落地）
+    { "eventId": "speed.set", "control": "btn.speed2", "gesture": "click",
+      "payload": { "speed": "Int" } } ],   // 载荷类型已有 String|Int|Float|Bool
+  "intents": [                         // 事件 → 玩法意图（面板永不直构 Order）
+    { "eventId": "speed.set", "intent": "game.setSpeed",
+      "args": { "speed": "$payload.speed" },
+      "playerSource": "seat", "actorSource": "commandSource.primary" } ]
+}
+```
+
+### 1.3 实例参数（四级链，已落地）
+
+`panelAnchor`（screen.topLeft/topRight/bottomLeft/bottomRight）· `panelSkin`（default/markup/compose/reactive/web）· `panelZOrder`（缺省 100）· `panelTheme`（game.json 全局；模板/op 级为缺口 G4）。
+
+### 1.4 行为侧骨架（设计位；#1012 落地）
+
+```jsonc
+"scope": "item"  |  "collection"  |  "global"
+// item:       一物一面（现状：scope=hero 实体）
+// collection: 一集一面——框选集合变化时同一模板切形态，模板 id 不变，
+//             变量读嘴允许集合聚合（缺口 G2: 聚合读嘴 sourceKind，如 AggSum 队列项）
+// global:     全局面板（无 scope 实体；地图变量/查表为源）——缺口 G3: scope=global 的
+//             实例语义（当前 Instantiate 要求 scope 实体）
+```
+
+### 1.5 缺口登记（设计即排期）
+
+| # | 缺口 | 归属 |
+|---|---|---|
+| G1 | 变量 kind 扩展 Bool/String（载荷已有，变量侧缺） | #1010 尾巴 |
+| G2 | 集合聚合读嘴（AggSum/Avg/Count 队列项） | #1012 |
+| G3 | scope=global 实例语义 | #1012 |
+| G4 | panelTheme 模板/op 级覆盖 | #1011 后续 |
+| G5 | 浮层/模态锚点（设置、子系统详情） | #840 前置小片 |
+
+---
+
+## 二、分组一：全局 HUD（9 类）
+
+约定：线框用锚点+尺寸语义描述；`【】`标交互控件（事件源）。
+
+### 2.1 玩家信息聚合 `panel.player.aggregate`
+
+```jsonc
+{ "id": "panel.player.aggregate", "scope": "global",
+  "variables": [
+    { "name": "gold", "kind": "Int", "realtime": true, "source": { "sourceKind": "TableLookup", "lookupTable": "economy", "lookupField": "gold", "keyAttribute": "TeamId" } },
+    { "name": "popUsed", "kind": "Int", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "pop.used" } },
+    { "name": "popCap", "kind": "Int", "source": { "sourceKind": "TableLookup", "lookupTable": "economy", "lookupField": "popCap", "keyAttribute": "TeamId" } } ],
+  "binds": [ { "control": "lbl.gold", "variable": "gold" }, { "control": "lbl.pop", "variable": "popUsed" } ] }
+```
+
+```text
+screen.topLeft ┌────────────────────────────┐
+               │ ⛁ 1,240   👥 8/20   ⚡ 65 │
+               └────────────────────────────┘
+```
+30 秒预期：顶栏左角资源条；花 200 金造兵 → 金数字掉、人口 +1，同帧刷新。
+依赖：G3（global scope）。现有读嘴即可，G1/G2 不需要。
+
+### 2.2 时间流逝 `panel.time.elapsed`
+
+```jsonc
+{ "id": "panel.time.elapsed", "scope": "global",
+  "variables": [
+    { "name": "elapsedMin", "kind": "Float", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "clock.elapsedMin" } },
+    { "name": "dayPhase", "kind": "Int", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "clock.dayPhase" } } ],
+  "binds": [ { "control": "lbl.clock", "variable": "elapsedMin" } ] }
+```
+
+```text
+screen.topRight 区、信息聚合左侧 ┌──────────┐
+                                 │ ☀ 12:34  │   （dayPhase 驱动日夜图标换肤）
+                                 └──────────┘
+```
+30 秒预期：表走字、昼夜图标随 dayPhase 切换。
+依赖：G3；无交互。
+
+### 2.3 日期 `panel.date.cycle`
+
+```jsonc
+{ "id": "panel.date.cycle", "scope": "global",
+  "variables": [
+    { "name": "dayIndex", "kind": "Int", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "clock.dayIndex" } } ],
+  "binds": [ { "control": "lbl.date", "variable": "dayIndex" } ] }
+```
+
+```text
+紧贴时间条右侧 ┌────────────────┐
+               │ 第 3 年 · 春 · 7 │   （年/季由 dayIndex 查表）
+               └────────────────┘
+```
+30 秒预期：过夜后日期 +1，季节图标换。
+依赖：G3；TableLookup 周期表（现有读嘴）。
+
+### 2.4 时间控制 `panel.time.control`
+
+```jsonc
+{ "id": "panel.time.control", "scope": "global",
+  "variables": [
+    { "name": "speed", "kind": "Int", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "clock.speed" } } ],
+  "binds": [ { "control": "lbl.speed", "variable": "speed" } ],
+  "events": [
+    { "eventId": "speed.set", "control": "btn.speed", "gesture": "click", "payload": { "speed": "Int" } } ],
+  "intents": [
+    { "eventId": "speed.set", "intent": "game.setSpeed",
+      "args": { "speed": "$payload.speed" }, "playerSource": "seat", "actorSource": "commandSource.primary" } ] }
+```
+
+```text
+时间条右侧 ┌───────────────────┐
+           │ 【⏸】【1x】【2x】【3x】│   ← 点击切挡，当前挡高亮（speed 变量回读）
+           └───────────────────┘
+```
+30 秒预期：点 3x 游戏明显加速，按钮高亮跟随。
+依赖：G3 + **#1015 交互回调**（事件/意图声明已落地，回调链路待建）。
+
+### 2.5 全局指令 `panel.command.global`
+
+```jsonc
+{ "id": "panel.command.global", "scope": "global",
+  "variables": [],
+  "events": [
+    { "eventId": "army.selectAll", "control": "btn.selectAll", "gesture": "click" },
+    { "eventId": "army.rally", "control": "btn.rally", "gesture": "click" } ],
+  "intents": [
+    { "eventId": "army.selectAll", "intent": "selection.all", "args": {}, "playerSource": "seat", "actorSource": "commandSource.primary" },
+    { "eventId": "army.rally", "intent": "army.setRally", "args": {}, "playerSource": "seat", "actorSource": "commandSource.primary" } ] }
+```
+注：variables 至少一条的现行约束（模板骨架）对纯命令面板需放开为 0 条（记 **G6**）。
+```text
+底栏中央 ┌──────────────────────────────┐
+         │ 【全选】【集结】【停止】【撤退】 │
+         └──────────────────────────────┘
+```
+30 秒预期：点全选 → 场上己方单位全亮；点集结 → 进入指定目标状态。
+依赖：G6 + #1015。
+
+### 2.6 全局功能 tab `panel.tabs.global`
+
+```jsonc
+{ "id": "panel.tabs.global", "scope": "global",
+  "variables": [
+    { "name": "activeTab", "kind": "Int", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "ui.activeTab" } } ],
+  "events": [
+    { "eventId": "tab.switch", "control": "tab.bar", "gesture": "click", "payload": { "tab": "Int" } } ],
+  "intents": [
+    { "eventId": "tab.switch", "intent": "ui.switchTab", "args": { "tab": "$payload.tab" }, "playerSource": "seat", "actorSource": "none" } ] }
+```
+
+```text
+左上（信息聚合下方）┌──────────────────────────┐
+                    │【信息】【科技】【外交】【生产】│  ← activeTab 高亮
+                    └──────────────────────────┘
+                     点击切换右侧主区域内容（子系统面板路由）
+```
+30 秒预期：点科技 → 右侧内容区切成科技面板，再点外交切走。
+依赖：G3 + #1015 + 子系统面板本体（2.9）。
+
+### 2.7 全局信息横幅 `panel.info.banner`
+
+```jsonc
+{ "id": "panel.info.banner", "scope": "global",
+  "variables": [
+    { "name": "bannerText", "kind": "Int", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "banner.current" } },   // G1: 应为 String（查表文案 id 兜底）
+    { "name": "bannerLevel", "kind": "Int", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "banner.level" } } ],
+  "binds": [ { "control": "lbl.banner", "variable": "bannerText" } ] }
+```
+
+```text
+screen.topCenter ┌────────────────────────────────┐
+                 │ ⚠ 敌军逼近北门（level=2 红底）  │   显隐由图：HidePanel 于平静、
+                 └────────────────────────────────┘   ShowPanel 于事件（#1014 现有）
+```
+30 秒预期：敌军进区 → 横幅弹出红字；威胁解除 → 消失。
+依赖：G3；G1（String 变量）让文案直读，否则查表 id。显隐图 op 现有。
+
+### 2.8 设置 `panel.settings`
+
+```jsonc
+{ "id": "panel.settings", "scope": "global",
+  "variables": [
+    { "name": "volume", "kind": "Float", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "settings.volume" } } ],
+  "events": [
+    { "eventId": "settings.volume", "control": "slider.volume", "gesture": "change", "payload": { "value": "Float" } },
+    { "eventId": "settings.exit", "control": "btn.exit", "gesture": "click" } ],
+  "intents": [
+    { "eventId": "settings.volume", "intent": "settings.setVolume", "args": { "value": "$payload.value" }, "playerSource": "seat", "actorSource": "none" },
+    { "eventId": "settings.exit", "intent": "game.exitToMenu", "args": {}, "playerSource": "seat", "actorSource": "none" } ] }
+```
+
+```text
+模态浮层（G5 锚点） ┌──────────────────────┐
+                    │ 设置            【✕】 │
+                    │ 音量 ▁▁▂▃▅▆▇ 【滑条】│
+                    │ 【退出到主菜单】       │
+                    └──────────────────────┘
+                     入口齿轮常驻右上；点开模态，其余输入挂起
+```
+30 秒预期：齿轮点开浮层拖音量即生效；点外部或 ✕ 关闭。
+依赖：G5（模态锚点）+ #1015（gesture=change 的滑条输入）。
+
+### 2.9 子系统入口 `panel.subsystem.entries`
+
+```jsonc
+{ "id": "panel.subsystem.entries", "scope": "global",
+  "variables": [
+    { "name": "techUnread", "kind": "Int", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "tech.unread" } } ],
+  "events": [
+    { "eventId": "sub.open", "control": "bar.subsystems", "gesture": "click", "payload": { "sub": "Int" } } ],
+  "intents": [
+    { "eventId": "sub.open", "intent": "ui.openSubsystem", "args": { "sub": "$payload.sub" }, "playerSource": "seat", "actorSource": "none" } ] }
+```
+
+```text
+右下角竖条 ┌───┐
+           │【🔬3】│ ← 角标=techUnread 未读数（超 9 显示 9+）
+           │【🛠】 │
+           │【📜】 │
+           └───┘   点击 = 路由打开对应子系统面板（与 2.6 tab 联动）
+```
+30 秒预期：科技完成 → 角标 +1 闪动；点开科技面板角标清零。
+依赖：G3 + #1015；与路由机制（原 #29）联动。
+
+---
+
+## 三、分组二~七（待逐组过）
+
+| 组 | 类数 | 状态 |
+|---|---|---|
+| 二 地图/空间指示（小地图/关系图/选中/屏外/染色/区域/路网） | 7 | 待设计 |
+| 三 选择与实体（列表/信息/关系/集合聚合/路由/关联集） | 6 | 待设计（含 #1012 集合行为主战场） |
+| 四 信息流（事件面板/日志入口/日志） | 3 | 待设计 |
+| 五 编队生产任务（编队/任务/进度树/生产队列） | 4 | 待设计（生产队列= #1012 验收场景） |
+| 六 单位操作（状态条/技能指令/物品装备） | 3 | 待设计（技能条=#1015 主战场） |
+| 七 其他（视图过滤器/额外文本/图鉴背包） | 3 | 待设计 |

--- a/gitbook/architecture/panel-catalog-designs.md
+++ b/gitbook/architecture/panel-catalog-designs.md
@@ -39,10 +39,10 @@
   "binds": [                           // 控件 ↔ 变量（皮侧按 control id 寻址）
     { "control": "lbl.gold", "variable": "gold" } ],
   "events": [                          // 0 编码事件（#1013 已落地）
-    { "eventId": "speed.set", "control": "btn.speed2", "gesture": "click",
+    { "event": "speed.set", "control": "btn.speed2", "gesture": "click",
       "payload": { "speed": "Int" } } ],   // 载荷类型已有 String|Int|Float|Bool
   "intents": [                         // 事件 → 玩法意图（面板永不直构 Order）
-    { "eventId": "speed.set", "intent": "game.setSpeed",
+    { "event": "speed.set", "intent": "game.setSpeed",
       "args": { "speed": "$payload.speed" },
       "playerSource": "seat", "actorSource": "commandSource.primary" } ]
 }
@@ -170,9 +170,9 @@ screen.topRight 区、信息聚合左侧 ┌──────────┐
   "variables": [
     { "name": "activeTab", "kind": "Int", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "ui.activeTab" } } ],
   "events": [
-    { "eventId": "tab.switch", "control": "tab.bar", "gesture": "click", "payload": { "tab": "Int" } } ],
+    { "event": "tab.switch", "control": "tab.bar", "gesture": "click", "payload": { "tab": "Int" } } ],
   "intents": [
-    { "eventId": "tab.switch", "intent": "ui.switchTab", "args": { "tab": "$payload.tab" }, "playerSource": "seat", "actorSource": "none" } ] }
+    { "event": "tab.switch", "intent": "ui.switchTab", "args": { "tab": "$payload.tab" }, "playerSource": "seat", "actorSource": "none" } ] }
 ```
 
 ```text
@@ -213,9 +213,9 @@ screen.topCenter ┌────────────────────
   "variables": [
     { "name": "techUnread", "kind": "Int", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "tech.unread" } } ],
   "events": [
-    { "eventId": "sub.open", "control": "bar.subsystems", "gesture": "click", "payload": { "sub": "Int" } } ],
+    { "event": "sub.open", "control": "bar.subsystems", "gesture": "click", "payload": { "sub": "Int" } } ],
   "intents": [
-    { "eventId": "sub.open", "intent": "ui.openSubsystem", "args": { "sub": "$payload.sub" }, "playerSource": "seat", "actorSource": "none" } ] }
+    { "event": "sub.open", "intent": "ui.openSubsystem", "args": { "sub": "$payload.sub" }, "playerSource": "seat", "actorSource": "none" } ] }
 ```
 
 ```text

--- a/gitbook/architecture/panel-catalog-designs.md
+++ b/gitbook/architecture/panel-catalog-designs.md
@@ -46,6 +46,20 @@
 }
 ```
 
+### 1.2.1 realtime 判定规则（总合同条款）
+
+`realtime: true` = 值本身会动，帧扫重算（`PanelRealtimeRefreshSystem`）。按读嘴定死：
+
+| 读嘴 | realtime | 理由 |
+|---|---|---|
+| SingleAttribute（活属性：血/蓝/资源） | ✅ | 战斗中真变 |
+| GraphOutput（活输出：时钟/经济聚合/未读数） | ✅ | 图每拍重算 |
+| AttributeBase | ❌（buff 改基数时显式 Refresh） | 基础值通常静止 |
+| TableLookup | ❌ | 查的是启动装载的静态表，结果不动；key 动态换行属例外，走显式 Refresh，不帧扫 |
+| Derived | 按被派生源 | 随源 |
+
+配套建模纪律：**活游戏状态（gold/人口/时钟）一律 GraphOutput 中转**——查表只放静态数据（税率/周期/文案表）。这同时满足完成核"数字溯源到图"。地图变量（MapVariableStore）不在五路读嘴内：全局状态经图输出中转是刻意设计；若实践中"每项全局状态开一张图"爆炸，再议第六读嘴（G7 候选，暂不立项）。
+
 ### 1.3 实例参数（四级链，已落地）
 
 `panelAnchor`（screen.topLeft/topRight/bottomLeft/bottomRight）· `panelSkin`（default/markup/compose/reactive/web）· `panelZOrder`（缺省 100）· `panelTheme`（game.json 全局；模板/op 级为缺口 G4）。
@@ -82,10 +96,13 @@
 ```jsonc
 { "id": "panel.player.aggregate", "scope": "global",
   "variables": [
-    { "name": "gold", "kind": "Int", "realtime": true, "source": { "sourceKind": "TableLookup", "lookupTable": "economy", "lookupField": "gold", "keyAttribute": "TeamId" } },
+    { "name": "gold", "kind": "Int", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "economy.gold" } },
     { "name": "popUsed", "kind": "Int", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "pop.used" } },
-    { "name": "popCap", "kind": "Int", "source": { "sourceKind": "TableLookup", "lookupTable": "economy", "lookupField": "popCap", "keyAttribute": "TeamId" } } ],
+    { "name": "popCap", "kind": "Int", "realtime": true, "source": { "sourceKind": "GraphOutput", "graphOutputKey": "pop.cap" } } ],
   "binds": [ { "control": "lbl.gold", "variable": "gold" }, { "control": "lbl.pop", "variable": "popUsed" } ] }
+// 注：gold/pop 是活状态 → GraphOutput 中转（§1.2.1 纪律）；economy 查表放静态（如
+// 每级人口上限 popCapByLevel），面板侧不标 realtime。初稿曾把活状态建模成查表+
+// realtime——用户审稿揪出的反例，规则因此入合同。
 ```
 
 ```text

--- a/gitbook/architecture/panel-catalog-designs.md
+++ b/gitbook/architecture/panel-catalog-designs.md
@@ -30,7 +30,9 @@
   "variables": [                       // 至少一条；kind 目前 Float|Int（缺口 G1: Bool|String）
     { "name": "gold", "kind": "Int", "realtime": true,
       "source": {                      // 五路读嘴，fail-closed：
-        "sourceKind": "TableLookup",   //   SingleAttribute / AttributeBase / Derived /
+        "sourceKind": "TableLookup",   //   六路读嘴（真实枚举名，fail-closed）：
+                                       //   SingleAttribute / DerivedAttribute / AggregateProjection /
+                                       //   GraphOutput / TableLookup / AttributeBase
         "lookupTable": "economy",      //   GraphOutput / TableLookup
         "lookupField": "goldPerTick",
         "keyAttribute": "TeamId" } } ],
@@ -54,9 +56,10 @@
 |---|---|---|
 | SingleAttribute（活属性：血/蓝/资源） | ✅ | 战斗中真变 |
 | GraphOutput（活输出：时钟/经济聚合/未读数） | ✅ | 图每拍重算 |
+| AggregateProjection（聚合投影） | ✅ | 随集合变化——#1012 集合面板的现成地基 |
 | AttributeBase | ❌（buff 改基数时显式 Refresh） | 基础值通常静止 |
 | TableLookup | ❌ | 查的是启动装载的静态表，结果不动；key 动态换行属例外，走显式 Refresh，不帧扫 |
-| Derived | 按被派生源 | 随源 |
+| DerivedAttribute | 随派生源 | 派生图绑定写入 AttributeBuffer |
 
 配套建模纪律：**活游戏状态（gold/人口/时钟）一律 GraphOutput 中转**——查表只放静态数据（税率/周期/文案表）。这同时满足完成核"数字溯源到图"。地图变量（MapVariableStore）不在五路读嘴内：全局状态经图输出中转是刻意设计；若实践中"每项全局状态开一张图"爆炸，再议第六读嘴（G7 候选，暂不立项）。
 
@@ -68,6 +71,8 @@
 
 ```jsonc
 "scope": "item"  |  "collection"  |  "global"
+// ⚠ 设计位字段：装载器 RootFields 白名单今日无 "scope"——出现即抛。G3 落地时增补，
+//   落地前案例文档凡用此字段均标 🔴 目标态，不得当作今日可装载配置抄写。
 // item:       一物一面（现状：scope=hero 实体）
 // collection: 一集一面——框选集合变化时同一模板切形态，模板 id 不变，
 //             变量读嘴允许集合聚合（缺口 G2: 聚合读嘴 sourceKind，如 AggSum 队列项）
@@ -84,6 +89,9 @@
 | G3 | scope=global 实例语义 | #1012 |
 | G4 | panelTheme 模板/op 级覆盖 | #1011 后续 |
 | G5 | 浮层/模态锚点（设置、子系统详情） | #840 前置小片 |
+| G8 | 手势载荷值来源（按钮→事件携带定值的机制）与 intent args 常量语义（"$payload.x" 引用与字面常量混排） | #1015 |
+| G9 | actorSource 值域扩展（"none"——设置类无实体归因意图；解析器现拒） | #1015 |
+| G10 | TriggerGraph 消费 UI 事件的接线（编排层入口：UI 事件→图触发；当前触发器事件词典无 UI 域） | #1013/#1030 交界 |
 
 ---
 


### PR DESCRIPTION
纯文档三文件：面板目录设计 SSOT（骨架/六路读嘴/realtime 规则/G1-G10 缺口）+ 四典型案例全设计（配置/线框/数据流/意图链/Gherkin 验收）+ SUMMARY 导航。经 opus-5（架构）/opus-4-6（配置可读）/deepseek-v4-flash（二审）/codex（终审四轮打回至收敛）四道七轮审计；validate-docs 绿。合并触发 Pages 门户重建。