### PR TITLE
fix(graph): close live debug and blackboard audit gaps

### DIFF
--- a/src/Core/Gameplay/AI/BehaviorTree/BehaviorTreeWorld.cs
+++ b/src/Core/Gameplay/AI/BehaviorTree/BehaviorTreeWorld.cs
@@ -22,6 +22,9 @@ namespace Ludots.Core.Gameplay.AI.BehaviorTree
         private readonly int[] _scriptResumeGraphIds;
         private readonly int[] _scriptIntRegs;
         private readonly byte[] _scriptBoolRegs;
+        private readonly float[] _scriptFloatRegs;
+        private readonly Entity[] _scriptEntityRegs;
+        private readonly Entity[] _scriptTargetRegs;
         private readonly int[] _scriptCallStacks;
         private int _count;
 
@@ -45,6 +48,9 @@ namespace Ludots.Core.Gameplay.AI.BehaviorTree
             _scriptResumeGraphIds = new int[capacity];
             _scriptIntRegs = new int[capacity * GraphVmLimits.MaxIntRegisters];
             _scriptBoolRegs = new byte[capacity * GraphVmLimits.MaxBoolRegisters];
+            _scriptFloatRegs = new float[capacity * GraphVmLimits.MaxFloatRegisters];
+            _scriptEntityRegs = new Entity[capacity * GraphVmLimits.MaxEntityRegisters];
+            _scriptTargetRegs = new Entity[capacity * GraphVmLimits.MaxTargets];
             _scriptCallStacks = new int[capacity * GraphVmLimits.MaxCallStackDepth];
         }
 
@@ -74,8 +80,14 @@ namespace Ludots.Core.Gameplay.AI.BehaviorTree
             _scriptResumeGraphIds[agent] = 0;
             int intBase = agent * GraphVmLimits.MaxIntRegisters;
             int boolBase = agent * GraphVmLimits.MaxBoolRegisters;
+            int floatBase = agent * GraphVmLimits.MaxFloatRegisters;
+            int entityBase = agent * GraphVmLimits.MaxEntityRegisters;
+            int targetBase = agent * GraphVmLimits.MaxTargets;
             Array.Clear(_scriptIntRegs, intBase, GraphVmLimits.MaxIntRegisters);
             Array.Clear(_scriptBoolRegs, boolBase, GraphVmLimits.MaxBoolRegisters);
+            Array.Clear(_scriptFloatRegs, floatBase, GraphVmLimits.MaxFloatRegisters);
+            Array.Clear(_scriptEntityRegs, entityBase, GraphVmLimits.MaxEntityRegisters);
+            Array.Clear(_scriptTargetRegs, targetBase, GraphVmLimits.MaxTargets);
             Array.Clear(_scriptCallStacks, agent * GraphVmLimits.MaxCallStackDepth, GraphVmLimits.MaxCallStackDepth);
         }
 
@@ -445,6 +457,9 @@ namespace Ludots.Core.Gameplay.AI.BehaviorTree
                     scriptSlices++;
                     Span<int> ints = _scriptIntRegs.AsSpan(agent * GraphVmLimits.MaxIntRegisters, GraphVmLimits.MaxIntRegisters);
                     Span<byte> bools = _scriptBoolRegs.AsSpan(agent * GraphVmLimits.MaxBoolRegisters, GraphVmLimits.MaxBoolRegisters);
+                    Span<float> floats = _scriptFloatRegs.AsSpan(agent * GraphVmLimits.MaxFloatRegisters, GraphVmLimits.MaxFloatRegisters);
+                    Span<Entity> entities = _scriptEntityRegs.AsSpan(agent * GraphVmLimits.MaxEntityRegisters, GraphVmLimits.MaxEntityRegisters);
+                    Span<Entity> targets = _scriptTargetRegs.AsSpan(agent * GraphVmLimits.MaxTargets, GraphVmLimits.MaxTargets);
                     Span<int> callStack = _scriptCallStacks.AsSpan(agent * GraphVmLimits.MaxCallStackDepth, GraphVmLimits.MaxCallStackDepth);
 
                     ref GraphExecutionCursor cursor = ref _scriptCursors[agent];
@@ -461,11 +476,7 @@ namespace Ludots.Core.Gameplay.AI.BehaviorTree
                     _scriptResumeGraphIds[agent] = node.GraphId;
 
                     GraphSliceResult result = GraphExecutor.ExecuteResolvedRegisteredScriptSlice(
-                        programs,
-                        program,
-                        ints,
-                        bools,
-                        callStack,
+                        programs, program, floats, ints, bools, entities, targets, callStack,
                         ref cursor,
                         scriptBudgetSteps,
                         world,

--- a/src/Core/Gameplay/AI/Fsm/GraphProgramHfsmHost.cs
+++ b/src/Core/Gameplay/AI/Fsm/GraphProgramHfsmHost.cs
@@ -13,6 +13,9 @@ public sealed class GraphProgramHfsmHost : IHfsmGraphHost
     private readonly IGraphRuntimeApi? _api;
     private readonly int[] _ints = new int[GraphVmLimits.MaxIntRegisters];
     private readonly byte[] _bools = new byte[GraphVmLimits.MaxBoolRegisters];
+    private readonly float[] _floats = new float[GraphVmLimits.MaxFloatRegisters];
+    private readonly Entity[] _entities = new Entity[GraphVmLimits.MaxEntityRegisters];
+    private readonly Entity[] _targets = new Entity[GraphVmLimits.MaxTargets];
     private readonly int[] _callStack = new int[GraphVmLimits.MaxCallStackDepth];
     private readonly int[] _cachedGraphIds = new int[ScriptCacheCapacity];
     private readonly int[] _cachedVersions = new int[ScriptCacheCapacity];
@@ -55,14 +58,13 @@ public sealed class GraphProgramHfsmHost : IHfsmGraphHost
 
         Array.Clear(_ints, 0, _ints.Length);
         Array.Clear(_bools, 0, _bools.Length);
+        Array.Clear(_floats, 0, _floats.Length);
+        Array.Clear(_entities, 0, _entities.Length);
+        Array.Clear(_targets, 0, _targets.Length);
         Array.Clear(_callStack, 0, _callStack.Length);
         var cursor = new GraphExecutionCursor();
         GraphSliceResult result = GraphExecutor.ExecuteResolvedRegisteredScriptSlice(
-            _programs,
-            program,
-            _ints,
-            _bools,
-            _callStack,
+            _programs, program, _floats, _ints, _bools, _entities, _targets, _callStack,
             ref cursor,
             budgetSteps: 64,
             _world,

--- a/src/Core/Gameplay/MapTriggers/TriggerGraphMountTrigger.cs
+++ b/src/Core/Gameplay/MapTriggers/TriggerGraphMountTrigger.cs
@@ -279,7 +279,6 @@ namespace Ludots.Core.Gameplay.MapTriggers
                 GraphKind.TriggerGraph,
                 "触发器图挂载");
 
-            int sourcePcBefore = _cursor.Pc;
             GraphSliceResult result = GraphExecutor.ExecuteScriptSlice(
                 dependencies.Engine.World,
                 _runCaster,
@@ -295,10 +294,12 @@ namespace Ludots.Core.Gameplay.MapTriggers
                 _vmTargetRegisters,
                 _vmCallStack,
                 ref _cursor,
-                TriggerGraphLimits.SliceBudgetSteps);
+                TriggerGraphLimits.SliceBudgetSteps,
+                GraphKind.Script,
+                _debugTrace);
             LastSliceResult = result;
 
-            RecordDebugTrace(sourcePcBefore, result);
+            RecordDebugTrace(result);
 
             if (result.Halted)
             {
@@ -316,22 +317,20 @@ namespace Ludots.Core.Gameplay.MapTriggers
             }
         }
 
-        private void RecordDebugTrace(int sourcePcBefore, GraphSliceResult result)
+        private void RecordDebugTrace(GraphSliceResult result)
         {
             if (_debugTrace.Mode == GraphDebugTraceMode.Disabled)
             {
                 return;
             }
 
-            _debugTrace.RecordNode(sourcePcBefore, _cursor.Pc, _cursor.Steps, GraphDebugTraceEvent.NodeEnter);
-            _debugTrace.RecordNode(sourcePcBefore, _cursor.Pc, _cursor.Steps, GraphDebugTraceEvent.NodeExit);
             if (result.Halted)
             {
-                _debugTrace.RecordNode(sourcePcBefore, _cursor.Pc, _cursor.Steps, GraphDebugTraceEvent.Halted);
+                _debugTrace.RecordNode(_cursor.Pc - 1, _cursor.Pc, _cursor.Steps, GraphDebugTraceEvent.Halted);
             }
             else if (result.Yielded || result.BudgetSuspended)
             {
-                _debugTrace.RecordNode(sourcePcBefore, _cursor.Pc, _cursor.Steps, GraphDebugTraceEvent.Suspended);
+                _debugTrace.RecordNode(_cursor.Pc - 1, _cursor.Pc, _cursor.Steps, GraphDebugTraceEvent.Suspended);
             }
 
             if (_debugTrace.Mode != GraphDebugTraceMode.NodeAndPins)
@@ -343,7 +342,7 @@ namespace Ludots.Core.Gameplay.MapTriggers
             {
                 if (_vmIntRegisters[i] != _previousIntRegisters[i])
                 {
-                    _debugTrace.RecordIntPin(sourcePcBefore, i, _vmIntRegisters[i], _cursor.Pc, _cursor.Steps);
+                    _debugTrace.RecordIntPin(_cursor.Pc - 1, i, _vmIntRegisters[i], _cursor.Pc, _cursor.Steps);
                     _previousIntRegisters[i] = _vmIntRegisters[i];
                 }
             }
@@ -352,7 +351,7 @@ namespace Ludots.Core.Gameplay.MapTriggers
             {
                 if (_vmBoolRegisters[i] != _previousBoolRegisters[i])
                 {
-                    _debugTrace.RecordBoolPin(sourcePcBefore, i, _vmBoolRegisters[i] != 0, _cursor.Pc, _cursor.Steps);
+                    _debugTrace.RecordBoolPin(_cursor.Pc - 1, i, _vmBoolRegisters[i] != 0, _cursor.Pc, _cursor.Steps);
                     _previousBoolRegisters[i] = _vmBoolRegisters[i];
                 }
             }
@@ -361,7 +360,7 @@ namespace Ludots.Core.Gameplay.MapTriggers
             {
                 if (_vmFloatRegisters[i] != _previousFloatRegisters[i])
                 {
-                    _debugTrace.RecordFloatPin(sourcePcBefore, i, _vmFloatRegisters[i], _cursor.Pc, _cursor.Steps);
+                    _debugTrace.RecordFloatPin(_cursor.Pc - 1, i, _vmFloatRegisters[i], _cursor.Pc, _cursor.Steps);
                     _previousFloatRegisters[i] = _vmFloatRegisters[i];
                 }
             }
@@ -370,7 +369,7 @@ namespace Ludots.Core.Gameplay.MapTriggers
             {
                 if (_vmEntityRegisters[i] != _previousEntityRegisters[i])
                 {
-                    _debugTrace.RecordEntityPin(sourcePcBefore, i, _vmEntityRegisters[i], _cursor.Pc, _cursor.Steps);
+                    _debugTrace.RecordEntityPin(_cursor.Pc - 1, i, _vmEntityRegisters[i], _cursor.Pc, _cursor.Steps);
                     _previousEntityRegisters[i] = _vmEntityRegisters[i];
                 }
             }

--- a/src/Core/GraphRuntime/GraphDebugTrace.cs
+++ b/src/Core/GraphRuntime/GraphDebugTrace.cs
@@ -19,6 +19,9 @@ namespace Ludots.Core.GraphRuntime
         PinFloat = 5,
         PinBool = 6,
         PinEntity = 7,
+        BlackboardInt = 8,
+        BlackboardFloat = 9,
+        BlackboardEntity = 10,
     }
 
     public readonly struct GraphDebugTraceRecord
@@ -151,6 +154,24 @@ namespace Ludots.Core.GraphRuntime
             }
 
             Write(GraphDebugTraceEvent.PinEntity, sourcePc, cursorPc, steps, registerIndex, 0, 0f, value);
+        }
+
+        public void RecordBlackboardInt(int sourcePc, int keyId, int value, int cursorPc, int steps)
+        {
+            if (Mode != GraphDebugTraceMode.NodeAndPins) return;
+            Write(GraphDebugTraceEvent.BlackboardInt, sourcePc, cursorPc, steps, keyId, value, 0f, default);
+        }
+
+        public void RecordBlackboardFloat(int sourcePc, int keyId, float value, int cursorPc, int steps)
+        {
+            if (Mode != GraphDebugTraceMode.NodeAndPins) return;
+            Write(GraphDebugTraceEvent.BlackboardFloat, sourcePc, cursorPc, steps, keyId, 0, value, default);
+        }
+
+        public void RecordBlackboardEntity(int sourcePc, int keyId, Entity value, int cursorPc, int steps)
+        {
+            if (Mode != GraphDebugTraceMode.NodeAndPins) return;
+            Write(GraphDebugTraceEvent.BlackboardEntity, sourcePc, cursorPc, steps, keyId, 0, 0f, value);
         }
 
         public int ReadSince(long since, Span<GraphDebugTraceRecord> destination, out long oldestSequence)

--- a/src/Core/NodeLibraries/GASGraph/GasGraphOpHandlerTable.cs
+++ b/src/Core/NodeLibraries/GASGraph/GasGraphOpHandlerTable.cs
@@ -512,6 +512,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                             }
                         }
 
+                        state.DebugTrace?.RecordNode(instructionIndex, pc, treeSteps, GraphDebugTraceEvent.NodeEnter);
                         continue;
                     }
                     else
@@ -519,12 +520,14 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                         ints[ins.Dst] = ints[ins.A];
                     }
 
+                    state.DebugTrace?.RecordNode(instructionIndex, pc, treeSteps, GraphDebugTraceEvent.NodeEnter);
                     continue;
                 }
 
                 if (op == constIntOp)
                 {
                     ints[ins.Dst] = ins.Imm;
+                    state.DebugTrace?.RecordNode(instructionIndex, pc, treeSteps, GraphDebugTraceEvent.NodeEnter);
                     continue;
                 }
 
@@ -593,6 +596,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 }
 
                 state.TreeSteps = treeSteps;
+                state.CurrentInstructionPc = instructionIndex;
                 handler(ref state, in ins, ref pc);
                 callStackCount = state.CallStackCount;
                 returnInt = state.ReturnInt;
@@ -600,6 +604,8 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 {
                     treeSteps = state.TreeSteps;
                 }
+
+                state.DebugTrace?.RecordNode(instructionIndex, pc, treeSteps, GraphDebugTraceEvent.NodeEnter);
 
                 if (state.Status == GraphExecutionStatus.Yielded)
                 {
@@ -1065,17 +1071,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
 
         private static MapId RequireMapVariableScopeMap(ref GraphExecutionState s, Entity scope, string opName)
         {
-            // Event-driven graphs often carry dead sources (EntityDied's caster is the
-            // destroyed entity); the trigger mount scope is always a live map anchor, so it
-            // is the fallback before failing.
-            if (s.World != null &&
-                (!s.World.IsAlive(scope) || !s.World.TryGet<MapEntity>(scope, out MapEntity mapEntity)) &&
-                s.World.IsAlive(s.ExplicitTarget) &&
-                s.World.TryGet(s.ExplicitTarget, out mapEntity))
-            {
-                scope = s.ExplicitTarget;
-            }
-
+            MapEntity mapEntity = default;
             if (s.World == null ||
                 !s.World.IsAlive(scope) ||
                 !s.World.TryGet<MapEntity>(scope, out mapEntity))
@@ -1084,11 +1080,6 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 // entity, not a map anchor) as caster; their map variables resolve against
                 // the sole loaded map, mirroring QueryAllMapEntities' world-scoped semantics.
                 // Ambiguous multi-map loads stay fail-closed.
-                if (TryResolveSoleLoadedMap(s.World, out MapId soleMapId))
-                {
-                    return soleMapId;
-                }
-
                 throw new InvalidOperationException(
                     $"GAS.GRAPH.ERR.MapVariableScopeEntity: {opName} requires a scope entity with a MapEntity component (caster or explicit register).");
             }
@@ -1783,30 +1774,33 @@ namespace Ludots.Core.NodeLibraries.GASGraph
         {
             // F[dst] = E[A].BB_Float[Imm]
             var entity = s.E[ins.A];
-            if (s.Api.TryReadBlackboardFloat(entity, ins.Imm, out float value))
-                s.F[ins.Dst] = value;
-            else
-                s.F[ins.Dst] = 0f;
+            if (!s.Api.TryReadBlackboardFloat(entity, ins.Imm, out float value))
+                throw MissingBlackboardRead(nameof(GraphNodeOp.ReadBlackboardFloat), entity, ins.Imm);
+            s.F[ins.Dst] = value;
+            s.DebugTrace?.RecordBlackboardFloat(s.CurrentInstructionPc, ins.Imm, value, pc, s.TreeSteps);
         }
+
+        private static InvalidOperationException MissingBlackboardRead(string opName, Entity entity, int keyId)
+            => new($"GAS.GRAPH.ERR.MissingBlackboard: {opName} requires a readable blackboard value; entity={entity.Id}, key={keyId}.");
 
         private static void HandleReadBlackboardInt(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)
         {
             // I[dst] = E[A].BB_Int[Imm]
             var entity = s.E[ins.A];
-            if (s.Api.TryReadBlackboardInt(entity, ins.Imm, out int value))
-                s.I[ins.Dst] = value;
-            else
-                s.I[ins.Dst] = 0;
+            if (!s.Api.TryReadBlackboardInt(entity, ins.Imm, out int value))
+                throw MissingBlackboardRead(nameof(GraphNodeOp.ReadBlackboardInt), entity, ins.Imm);
+            s.I[ins.Dst] = value;
+            s.DebugTrace?.RecordBlackboardInt(s.CurrentInstructionPc, ins.Imm, value, pc, s.TreeSteps);
         }
 
         private static void HandleReadBlackboardEntity(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)
         {
             // E[dst] = E[A].BB_Entity[Imm]
             var entity = s.E[ins.A];
-            if (s.Api.TryReadBlackboardEntity(entity, ins.Imm, out Entity value))
-                s.E[ins.Dst] = value;
-            else
-                s.E[ins.Dst] = default;
+            if (!s.Api.TryReadBlackboardEntity(entity, ins.Imm, out Entity value))
+                throw MissingBlackboardRead(nameof(GraphNodeOp.ReadBlackboardEntity), entity, ins.Imm);
+            s.E[ins.Dst] = value;
+            s.DebugTrace?.RecordBlackboardEntity(s.CurrentInstructionPc, ins.Imm, value, pc, s.TreeSteps);
         }
 
         private static void HandleWriteBlackboardFloat(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)
@@ -1814,6 +1808,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             // E[A].BB_Float[Imm] = F[B]   (immediate write)
             var entity = s.E[ins.A];
             s.Api.WriteBlackboardFloat(entity, ins.Imm, s.F[ins.B]);
+            s.DebugTrace?.RecordBlackboardFloat(s.CurrentInstructionPc, ins.Imm, s.F[ins.B], pc, s.TreeSteps);
         }
 
         private static void HandleWriteBlackboardInt(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)
@@ -1821,6 +1816,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             // E[A].BB_Int[Imm] = I[B]
             var entity = s.E[ins.A];
             s.Api.WriteBlackboardInt(entity, ins.Imm, s.I[ins.B]);
+            s.DebugTrace?.RecordBlackboardInt(s.CurrentInstructionPc, ins.Imm, s.I[ins.B], pc, s.TreeSteps);
         }
 
         private static void HandleWriteBlackboardEntity(ref GraphExecutionState s, in GraphInstruction ins, ref int pc)
@@ -1828,6 +1824,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             // E[A].BB_Entity[Imm] = E[B]
             var entity = s.E[ins.A];
             s.Api.WriteBlackboardEntity(entity, ins.Imm, s.E[ins.B]);
+            s.DebugTrace?.RecordBlackboardEntity(s.CurrentInstructionPc, ins.Imm, s.E[ins.B], pc, s.TreeSteps);
         }
 
         // ── Config parameter reading (310-312) ──

--- a/src/Core/NodeLibraries/GASGraph/GraphExecutionState.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphExecutionState.cs
@@ -61,5 +61,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
         public int ProgramLength;
         public int InvokeDepth;
         public int TreeSteps;
+        public int CurrentInstructionPc;
+        public GraphDebugTrace? DebugTrace;
     }
 }

--- a/src/Core/NodeLibraries/GASGraph/GraphExecutor.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphExecutor.cs
@@ -268,6 +268,32 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             Span<float> floats = stackalloc float[GraphVmLimits.MaxFloatRegisters];
             Span<Entity> entities = stackalloc Entity[GraphVmLimits.MaxEntityRegisters];
             Span<Entity> targets = stackalloc Entity[GraphVmLimits.MaxTargets];
+            GraphSliceResult result = ExecuteResolvedRegisteredScriptSlice(
+                programs, program, floats, ints, bools, entities, targets, callStack, ref cursor,
+                budgetSteps, world, caster, explicitTarget, api);
+            if (!result.Halted)
+            {
+                throw new InvalidOperationException("Resumable Script execution requires caller-owned float, entity, and target register spans.");
+            }
+            return result;
+        }
+
+        public static GraphSliceResult ExecuteResolvedRegisteredScriptSlice(
+            GraphProgramRegistry programs,
+            ReadOnlySpan<GraphInstruction> program,
+            Span<float> floats,
+            Span<int> ints,
+            Span<byte> bools,
+            Span<Entity> entities,
+            Span<Entity> targets,
+            Span<int> callStack,
+            ref GraphExecutionCursor cursor,
+            int budgetSteps,
+            World? world = null,
+            Entity caster = default,
+            Entity explicitTarget = default,
+            IGraphRuntimeApi? api = null)
+        {
             GraphFrame frame = GraphFrame.Bind(
                 GraphKind.Script,
                 GraphEntityPreset.None,
@@ -305,7 +331,8 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             Span<int> callStack,
             ref GraphExecutionCursor cursor,
             int budgetSteps,
-            GraphKind kind = GraphKind.Script)
+            GraphKind kind = GraphKind.Script,
+            GraphDebugTrace? debugTrace = null)
         {
             RequireKind(kind, GraphKind.Script, nameof(ExecuteScriptSlice));
             GraphFrame frame = GraphFrame.Bind(
@@ -323,7 +350,8 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 entities,
                 targets,
                 callStack,
-                cursor);
+                cursor,
+                debugTrace: debugTrace);
             GraphSliceResult result = ExecuteSlice(ref frame, program, budgetSteps);
             cursor = frame.Cursor;
             return result;

--- a/src/Core/NodeLibraries/GASGraph/GraphFrame.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphFrame.cs
@@ -65,6 +65,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
         public GraphTargetList TargetList;
         public Span<int> CallStack;
         public GraphExecutionCursor Cursor;
+        public GraphDebugTrace? DebugTrace;
 
         public static GraphFrame Bind(
             GraphKind kind,
@@ -83,7 +84,8 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             Span<int> callStack,
             GraphExecutionCursor cursor = default,
             uint randomSeed = 0,
-            GraphEventPayload eventPayload = default)
+            GraphEventPayload eventPayload = default,
+            GraphDebugTrace? debugTrace = null)
         {
             if (kind is not (GraphKind.Effect or GraphKind.Query or GraphKind.Score or GraphKind.Validation or GraphKind.Derived or GraphKind.Script))
             {
@@ -142,7 +144,8 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 Targets = targets,
                 TargetList = new GraphTargetList(targets),
                 CallStack = callStack,
-                Cursor = cursor
+                Cursor = cursor,
+                DebugTrace = debugTrace
             };
         }
 
@@ -170,7 +173,8 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 CallStackCount = Cursor.CallStackCount,
                 ReturnInt = Cursor.ReturnInt,
                 InvokeDepth = Cursor.InvokeDepth,
-                Status = GraphExecutionStatus.Running
+                Status = GraphExecutionStatus.Running,
+                DebugTrace = DebugTrace
             };
         }
     }

--- a/src/Libraries/Ludots.AgentBridge/Tools/GraphDebugTool.cs
+++ b/src/Libraries/Ludots.AgentBridge/Tools/GraphDebugTool.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json.Nodes;
 using Ludots.Core.Gameplay.MapTriggers;
 using Ludots.Core.GraphRuntime;
@@ -107,11 +108,12 @@ namespace Ludots.AgentBridge.Tools
             int count = mount.DebugTrace.ReadSince(since, buffer, out long oldestSequence);
             var events = new JsonArray();
 
-            context.Engine.TryGetService(Ludots.Core.Scripting.CoreServiceKeys.GraphProgramRegistry, out GraphProgramRegistry? programs);
-            GraphInstructionSourceMap sourceMap = GraphInstructionSourceMap.Empty;
-            if (programs != null)
+            if (!context.Engine.TryGetService(Ludots.Core.Scripting.CoreServiceKeys.GraphProgramRegistry, out GraphProgramRegistry? programs) ||
+                programs == null || !programs.TryGetSourceMap(mount.GraphId, out GraphInstructionSourceMap sourceMap) ||
+                !sourceMap.HasSources || !string.Equals(sourceMap.GraphId, mount.GraphName, StringComparison.OrdinalIgnoreCase))
             {
-                programs.TryGetSourceMap(mount.GraphId, out sourceMap);
+                throw new AgentToolException(AgentBridgeErrorCodes.ServiceUnavailable,
+                    $"Graph debug source map is unavailable for mounted graph '{mount.GraphName}'.");
             }
 
             for (int i = 0; i < count; i++)
@@ -123,7 +125,7 @@ namespace Ludots.AgentBridge.Tools
             }
 
             long latest = mount.DebugTrace.LatestSequence;
-            bool gap = since > 0 && oldestSequence > since + 1;
+            bool gap = oldestSequence <= latest && oldestSequence > since + 1;
             return new JsonObject
             {
                 ["mount"] = MountSnapshot(mount),
@@ -184,10 +186,15 @@ namespace Ludots.AgentBridge.Tools
                 result["pinIndex"] = record.RegisterIndex;
                 result["value"] = record.FloatValue;
             }
-            else if (record.EventKind == GraphDebugTraceEvent.PinEntity)
+            else if (record.EventKind == GraphDebugTraceEvent.PinEntity || record.EventKind == GraphDebugTraceEvent.BlackboardEntity)
             {
                 result["pinIndex"] = record.RegisterIndex;
                 result["value"] = record.EntityValue.Id;
+            }
+            else if (record.EventKind is GraphDebugTraceEvent.BlackboardInt or GraphDebugTraceEvent.BlackboardFloat)
+            {
+                result["keyId"] = record.RegisterIndex;
+                result["value"] = record.EventKind == GraphDebugTraceEvent.BlackboardInt ? record.IntValue : record.FloatValue;
             }
 
             return result;

--- a/src/Tools/Ludots.Editor.Bridge/Program.cs
+++ b/src/Tools/Ludots.Editor.Bridge/Program.cs
@@ -49,6 +49,39 @@ builder.Services.AddCors(o =>
 var app = builder.Build();
 app.UseCors("dev");
 
+static bool IsValidGraphEditorLayout(JsonNode? node, out string error)
+{
+    error = string.Empty;
+    if (node is not JsonObject layout) { error = "layout must be an object."; return false; }
+    if (layout["nodes"] is JsonNode nodesNode)
+    {
+        if (nodesNode is not JsonObject nodes) { error = "layout.nodes must be an object."; return false; }
+        foreach (KeyValuePair<string, JsonNode?> entry in nodes)
+        {
+            if (entry.Value is not JsonObject position ||
+                position["x"] is not JsonValue x || !x.TryGetValue<double>(out _) ||
+                position["y"] is not JsonValue y || !y.TryGetValue<double>(out _))
+            { error = $"layout.nodes['{entry.Key}'] requires numeric x and y."; return false; }
+            if (position["collapsed"] is JsonNode collapsed &&
+                (collapsed is not JsonValue cb || !cb.TryGetValue<bool>(out _)))
+            { error = $"layout.nodes['{entry.Key}'].collapsed must be boolean."; return false; }
+        }
+    }
+    if (layout["viewport"] is JsonNode viewportNode)
+    {
+        if (viewportNode is not JsonObject viewport ||
+            viewport["x"] is not JsonValue vx || !vx.TryGetValue<double>(out _) ||
+            viewport["y"] is not JsonValue vy || !vy.TryGetValue<double>(out _) ||
+            viewport["zoom"] is not JsonValue vz || !vz.TryGetValue<double>(out _))
+        { error = "layout.viewport requires numeric x, y, and zoom."; return false; }
+    }
+    foreach (KeyValuePair<string, JsonNode?> field in layout)
+    {
+        if (field.Key is not ("nodes" or "viewport")) { error = $"Unknown layout field '{field.Key}'."; return false; }
+    }
+    return true;
+}
+
 if (Directory.Exists(launcherDistPath))
 {
     var launcherDistProvider = new PhysicalFileProvider(launcherDistPath);
@@ -1601,13 +1634,16 @@ app.MapGet("/api/mods/{modId}/gas/graph-editor/{graphId}", (string modId, string
         JsonNode? rootNode = JsonNode.Parse(File.ReadAllText(sidecarPath));
         if (rootNode is not JsonObject root || root["graphs"] is not JsonObject graphs)
             return Results.BadRequest(new { ok = false, error = "graph_editor.json must contain an object property 'graphs'." });
+        JsonNode? layoutNode = graphs[graphId];
+        if (layoutNode != null && !IsValidGraphEditorLayout(layoutNode, out string layoutError))
+            return Results.BadRequest(new { ok = false, error = layoutError });
 
         return Results.Ok(new
         {
             ok = true,
             graphId,
             path = sidecarPath,
-            layout = graphs[graphId]?.DeepClone() ?? new JsonObject(),
+            layout = layoutNode?.DeepClone() ?? new JsonObject(),
         });
     }
     catch (JsonException ex)
@@ -1628,6 +1664,8 @@ app.MapPut("/api/mods/{modId}/gas/graph-editor/{graphId}", async (string modId, 
     catch (JsonException ex) { return Results.BadRequest(new { ok = false, error = $"Malformed layout JSON: {ex.Message}" }); }
     if (layoutNode is not JsonObject layout)
         return Results.BadRequest(new { ok = false, error = "Layout must be a JSON object." });
+    if (!IsValidGraphEditorLayout(layout, out string layoutError))
+        return Results.BadRequest(new { ok = false, error = layoutError });
 
     string sidecarPath = Path.Combine(modRoot, "assets", "GAS", "graph_editor.json");
     JsonObject root;
@@ -1648,6 +1686,12 @@ app.MapPut("/api/mods/{modId}/gas/graph-editor/{graphId}", async (string modId, 
     }
 
     JsonObject graphs = (JsonObject)root["graphs"]!;
+
+    foreach (KeyValuePair<string, JsonNode?> existingLayout in graphs)
+    {
+        if (!IsValidGraphEditorLayout(existingLayout.Value, out string existingLayoutError))
+            return Results.BadRequest(new { ok = false, error = $"Invalid layout for graph '{existingLayout.Key}': {existingLayoutError}" });
+    }
 
     graphs[graphId] = layout.DeepClone();
     Directory.CreateDirectory(Path.GetDirectoryName(sidecarPath)!);

--- a/src/Tools/Ludots.Editor.React/src/pages/GasGraphEditorPage.tsx
+++ b/src/Tools/Ludots.Editor.React/src/pages/GasGraphEditorPage.tsx
@@ -401,6 +401,7 @@ export const GasGraphEditorPage: React.FC = () => {
   const [debugEvents, setDebugEvents] = React.useState<DebugEvent[]>([]);
   const [debugSince, setDebugSince] = React.useState(0);
   const [debugStatus, setDebugStatus] = React.useState('Bridge idle');
+  const debugPollInFlight = React.useRef(false);
 
   const selectedNode = React.useMemo(
     () => nodes.find((n) => n.id === selectedNodeId) ?? null,
@@ -433,10 +434,15 @@ export const GasGraphEditorPage: React.FC = () => {
       if (!descriptorRes.ok || !descriptorPayload.ok) {
         throw new Error(descriptorPayload.error ?? `Descriptor load failed (${descriptorRes.status})`);
       }
+      if (!layoutRes.ok || !layoutPayload.ok || !layoutPayload.layout || typeof layoutPayload.layout !== 'object' || Array.isArray(layoutPayload.layout)) {
+        throw new Error(layoutPayload.error ?? `Layout load failed (${layoutRes.status})`);
+      }
       const nextDescriptors: Record<string, GraphDescriptor> = {};
       for (const descriptor of (descriptorPayload.descriptors ?? []) as GraphDescriptor[]) {
         nextDescriptors[descriptor.op] = descriptor;
       }
+      const missingDescriptor = loaded.nodes.find((node) => !nextDescriptors[node.op]);
+      if (missingDescriptor) throw new Error(`Descriptor missing for graph op '${missingDescriptor.op}'.`);
       const nextLayout = (layoutPayload.layout ?? {}) as EditorLayout;
       setDescriptors(nextDescriptors);
       setLayout(nextLayout);
@@ -633,6 +639,8 @@ export const GasGraphEditorPage: React.FC = () => {
 
   const pollDebug = React.useCallback(async () => {
     if (!debugEnabled || !debugEntryLabel) return;
+    if (debugPollInFlight.current) return;
+    debugPollInFlight.current = true;
     try {
       const result = await bridgeRpc('ludots.graph.debug', {
         action: 'drain', graphId, entryLabel: debugEntryLabel, since: debugSince, max: 128,
@@ -643,10 +651,13 @@ export const GasGraphEditorPage: React.FC = () => {
       if (incoming.length > 0) {
         setDebugEvents((previous) => [...previous, ...incoming].slice(-300));
       }
+      if (latestSequence < debugSince) return;
       if (result.gap || incoming.length > 0) setDebugSince(latestSequence);
       setDebugStatus(`Live: ${String(result.mount ? (result.mount as DebugMount).cursor.status : 'unknown')} · ${incoming.length} changes`);
     } catch (err) {
       setDebugStatus(err instanceof Error ? err.message : String(err));
+    } finally {
+      debugPollInFlight.current = false;
     }
   }, [bridgeRpc, debugEnabled, debugEntryLabel, debugSince, graphId]);
 


### PR DESCRIPTION
Independent architecture and regression audits found fail-open blackboard/map/source-map/layout and live trace attribution gaps after PR #1101. This follow-up makes script register state caller-owned across slices, removes map-variable fallback, fails closed on missing blackboard reads, records per-instruction and blackboard trace events, and validates source maps/layouts plus serialized debug polling.