### PR TITLE
refactor(portal): 面板矩阵页对齐 graph wiki 正路——SSOT 数据管线

### DIFF
--- a/docs/panels.html
+++ b/docs/panels.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>面板矩阵 — Ludots</title>
+<meta name="description" content="Ludots 面板矩阵：35 类面板设计一站式——高保真 web 预期（三主题切换）、设计文档直达、showcase 预留位。目录数据由构建脚本从 panel-case-designs.md 解析生成。">
+<link rel="stylesheet" href="site-assets/site.css">
+<style>
+  .docs-layout {
+    display: grid; grid-template-columns: 320px 1fr; gap: 26px; align-items: start;
+  }
+  .docs-tree {
+    background: var(--card); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: 18px 14px;
+    max-height: 74vh; overflow-y: auto; position: sticky; top: 84px;
+  }
+  .docs-tree .tree-title {
+    font-size: 13px; font-weight: 700; color: var(--muted);
+    padding: 0 10px 10px; letter-spacing: 1px;
+  }
+  .docs-tree a, .docs-tree .entry {
+    display: block; padding: 5px 10px; border-radius: var(--radius-sm);
+    color: var(--fg); font-size: 13.5px; line-height: 1.55;
+  }
+  .docs-tree a:hover { background: var(--accent-light); color: var(--accent); text-decoration: none; }
+  .docs-tree a.active { background: var(--accent-light); color: var(--accent); font-weight: 600; }
+  .docs-tree .grp > .entry { font-weight: 600; }
+  .docs-tree .children { margin-left: 14px; border-left: 1px solid var(--border); padding-left: 6px; }
+  .docs-tree .id { font-family: ui-monospace, Consolas, monospace; font-size: 12px; color: var(--faint); margin-right: 6px; }
+  .wiki-filter {
+    width: 100%; margin: 0 0 10px; padding: 7px 10px; font-size: 13px;
+    border: 1px solid var(--border); border-radius: var(--radius-sm);
+    background: var(--bg); color: var(--fg);
+  }
+  .md-body { min-width: 0; }
+  .docs-loading { color: var(--muted); padding: 40px 0; text-align: center; }
+
+  .panels-toolbar { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin: 0 0 18px; }
+  .panels-toolbar button {
+    background: var(--card); color: var(--fg); border: 1px solid var(--border);
+    border-radius: var(--radius-sm); padding: 6px 13px; font-size: 13px; cursor: pointer;
+  }
+  .panels-toolbar button.on { border-color: var(--accent); color: var(--accent); font-weight: 700; }
+
+  .st { font-size: 12px; padding: 1px 9px; border-radius: 99px; border: 1px solid var(--border); color: var(--muted); white-space: nowrap; }
+  .st.g { color: var(--green); border-color: var(--green); }
+  .st.r { color: #e0a24a; border-color: #e0a24a; }
+  .st.b { color: var(--red); border-color: var(--red); }
+  .st.x { color: var(--steel); border-color: var(--steel); }
+
+  /* 三主题皮肤：仅作用于正文里的线框代码块（```text 预期图） */
+  .md-body pre code.wire { display: block; padding: 12px 14px; border-radius: 10px;
+    border: 1.5px solid var(--border); background: var(--card); overflow-x: auto; }
+  body[data-skin="ink-wash"] .md-body pre code.wire {
+    background: #f5f0e4e0; border-color: #2b2b2bd0; color: #1c1c1c;
+    font-family: "KaiTi", "STKaiti", serif; }
+  body[data-skin="fantasy"] .md-body pre code.wire {
+    background: #3d2c1ceb; border-color: #c9a65a; color: #e2d6bc;
+    font-family: Georgia, "Palatino Linotype", serif; }
+  body[data-skin="minimal"] .md-body pre code.wire {
+    background: #fafafaf5; border-color: #141414c8; color: #111;
+    font-family: "Segoe UI", "Helvetica Neue", sans-serif; }
+</style>
+</head>
+<body data-skin="default">
+<header class="topbar"><div class="wrap">
+  <a class="brand" href="index.html">Ludots <span>门户</span></a>
+  <nav class="topnav">
+    <a href="index.html#docs">文档</a><a href="gallery.html">Showcase</a><a href="tests.html">验收</a>
+    <a href="diagrams.html">图库</a><a class="on" href="panels.html">面板矩阵</a>
+  </nav>
+</div></header>
+
+<main class="wrap">
+  <section class="section">
+    <div class="section-head">
+      <div class="kicker">PANEL MATRIX</div>
+      <h1>面板矩阵 — 35 类设计 · 高保真预期 · Showcase 预留位</h1>
+      <p>面板 = 一张图的输出引脚集（graph + pins）。正文即 35 案全设计文档（与本页同源，
+        <a href="index.html#docs/architecture/panel-quickstart.md">快速上手</a> ·
+        <a href="index.html#docs/architecture/panel-catalog-designs.md">总合同</a>）；
+        主题皮肤切换作用于各案线框预期图的观感预览。实机以 launcher 预设为准。</p>
+    </div>
+    <div class="panels-toolbar">
+      <span style="color:var(--muted);font-size:13px;">线框主题皮肤：</span>
+      <button data-skin="default" class="on">默认</button>
+      <button data-skin="ink-wash">水墨</button>
+      <button data-skin="fantasy">西方魔幻</button>
+      <button data-skin="minimal">极简</button>
+      <span style="flex:1"></span>
+      <span style="color:var(--muted);font-size:13px;">
+        <span class="st g">🟢 可开发</span> <span class="st r">🔴 链缺口</span>
+        <span class="st b">⛔ 装载拒</span> <span class="st x">⚙ 机制</span>
+        · showcase 位随阶段 5 逐案点亮
+      </span>
+    </div>
+    <div class="docs-layout">
+      <aside class="docs-tree" id="panel-tree">
+        <div class="docs-loading">目录加载中…（请先运行 python scripts/build-site.py）</div>
+      </aside>
+      <article class="md-body" id="panel-body">
+        <div class="docs-loading">文档加载中…</div>
+      </article>
+    </div>
+  </section>
+</main>
+
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="site-assets/site.js"></script>
+<script src="site-assets/panels-nav.js"></script>
+<script>
+(function () {
+  "use strict";
+  var esc = LudotsSite.esc;
+  var DOC_PATH = "gitbook/architecture/panel-case-designs.md";
+  var STATUS = { "🟢": ["可开发", "g"], "🔴": ["链缺口", "r"], "⛔": ["装载拒", "b"], "⚙": ["机制", "x"] };
+
+  function flatCases() {
+    var flat = [];
+    var nav = window.PANELS_NAV;
+    if (!nav) return flat;
+    for (var i = 0; i < nav.groups.length; i++) {
+      for (var j = 0; j < nav.groups[i].cases.length; j++) flat.push(nav.groups[i].cases[j]);
+    }
+    return flat;
+  }
+
+  function buildTree() {
+    var host = document.getElementById("panel-tree");
+    var nav = window.PANELS_NAV;
+    if (!nav || !nav.groups) {
+      host.innerHTML = '<div class="tree-title">目录不可用</div><div class="docs-loading">请先运行构建。</div>';
+      return;
+    }
+    var html = '<div class="tree-title">面板矩阵 · ' + nav.total + " 案 · " + nav.groups.length + " 组</div>";
+    html += '<input class="wiki-filter" id="panel-filter" type="search" placeholder="过滤：面板 id / 名称 / 状态">';
+    for (var i = 0; i < nav.groups.length; i++) {
+      var g = nav.groups[i];
+      html += '<div class="grp"><div class="entry">' + esc(g.title) +
+        ' <span style="color:var(--faint);font-weight:400;font-size:12px;">' + g.cases.length + "</span></div><div class=\"children\">";
+      for (var j = 0; j < g.cases.length; j++) {
+        var c = g.cases[j];
+        var st = STATUS[c.status] || ["?", ""];
+        html += '<a href="#panel/' + esc(c.id) + '"><span class="id">' + esc(c.no) + "</span>" + esc(c.title || c.id) +
+          ' <span class="st ' + st[1] + '">' + esc(st[0]) + "</span></a>";
+      }
+      html += "</div></div>";
+    }
+    host.innerHTML = html;
+
+    var filter = document.getElementById("panel-filter");
+    filter.addEventListener("input", function () {
+      var q = filter.value.trim().toLowerCase();
+      host.querySelectorAll(".grp").forEach(function (grp) {
+        var visible = 0;
+        grp.querySelectorAll("a").forEach(function (a) {
+          var hit = !q || a.textContent.toLowerCase().indexOf(q) >= 0;
+          a.style.display = hit ? "" : "none";
+          if (hit) visible++;
+        });
+        grp.style.display = visible ? "" : "none";
+      });
+    });
+  }
+
+  function loadDoc() {
+    var body = document.getElementById("panel-body");
+    LudotsSite.fetchText(DOC_PATH).then(function (md) {
+      body.innerHTML = marked.parse(md);
+      // 线框预期图（```text 块）加皮肤钩子；案标题注入状态徽章 + showcase 预留位
+      body.querySelectorAll("pre code.language-text").forEach(function (c) { c.classList.add("wire"); });
+      var byId = {};
+      flatCases().forEach(function (c) { byId[c.id] = c; });
+      body.querySelectorAll("h2, h3, h4").forEach(function (h) {
+        var m = h.textContent.match(/(panel\.[a-z_.]+)/);
+        if (!m) return;
+        var c = byId[m[1]];
+        if (!c) return;
+        var st = STATUS[c.status] || ["?", ""];
+        var span = document.createElement("span");
+        span.className = "st " + st[1];
+        span.style.marginLeft = "10px";
+        span.textContent = st[0] + " · showcase " + (c.status === "🟢" ? "待立项（可开工）" : "随缺口批次");
+        h.appendChild(span);
+      });
+      route(true);
+    }).catch(function () {
+      body.innerHTML = '<div class="docs-loading">无法加载 ' + esc(DOC_PATH) + "</div>";
+    });
+  }
+
+  function route(scroll) {
+    var h = window.location.hash || "";
+    if (h.indexOf("#panel/") !== 0) return;
+    var pid = decodeURIComponent(h.slice("#panel/".length));
+    var hit = null;
+    document.querySelectorAll("#panel-body h2, #panel-body h3, #panel-body h4").forEach(function (el) {
+      if (!hit && el.textContent.indexOf(pid) >= 0) hit = el;
+    });
+    document.querySelectorAll("#panel-tree a").forEach(function (a) {
+      a.classList.toggle("active", a.getAttribute("href") === "#" + h.slice(1) || a.getAttribute("href") === h);
+    });
+    if (hit && scroll) hit.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
+  document.querySelectorAll(".panels-toolbar button").forEach(function (b) {
+    b.addEventListener("click", function () {
+      document.querySelectorAll(".panels-toolbar button").forEach(function (x) { x.classList.remove("on"); });
+      b.classList.add("on");
+      document.body.dataset.skin = b.dataset.skin;
+    });
+  });
+
+  document.addEventListener("DOMContentLoaded", function () {
+    if (window.marked && marked.setOptions) {
+      marked.setOptions({ gfm: true, breaks: false, headerIds: true, mangle: false });
+    }
+    buildTree();
+    loadDoc();
+    window.addEventListener("hashchange", function () { route(true); });
+  });
+})();
+</script>
+</body>
+</html>

--- a/scripts/build-site.py
+++ b/scripts/build-site.py
@@ -198,6 +198,54 @@ WIKI_FAMILY_HEADING = re.compile(r"^## (.+?)\s*$")
 WIKI_OP_ITEM = re.compile(r"^-\s+\[(?P<title>[^\]]+)\]\((?P<file>[^)]+?\.md)\)\s*(?:—|-)\s*(?P<desc>.*)$")
 
 
+
+PANEL_CASE_HEADING = re.compile(r"^#{2,4} 案 (?P<no>[A-Z]|\d+)[：:](?P<rest>.+)$")
+PANEL_ID_IN_TEXT = re.compile(r"`?(panel\.[a-z_.]+)`?")
+PANEL_STATUS_LINE = re.compile(r"^>\s*(?:状态[：:]\s*)?(?P<status>[🟢🔴⛔⚙])")
+
+def parse_panel_cases(md_path: Path, label: str) -> dict:
+    """解析 panel-case-designs.md 的案标题/状态行为分组树（面板矩阵页数据源）。
+
+    两种标题排列都收：`案 A：玩家信息聚合 \`panel.x\` —— 定位`（前四案）与
+    `案 5：panel.x —— 定位`（31 案）；状态徽章取案首引用行的 emoji。
+    """
+    nav: dict = {"groups": [], "total": 0}
+    if not md_path.exists():
+        warn(f"{label} 不存在 -> 面板目录为空")
+        return nav
+    current_group = None
+    pending_case = None
+    for raw in md_path.read_text(encoding="utf-8").splitlines():
+        heading = PANEL_CASE_HEADING.match(raw)
+        if heading:
+            rest = heading.group("rest")
+            found = PANEL_ID_IN_TEXT.search(rest)
+            if not found:
+                continue
+            pid = found.group(1)
+            title = re.sub(r"\s+", " ", " — ".join(rest.replace(found.group(0), "").split(" —— "))).strip()
+            if current_group is None:
+                current_group = {"title": "前四案（全设计）", "cases": []}
+                nav["groups"].insert(0, current_group)
+            pending_case = {"id": pid, "no": heading.group("no"), "title": title, "status": ""}
+            current_group["cases"].append(pending_case)
+            nav["total"] += 1
+            continue
+        if raw.startswith("## ") and not raw.startswith("## 案"):
+            title = raw.strip("# ").strip()
+            if title.startswith("五、") or title.startswith("二、") or title.startswith("三、") or title.startswith("四、") or title.startswith("六、") or title.startswith("七、"):
+                current_group = {"title": title, "cases": []}
+                nav["groups"].append(current_group)
+                pending_case = None
+            continue
+        status = PANEL_STATUS_LINE.match(raw)
+        if status and pending_case is not None:
+            pending_case["status"] = status.group("status")
+            pending_case = None
+    if nav["total"] == 0:
+        warn(f"{label} 未解析到任何案条目 -> 检查案标题格式")
+    return nav
+
 def parse_wiki_catalog(readme_path: Path, label: str) -> dict:
     """解析 wiki 总目录为家族树（站点画廊页数据源；条目缺失页面时硬失败防 404）。"""
     nav: dict = {"families": [], "total": 0}
@@ -489,6 +537,14 @@ def build(out_dir: Path) -> int:
         **parse_wiki_catalog(ENGINE_GALLERY_WIKI_DIR / "README.md", "engine-gallery-wiki"),
     }
 
+    print("-- 解析 panel-case-designs.md 案目录 -> panels-nav.js")
+    panels_nav = {
+        "generatedAt": now,
+        "source": "gitbook/architecture/panel-case-designs.md",
+        **parse_panel_cases(GITBOOK_DIR / "architecture" / "panel-case-designs.md", "panel-case-designs"),
+    }
+    write_js(out_dir / "site-assets" / "panels-nav.js", "PANELS_NAV", panels_nav)
+
     print("-- 读取 showcase.registry.json → gallery-data.js")
     showcases, schema_version = load_registry(REGISTRY_JSON)
     gallery_data = {
@@ -543,6 +599,7 @@ def build(out_dir: Path) -> int:
         "graph-op-wiki.html", "raylib-engine.html", "agent-bridge.html",
         "site-assets/site.css", "site-assets/site.js",
         "site-assets/docs-nav.js", "site-assets/prd-nav.js", "site-assets/graph-op-nav.js",
+        "site-assets/panels-nav.js",
         "site-assets/engine-gallery-nav.js",
         "site-assets/gallery-data.js", "site-assets/evidence-data.js",
         ".nojekyll",


### PR DESCRIPTION
修正 #1072 的标新立异（用户指正）：上一版把 35 案数据内嵌 HTML，违反 SSOT。

对齐 docs/graph-op-wiki.html 的既定模式：
- **数据管线**：build-site.py 新增 parse_panel_cases()——从 gitbook/architecture/panel-case-designs.md 解析 35 案（前四案/31 案两种标题排列都收，状态徽章取案首引用行 emoji）→ 生成 site-assets/panels-nav.js。设计文档改一处，门户自动跟。
- **页面骨架**：与 graph wiki 同款——左树（七组+过滤框）右 marked 渲染正文（fetch 同一份 markdown，单数据源单渲染），deep-link #panel/<id> 滚动定位；案标题注入状态徽章 + showcase 预留位（🟢 标'待立项可开工'）。
- **三主题皮肤**收敛为线框预期图（正文 text 代码块）的观感预览，删掉自造 mock 组件。
- 构建自验：退出 0、required 清单收编 panels-nav.js、35 案计数断言。