### PR TITLE
fix(portal): 顶栏导航收录面板矩阵（site.js NAV 登记+统一渲染器）

### DIFF
--- a/docs/panels.html
+++ b/docs/panels.html
@@ -63,14 +63,8 @@
     font-family: "Segoe UI", "Helvetica Neue", sans-serif; }
 </style>
 </head>
-<body data-skin="default">
-<header class="topbar"><div class="wrap">
-  <a class="brand" href="index.html">Ludots <span>门户</span></a>
-  <nav class="topnav">
-    <a href="index.html#docs">文档</a><a href="gallery.html">Showcase</a><a href="tests.html">验收</a>
-    <a href="diagrams.html">图库</a><a class="on" href="panels.html">面板矩阵</a>
-  </nav>
-</div></header>
+<body data-skin="default" data-page="panels">
+<header id="topbar"></header>
 
 <main class="wrap">
   <section class="section">

--- a/docs/site-assets/site.js
+++ b/docs/site-assets/site.js
@@ -33,7 +33,8 @@
     { href: "agent-bridge.html", label: "Agent 调试桥", page: "agentbridge" },
     { href: "gallery.html", label: "Showcase 画廊", page: "gallery" },
     { href: "tests.html", label: "测试与验收", page: "tests" },
-    { href: "diagrams.html", label: "架构图库", page: "diagrams" }
+    { href: "diagrams.html", label: "架构图库", page: "diagrams" },
+    { href: "panels.html", label: "面板矩阵", page: "panels" }
   ];
 
   /* docs 文档页侧栏目录（原 31 页各自硬编码的 navData 收敛于此；


### PR DESCRIPTION
全站顶栏缺'面板矩阵'入口：顶栏由 site.js NAV 数组统一渲染，panels 未登记。本 PR：NAV 数组加条目；panels.html 手写 topbar 换统一渲染器（header id=topbar + data-page=panels）。