### PR TITLE
feat(save): MapVariableStore 存档 participant——map 级变量读档可恢复

### DIFF
--- a/src/Core/Gameplay/MapTriggers/MapVariableStore.cs
+++ b/src/Core/Gameplay/MapTriggers/MapVariableStore.cs
@@ -32,6 +32,16 @@ namespace Ludots.Core.Gameplay.MapTriggers
         public bool Phase { get; set; }
     }
 
+    /// <summary>One variable in a save snapshot; only the field matching <see cref="Type"/> carries a live value.</summary>
+    public sealed record MapVariableValueSnapshot(string Name, MapVariableType Type, int IntValue, float FloatValue);
+
+    /// <summary>
+    /// Save payload for a <see cref="MapVariableStore"/>. Revisions are not persisted: restore
+    /// writes values directly onto the freshly declared slots (revisions stay at zero) and does
+    /// not dispatch PhaseChanged, so the first post-restore write diffs against the restored value.
+    /// </summary>
+    public sealed record MapVariableStoreSnapshot(IReadOnlyList<MapVariableValueSnapshot> Variables);
+
     public static class MapVariableDeclarations
     {
         private const string AllowedFields = "name, type, initial, phase";
@@ -304,6 +314,74 @@ namespace Ludots.Core.Gameplay.MapTriggers
         }
 
         public uint GetRevision(string name) => RequireSlot(name).Revision;
+
+        public MapVariableStoreSnapshot CaptureSnapshot()
+        {
+            var entries = new List<MapVariableValueSnapshot>(_slots.Count);
+            foreach (KeyValuePair<string, Slot> pair in _slots)
+            {
+                Slot slot = pair.Value;
+                entries.Add(new MapVariableValueSnapshot(pair.Key, slot.Type, slot.IntValue, slot.FloatValue));
+            }
+
+            entries.Sort(static (a, b) => string.CompareOrdinal(a.Name, b.Name));
+            return new MapVariableStoreSnapshot(entries);
+        }
+
+        public void RestoreSnapshot(MapVariableStoreSnapshot snapshot)
+        {
+            if (snapshot == null) throw new ArgumentNullException(nameof(snapshot));
+
+            var pending = new List<(Slot Slot, MapVariableValueSnapshot Entry)>(snapshot.Variables.Count);
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            for (int i = 0; i < snapshot.Variables.Count; i++)
+            {
+                MapVariableValueSnapshot entry = snapshot.Variables[i];
+                if (entry == null)
+                {
+                    throw new InvalidOperationException(
+                        $"Map '{MapId.Value}' save variable entry at index {i} is null.");
+                }
+
+                if (!seen.Add(entry.Name))
+                {
+                    throw new InvalidOperationException(
+                        $"Map '{MapId.Value}' save contains variable '{entry.Name}' more than once.");
+                }
+
+                if (!_slots.TryGetValue(entry.Name, out Slot? slot))
+                {
+                    throw new InvalidOperationException(
+                        $"Map '{MapId.Value}' save contains variable '{entry.Name}' that the map does not declare.");
+                }
+
+                if (slot.Type != entry.Type)
+                {
+                    throw new InvalidOperationException(
+                        $"Map '{MapId.Value}' variable '{entry.Name}' is declared as {slot.Type} but the save stores {entry.Type}.");
+                }
+
+                pending.Add((slot, entry));
+            }
+
+            if (pending.Count != _slots.Count)
+            {
+                foreach (string declared in _slots.Keys)
+                {
+                    if (!seen.Contains(declared))
+                    {
+                        throw new InvalidOperationException(
+                            $"Map '{MapId.Value}' save is missing declared variable '{declared}'.");
+                    }
+                }
+            }
+
+            for (int i = 0; i < pending.Count; i++)
+            {
+                pending[i].Slot.IntValue = pending[i].Entry.IntValue;
+                pending[i].Slot.FloatValue = pending[i].Entry.FloatValue;
+            }
+        }
 
         public void WriteInt(string name, int value)
         {

--- a/src/Core/Map/MapSessionManager.cs
+++ b/src/Core/Map/MapSessionManager.cs
@@ -3,13 +3,15 @@ using System.Collections.Generic;
 using Arch.Core;
 using Ludots.Core.Config;
 using Ludots.Core.Diagnostics;
+using Ludots.Core.Gameplay.MapTriggers;
 
 namespace Ludots.Core.Map
 {
     public sealed record MapSessionEntrySnapshot(
         string MapId,
         MapSessionState State,
-        MapLaunchContext? LaunchContext = null);
+        MapLaunchContext? LaunchContext = null,
+        MapVariableStoreSnapshot? Variables = null);
 
     public sealed record MapSessionManagerSnapshot(
         IReadOnlyList<MapSessionEntrySnapshot> Sessions,
@@ -145,7 +147,10 @@ namespace Ludots.Core.Map
             var sessions = new List<MapSessionEntrySnapshot>(_sessions.Count);
             foreach (var pair in _sessions)
             {
-                sessions.Add(new MapSessionEntrySnapshot(pair.Key.Value, pair.Value.State, pair.Value.LaunchContext));
+                MapVariableStore variables = pair.Value.Variables ??
+                    throw new InvalidOperationException(
+                        $"Map session '{pair.Key.Value}' has no variable store to capture; the session is not alive.");
+                sessions.Add(new MapSessionEntrySnapshot(pair.Key.Value, pair.Value.State, pair.Value.LaunchContext, variables.CaptureSnapshot()));
             }
 
             var focusTopFirst = _focusStack.ToArray();
@@ -175,6 +180,14 @@ namespace Ludots.Core.Map
 
                 session.State = sessionSnapshot.State;
                 session.LaunchContext = sessionSnapshot.LaunchContext;
+
+                MapVariableStoreSnapshot variables = sessionSnapshot.Variables ??
+                    throw new InvalidOperationException(
+                        $"Map session '{sessionSnapshot.MapId}' save entry carries no variables.");
+                MapVariableStore store = session.Variables ??
+                    throw new InvalidOperationException(
+                        $"Cannot restore variables for map session '{sessionSnapshot.MapId}' because its variable store is gone.");
+                store.RestoreSnapshot(variables);
             }
 
             for (int i = 0; i < snapshot.FocusStack.Count; i++)

--- a/src/Core/Persistence/CoreSaveParticipants.cs
+++ b/src/Core/Persistence/CoreSaveParticipants.cs
@@ -8,6 +8,7 @@ using Ludots.Core.Engine.TimeFlow;
 using Ludots.Core.Gameplay;
 using Ludots.Core.Gameplay.Camera;
 using Ludots.Core.Gameplay.GAS;
+using Ludots.Core.Gameplay.MapTriggers;
 using Ludots.Core.Gameplay.Narrative;
 using Ludots.Core.Gameplay.Quests;
 using Ludots.Core.Gameplay.Relationships;
@@ -389,7 +390,8 @@ namespace Ludots.Core.Persistence
                     var sessionObject = new JsonObject
                     {
                         ["mapId"] = session.MapId,
-                        ["state"] = session.State.ToString()
+                        ["state"] = session.State.ToString(),
+                        ["variables"] = WriteMapVariables(session.Variables)
                     };
                     JsonObject? launchContext = WriteLaunchContext(session.LaunchContext);
                     if (launchContext != null)
@@ -434,7 +436,8 @@ namespace Ludots.Core.Persistence
                     sessions.Add(new MapSessionEntrySnapshot(
                         RequireString(session, "mapId"),
                         sessionState,
-                        ReadLaunchContext(session["launchContext"])));
+                        ReadLaunchContext(session["launchContext"]),
+                        ReadMapVariables(RequireObject(session["variables"], $"sessions[{i}].variables"), $"sessions[{i}].variables")));
                 }
 
                 JsonArray focusStackArray = RequireArray(root, "focusStack");
@@ -444,7 +447,14 @@ namespace Ludots.Core.Persistence
                     focusStack[i] = RequireStringValue(focusStackArray[i], $"focusStack[{i}]");
                 }
 
-                _manager.RestoreSnapshot(new MapSessionManagerSnapshot(sessions, focusStack));
+                try
+                {
+                    _manager.RestoreSnapshot(new MapSessionManagerSnapshot(sessions, focusStack));
+                }
+                catch (InvalidOperationException ex)
+                {
+                    throw new SaveContextException($"Map sessions save state is invalid: {ex.Message}");
+                }
             }
         }
 
@@ -880,6 +890,85 @@ namespace Ludots.Core.Persistence
             }
 
             return node.GetValue<string>();
+        }
+
+        private static JsonObject WriteMapVariables(MapVariableStoreSnapshot? snapshot)
+        {
+            if (snapshot == null)
+            {
+                throw new SaveContextException("Map session snapshot carries no variable store state.");
+            }
+
+            var variables = new JsonObject();
+            for (int i = 0; i < snapshot.Variables.Count; i++)
+            {
+                MapVariableValueSnapshot entry = snapshot.Variables[i];
+                var slotValue = new JsonObject
+                {
+                    ["type"] = entry.Type.ToString()
+                };
+                slotValue["value"] = entry.Type == MapVariableType.Int
+                    ? JsonValue.Create(entry.IntValue)!
+                    : JsonValue.Create(entry.FloatValue)!;
+                variables[entry.Name] = slotValue;
+            }
+
+            return variables;
+        }
+
+        private static MapVariableStoreSnapshot ReadMapVariables(JsonObject variables, string field)
+        {
+            var entries = new List<MapVariableValueSnapshot>(variables.Count);
+            foreach (KeyValuePair<string, JsonNode?> pair in variables)
+            {
+                JsonObject entry = RequireObject(pair.Value, $"{field}.{pair.Key}");
+                string typeText = RequireString(entry, "type");
+                if (!Enum.TryParse(typeText, ignoreCase: false, out MapVariableType type) ||
+                    !string.Equals(type.ToString(), typeText, StringComparison.Ordinal))
+                {
+                    throw new SaveContextException($"Map variable '{pair.Key}' type '{typeText}' at {field} is invalid.");
+                }
+
+                double raw = RequireDouble(entry, "value", $"{field}.{pair.Key}.value");
+                int intValue = 0;
+                float floatValue = 0f;
+                if (type == MapVariableType.Int)
+                {
+                    if (Math.Floor(raw) != raw || raw > int.MaxValue || raw < int.MinValue)
+                    {
+                        throw new SaveContextException($"Map variable '{pair.Key}' int value {raw} at {field} is invalid.");
+                    }
+
+                    intValue = (int)raw;
+                }
+                else
+                {
+                    floatValue = (float)raw;
+                }
+
+                entries.Add(new MapVariableValueSnapshot(pair.Key, type, intValue, floatValue));
+            }
+
+            return new MapVariableStoreSnapshot(entries);
+        }
+
+        private static double RequireDouble(JsonObject root, string field, string label)
+        {
+            JsonNode? node = root[field];
+            if (node == null)
+            {
+                throw new SaveContextException($"Save domain field '{label}' is missing.");
+            }
+
+            if (node is JsonValue value)
+            {
+                if (value.TryGetValue<int>(out int integer)) return integer;
+                if (value.TryGetValue<long>(out long longInteger)) return longInteger;
+                if (value.TryGetValue<float>(out float single)) return single;
+                if (value.TryGetValue<double>(out double number)) return number;
+            }
+
+            throw new SaveContextException($"Save domain field '{label}' must be a number.");
         }
 
         private static JsonObject? WriteLaunchContext(MapLaunchContext? launchContext)

--- a/src/Tests/PersistenceTests/MapVariableSaveParticipantTests.cs
+++ b/src/Tests/PersistenceTests/MapVariableSaveParticipantTests.cs
@@ -1,0 +1,195 @@
+using System.Text.Json.Nodes;
+using Ludots.Core.Config;
+using Ludots.Core.Gameplay.MapTriggers;
+using Ludots.Core.Map;
+using Ludots.Core.Persistence;
+using NUnit.Framework;
+
+namespace Ludots.Tests.Persistence;
+
+[TestFixture]
+public sealed class MapVariableSaveParticipantTests
+{
+    private const string MapIdValue = "mapvar_save_probe";
+
+    private static MapConfig CreateConfig()
+    {
+        return new MapConfig
+        {
+            Variables =
+            {
+                new MapVariableDeclaration { Name = "phase", Type = MapVariableType.Int, Initial = 0, Phase = true },
+                new MapVariableDeclaration { Name = "kills", Type = MapVariableType.Int, Initial = 0 },
+                new MapVariableDeclaration { Name = "ammo", Type = MapVariableType.Float, Initial = 1.5 },
+            }
+        };
+    }
+
+    private static MapSessionManager CreateManagerWithSession()
+    {
+        var manager = new MapSessionManager();
+        manager.CreateSession(new MapId(MapIdValue), CreateConfig());
+        manager.PushFocused(new MapId(MapIdValue));
+        return manager;
+    }
+
+    private static JsonObject CaptureDomain(MapSessionManager manager)
+    {
+        return CoreSaveParticipants.CreateMapSessionsParticipant(manager).CaptureState().AsObject();
+    }
+
+    private static JsonObject SessionVariables(JsonObject domain)
+    {
+        return domain["sessions"]!.AsArray()[0]!.AsObject()["variables"]!.AsObject();
+    }
+
+    [Test]
+    public void RoundTrip_RestoresValuesExactly_AndKeepsRevisionsAtZero()
+    {
+        MapSessionManager source = CreateManagerWithSession();
+        MapVariableStore sourceStore = source.FocusedSession!.Variables!;
+        sourceStore.WriteInt("phase", 2);
+        sourceStore.WriteInt("kills", 7);
+        sourceStore.WriteFloat("ammo", 3.25f);
+
+        JsonObject domain = CaptureDomain(source);
+
+        MapSessionManager target = CreateManagerWithSession();
+        MapVariableStore targetStore = target.FocusedSession!.Variables!;
+        CoreSaveParticipants.CreateMapSessionsParticipant(target).RestoreState(domain);
+
+        Assert.That(targetStore.ReadInt("phase"), Is.EqualTo(2));
+        Assert.That(targetStore.ReadInt("kills"), Is.EqualTo(7));
+        Assert.That(targetStore.ReadFloat("ammo"), Is.EqualTo(3.25f));
+        Assert.That(targetStore.GetRevision("phase"), Is.EqualTo(0u), "revisions are not persisted; restore leaves them at zero");
+        Assert.That(targetStore.GetRevision("kills"), Is.EqualTo(0u));
+        Assert.That(targetStore.GetRevision("ammo"), Is.EqualTo(0u));
+    }
+
+    [Test]
+    public void Restore_DoesNotFirePhaseChanged_FirstWriteDiffsAgainstRestoredValue()
+    {
+        MapSessionManager source = CreateManagerWithSession();
+        source.FocusedSession!.Variables!.WriteInt("phase", 2);
+        JsonObject domain = CaptureDomain(source);
+
+        MapSessionManager target = CreateManagerWithSession();
+        MapVariableStore targetStore = target.FocusedSession!.Variables!;
+        var changes = new List<(string Name, int Value)>();
+        targetStore.PhaseChangedDispatcher = (_, name, value) => changes.Add((name, value));
+
+        CoreSaveParticipants.CreateMapSessionsParticipant(target).RestoreState(domain);
+
+        Assert.That(changes, Is.Empty, "restore must not dispatch PhaseChanged");
+
+        targetStore.WriteInt("phase", 2);
+        Assert.That(changes, Is.Empty, "same-value write after restore must not fire");
+
+        targetStore.WriteInt("phase", 3);
+        Assert.That(changes, Is.EqualTo(new[] { ("phase", 3) }));
+    }
+
+    [Test]
+    public void Restore_MissingDeclaredVariable_RejectedNamingVariable()
+    {
+        MapSessionManager source = CreateManagerWithSession();
+        JsonObject domain = CaptureDomain(source);
+        SessionVariables(domain).Remove("kills");
+
+        MapSessionManager target = CreateManagerWithSession();
+        MapVariableStore targetStore = target.FocusedSession!.Variables!;
+
+        SaveContextException? error = Assert.Throws<SaveContextException>(
+            () => CoreSaveParticipants.CreateMapSessionsParticipant(target).RestoreState(domain));
+
+        Assert.That(error!.Message, Does.Contain("kills"));
+        Assert.That(error.Message, Does.Contain(MapIdValue));
+        Assert.That(targetStore.ReadInt("phase"), Is.EqualTo(0), "rejected restore must not mutate values");
+        Assert.That(targetStore.ReadFloat("ammo"), Is.EqualTo(1.5f));
+    }
+
+    [Test]
+    public void Restore_UndeclaredVariable_RejectedNamingVariable()
+    {
+        MapSessionManager source = CreateManagerWithSession();
+        JsonObject domain = CaptureDomain(source);
+        SessionVariables(domain)["smuggled"] = new JsonObject
+        {
+            ["type"] = MapVariableType.Int.ToString(),
+            ["value"] = 1
+        };
+
+        MapSessionManager target = CreateManagerWithSession();
+
+        SaveContextException? error = Assert.Throws<SaveContextException>(
+            () => CoreSaveParticipants.CreateMapSessionsParticipant(target).RestoreState(domain));
+
+        Assert.That(error!.Message, Does.Contain("smuggled"));
+        Assert.That(error.Message, Does.Contain(MapIdValue));
+    }
+
+    [Test]
+    public void Restore_TypeMismatch_RejectedNamingVariable()
+    {
+        MapSessionManager source = CreateManagerWithSession();
+        JsonObject domain = CaptureDomain(source);
+        SessionVariables(domain)["kills"] = new JsonObject
+        {
+            ["type"] = MapVariableType.Float.ToString(),
+            ["value"] = 7.0
+        };
+
+        MapSessionManager target = CreateManagerWithSession();
+
+        SaveContextException? error = Assert.Throws<SaveContextException>(
+            () => CoreSaveParticipants.CreateMapSessionsParticipant(target).RestoreState(domain));
+
+        Assert.That(error!.Message, Does.Contain("kills"));
+        Assert.That(error.Message, Does.Contain(MapIdValue));
+    }
+
+    [Test]
+    public void Restore_FractionalIntValue_RejectedNamingVariable()
+    {
+        MapSessionManager source = CreateManagerWithSession();
+        JsonObject domain = CaptureDomain(source);
+        SessionVariables(domain)["kills"]!["value"] = 1.5;
+
+        MapSessionManager target = CreateManagerWithSession();
+
+        SaveContextException? error = Assert.Throws<SaveContextException>(
+            () => CoreSaveParticipants.CreateMapSessionsParticipant(target).RestoreState(domain));
+
+        Assert.That(error!.Message, Does.Contain("kills"));
+    }
+
+    [Test]
+    public void Restore_DuplicateVariable_RejectedNamingVariable()
+    {
+        MapVariableStore store = MapVariableStore.Create(new MapId(MapIdValue), CreateConfig().Variables);
+        var snapshot = new MapVariableStoreSnapshot(new MapVariableValueSnapshot[]
+        {
+            new("phase", MapVariableType.Int, 1, 0f),
+            new("phase", MapVariableType.Int, 2, 0f),
+            new("kills", MapVariableType.Int, 0, 0f),
+            new("ammo", MapVariableType.Float, 0, 1.5f),
+        });
+
+        Assert.That(
+            () => store.RestoreSnapshot(snapshot),
+            Throws.InvalidOperationException.With.Message.Contains("phase"));
+        Assert.That(store.ReadInt("phase"), Is.EqualTo(0), "rejected restore must not mutate values");
+    }
+
+    [Test]
+    public void Capture_SessionWithoutVariableStore_Fails()
+    {
+        var manager = new MapSessionManager();
+        MapSession session = manager.CreateSession(new MapId(MapIdValue), CreateConfig());
+        session.Dispose();
+
+        Assert.That(
+            () => manager.CaptureSnapshot(),
+            Throws.InvalidOperationException.With.Message.Contains(MapIdValue));
+    }
+}


### PR DESCRIPTION
## 设计落点

跟随仓库既有 map 级存档先例——`mapSessions` 域（`MapSessionsSaveParticipant` + `MapSessionManager.CaptureSnapshot/RestoreSnapshot`），不新造平行 participant。理由：

- 该域已按 mapId 键控逐 session 存档，且恢复语义就是“应用到已加载的 session 上”——`MapVariableStore` 由 `MapSession` 构造时按地图 JSON `Variables[]` 声明创建，恢复时声明集天然在场，可以在同一条恢复通道里完成 fail-closed 校验。
- 存档键因此自带 MapId 维度：`sessions[].variables`，无需新键空间。

## 存档内容与 Revision 约定

- 每个已声明变量存 `(name, type, value)`，int/float 按声明类型分别落 `value`（int 不做 float 有损转换）。
- **Revision 不入档**：恢复时值直写到新建 store 的 slot 上，所有 Revision 保持 0（约定，见 `MapVariableStoreSnapshot` 文档注释）。
- 恢复**不触发 PhaseChanged**；恢复后首次写按既有语义与恢复值 diff——写同值不发事件，写新值正常发 `PhaseChanged`（有测试锁定）。

## Fail-closed 语义

快照键集与声明集必须精确一致，全部错误带 mapId 与变量名：

- 快照缺已声明变量 / 多出未声明变量 / 变量重复 → 拒绝
- 快照类型与声明类型不符 / int 变量值非整数或超 int 范围 → 拒绝
- 单 store 恢复先全量校验后应用（拒绝时不改任何值）；manager 侧异常包装为 `SaveContextException`（Quest participant 范式）

## 文件清单

- `src/Core/Gameplay/MapTriggers/MapVariableStore.cs`：`MapVariableValueSnapshot` / `MapVariableStoreSnapshot` 记录 + `CaptureSnapshot` / `RestoreSnapshot`
- `src/Core/Map/MapSessionManager.cs`：`MapSessionEntrySnapshot` 增加 `Variables`；捕获/恢复随 sessions 一并走；session store 已销毁仍被捕获即抛（不静默跳过）
- `src/Core/Persistence/CoreSaveParticipants.cs`：`MapSessionsSaveParticipant` 序列化 `sessions[].variables`，新增 `WriteMapVariables` / `ReadMapVariables` / `RequireDouble`
- `src/Tests/PersistenceTests/MapVariableSaveParticipantTests.cs`：8 个新测试

## 测试

- 新增 8：值逐字段往返相等 + Revision 归 0；恢复不发 PhaseChanged、首次写 diff 语义；缺变量/多变量/类型不符/int 非整数/重复变量均拒绝且错误带变量名；被拒恢复不改值；无 store 的 session 捕获即抛
- `PersistenceTests` 83 中 77 过；6 个失败（3 个固定步确定性 + 3 个 SnapshotRestoreRoundTrip）在干净 `origin/main` 上同样失败，与本改动无关（已 stash 对照验证）
- `GasTests` 中 `MapVariableStoreTests` + `MapLoadLifecycleOrderingTests` 24/24 全绿
- `Ludots.Core.csproj` 构建零错误