### PR TITLE
fix(portal): 首页五卡孤行修复——cols-5 网格

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -192,7 +192,7 @@
       <h2>从这里进入</h2>
       <p>门户的五个主区域：正式文档、Showcase 画廊、测试与验收证据、架构图库、面板矩阵。</p>
     </div>
-    <div class="grid cols-4">
+    <div class="grid cols-5">
       <a class="card nav-card" href="#docs">
         <div class="icon" style="background: var(--accent-light); color: var(--accent);">📖</div>
         <h3>文档</h3>

--- a/docs/site-assets/site.css
+++ b/docs/site-assets/site.css
@@ -170,6 +170,7 @@ a:hover { color: var(--accent-dark); text-decoration: underline; }
 .grid.cols-2 { grid-template-columns: repeat(2, 1fr); }
 .grid.cols-3 { grid-template-columns: repeat(3, 1fr); }
 .grid.cols-4 { grid-template-columns: repeat(4, 1fr); }
+.grid.cols-5 { grid-template-columns: repeat(5, 1fr); }
 
 /* ============ 统计卡（index / tests 共用） ============ */
 .stat-card { padding: 26px 24px; text-align: left; }
@@ -403,12 +404,13 @@ table.data tbody tr:hover td { background: var(--bg-soft); }
 
 /* ============ 响应式 ============ */
 @media (max-width: 960px) {
-  .grid.cols-4 { grid-template-columns: repeat(2, 1fr); }
+  .grid.cols-5 { grid-template-columns: repeat(3, 1fr); }
+.grid.cols-4 { grid-template-columns: repeat(2, 1fr); }
   .grid.cols-3 { grid-template-columns: repeat(2, 1fr); }
 }
 @media (max-width: 720px) {
   .page { padding: 32px 18px 72px; }
-  .grid.cols-4, .grid.cols-3, .grid.cols-2 { grid-template-columns: 1fr; }
+  .grid.cols-5, .grid.cols-4, .grid.cols-3, .grid.cols-2 { grid-template-columns: 1fr; }
   .topbar-inner { padding: 0 16px; gap: 12px; }
   .topbar nav {
     display: none;


### PR DESCRIPTION
上一批加第五张导航卡时沿用了 cols-4（固定四列），第五张卡换行孤悬破坏首页布局。补 site.css cols-5 类（桌面 5 列 / 960px 3 列 / 720px 1 列，与既有断点纪律一致），导航卡区换 cols-5。