### PR TITLE
fix(graph): harden editor blackboard and live trace contracts

### DIFF
--- a/artifacts/gas-composition-gate-graph-editor-milestone.md
+++ b/artifacts/gas-composition-gate-graph-editor-milestone.md
@@ -1,0 +1,63 @@
+## GAS Composition Gate - Self Review
+
+- **Task / Issue**: Graph editor milestone audit: node association, Select/Break authoring, composition entry points, and string-template/Concat boundary
+- **Date**: 2026-08-24
+- **Agent / Author**: Codex
+
+### 1. Core judgment
+
+新变体主要交付物是（A/B/C/D）: **A**
+
+结论: **PASS**
+
+一句话理由: 节点联想、Break 和组合入口复用运行时 descriptor/compiler；字符串模板与 Concat 只有在正式 graph value/runtime 合同存在后才能成为可保存节点，本次不以编辑器假能力绕过该边界。
+
+### 2. Layer assignment
+
+| 步骤/能力 | Layer (0/1/2) | 实现载体 |
+|-----------|-----------------|----------|
+| 节点联想与端口展示 | 2 | Editor Bridge runtime descriptor projection + React authoring surface |
+| Break 控制流糖 | 2 | `GraphAuthoringSugar` + `GraphControlFlowCompiler` lowers to existing Jump |
+| Select | 2 | Existing `SelectEntity` descriptor/compiler/runtime contract |
+| Composition entry | 2 | Existing `InvokeScript`/FuncLib descriptor and compiler contract |
+| String template / Concat boundary | 2 (deferred) | Requires a formal text value/runtime API; editor must reject until registered |
+
+### 3. Reuse list
+
+- Handlers: existing `Jump`, `SelectEntity`, `InvokeScript` handlers
+- Queues / Systems: existing graph compiler and program registry; no new execution pipeline
+- Resolvers / Registries: `GraphOpDescriptorTable`, `GraphAuthoringSugar`, Bridge descriptor endpoint
+- Existing presets / graphs: existing Script/TriggerGraph composition and FuncLib catalog
+
+### 4. New Layer 0 ops (if any)
+
+N/A. Break is authoring sugar and lowers to existing `Jump`; no new runtime handler.
+
+### 5. Transaction boundary
+
+None. This editor milestone does not mutate entity lifecycle state.
+
+### 6. Config SSOT
+
+Behavior configuration remains in graph JSON (`assets/GAS/graphs.json`) and the runtime descriptor/compiler tables. The editor layout remains in `assets/GAS/graph_editor.json`.
+
+是否新增 JSON schema: **NO**.
+
+### 7. Red flag scan
+
+- [x] 未新增 profile inherit/placement enum
+- [x] 未新建与 spawn 平行的物化管线
+- [x] 未把 placement 校验塞进 lifecycle op
+- [x] 未添加默认 fallback；缺 descriptor/unsupported op remains an explicit error
+
+### 8. Next variant test
+
+「下一个 Mod 变体」将修改: **graph 连线 / effect 步骤**
+
+字符串花括号自动引脚和 Concat 的运行时实现仍是后续独立切片，必须先增加 text value contract、固定容量/零分配策略、symbol patching 和 presentation sink，再开放为可保存节点。
+
+### 9. Audit hardening applied
+
+- Blackboard capability now installs and batch-materializes `BlackboardFloatBuffer` together with the existing order blackboard buffers; `RequireInstalled` checks the complete set.
+- Trigger graph debug trace carries the last instruction PC through the execution cursor. Live pin/watch records therefore resolve to the instruction that actually ran, and missing source-map entries fail closed in AgentBridge.
+- Editor graph descriptors are mandatory, layout entries are schema-checked, and node deletion removes connected edges before validation/save.

--- a/gitbook/architecture/graph-capability-status.md
+++ b/gitbook/architecture/graph-capability-status.md
@@ -73,6 +73,11 @@
 
 ### 3.3 真正还在做的
 
+**编辑器里程碑（本轮已收口的能力）。**
+节点联想只从运行时 descriptor 获取；Break 是 Script/TriggerGraph 的作者糖，编译时严格降低为带显式 `target` 边的 Jump；Select 仍明确是实体选择 `SelectEntity`，不是尚不存在的通用 Select。编辑器连线、删节点后的悬挂边清理、布局数据校验和 live trace source map 校验均走失败关闭。
+
+字符串花括号自动引脚、字符串寄存器、组合文本与 `Concat` 仍未完成。当前运行时没有正式的 text value、固定容量/零分配传递、符号 patch 和 presentation sink 合同，因此编辑器不会展示可保存但运行时不可执行的假节点。它们必须作为独立基建切片先补齐合同，再进入 descriptor 名册。
+
 **分层：架子有了，墙没有。**  
 工程里多了两份薄的契约，核心工程还是一大坨。展厅大多还能一把抓住整台引擎。把空间、输入、画面、结算真正拆开，以及不许再抓整台引擎，这两步没做。要做就单独开活，对照 `docs/audits/s14_layering_physicalization_design.md`，别和修演示、修构建捆在一起。没拆完之前，总规矩继续写「修复中」。
 

--- a/src/Core/Config/ComponentRegistry.cs
+++ b/src/Core/Config/ComponentRegistry.cs
@@ -92,6 +92,7 @@ namespace Ludots.Core.Config
             Register<BlackboardSpatialBuffer>("BlackboardSpatialBuffer");
             Register<BlackboardEntityBuffer>("BlackboardEntityBuffer");
             Register<BlackboardIntBuffer>("BlackboardIntBuffer");
+            Register<BlackboardFloatBuffer>("BlackboardFloatBuffer");
             Register("AbilityExecAimSync", SetAbilityExecAimSync);
             Register<VisualTransform>("VisualTransform");
             Register<VisualHeightmapSampleState>("VisualHeightmapSampleState");

--- a/src/Core/Config/TemplateEntityBatchSpawner.cs
+++ b/src/Core/Config/TemplateEntityBatchSpawner.cs
@@ -260,6 +260,7 @@ namespace Ludots.Core.Config
                 Span<EntityTemplateKeyRef> templateKeys = chunk.GetSpan<EntityTemplateKeyRef>();
                 Span<OrderBuffer> orderBuffers = descriptor.HasOrderBuffer ? chunk.GetSpan<OrderBuffer>() : default;
                 Span<BlackboardIntBuffer> blackboardInts = descriptor.HasOrderBuffer ? chunk.GetSpan<BlackboardIntBuffer>() : default;
+                Span<BlackboardFloatBuffer> blackboardFloats = descriptor.HasOrderBuffer ? chunk.GetSpan<BlackboardFloatBuffer>() : default;
                 Span<BlackboardSpatialBuffer> blackboardSpatial = descriptor.HasOrderBuffer ? chunk.GetSpan<BlackboardSpatialBuffer>() : default;
                 Span<BlackboardEntityBuffer> blackboardEntities = descriptor.HasOrderBuffer ? chunk.GetSpan<BlackboardEntityBuffer>() : default;
                 Span<CommandSourceSelectableState> commandSourceStates = descriptor.HasCommandSourceSelectableState ? chunk.GetSpan<CommandSourceSelectableState>() : default;
@@ -328,6 +329,7 @@ namespace Ludots.Core.Config
                     {
                         orderBuffers[componentIndex] = OrderBuffer.CreateEmpty();
                         blackboardInts[componentIndex] = default;
+                        blackboardFloats[componentIndex] = default;
                         blackboardSpatial[componentIndex] = default;
                         blackboardEntities[componentIndex] = default;
                     }
@@ -821,6 +823,7 @@ namespace Ludots.Core.Config
                 {
                     signature += Component<OrderBuffer>.Signature;
                     signature += Component<BlackboardIntBuffer>.Signature;
+                    signature += Component<BlackboardFloatBuffer>.Signature;
                     signature += Component<BlackboardSpatialBuffer>.Signature;
                     signature += Component<BlackboardEntityBuffer>.Signature;
                     signature += Component<OrderContinuationBuffer>.Signature;

--- a/src/Core/Gameplay/GAS/Orders/OrderBlackboardStateInstaller.cs
+++ b/src/Core/Gameplay/GAS/Orders/OrderBlackboardStateInstaller.cs
@@ -20,6 +20,10 @@ namespace Ludots.Core.Gameplay.GAS.Orders
             {
                 world.Add(entity, new BlackboardIntBuffer());
             }
+            if (!world.Has<BlackboardFloatBuffer>(entity))
+            {
+                world.Add(entity, new BlackboardFloatBuffer());
+            }
             if (!world.Has<BlackboardSpatialBuffer>(entity))
             {
                 world.Add(entity, new BlackboardSpatialBuffer());
@@ -39,16 +43,17 @@ namespace Ludots.Core.Gameplay.GAS.Orders
             }
 
             bool hasInts = world.Has<BlackboardIntBuffer>(entity);
+            bool hasFloats = world.Has<BlackboardFloatBuffer>(entity);
             bool hasSpatial = world.Has<BlackboardSpatialBuffer>(entity);
             bool hasEntities = world.Has<BlackboardEntityBuffer>(entity);
-            if (hasInts && hasSpatial && hasEntities)
+            if (hasInts && hasFloats && hasSpatial && hasEntities)
             {
                 return;
             }
 
             throw new InvalidOperationException(
                 $"{MissingStateError}: entity={entity.Id}, " +
-                $"BlackboardIntBuffer={hasInts}, BlackboardSpatialBuffer={hasSpatial}, BlackboardEntityBuffer={hasEntities}.");
+                $"BlackboardIntBuffer={hasInts}, BlackboardFloatBuffer={hasFloats}, BlackboardSpatialBuffer={hasSpatial}, BlackboardEntityBuffer={hasEntities}.");
         }
     }
 }

--- a/src/Core/Gameplay/MapTriggers/TriggerGraphMountTrigger.cs
+++ b/src/Core/Gameplay/MapTriggers/TriggerGraphMountTrigger.cs
@@ -324,13 +324,20 @@ namespace Ludots.Core.Gameplay.MapTriggers
                 return;
             }
 
+            int sourcePc = _cursor.LastInstructionPc;
+            if (sourcePc < 0)
+            {
+                throw new InvalidOperationException(
+                    $"TriggerGraph '{_graphName}' produced a debug slice without an executed instruction source.");
+            }
+
             if (result.Halted)
             {
-                _debugTrace.RecordNode(_cursor.Pc - 1, _cursor.Pc, _cursor.Steps, GraphDebugTraceEvent.Halted);
+                _debugTrace.RecordNode(sourcePc, _cursor.Pc, _cursor.Steps, GraphDebugTraceEvent.Halted);
             }
             else if (result.Yielded || result.BudgetSuspended)
             {
-                _debugTrace.RecordNode(_cursor.Pc - 1, _cursor.Pc, _cursor.Steps, GraphDebugTraceEvent.Suspended);
+                _debugTrace.RecordNode(sourcePc, _cursor.Pc, _cursor.Steps, GraphDebugTraceEvent.Suspended);
             }
 
             if (_debugTrace.Mode != GraphDebugTraceMode.NodeAndPins)
@@ -342,7 +349,7 @@ namespace Ludots.Core.Gameplay.MapTriggers
             {
                 if (_vmIntRegisters[i] != _previousIntRegisters[i])
                 {
-                    _debugTrace.RecordIntPin(_cursor.Pc - 1, i, _vmIntRegisters[i], _cursor.Pc, _cursor.Steps);
+                    _debugTrace.RecordIntPin(sourcePc, i, _vmIntRegisters[i], _cursor.Pc, _cursor.Steps);
                     _previousIntRegisters[i] = _vmIntRegisters[i];
                 }
             }
@@ -351,7 +358,7 @@ namespace Ludots.Core.Gameplay.MapTriggers
             {
                 if (_vmBoolRegisters[i] != _previousBoolRegisters[i])
                 {
-                    _debugTrace.RecordBoolPin(_cursor.Pc - 1, i, _vmBoolRegisters[i] != 0, _cursor.Pc, _cursor.Steps);
+                    _debugTrace.RecordBoolPin(sourcePc, i, _vmBoolRegisters[i] != 0, _cursor.Pc, _cursor.Steps);
                     _previousBoolRegisters[i] = _vmBoolRegisters[i];
                 }
             }
@@ -360,7 +367,7 @@ namespace Ludots.Core.Gameplay.MapTriggers
             {
                 if (_vmFloatRegisters[i] != _previousFloatRegisters[i])
                 {
-                    _debugTrace.RecordFloatPin(_cursor.Pc - 1, i, _vmFloatRegisters[i], _cursor.Pc, _cursor.Steps);
+                    _debugTrace.RecordFloatPin(sourcePc, i, _vmFloatRegisters[i], _cursor.Pc, _cursor.Steps);
                     _previousFloatRegisters[i] = _vmFloatRegisters[i];
                 }
             }
@@ -369,7 +376,7 @@ namespace Ludots.Core.Gameplay.MapTriggers
             {
                 if (_vmEntityRegisters[i] != _previousEntityRegisters[i])
                 {
-                    _debugTrace.RecordEntityPin(_cursor.Pc - 1, i, _vmEntityRegisters[i], _cursor.Pc, _cursor.Steps);
+                    _debugTrace.RecordEntityPin(sourcePc, i, _vmEntityRegisters[i], _cursor.Pc, _cursor.Steps);
                     _previousEntityRegisters[i] = _vmEntityRegisters[i];
                 }
             }

--- a/src/Core/GraphRuntime/GraphExecutionCursor.cs
+++ b/src/Core/GraphRuntime/GraphExecutionCursor.cs
@@ -14,6 +14,7 @@ namespace Ludots.Core.GraphRuntime
         public GraphExecutionCursor(int startPc)
         {
             Pc = startPc;
+            LastInstructionPc = -1;
             Steps = 0;
             CallStackCount = 0;
             ReturnInt = 0;
@@ -22,6 +23,7 @@ namespace Ludots.Core.GraphRuntime
         }
 
         public int Pc;
+        public int LastInstructionPc;
         public int Steps;
         public int CallStackCount;
         public int ReturnInt;
@@ -34,6 +36,7 @@ namespace Ludots.Core.GraphRuntime
         public void Reset()
         {
             Pc = 0;
+            LastInstructionPc = -1;
             Steps = 0;
             CallStackCount = 0;
             ReturnInt = 0;

--- a/src/Core/NodeLibraries/GASGraph/GasGraphOpHandlerTable.cs
+++ b/src/Core/NodeLibraries/GASGraph/GasGraphOpHandlerTable.cs
@@ -457,6 +457,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 pc++;
                 treeSteps++;
                 stepsThisSlice++;
+                state.CurrentInstructionPc = instructionIndex;
 
                 ushort op = ins.Op;
                 if (op == moveIntOp)
@@ -596,7 +597,6 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                 }
 
                 state.TreeSteps = treeSteps;
-                state.CurrentInstructionPc = instructionIndex;
                 handler(ref state, in ins, ref pc);
                 callStackCount = state.CallStackCount;
                 returnInt = state.ReturnInt;
@@ -669,6 +669,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
             state.TreeSteps = treeSteps;
             state.Status = status;
             cursor.Pc = pc;
+            cursor.LastInstructionPc = state.CurrentInstructionPc;
             cursor.CallStackCount = callStackCount;
             cursor.ReturnInt = returnInt;
             cursor.Steps = treeSteps;

--- a/src/Core/NodeLibraries/GASGraph/GraphAuthoringSugar.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphAuthoringSugar.cs
@@ -4,7 +4,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
 {
     /// <summary>
     /// ControlFlow authoring sugar SSOT. Kind gates live in <see cref="GraphControlFlowCompiler"/>
-    /// (Wait/While/SwitchInt/Until are Script/TriggerGraph; BranchBool also allows Effect).
+    /// (Wait/While/SwitchInt/Until/Break are Script/TriggerGraph; BranchBool also allows Effect).
     /// These names are compile-time sugar (not <see cref="GraphNodeOp"/> values);
     /// they lower in <see cref="GraphControlFlowCompiler"/> to Jump / Yield / compares.
     /// </summary>
@@ -15,6 +15,7 @@ namespace Ludots.Core.NodeLibraries.GASGraph
         public const string Wait = "Wait";
         public const string While = "While";
         public const string Until = "Until";
+        public const string Break = "Break";
 
         public static bool IsScriptOnlySugar(string? opName)
         {
@@ -27,10 +28,11 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                    string.Equals(opName, SwitchInt, StringComparison.Ordinal) ||
                    string.Equals(opName, Wait, StringComparison.Ordinal) ||
                    string.Equals(opName, While, StringComparison.Ordinal) ||
-                   string.Equals(opName, Until, StringComparison.Ordinal);
+                   string.Equals(opName, Until, StringComparison.Ordinal) ||
+                   string.Equals(opName, Break, StringComparison.Ordinal);
         }
 
         public static string DescribeScriptOnlySugar()
-            => $"{BranchBool}, {SwitchInt}, {Wait}, {While}, {Until}";
+            => $"{BranchBool}, {SwitchInt}, {Wait}, {While}, {Until}, {Break}";
     }
 }

--- a/src/Core/NodeLibraries/GASGraph/GraphControlFlowCompiler.cs
+++ b/src/Core/NodeLibraries/GASGraph/GraphControlFlowCompiler.cs
@@ -688,6 +688,23 @@ namespace Ludots.Core.NodeLibraries.GASGraph
                     continue;
                 }
 
+                if (string.Equals(node.Op, GraphAuthoringSugar.Break, StringComparison.Ordinal))
+                {
+                    if (graphKind is not (GraphKind.Script or GraphKind.TriggerGraph))
+                    {
+                        diagnostics.Add(Error(graphId, GraphDiagnosticCodes.UnknownNodeOp,
+                            $"{GraphAuthoringSugar.Break} is Script/TriggerGraph compile-time sugar only.", node.Id));
+                        ops[i] = new AuthoredOp(AuthoredOpKind.GraphNodeOp, GraphNodeOp.None);
+                        continue;
+                    }
+
+                    // Break is an author-facing name for an unconditional jump to an
+                    // explicitly authored exit. There is no implicit loop-scope lookup;
+                    // the target edge keeps control flow visible and rejects dangling breaks.
+                    ops[i] = new AuthoredOp(AuthoredOpKind.GraphNodeOp, GraphNodeOp.Jump);
+                    continue;
+                }
+
                 // Wait is author alias for Yield — Script/TriggerGraph CF only; never a second waiter opcode.
                 if (string.Equals(node.Op, WaitOp, StringComparison.Ordinal))
                 {

--- a/src/Libraries/Ludots.AgentBridge/Tools/GraphDebugTool.cs
+++ b/src/Libraries/Ludots.AgentBridge/Tools/GraphDebugTool.cs
@@ -120,7 +120,12 @@ namespace Ludots.AgentBridge.Tools
             {
                 GraphDebugTraceRecord record = buffer[i];
                 int sourcePc = record.SourcePc >= 0 ? record.SourcePc : record.CursorPc;
-                sourceMap.TryGetSource(sourcePc, out GraphInstructionSource source);
+                if (!sourceMap.TryGetSource(sourcePc, out GraphInstructionSource source))
+                {
+                    throw new AgentToolException(
+                        AgentBridgeErrorCodes.ServiceUnavailable,
+                        $"Graph debug source map has no instruction source for graph '{mount.GraphName}', pc={sourcePc}.");
+                }
                 events.Add(ToJson(record, source));
             }
 

--- a/src/Tests/GasTests/Graph/GraphBranchSwitchSugarTests.cs
+++ b/src/Tests/GasTests/Graph/GraphBranchSwitchSugarTests.cs
@@ -147,6 +147,57 @@ namespace Ludots.Tests.Gas.Graph
                 d.Message.Contains(GraphControlFlowCompiler.SwitchIntOp, StringComparison.Ordinal)));
         }
 
+        [Test]
+        public void Break_LowersToExplicitJumpTarget()
+        {
+            var graph = new GraphControlFlowDocument
+            {
+                Id = "tests.script.break",
+                Kind = "Script",
+                Entry = "value",
+                Nodes = new List<GraphControlFlowNode>
+                {
+                    new() { Id = "value", Op = nameof(GraphNodeOp.ConstInt), IntValue = 7 },
+                    new() { Id = "break", Op = GraphAuthoringSugar.Break },
+                    new() { Id = "halt", Op = nameof(GraphNodeOp.HaltReturnInt) }
+                },
+                ControlEdges = new List<GraphControlFlowEdge>
+                {
+                    new("value", GraphControlFlowPorts.Next, "break"),
+                    new("break", GraphControlFlowPorts.Target, "halt")
+                },
+                ValueEdges = new List<GraphControlFlowValueEdge>
+                {
+                    new("value", GraphControlFlowPorts.Value, "halt", GraphControlFlowPorts.Value)
+                }
+            };
+
+            GraphControlFlowCompileResult compiled = GraphControlFlowCompiler.Compile(graph);
+            Assert.That(compiled.Succeeded, Is.True, GraphScriptTestGraphs.FormatDiagnostics(compiled.Diagnostics));
+            Assert.That(compiled.Program.Select(i => (GraphNodeOp)i.Op), Does.Contain(GraphNodeOp.Jump));
+            Assert.That(ExecuteHaltReturn(compiled.Program), Is.EqualTo(7));
+        }
+
+        [Test]
+        public void Break_WithoutTarget_FailsClosed()
+        {
+            var graph = new GraphControlFlowDocument
+            {
+                Id = "tests.script.break.missing-target",
+                Kind = "Script",
+                Entry = "break",
+                Nodes = new List<GraphControlFlowNode>
+                {
+                    new() { Id = "break", Op = GraphAuthoringSugar.Break }
+                }
+            };
+
+            GraphControlFlowCompileResult compiled = GraphControlFlowCompiler.Compile(graph);
+            Assert.That(compiled.Succeeded, Is.False);
+            Assert.That(compiled.Diagnostics, Has.Some.Matches<GraphDiagnostic>(d =>
+                d.Code == GraphDiagnosticCodes.MissingControlEdge && d.NodeId == "break"));
+        }
+
         private static GraphControlFlowDocument CreateBranchBoolGraph(int left, int right)
         {
             return new GraphControlFlowDocument

--- a/src/Tools/Ludots.Editor.Bridge/Program.cs
+++ b/src/Tools/Ludots.Editor.Bridge/Program.cs
@@ -1617,7 +1617,20 @@ app.MapGet("/api/graph/descriptors/{kind}", (string kind) =>
         });
     }
 
-    return Results.Ok(new { ok = true, kind = graphKind.ToString(), descriptors });
+    var authoringSugars = new List<object>();
+    if (graphKind is GraphKind.Script or GraphKind.TriggerGraph)
+    {
+        authoringSugars.Add(new
+        {
+            op = GraphAuthoringSugar.Break,
+            controlOutputPorts = new[] { GraphControlFlowPorts.Target },
+            valueInputPorts = Array.Empty<string>(),
+            outputType = GraphValueType.Void.ToString(),
+            lowersTo = GraphNodeOp.Jump.ToString(),
+        });
+    }
+
+    return Results.Ok(new { ok = true, kind = graphKind.ToString(), descriptors, authoringSugars });
 });
 
 app.MapGet("/api/mods/{modId}/gas/graph-editor/{graphId}", (string modId, string graphId) =>

--- a/src/Tools/Ludots.Editor.React/src/pages/GasGraphEditorPage.tsx
+++ b/src/Tools/Ludots.Editor.React/src/pages/GasGraphEditorPage.tsx
@@ -8,12 +8,15 @@ import {
   Handle,
   Position,
   applyNodeChanges,
+  addEdge,
   type Node,
   type Edge,
+  type Connection,
   type NodeProps,
   type NodeChange,
   MarkerType,
 } from '@xyflow/react';
+import { Search, Plus } from 'lucide-react';
 import '@xyflow/react/dist/style.css';
 
 type GraphNodeConfig = {
@@ -58,7 +61,7 @@ type GraphNodeConfig = {
   queryCapacityPolicy?: string | null;
 };
 
-type GasNodeData = GraphNodeConfig & { label: string; descriptor?: GraphDescriptor };
+type GasNodeData = GraphNodeConfig & { label: string; descriptor?: GraphDescriptor; sugar?: GraphSugarDescriptor };
 
 type GraphDescriptor = {
   op: string;
@@ -72,6 +75,14 @@ type GraphDescriptor = {
   flagsRole: string;
   immRole: string;
   scriptSliceOnly: boolean;
+};
+
+type GraphSugarDescriptor = {
+  op: string;
+  controlOutputPorts: string[];
+  valueInputPorts: string[];
+  outputType: string;
+  lowersTo: string;
 };
 
 type EditorLayout = {
@@ -155,10 +166,12 @@ const DEFAULT_GRAPH_ID = 'ui.panel.player.resource.aggregate';
 
 function GasNode({ data, selected }: NodeProps<Node<GasNodeData>>) {
   const descriptor = data.descriptor;
+  const sugar = data.sugar;
   const inputPorts = Array.from(new Set([
     ...(descriptor?.linearInputPorts ?? []),
     ...(descriptor?.queryInputPorts ?? []),
     ...(descriptor?.scriptInputPorts ?? []),
+    ...(sugar?.valueInputPorts ?? []),
   ]));
   const outputType = descriptor?.queryOutputType !== 'Void'
     ? descriptor?.queryOutputType
@@ -190,7 +203,7 @@ function GasNode({ data, selected }: NodeProps<Node<GasNodeData>>) {
         {valueOutput ? <span className="rounded bg-violet-950 px-1 text-violet-300">{valueOutput}</span> : null}
         {inputPorts.map((port) => <span key={port} className="rounded bg-emerald-950 px-1 text-emerald-300">{port}</span>)}
       </div>
-      <Handle id="next" type="source" position={Position.Right} className="!top-4 !bg-sky-400" />
+      <Handle id={sugar?.controlOutputPorts[0] ?? 'next'} type="source" position={Position.Right} className="!top-4 !bg-sky-400" />
       {valueOutput ? (
         <Handle id={valueOutput} type="source" position={Position.Right} className="!top-12 !bg-violet-400" />
       ) : null}
@@ -267,13 +280,14 @@ function edgeLabel(edge: Edge<GasEdgeData>): string {
 function graphToFlow(
   graph: GraphConfig,
   descriptors: Record<string, GraphDescriptor> = {},
+  sugars: Record<string, GraphSugarDescriptor> = {},
   layout: EditorLayout = {},
 ): { nodes: Node<GasNodeData>[]; edges: Edge<GasEdgeData>[] } {
   const nodes: Node<GasNodeData>[] = graph.nodes.map((n, index) => ({
     id: n.id,
     type: 'gas',
     position: layout.nodes?.[n.id] ?? { x: 40 + index * 220, y: 80 + (index % 2) * 40 },
-    data: { ...n, label: n.id, descriptor: descriptors[n.op] },
+    data: { ...n, label: n.id, descriptor: descriptors[n.op], sugar: sugars[n.op] },
   }));
 
   const edges: Edge<GasEdgeData>[] = [];
@@ -328,12 +342,17 @@ function graphToFlow(
 }
 
 function flowToGraph(graph: GraphConfig, nodes: Node<GasNodeData>[], edges: Edge<GasEdgeData>[]): GraphConfig {
-  const byId = new Map(nodes.map((n) => [n.id, n.data]));
-  const wireNodes = graph.nodes.map((n) => {
-    const edited = byId.get(n.id);
-    if (!edited) return toWireNode(n);
+  const sourceById = new Map(graph.nodes.map((n) => [n.id, n]));
+  const wireNodes = nodes.map((flowNode) => {
+    const n = sourceById.get(flowNode.id);
+    const edited = flowNode.data;
+    if (!n) {
+      return toWireNode({ ...edited, id: flowNode.id, op: edited.op });
+    }
     const rest = { ...edited };
     delete rest.label;
+    delete rest.descriptor;
+    delete rest.sugar;
     return toWireNode({
       ...n,
       ...rest,
@@ -387,6 +406,8 @@ export const GasGraphEditorPage: React.FC = () => {
   const [graphId, setGraphId] = React.useState(DEFAULT_GRAPH_ID);
   const [graph, setGraph] = React.useState<GraphConfig | null>(null);
   const [descriptors, setDescriptors] = React.useState<Record<string, GraphDescriptor>>({});
+  const [sugars, setSugars] = React.useState<Record<string, GraphSugarDescriptor>>({});
+  const [nodeSearch, setNodeSearch] = React.useState('');
   const [layout, setLayout] = React.useState<EditorLayout>({});
   const [nodes, setNodes] = React.useState<Node<GasNodeData>[]>([]);
   const [edges, setEdges] = React.useState<Edge<GasEdgeData>[]>([]);
@@ -441,13 +462,18 @@ export const GasGraphEditorPage: React.FC = () => {
       for (const descriptor of (descriptorPayload.descriptors ?? []) as GraphDescriptor[]) {
         nextDescriptors[descriptor.op] = descriptor;
       }
-      const missingDescriptor = loaded.nodes.find((node) => !nextDescriptors[node.op]);
+      const nextSugars: Record<string, GraphSugarDescriptor> = {};
+      for (const sugar of (descriptorPayload.authoringSugars ?? []) as GraphSugarDescriptor[]) {
+        nextSugars[sugar.op] = sugar;
+      }
+      const missingDescriptor = loaded.nodes.find((node) => !nextDescriptors[node.op] && !nextSugars[node.op]);
       if (missingDescriptor) throw new Error(`Descriptor missing for graph op '${missingDescriptor.op}'.`);
       const nextLayout = (layoutPayload.layout ?? {}) as EditorLayout;
       setDescriptors(nextDescriptors);
+      setSugars(nextSugars);
       setLayout(nextLayout);
       setGraph(loaded);
-      const flow = graphToFlow(loaded, nextDescriptors, nextLayout);
+      const flow = graphToFlow(loaded, nextDescriptors, nextSugars, nextLayout);
       setNodes(flow.nodes);
       setEdges(flow.edges);
       setSelectedNodeId(null);
@@ -489,7 +515,7 @@ export const GasGraphEditorPage: React.FC = () => {
     });
     setNodes(nextNodes);
     if (field === 'next') {
-      setEdges(graphToFlow(flowToGraph(graph, nextNodes, edges), descriptors, layout).edges);
+      setEdges(graphToFlow(flowToGraph(graph, nextNodes, edges), descriptors, sugars, layout).edges);
     }
   };
 
@@ -516,7 +542,55 @@ export const GasGraphEditorPage: React.FC = () => {
 
   const onNodesChange = React.useCallback((changes: NodeChange<Node<GasNodeData>>[]) => {
     setNodes((prev) => applyNodeChanges(changes, prev));
+    const removed = new Set(changes.filter((change) => change.type === 'remove').map((change) => change.id));
+    if (removed.size > 0) {
+      setEdges((prev) => prev.filter((edge) => !removed.has(edge.source) && !removed.has(edge.target)));
+    }
   }, []);
+
+  const onConnect = React.useCallback((connection: Connection) => {
+    if (!connection.source || !connection.target || !connection.sourceHandle || !connection.targetHandle) return;
+    const kind: GasEdgeData['kind'] = connection.targetHandle === 'control-in' ? 'control' : 'value';
+    setEdges((prev) => addEdge({
+      ...connection,
+      id: `${kind}:${connection.source}:${connection.sourceHandle}:${connection.target}:${connection.targetHandle}`,
+      markerEnd: { type: MarkerType.ArrowClosed },
+      label: kind === 'control'
+        ? connection.sourceHandle
+        : `${connection.sourceHandle} -> ${connection.targetHandle}`,
+      data: { kind },
+    }, prev));
+  }, []);
+
+  const availableNodes = React.useMemo(() => {
+    const entries = [
+      ...Object.values(descriptors).map((descriptor) => ({ op: descriptor.op, descriptor, sugar: undefined })),
+      ...Object.values(sugars).map((sugar) => ({ op: sugar.op, descriptor: undefined, sugar })),
+    ];
+    const query = nodeSearch.trim().toLocaleLowerCase();
+    return entries
+      .filter((entry) => !query || entry.op.toLocaleLowerCase().includes(query))
+      .sort((a, b) => a.op.localeCompare(b.op));
+  }, [descriptors, nodeSearch, sugars]);
+
+  const addAuthoringNode = React.useCallback((op: string) => {
+    if (!graph) return;
+    const idBase = op.replace(/[^A-Za-z0-9_]/g, '_').toLocaleLowerCase();
+    const used = new Set(nodes.map((node) => node.id));
+    let suffix = 1;
+    let id = idBase;
+    while (used.has(id)) id = `${idBase}_${suffix++}`;
+    const next: Node<GasNodeData> = {
+      id,
+      type: 'gas',
+      position: { x: 80 + (nodes.length % 3) * 240, y: 120 + Math.floor(nodes.length / 3) * 150 },
+      data: { id, op, label: id, descriptor: descriptors[op], sugar: sugars[op] },
+    };
+    setNodes((previous) => [...previous, next]);
+    setSelectedNodeId(id);
+    setSelectedEdgeId(null);
+    setStatus(`Added ${op}; wire its pins before validation.`);
+  }, [descriptors, graph, nodes, sugars]);
 
   const saveLayout = React.useCallback(async () => {
     const nextLayout: EditorLayout = {
@@ -768,22 +842,56 @@ export const GasGraphEditorPage: React.FC = () => {
       <div className="grid min-h-0 flex-1 grid-cols-[1fr_320px]">
         <div className="min-h-0">
           {graph ? (
-            <ReactFlow
-              nodes={displayNodes}
-              edges={edges}
-              nodeTypes={nodeTypes}
-              onNodesChange={onNodesChange}
-              onSelectionChange={({ nodes: selected, edges: selectedEdges }) => {
-                setSelectedNodeId(selected[0]?.id ?? null);
-                setSelectedEdgeId(selectedEdges[0]?.id ?? null);
-              }}
-              fitView
-              proOptions={{ hideAttribution: true }}
-            >
-              <Background gap={16} color="#334155" />
-              <Controls />
-              <MiniMap pannable zoomable />
-            </ReactFlow>
+            <div className="relative h-full">
+              <ReactFlow
+                nodes={displayNodes}
+                edges={edges}
+                nodeTypes={nodeTypes}
+                onNodesChange={onNodesChange}
+                onConnect={onConnect}
+                onSelectionChange={({ nodes: selected, edges: selectedEdges }) => {
+                  setSelectedNodeId(selected[0]?.id ?? null);
+                  setSelectedEdgeId(selectedEdges[0]?.id ?? null);
+                }}
+                fitView
+                proOptions={{ hideAttribution: true }}
+              >
+                <Background gap={16} color="#334155" />
+                <Controls />
+                <MiniMap pannable zoomable />
+              </ReactFlow>
+              <div className="absolute left-3 top-3 z-10 w-72 rounded border border-slate-700 bg-slate-950/95 p-2 shadow-xl">
+                <div className="flex items-center gap-2 border-b border-slate-800 pb-2">
+                  <Search size={14} className="text-slate-500" aria-hidden="true" />
+                  <input
+                    value={nodeSearch}
+                    onChange={(event) => setNodeSearch(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' && availableNodes[0]) addAuthoringNode(availableNodes[0].op);
+                    }}
+                    placeholder="Find node"
+                    aria-label="Find graph node"
+                    className="min-w-0 flex-1 bg-transparent text-xs text-slate-100 outline-none placeholder:text-slate-600"
+                  />
+                  <span className="text-[10px] text-slate-600">Enter</span>
+                </div>
+                <div className="mt-2 max-h-64 overflow-auto">
+                  {availableNodes.slice(0, 24).map((entry) => (
+                    <button
+                      key={entry.op}
+                      type="button"
+                      onClick={() => addAuthoringNode(entry.op)}
+                      className="flex w-full items-center gap-2 px-2 py-1.5 text-left text-xs text-slate-300 hover:bg-slate-800"
+                    >
+                      <Plus size={12} className="text-emerald-400" aria-hidden="true" />
+                      <span className="font-mono">{entry.op}</span>
+                      {entry.sugar ? <span className="ml-auto text-[10px] text-amber-300">sugar</span> : null}
+                    </button>
+                  ))}
+                  {availableNodes.length === 0 ? <div className="px-2 py-2 text-xs text-slate-600">No runtime node matches.</div> : null}
+                </div>
+              </div>
+            </div>
           ) : (
             <div className="flex h-full items-center justify-center text-sm text-slate-500">
               No graph loaded. Check Bridge is running on :5299.


### PR DESCRIPTION
## Summary\n- close blackboard float capability and batch archetype gap\n- attribute live graph trace to the last executed instruction PC\n- fail closed on missing trace source map entries\n- keep editor descriptor/layout/edge operations fail-closed\n- document Select/Break completion and defer string template/Concat until a formal text runtime contract exists\n\n## Verification\n- React editor: npm run build\n- Editor Bridge: dotnet build --no-restore\n- Gas graph tests: 38 passed\n- git diff --check\n\n## Boundary\nSelect remains SelectEntity. Break lowers to Jump with an explicit target edge. String brace pin exposure and Concat remain intentionally unavailable until text value, fixed-capacity transport, symbol patching, and presentation sink contracts are implemented.