### PR TITLE
feat(seat): #902 P2.5 收口——sole seat controlSchemeId 激活链 + 存档 localSeats round-trip 测试

### DIFF
--- a/gitbook/architecture/client-local-seat-and-logic-view.md
+++ b/gitbook/architecture/client-local-seat-and-logic-view.md
@@ -62,7 +62,7 @@ Possession 转移只改箭头；Participant、LogicView、collection 不搬家�
 
 - `seatId`（非空、同次唯一）
 - `playerId`（必须已在 map Players 绑定）
-- 可选 `controlSchemeId`
+- 可选 `controlSchemeId`：进图激活真相（见 3.3 控制方案激活链）；存档 `launchContext.localSeats[]` 原样 round-trip，未声明时省略字段
 
 ### 3.2 启动与进图链路
 
@@ -77,7 +77,7 @@ Possession 转移只改箭头；Participant、LogicView、collection 不搬家�
 4. 加载地图内容（板面等）
 5. MapConfig.Entities → 刷实体（先）
 6. MapConfig.Players/Teams → 绑定 Participant（后）
-7. PublishLocalSeats：座位占有 →（仅对有占有的 seat）EnsureDefaultView → 可选 PresentBinding
+7. PublishLocalSeats：座位占有 →（仅对有占有的 seat）EnsureDefaultView → 可选 PresentBinding → sole seat 声明的 controlSchemeId 激活（见 3.3）
 8. MapLoaded；快照 session.LocalSeats
 ```
 
@@ -89,6 +89,13 @@ Possession 转移只改箭头；Participant、LogicView、collection 不搬家�
 - 输入 / Cast owner / 下令 / Follow 锚：**显式 seat 或 seat 的 possessed rep**
 - 禁止隐式「本机唯一玩家」全局服务键
 - 恰有一个 seat 时，可用 `RequireSolePossessedRep()`（座位数量 ≠ 1 则失败）——这是基数断言，不是 Active 槽
+
+**控制方案激活链（P2.5 收口）**：
+
+- 唯一 seat 声明的 `controlSchemeId` 是本次进图的激活真相：`PublishLocalSeats` 末尾通过全局 `ControlSchemeRuntime.TrySwitch` 激活，优先于偏好存储的旧选择
+- seat 未声明 `controlSchemeId`：维持既有激活链（偏好存储 → 首个 allowed），`TrySwitch` 热切换照常写偏好存储
+- 声明了但 scheme 未安装、或被 mod allowed-set 拒绝：map load **fail-fast**，不静默回退到初始 scheme
+- 多 seat 的 per-seat scheme 路由是 P3：多座位发布时不激活任何声明（今日多座位本就止步于 present 管线之前）
 
 ### 3.4 LogicView（纯逻辑视觉）
 
@@ -189,6 +196,24 @@ Feature: 本机座位与逻辑视觉
     When 用水平对半分屏布局写入各自 rect
     Then 两个 PresentBinding 的矩形不重叠且并集覆盖全屏
     And 各自镜头权威仍来自绑定的 LogicView
+
+  Scenario: 座位声明的控制方案在发布时激活
+    Given 唯一 seat 的 LocalSeats 项声明 controlSchemeId 且该 scheme 已安装并被 allowed-set 允许
+    When PublishLocalSeats 发布座位
+    Then ControlSchemeRuntime 激活该 scheme 并覆盖偏好存储的旧选择
+    And 未声明 controlSchemeId 的 seat 维持偏好存储 → 首个 allowed 的既有激活链
+
+  Scenario: 声明非法控制方案时进图失败
+    Given 唯一 seat 声明的 controlSchemeId 未安装或被 allowed-set 拒绝
+    When PublishLocalSeats 发布座位
+    Then map load fail-fast 并指明该 scheme
+    And 不静默回退到初始 scheme
+
+  Scenario: 座位表存档 round-trip 不丢失
+    Given MapSession.LaunchContext 的 localSeats 含 controlSchemeId 声明与 metadata
+    When mapSessions 存档域 CaptureState 后 RestoreState
+    Then 每项 seatId / playerId / controlSchemeId 与 metadata 原样恢复
+    And 未声明的 controlSchemeId 不序列化为空默认值
 ```
 
 
@@ -197,5 +222,5 @@ Feature: 本机座位与逻辑视觉
 - P0 合同（本页 + participant 合同修订 + RFC 修订）— #897  
 - P1 SeatRegistry + Possession + 删除全局 LocalPlayer* — #898  
 - P2 LogicView 多实例 + PresentBinding 呈现/拾取 — #899（Sole PresentBinding → Presenter / ScreenRay / ScreenProjector / 呈现剔除；LogicView 自有相机权威；已删除 `GameSession.Camera` 会话单例；无座图可用 `logicview.client.present`）  
-- P2.5 多分屏基建底座 — PresentBinding.rect 布局工厂 + `CopyPresentBindings` / per-seat 解析；Sole 消费路径仍是今日默认  
-- P3 分屏布局产品化与 UI per-seat owner（同模型，另开子单）
+- P2.5 多分屏基建底座 — PresentBinding.rect 布局工厂 + `CopyPresentBindings` / per-seat 解析；Sole 消费路径仍是今日默认。已收口：存档 `launchContext.localSeats[]` round-trip 直接测试（mapSessions 存档域）+ sole seat `controlSchemeId` 激活链（3.3）  
+- P3 分屏布局产品化、per-seat scheme 路由与 UI per-seat owner（同模型，另开子单）

--- a/gitbook/architecture/client-local-seat-and-logic-view.md
+++ b/gitbook/architecture/client-local-seat-and-logic-view.md
@@ -16,8 +16,8 @@
 | **ClientLocalSeat** | 本机 I/O：设备、ControlScheme、InteractionContextStack | 有设备才有 |
 | **PresentBinding** | Seat → 某个 LogicView 的呈现绑定（rect / 呈现分辨率） | 仅要画时 |
 
-`EntityCollectionStore` 地址仍是 `(participantRep, collectionKey)`。  
-Control Plane = 化身当前可控对象（拓扑现算）。  
+`EntityCollectionStore` 地址仍是 `(participantRep, collectionKey)`。
+Control Plane = 化身当前可控对象（拓扑现算）。
 Cast 是几何原语；写集合是业务/蓝图另线。
 
 ## 2. 结构
@@ -81,7 +81,7 @@ Possession 转移只改箭头；Participant、LogicView、collection 不搬家�
 8. MapLoaded；快照 session.LocalSeats
 ```
 
-非法 seat / 未绑定 player → map load fail-fast。  
+非法 seat / 未绑定 player → map load fail-fast。
 **不是每个 Participant 都有 LogicView**：今天只对「本机座位占有」自动建；AI/其它玩家代表可只有身份。
 
 ### 3.3 消费规则
@@ -132,20 +132,20 @@ Possession 转移只改箭头；Participant、LogicView、collection 不搬家�
 
 ## 4. 场景
 
-- 单机单人：`startupLocalSeats: [{ seat.0, playerId: 1 }]` → 占有甲 → PresentBinding 全屏  
-- 同屏双人：两条 seat 写入 launch / game 默认  
-- AI bot：地图 Players 有代表，无 seat → 无自动 LogicView  
-- 换 client：改 Possession / PresentBinding；甲的集合与 LogicView 不动  
-- 旁观：Seat 可 PresentBinding 盯乙的 LogicView，而不 possess 乙  
+- 单机单人：`startupLocalSeats: [{ seat.0, playerId: 1 }]` → 占有甲 → PresentBinding 全屏
+- 同屏双人：两条 seat 写入 launch / game 默认
+- AI bot：地图 Players 有代表，无 seat → 无自动 LogicView
+- 换 client：改 Possession / PresentBinding；甲的集合与 LogicView 不动
+- 旁观：Seat 可 PresentBinding 盯乙的 LogicView，而不 possess 乙
 
 ## 5. 边界
 
-- Seat ≠ 「玩家属于 client」  
-- `GameConfig.startupLocalSeats` 不是运行时座位真相；进图后以 `ClientLocalSeatRegistry` 为准  
-- 不把 InteractionContextStack 的 ownerToken 当成座位表  
-- 本页不定义 Cast→Query→WriteCollection 业务图（见交互/蓝图合同）  
-- 分屏布局是 PresentBinding.rect 配置，不另起视觉子系统  
-- 画面剔除挂 PresentBinding，不挂裸 LogicView；LogicView 只提供镜头权威  
+- Seat ≠ 「玩家属于 client」
+- `GameConfig.startupLocalSeats` 不是运行时座位真相；进图后以 `ClientLocalSeatRegistry` 为准
+- 不把 InteractionContextStack 的 ownerToken 当成座位表
+- 本页不定义 Cast→Query→WriteCollection 业务图（见交互/蓝图合同）
+- 分屏布局是 PresentBinding.rect 配置，不另起视觉子系统
+- 画面剔除挂 PresentBinding，不挂裸 LogicView；LogicView 只提供镜头权威
 
 ## 6. UAT
 
@@ -219,8 +219,8 @@ Feature: 本机座位与逻辑视觉
 
 ## 7. 分期
 
-- P0 合同（本页 + participant 合同修订 + RFC 修订）— #897  
-- P1 SeatRegistry + Possession + 删除全局 LocalPlayer* — #898  
-- P2 LogicView 多实例 + PresentBinding 呈现/拾取 — #899（Sole PresentBinding → Presenter / ScreenRay / ScreenProjector / 呈现剔除；LogicView 自有相机权威；已删除 `GameSession.Camera` 会话单例；无座图可用 `logicview.client.present`）  
-- P2.5 多分屏基建底座 — PresentBinding.rect 布局工厂 + `CopyPresentBindings` / per-seat 解析；Sole 消费路径仍是今日默认。已收口：存档 `launchContext.localSeats[]` round-trip 直接测试（mapSessions 存档域）+ sole seat `controlSchemeId` 激活链（3.3）  
+- P0 合同（本页 + participant 合同修订 + RFC 修订）— #897
+- P1 SeatRegistry + Possession + 删除全局 LocalPlayer* — #898
+- P2 LogicView 多实例 + PresentBinding 呈现/拾取 — #899（Sole PresentBinding → Presenter / ScreenRay / ScreenProjector / 呈现剔除；LogicView 自有相机权威；已删除 `GameSession.Camera` 会话单例；无座图可用 `logicview.client.present`）
+- P2.5 多分屏基建底座 — PresentBinding.rect 布局工厂 + `CopyPresentBindings` / per-seat 解析；Sole 消费路径仍是今日默认。已收口：存档 `launchContext.localSeats[]` round-trip 直接测试（mapSessions 存档域）+ sole seat `controlSchemeId` 激活链（3.3）
 - P3 分屏布局产品化、per-seat scheme 路由与 UI per-seat owner（同模型，另开子单）

--- a/src/Core/Gameplay/Teams/ParticipantBindingResolver.cs
+++ b/src/Core/Gameplay/Teams/ParticipantBindingResolver.cs
@@ -287,8 +287,9 @@ namespace Ludots.Core.Gameplay.Teams
         /// The sole seat's declared ControlSchemeId is the per-entry launch truth and activates the
         /// global ControlSchemeRuntime (P2.5 sole consumption path); seats without a declaration keep
         /// the runtime's initial/preference activation. Multi-seat scheme routing is P3: with more
-        /// than one seat nothing activates here. Declared-but-uninstalled or refused schemes are
-        /// configuration errors and fail fast instead of falling back to the initial scheme.
+        /// than one seat nothing activates here. A declared scheme with the runtime unregistered,
+        /// uninstalled, or refused by the allowed-set is a configuration error and fails fast instead
+        /// of falling back to the initial scheme.
         /// </summary>
         private static void ActivateSoleSeatControlScheme(
             IDictionary<string, object> globals,
@@ -299,16 +300,17 @@ namespace Ludots.Core.Gameplay.Teams
                 return;
             }
 
-            if (!globals.TryGetValue(CoreServiceKeys.ControlSchemeRuntime.Name, out object? schemeObj) ||
-                schemeObj is not ControlSchemeRuntime schemes)
-            {
-                return;
-            }
-
             ClientLocalSeat seat = seats.Require(seats.SeatIds[0]);
             if (string.IsNullOrWhiteSpace(seat.ControlSchemeId))
             {
                 return;
+            }
+
+            if (!globals.TryGetValue(CoreServiceKeys.ControlSchemeRuntime.Name, out object? schemeObj) ||
+                schemeObj is not ControlSchemeRuntime schemes)
+            {
+                throw new InvalidOperationException(
+                    $"ClientLocalSeat '{seat.SeatId}' declares control scheme '{seat.ControlSchemeId}' but the ControlSchemeRuntime service is not registered.");
             }
 
             string schemeId = seat.ControlSchemeId!.Trim();

--- a/src/Core/Gameplay/Teams/ParticipantBindingResolver.cs
+++ b/src/Core/Gameplay/Teams/ParticipantBindingResolver.cs
@@ -8,6 +8,7 @@ using Ludots.Core.Config;
 using Ludots.Core.Gameplay.Components;
 using Ludots.Core.Gameplay.Relationships;
 using Ludots.Core.Gameplay.Relationships.Config;
+using Ludots.Core.Input.Interaction;
 using Ludots.Core.Map;
 using Ludots.Core.Scripting;
 using Ludots.Core.Systems;
@@ -279,6 +280,49 @@ namespace Ludots.Core.Gameplay.Teams
 
             seats.ReplaceAll(built);
             ConfigureLogicViewCameras(globals, views);
+            ActivateSoleSeatControlScheme(globals, seats);
+        }
+
+        /// <summary>
+        /// The sole seat's declared ControlSchemeId is the per-entry launch truth and activates the
+        /// global ControlSchemeRuntime (P2.5 sole consumption path); seats without a declaration keep
+        /// the runtime's initial/preference activation. Multi-seat scheme routing is P3: with more
+        /// than one seat nothing activates here. Declared-but-uninstalled or refused schemes are
+        /// configuration errors and fail fast instead of falling back to the initial scheme.
+        /// </summary>
+        private static void ActivateSoleSeatControlScheme(
+            IDictionary<string, object> globals,
+            ClientLocalSeatRegistry seats)
+        {
+            if (seats.Count != 1)
+            {
+                return;
+            }
+
+            if (!globals.TryGetValue(CoreServiceKeys.ControlSchemeRuntime.Name, out object? schemeObj) ||
+                schemeObj is not ControlSchemeRuntime schemes)
+            {
+                return;
+            }
+
+            ClientLocalSeat seat = seats.Require(seats.SeatIds[0]);
+            if (string.IsNullOrWhiteSpace(seat.ControlSchemeId))
+            {
+                return;
+            }
+
+            string schemeId = seat.ControlSchemeId!.Trim();
+            if (!schemes.SchemeIdRegistry.TryGetId(schemeId, out int compiledSchemeId))
+            {
+                throw new InvalidOperationException(
+                    $"ClientLocalSeat '{seat.SeatId}' declares control scheme '{schemeId}' which is not installed.");
+            }
+
+            if (!schemes.TrySwitch(compiledSchemeId))
+            {
+                throw new InvalidOperationException(
+                    $"ClientLocalSeat '{seat.SeatId}' declares control scheme '{schemeId}' which the mod allowed-set refuses.");
+            }
         }
 
         private static bool TryResolvePresentResolutionPx(

--- a/src/Tests/GasTests/Association/ParticipantBindingContractTests.cs
+++ b/src/Tests/GasTests/Association/ParticipantBindingContractTests.cs
@@ -440,6 +440,29 @@ namespace Ludots.Tests.GAS
                 "multi-seat scheme routing is P3; publishing multiple seats must not activate any declared scheme.");
         }
 
+        [Test]
+        public void ParticipantBindingResolver_PublishFocused_SoleSeatControlSchemeId_FailsFastWhenRuntimeNotRegistered()
+        {
+            using var world = World.Create();
+            Entity player = world.Create(new PlayerIdentity { PlayerId = 7 }, new PlayerOwner { PlayerId = 7 });
+            var players = new PlayerEntityLookup();
+            players.Register(7, player);
+            var globals = new Dictionary<string, object>
+            {
+                [CoreServiceKeys.TeamEntityLookup.Name] = new TeamEntityLookup(),
+                [CoreServiceKeys.PlayerEntityLookup.Name] = players,
+                [CoreServiceKeys.ClientLocalSeatRegistry.Name] = new ClientLocalSeatRegistry(),
+                [CoreServiceKeys.LogicViewRegistry.Name] = new LogicViewRegistry(),
+            };
+            var result = SoleSeatResult(players, 7, player, controlSchemeId: "scheme.seat.declared");
+
+            InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+                () => ParticipantBindingResolver.PublishFocused(globals, result));
+
+            Assert.That(error!.Message, Does.Contain("scheme.seat.declared"));
+            Assert.That(error.Message, Does.Contain("ControlSchemeRuntime"));
+        }
+
         private static ParticipantBindingResult SoleSeatResult(
             PlayerEntityLookup players,
             int playerId,

--- a/src/Tests/GasTests/Association/ParticipantBindingContractTests.cs
+++ b/src/Tests/GasTests/Association/ParticipantBindingContractTests.cs
@@ -14,9 +14,12 @@ using Ludots.Core.Gameplay.GAS.Registry;
 using Ludots.Core.Gameplay.Relationships;
 using Ludots.Core.Gameplay.Relationships.Config;
 using Ludots.Core.Gameplay.Teams;
+using Ludots.Core.Gameplay.GAS.Orders;
+using Ludots.Core.Input.Interaction;
 using Ludots.Core.Input.Systems;
 using Ludots.Core.Map;
 using Ludots.Core.Presentation.Camera;
+using Ludots.Core.Registry;
 using Ludots.Core.Scripting;
 using Ludots.Core.Systems;
 using NUnit.Framework;
@@ -337,6 +340,213 @@ namespace Ludots.Tests.GAS
             Assert.That(ClientLocalSeatAccess.RequireLogicViews(globals).Count, Is.EqualTo(2));
             Assert.That(ClientLocalSeatAccess.TryGetSolePossessedRep(globals, out _), Is.False);
             Assert.Throws<InvalidOperationException>(() => seats.RequireSolePossessedRep());
+        }
+
+        [Test]
+        public void ParticipantBindingResolver_PublishFocused_SoleSeatControlSchemeId_ActivatesDeclaredScheme()
+        {
+            using var world = World.Create();
+            Entity player = world.Create(new PlayerIdentity { PlayerId = 7 }, new PlayerOwner { PlayerId = 7 });
+            var players = new PlayerEntityLookup();
+            players.Register(7, player);
+            ControlSchemeRuntime schemes = CreateInstalledControlSchemeRuntime(world, "scheme.seat.first", "scheme.seat.declared");
+            Assert.That(schemes.ActiveSchemeId, Is.EqualTo(schemes.SchemeIdRegistry.GetId("scheme.seat.first")),
+                "install activates the first allowed scheme before any seat is published.");
+            var globals = CreateSeatPublishGlobals(players, schemes);
+            var result = SoleSeatResult(players, 7, player, controlSchemeId: "scheme.seat.declared");
+
+            ParticipantBindingResolver.PublishFocused(globals, result);
+
+            Assert.That(schemes.ActiveSchemeId, Is.EqualTo(schemes.SchemeIdRegistry.GetId("scheme.seat.declared")),
+                "the sole seat's declared ControlSchemeId is the per-entry launch truth and must activate.");
+        }
+
+        [Test]
+        public void ParticipantBindingResolver_PublishFocused_SoleSeatWithoutScheme_LeavesRuntimeActivationUnchanged()
+        {
+            using var world = World.Create();
+            Entity player = world.Create(new PlayerIdentity { PlayerId = 7 }, new PlayerOwner { PlayerId = 7 });
+            var players = new PlayerEntityLookup();
+            players.Register(7, player);
+            ControlSchemeRuntime schemes = CreateInstalledControlSchemeRuntime(world, "scheme.seat.first", "scheme.seat.declared");
+            var globals = CreateSeatPublishGlobals(players, schemes);
+            var result = SoleSeatResult(players, 7, player, controlSchemeId: null);
+
+            ParticipantBindingResolver.PublishFocused(globals, result);
+
+            Assert.That(schemes.ActiveSchemeId, Is.EqualTo(schemes.SchemeIdRegistry.GetId("scheme.seat.first")),
+                "seats without a declaration keep the runtime's initial/preference activation.");
+        }
+
+        [Test]
+        public void ParticipantBindingResolver_PublishFocused_SoleSeatControlSchemeId_FailsFastWhenSchemeNotInstalled()
+        {
+            using var world = World.Create();
+            Entity player = world.Create(new PlayerIdentity { PlayerId = 7 }, new PlayerOwner { PlayerId = 7 });
+            var players = new PlayerEntityLookup();
+            players.Register(7, player);
+            ControlSchemeRuntime schemes = CreateInstalledControlSchemeRuntime(world, "scheme.seat.first", "scheme.seat.declared");
+            var globals = CreateSeatPublishGlobals(players, schemes);
+            var result = SoleSeatResult(players, 7, player, controlSchemeId: "scheme.seat.missing");
+
+            InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+                () => ParticipantBindingResolver.PublishFocused(globals, result));
+
+            Assert.That(error!.Message, Does.Contain("scheme.seat.missing"));
+            Assert.That(error.Message, Does.Contain("not installed"));
+        }
+
+        [Test]
+        public void ParticipantBindingResolver_PublishFocused_SoleSeatControlSchemeId_FailsFastWhenRefusedByAllowedSet()
+        {
+            using var world = World.Create();
+            Entity player = world.Create(new PlayerIdentity { PlayerId = 7 }, new PlayerOwner { PlayerId = 7 });
+            var players = new PlayerEntityLookup();
+            players.Register(7, player);
+            ControlSchemeRuntime schemes = CreateInstalledControlSchemeRuntime(
+                world, "scheme.seat.first", "scheme.seat.declared", allowedSchemes: new List<string> { "scheme.seat.first" });
+            var globals = CreateSeatPublishGlobals(players, schemes);
+            var result = SoleSeatResult(players, 7, player, controlSchemeId: "scheme.seat.declared");
+
+            InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+                () => ParticipantBindingResolver.PublishFocused(globals, result));
+
+            Assert.That(error!.Message, Does.Contain("allowed-set"));
+        }
+
+        [Test]
+        public void ParticipantBindingResolver_PublishFocused_DualSeatsWithSchemes_DoNotActivateSeatControlSchemes()
+        {
+            using var world = World.Create();
+            Entity playerSeven = world.Create(new PlayerIdentity { PlayerId = 7 }, new PlayerOwner { PlayerId = 7 });
+            Entity playerEight = world.Create(new PlayerIdentity { PlayerId = 8 }, new PlayerOwner { PlayerId = 8 });
+            var players = new PlayerEntityLookup();
+            players.Register(7, playerSeven);
+            players.Register(8, playerEight);
+            ControlSchemeRuntime schemes = CreateInstalledControlSchemeRuntime(world, "scheme.seat.first", "scheme.seat.declared");
+            var globals = CreateSeatPublishGlobals(players, schemes);
+            var result = new ParticipantBindingResult(
+                new TeamEntityLookup(),
+                players,
+                localSeats: new[]
+                {
+                    new ResolvedLocalSeatPossession("seat.0", 7, playerSeven, ControlSchemeId: "scheme.seat.declared"),
+                    new ResolvedLocalSeatPossession("seat.1", 8, playerEight, ControlSchemeId: "scheme.seat.first"),
+                });
+
+            ParticipantBindingResolver.PublishFocused(globals, result);
+
+            Assert.That(schemes.ActiveSchemeId, Is.EqualTo(schemes.SchemeIdRegistry.GetId("scheme.seat.first")),
+                "multi-seat scheme routing is P3; publishing multiple seats must not activate any declared scheme.");
+        }
+
+        private static ParticipantBindingResult SoleSeatResult(
+            PlayerEntityLookup players,
+            int playerId,
+            Entity player,
+            string controlSchemeId)
+        {
+            return new ParticipantBindingResult(
+                new TeamEntityLookup(),
+                players,
+                localSeats: new[] { new ResolvedLocalSeatPossession("seat.0", playerId, player, controlSchemeId) });
+        }
+
+        private static Dictionary<string, object> CreateSeatPublishGlobals(PlayerEntityLookup players, ControlSchemeRuntime schemes)
+        {
+            return new Dictionary<string, object>
+            {
+                [CoreServiceKeys.TeamEntityLookup.Name] = new TeamEntityLookup(),
+                [CoreServiceKeys.PlayerEntityLookup.Name] = players,
+                [CoreServiceKeys.ClientLocalSeatRegistry.Name] = new ClientLocalSeatRegistry(),
+                [CoreServiceKeys.LogicViewRegistry.Name] = new LogicViewRegistry(),
+                [CoreServiceKeys.ControlSchemeRuntime.Name] = schemes,
+            };
+        }
+
+        private static ControlSchemeRuntime CreateInstalledControlSchemeRuntime(
+            World world,
+            string initialScheme,
+            string alternateScheme,
+            List<string> allowedSchemes = null)
+        {
+            CommandIntentProfileTests.Harness intents = CommandIntentProfileTests.Harness.Create(world);
+            InstallSeatGroundIntent(intents, "intent.seat.default");
+            InstallSeatGroundIntent(intents, "intent.seat.alt");
+
+            var collectionKeys = new StringIntRegistry(capacity: 16, startId: 1, invalidId: 0, comparer: StringComparer.Ordinal);
+            var stack = new InteractionContextStack(collectionKeys);
+            stack.Push(InteractionContextFrameDescriptor.Create(
+                InteractionContextIds.Default,
+                "collection.seat.command_source",
+                "view.seat.default"));
+
+            var orderTypes = new OrderTypeRegistry(new OrderTerminalResultBuffer(capacity: OrderTerminalResultBuffer.DefaultCapacity));
+            orderTypes.Register(new OrderTypeConfig { Key = "moveTo", OrderTypeId = 2 });
+            var dispatch = new CastDispatchProfileRegistry(
+                new StringIntRegistry(capacity: 16, startId: 1, invalidId: 0, comparer: StringComparer.Ordinal),
+                new StringIntRegistry(capacity: 16, startId: 1, invalidId: 0, comparer: StringComparer.Ordinal));
+            dispatch.Install(CastDispatchProfileTests.Harness.Config(
+                new CastDispatchProfileDefinition
+                {
+                    Id = "dispatch.seat.default",
+                    Selector = new CastDispatchSelectorDefinition { Kind = "all" },
+                    Router = new CastDispatchRouterDefinition { Kind = "parallel", SharedOrderId = true },
+                },
+                new CastDispatchProfileDefinition
+                {
+                    Id = "dispatch.seat.alt",
+                    Selector = new CastDispatchSelectorDefinition { Kind = "cycle", AdvanceOn = "orderAccepted" },
+                    Router = new CastDispatchRouterDefinition { Kind = "sequential" },
+                }));
+
+            var runtime = new ControlSchemeRuntime(
+                new StringIntRegistry(capacity: 8, startId: 1, invalidId: 0, comparer: StringComparer.Ordinal),
+                stack,
+                intents.Intents,
+                dispatch,
+                orderTypes);
+            runtime.Install(new ControlSchemesConfig
+            {
+                Schemes = new List<ControlSchemeDefinition>
+                {
+                    new()
+                    {
+                        Id = initialScheme,
+                        InputContexts = new List<string>(),
+                        Defaults = new ControlSchemeDefaults
+                        {
+                            CommandIntentId = "intent.seat.default",
+                            CastDispatchProfileId = "dispatch.seat.default",
+                        },
+                    },
+                    new()
+                    {
+                        Id = alternateScheme,
+                        InputContexts = new List<string>(),
+                        Defaults = new ControlSchemeDefaults
+                        {
+                            CommandIntentId = "intent.seat.alt",
+                            CastDispatchProfileId = "dispatch.seat.alt",
+                        },
+                    },
+                },
+                AllowedSchemes = allowedSchemes,
+            });
+            return runtime;
+        }
+
+        private static void InstallSeatGroundIntent(CommandIntentProfileTests.Harness intents, string profileId)
+        {
+            intents.Intents.Install(CommandIntentProfileTests.Harness.Config(new CommandIntentProfileDefinition
+            {
+                Id = profileId,
+                GroupPolicy = new CommandIntentGroupPolicyDefinition { Kind = "independent" },
+                Rules = new List<CommandIntentRuleDefinition>
+                {
+                    CommandIntentProfileTests.Harness.GroundRule(priority: 10, orderTypeKey: "moveTo"),
+                },
+            }));
         }
 
         [Test]

--- a/src/Tests/PersistenceTests/SaveParticipantRegistryTests.cs
+++ b/src/Tests/PersistenceTests/SaveParticipantRegistryTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Nodes;
 using Arch.Core;
 using Arch.Relationships;
+using Ludots.Core.Client;
 using Ludots.Core.Engine;
 using Ludots.Core.Engine.TimeFlow;
 using Ludots.Core.Gameplay;
@@ -278,6 +279,50 @@ public sealed class SaveParticipantRegistryTests
         Assert.That(target.HasPendingReturn, Is.True);
         Assert.That(target.GetSession(new MapId("outer"))?.State, Is.EqualTo(MapSessionState.Suspended));
         Assert.That(target.GetSession(new MapId("inner"))?.State, Is.EqualTo(MapSessionState.Active));
+    }
+
+    [Test]
+    public void MapSessionParticipant_RoundTripsLaunchContextLocalSeatsAndMetadata()
+    {
+        var source = new MapSessionManager();
+        MapSession sourceSession = source.CreateSession(new MapId("seats"), new Ludots.Core.Config.MapConfig());
+        sourceSession.LaunchContext = MapLaunchContext.Create(
+            new[]
+            {
+                new LocalSeatLaunchBinding("seat.0", 1, "scheme.wasd"),
+                new LocalSeatLaunchBinding("seat.1", 2, null),
+            },
+            new Dictionary<string, object> { ["difficulty"] = "hard" });
+        source.PushFocused(new MapId("seats"));
+
+        var target = new MapSessionManager();
+        target.CreateSession(new MapId("seats"), new Ludots.Core.Config.MapConfig());
+
+        ISaveParticipant participant = CoreSaveParticipants.CreateMapSessionsParticipant(source);
+        ISaveParticipant targetParticipant = CoreSaveParticipants.CreateMapSessionsParticipant(target);
+
+        JsonNode captured = participant.CaptureState();
+        JsonNode? seatZero = captured["sessions"]![0]!["launchContext"]!["localSeats"]![0];
+        JsonNode? seatOne = captured["sessions"]![0]!["launchContext"]!["localSeats"]![1];
+        Assert.That(seatZero!["controlSchemeId"]!.GetValue<string>(), Is.EqualTo("scheme.wasd"));
+        Assert.That(seatZero["seatId"]!.GetValue<string>(), Is.EqualTo("seat.0"));
+        Assert.That(seatZero["playerId"]!.GetValue<int>(), Is.EqualTo(1));
+        Assert.That(seatOne is JsonObject { Count: > 0 } seatOneObject && seatOneObject.ContainsKey("controlSchemeId"), Is.False,
+            "an undeclared controlSchemeId is omitted instead of serialized as an empty default.");
+
+        targetParticipant.RestoreState(captured);
+
+        MapLaunchContext? restored = target.GetSession(new MapId("seats"))!.LaunchContext;
+        Assert.That(restored, Is.Not.Null);
+        Assert.That(restored!.LocalSeats.Count, Is.EqualTo(2));
+        Assert.That(restored.LocalSeats[0].SeatId, Is.EqualTo("seat.0"));
+        Assert.That(restored.LocalSeats[0].PlayerId, Is.EqualTo(1));
+        Assert.That(restored.LocalSeats[0].ControlSchemeId, Is.EqualTo("scheme.wasd"));
+        Assert.That(restored.LocalSeats[1].SeatId, Is.EqualTo("seat.1"));
+        Assert.That(restored.LocalSeats[1].PlayerId, Is.EqualTo(2));
+        Assert.That(restored.LocalSeats[1].ControlSchemeId, Is.Null);
+        Assert.That(restored.Metadata!, Is.Not.Null);
+        Assert.That(restored.Metadata!["difficulty"], Is.EqualTo("hard"));
     }
 
     [Test]


### PR DESCRIPTION
## 概要

- 变更目标：关闭 #902 的 P2.5 遗留两件事——`seat.ControlSchemeId` 此前全链路只被携带/序列化、从未被 `ControlSchemeRuntime` 消费；存档 `launchContext.localSeats[]` round-trip 无直接测试。
- 影响范围：`ParticipantBindingResolver.PublishLocalSeats`（激活钩子）、GasTests/PersistenceTests、合同文档。P3 多座位生产化已另开 #1058。

## 行为语义（合同页 3.3 已同步）

- 唯一 seat 声明的 `controlSchemeId` 是本次进图的激活真相：发布时 `TrySwitch` 激活，优先于偏好存储旧选择；`TrySwitch` 照常写偏好存储
- seat 未声明：既有链路（偏好 → 首个 allowed）不变，热切换 showcase 行为零变化
- 声明但未安装 / 被 allowed-set 拒绝：fail-fast 指名 scheme，不静默回退（延续 #1024/#1025 显式绑定治理）
- 多 seat：不激活任何声明（per-seat 路由是 #1058 P3）

## 验证

- `dotnet build src/Core/Ludots.Core.csproj` 0 错误
- GasTests `ParticipantBindingContractTests` 35/35（含 6 个新激活链测试：激活/未声明不变/未安装 fail-fast/allowed-set 拒绝 fail-fast/双 seat 不激活）
- PersistenceTests `MapSessionParticipant*` 3/3（新增 round-trip：双 seat 含 controlSchemeId 声明与省略 + metadata）
- GasTests `ControlSchemeRuntimeTests` + Association 目录 39/39
- ArchitectureTests 240/245：5 个失败（Mods_DoNotReference_SkiaSharp / FormalGraphsJson_MustNotUseNodesNext / AuthoredMapTeamComponents_HaveExplicitParticipantTeamBindings / ConfigPipeline_MergesPresentationRuntimeCapacities / RelationshipRuntimeCollectIncoming_UsesReverseIndexWithoutWorldScan）已在 pristine origin/main 复跑确认失败，属 main 存量问题，与本 PR 无关

## 文档同步

- [x] `gitbook/architecture/client-local-seat-and-logic-view.md`：3.1 字段语义、3.2 链路第 7 步、3.3 控制方案激活链小节、UAT 三场景、§7 分期 P2.5 收口/P3 措辞